### PR TITLE
Docker compose - local development fixes

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,5 @@
 node_modules
 npm-debug.log
+public/vendor
+config.json
+.env

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,8 @@ FROM node:boron
 RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app
 
-COPY package.json /usr/src/app/
-RUN npm install -q
+COPY package.json bower.json .bowerrc /usr/src/app/
+RUN yarn
 
 COPY . /usr/src/app
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN yarn
 
 COPY . /usr/src/app
 
-RUN npm run config -- -d
+RUN npm run config -- -df
 
 ENV DEBUG=rallly
 EXPOSE 3000

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ To get started quickly and easily, simply run the following:
 git clone git@github.com:lukevella/Rallly.git
 cd Rallly
 ```
-Copy the sample `.env` file then open it and set the variables. 
+Copy the sample `.env` file. This contains a working development configuration.
 ```bash
 cp sample.env .env
 ```
@@ -26,6 +26,16 @@ docker-compose up -d
 ```
 
 Now that was simple!
+
+The following services are bound to `localhost` ports:
+
+| Port  | Service             |
+|-------|---------------------|
+| 3000  | Rallly UI           |
+| 3001  | Maildev UI          |
+| 3587  | Maildev SMTP        |
+| 27017 | Rallly MongoDB      |
+
 
 ## Manual Setup [Detailed Production Docs](docs/production/README.md)
 ### Requirements

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,7 @@ services:
       db:
         condition: service_healthy
   db:
-    image: mongo
+    image: mongo:3.4
     restart: always
     ports:
      - "27017:27017"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,8 @@ services:
     depends_on:
       db:
         condition: service_healthy
+      mail:
+        condition: service_started
   db:
     image: mongo:3.4
     restart: always
@@ -18,10 +20,19 @@ services:
      - "27017:27017"
     healthcheck:
       test: ["CMD-SHELL", "echo 'db.stats().ok' | mongo 127.0.0.1/test --quiet"]
-      interval: 1m30s
-      timeout: 10s
-      retries: 3
+      interval: 10s
+      timeout: 3s
+      retries: 10
     volumes:
       - /data/db
       - /var/lib/mongodb
       - /var/log/mongodb
+  mail:
+    image: djfarrelly/maildev
+    command: ["bin/maildev", "--web", "3001", "--smtp", "${SMTP_PORT:?SMTP_PORT}"]
+    restart: always
+    ports:
+     # SMTP port
+     - "${SMTP_PORT}:${SMTP_PORT}"
+     # Web UI for debugging mail
+     - "3001:3001"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     build:
       context: .
     ports:
-     - "3000:3000"
+     - "${PORT}:${PORT}"
     env_file:
      - .env
     depends_on:
@@ -27,9 +27,12 @@ services:
       - /data/db
       - /var/lib/mongodb
       - /var/log/mongodb
+  
+  # Maildev will catch all mail sent to it
+  # It does not require authorisation
   mail:
     image: djfarrelly/maildev
-    command: ["bin/maildev", "--web", "3001", "--smtp", "${SMTP_PORT:?SMTP_PORT}"]
+    command: ["bin/maildev", "--web", "3001", "--smtp", "${SMTP_PORT}"]
     restart: always
     ports:
      # SMTP port

--- a/sample.env
+++ b/sample.env
@@ -1,12 +1,12 @@
-NODE_ENV=production
+NODE_ENV=development
 PORT=3000
 SITE_URL=http://localhost:3000
 FROM_NAME=Rallly
 FROM_EMAIL=noreply@rallly.co
 DB_ADDRESS=db
 DB_NAME=rallly
-SMTP_HOST=
-SMTP_PORT=587
+SMTP_HOST=mail
+SMTP_PORT=3587
 SMTP_USER=
 SMTP_PWD=
 SMTP_SECURE=false


### PR DESCRIPTION
I'm interested in the project, and thinking of taking on one of the open issues. I ran into a few issues getting local development with `docker-compose` set up - this PR suggests some fixes:

- incompatible with `mongo:latest`
  - changed docker compose to use `mongo:3.4`
- `npm install -q` fails to install `bower` modules.
  - use `yarn` and and copy bower config files to the build container
- cannot debug sent emails
  - added a `mail` service based on `maildev`. This lightweight container allows UI debugging of emails during development
- always regenerate configuration when running `Dockerfile`

Feedback welcome, as well as any thoughts you have on the project roadmap?