### PR TITLE
fixed min length of SECRET_PASSWORD.

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ yarn start
 | Parameter       | Default                                        | Description                                                                                                                         |
 | --------------- | ---------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------- |
 | DATABASE_URL    | postgres://postgres:postgres@rallly_db:5432/db | A postgres database URL. Leave out if using the docker-compose file since it will spin up and connect to its own database instance. |
-| SECRET_PASSWORD | -                                              | A long string (minimum 25 characters) that is used to encrypt session data.                                                         |
+| SECRET_PASSWORD | -                                              | A long string (minimum 32 characters) that is used to encrypt session data.                                                         |
 | SUPPORT_EMAIL   | -                                              | An email address that will appear as the FROM email for all emails being sent out.                                                  |
 | SMTP_HOST       | -                                              | Host name of your SMTP server                                                                                                       |
 | SMTP_PORT       | -                                              | Port of your SMTP server                                                                                                            |

--- a/sample.env
+++ b/sample.env
@@ -1,5 +1,5 @@
 DATABASE_URL=postgres://your-database/db
-SECRET_PASSWORD=minimum-25-characters
+SECRET_PASSWORD=minimum-32-characters
 SUPPORT_EMAIL=foo@yourdomain.com
 SMTP_HOST=your-smtp-server
 SMTP_PORT=587


### PR DESCRIPTION
I had the following error in my docker logs:

```bash
rallly-rallly-1 | Error: iron-session: Bad usage. Password must be at least 32 characters long.
rallly-rallly-1 | at file:///usr/src/app/node_modules/iron-session/dist/index.mjs:24:13
rallly-rallly-1 | at Array.forEach (<anonymous>)
rallly-rallly-1 | at getIronSession (file:///usr/src/app/node_modules/iron-session/dist/index.mjs:22:76)
```
