### PR TITLE
Move prisma command to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,4 +19,4 @@ RUN yarn build
 
 EXPOSE 3000
 
-CMD [ "yarn", "start" ]
+CMD sh -c "yarn prisma migrate deploy --schema prisma/schema.prisma && yarn start"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,6 @@ services:
       args:
         - DATABASE_URL=postgres://postgres:postgres@rallly_db:5432/db?pgbouncer=true
     restart: always
-    command: sh -c "yarn prisma migrate deploy --schema prisma/schema.prisma && yarn start"
     depends_on:
       - rallly_db
     ports:


### PR DESCRIPTION
This is required for a successful startup, so this makes it the
default command rather than requiring it to be overridden in the
compose file.