### PR TITLE
Fixes #6 Added user setting for participants and votes reset

### DIFF
--- a/api/event/event.controller.js
+++ b/api/event/event.controller.js
@@ -75,6 +75,10 @@ exports.update = function(req, res){
                     communicator.emit('event:update:creator.email', updatedEvent, event);
             }
 
+            if (event.creator.shouldResetParticipants != updatedEvent.creator.shouldResetParticipants) {
+              communicator.emit('event:update:creator.shouldResetParticipants', updatedEvent, event);
+            }
+
             Event
                 .update({ '_id' : req.params.id }, updatedEvent)
                 .exec(function(){

--- a/api/event/event.model.js
+++ b/api/event/event.model.js
@@ -20,6 +20,10 @@ var EventSchema = new Schema({
         allowNotifications : {
             type : Boolean,
             default : true
+        },
+        shouldResetParticipants : {
+           type : Boolean,
+           default : false
         }
     },
     created : {

--- a/public/js/controllers/editevent.controller.js
+++ b/public/js/controllers/editevent.controller.js
@@ -23,7 +23,7 @@ angular.module('rallly')
     }
     $scope.submit = function(){
         if ($scope.form.$valid){
-            if ($scope.didChangeDates() ){
+            if ($scope.didChangeDates() && $scope.event.creator.shouldResetParticipants){
                 var modal = new ConfirmModal({
                     title : 'Hold up!',
                     message : 'Changing the dates will reset all entries by the participants. Are you sure you want to do that?',

--- a/public/js/controllers/newevent.controller.js
+++ b/public/js/controllers/newevent.controller.js
@@ -4,8 +4,10 @@ angular.module('rallly')
     $scope.title = "Schedule a New Event";
     $scope.description = "Fill in the form below to create your event and share it with your friends and colleagues.";
     $scope.event = { creator : {
-        allowNotifications : true
-    }};
+        allowNotifications : true,
+        shouldResetParticipants : false
+      }
+    };
 
 
     $scope.submit = function(){

--- a/public/templates/form/settingsForm.html
+++ b/public/templates/form/settingsForm.html
@@ -36,6 +36,23 @@
             </div>
         </div>
     </div>
+    <div class="switch-row">
+        <div class="switch-details">
+            <div class="title">
+                Reset participants and votes
+            </div>
+            <div class="description">
+                Reset all the current participiants and their votes when you edit the event dates.
+            </div>
+        </div>
+        <div class="switch">
+            <div class="switch-value">
+                {{event.creator.shouldResetParticipants ? 'On' : 'Off' }}
+            </div>
+            <div switch-toggle ng-model="event.creator.shouldResetParticipants">
+            </div>
+        </div>
+    </div>
     <div class="switch-row" ng-if="event._id">
         <div class="switch-details">
             <div class="title">


### PR DESCRIPTION
Enable users to choose whether they want to reset all participants and their votes after editing their event's date options. Default setting is defined as `false`.