### PR TITLE
Ignore more files in docker image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,11 @@
 node_modules
+.git
+.github
+.vscode
 .env
 .sentryclirc
 sentry.properties
+Dockerfile
+docker-compose.yml
+docs
+README.md


### PR DESCRIPTION
These files and directories aren't needed in the image and ignoring
them means that changes to these files won't invalidate the docker
build cache the image will be smaller.

---

The size savings aren't substantial in the grand scheme of things. The `COPY . /usrc/src/app/` changes from ~9.6mb to ~900kb. This size would grow as the repo grows though since `.git` was included.

The bigger thing here is that changes to these files won't require a full `yarn build` again since it'll now be a cache hit.

I couldn't immediately identify if this file was sorted or organized in a particular way. Happy to rearrange.