### PR TITLE
docker-compose: pass schema to migrate deploy

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,7 @@ services:
         - DATABASE_URL=postgres://postgres:postgres@rallly_db:5432/db?pgbouncer=true
         - NEXT_PUBLIC_BASE_URL=${NEXT_PUBLIC_BASE_URL}
     restart: always
-    command: sh -c "yarn prisma migrate deploy && yarn start"
+    command: sh -c "yarn prisma migrate deploy --schema prisma/schema.prisma && yarn start"
     depends_on:
       - rallly_db
     ports:


### PR DESCRIPTION
This patch passes the explicit path to the prisma schema so that the initial table creation is performed.  Otherwise the command will print:

    No migration found in prisma/migrations

And attempting to create a poll produces the postgres error:

    ERROR:  relation "public.users" does not exist at character 35
    STATEMENT:  SELECT "public"."users"."id" FROM "public"."users" WHERE "public"."users"."email" = $1 OFFSET $2
