### PR TITLE
Add Docker publishing workflow

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,6 +1,5 @@
 on:
   push:
-  pull_request:
   workflow_dispatch:
     inputs:
       debug_enabled:

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -11,7 +11,8 @@ on:
 jobs:
   build:
     name: Build, push, and deploy
-    #if: ${{ startsWith(github.ref, 'refs/tags/v') }}
+    if: ${{ startsWith(github.ref, 'refs/tags/v') }}
+    #if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     steps:
 
@@ -36,7 +37,6 @@ jobs:
         echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
       
     - name: Push image to GitHub
-      #if: github.ref == 'refs/heads/main'
       run: |
         docker push ghcr.io/m3nu/rallly:${{ env.RELEASE_VERSION }}
         docker push ghcr.io/m3nu/rallly:latest

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -36,7 +36,7 @@ jobs:
         echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
       
     - name: Push image to GitHub
-      if: github.ref == 'refs/heads/main'
+      #if: github.ref == 'refs/heads/main'
       run: |
         docker push ghcr.io/m3nu/rallly:${{ env.RELEASE_VERSION }}
         docker push ghcr.io/m3nu/rallly:latest

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,0 +1,42 @@
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+    inputs:
+      debug_enabled:
+        description: 'Run the build with tmate debugging enabled'
+        required: false
+        default: false
+
+jobs:
+  build:
+    name: Build, push, and deploy
+    #if: ${{ startsWith(github.ref, 'refs/tags/v') }}
+    runs-on: ubuntu-latest
+    steps:
+
+    - name: Set version from tag
+      run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
+
+    - name: Checkout
+      uses: actions/checkout@v2
+
+    - name: Setup tmate debug session
+      uses: mxschmitt/action-tmate@v3
+      if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.debug_enabled }}
+
+    - name: Build container image
+      run: |
+        docker build \
+        --tag ghcr.io/m3nu/rallly:${{ env.RELEASE_VERSION }} \
+        --tag ghcr.io/m3nu/rallly:latest \
+        .
+    - name: Container registry login
+      run: |
+        echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
+      
+    - name: Push image to GitHub
+      if: github.ref == 'refs/heads/main'
+      run: |
+        docker push ghcr.io/m3nu/rallly:${{ env.RELEASE_VERSION }}
+        docker push ghcr.io/m3nu/rallly:latest

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -29,8 +29,8 @@ jobs:
     - name: Build container image
       run: |
         docker build \
-        --tag ghcr.io/m3nu/rallly:${{ env.RELEASE_VERSION }} \
-        --tag ghcr.io/m3nu/rallly:latest \
+        --tag ghcr.io/lukevella/rallly:${{ env.RELEASE_VERSION }} \
+        --tag ghcr.io/lukevella/rallly:latest \
         .
     - name: Container registry login
       run: |
@@ -38,5 +38,5 @@ jobs:
       
     - name: Push image to GitHub
       run: |
-        docker push ghcr.io/m3nu/rallly:${{ env.RELEASE_VERSION }}
-        docker push ghcr.io/m3nu/rallly:latest
+        docker push ghcr.io/lukevella/rallly:${{ env.RELEASE_VERSION }}
+        docker push ghcr.io/lukevella/rallly:latest


### PR DESCRIPTION
This adds a simple workflow to build Docker images via Github Actions and push them to Github's container registry.

This will only happen for tagged commits or when run manually from *Actions*. To add a tag:

```
$ git tag -a v0.2
$ git push origin v0.2
```

This could be adjusted to e.g. use SHAs as tags or run more often.

This should automatically use the repo's permissions after merging, so no further setup needed.

Test package here: https://github.com/m3nu/rallly/pkgs/container/rallly