### PR TITLE
Add SMTP_IGNORETLS support

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ yarn start
 | SMTP_HOST            | -                                              | Host name of your SMTP server                                                                                                       |
 | SMTP_PORT            | -                                              | Port of your SMTP server                                                                                                            |
 | SMTP_SECURE          | false                                          | Set to "true" if SSL is enabled for your SMTP connection                                                                            |
+| SMTP_IGNORETLS       | false                                          | Set to "true" if your SMTP server only works without STARTTLS                                                                       |
 | SMTP_USER            | -                                              | Username to use for your SMTP connection                                                                                            |
 | SMTP_PWD             | -                                              | Password to use for your SMTP connection                                                                                            |
 

--- a/declarations/environment.d.ts
+++ b/declarations/environment.d.ts
@@ -14,6 +14,7 @@ declare global {
       SMTP_USER: string;
       SMTP_PWD: string;
       SMTP_SECURE: string;
+      SMTP_IGNORETLS: string;
       SMTP_PORT: string;
     }
   }

--- a/sample.env
+++ b/sample.env
@@ -5,5 +5,6 @@ SUPPORT_EMAIL=foo@yourdomain.com
 SMTP_HOST=your-smtp-server
 SMTP_PORT=587
 SMTP_SECURE=false
+SMTP_IGNORETLS=false
 SMTP_USER=your-smtp-user
 SMTP_PWD=your-smtp-password

--- a/src/utils/send-email.ts
+++ b/src/utils/send-email.ts
@@ -14,6 +14,7 @@ const getTransport = async () => {
       host: process.env.SMTP_HOST,
       port: parseInt(process.env.SMTP_PORT),
       secure: process.env.SMTP_SECURE === "true",
+      ignoreTLS: process.env.SMTP_IGNORETLS === "true",
       auth: {
         user: process.env.SMTP_USER,
         pass: process.env.SMTP_PWD,


### PR DESCRIPTION
In configuring this service for my mom, she had problems with it sending email. Upon my review, I found its because my local mail server supports STARTTLS, but there is a problem upgrading. See test script below:

```js
"use strict";
const nodemailer = require("nodemailer");

// async..await is not allowed in global scope, must use a wrapper
async function main() {
  // create reusable transporter object using the default SMTP transport
  let transporter = nodemailer.createTransport({
    host: "10.0.0.5",
    port: 25,
    secure: false, // true for 465, false for other ports
    //ignoreTLS: true,
    auth: {
      user: "",
      pass: "",
    },
  });

  // send mail with defined transport object
  let info = await transporter.sendMail({
    from: '"Test" <test@gec.im>', // sender address
    to: '"James Coleman" <grmrgecko@gmail.com>', // list of receivers
    subject: "Hello ✔", // Subject line
    text: "Hello world?", // plain text body
    html: "<b>Hello world?</b>", // html body
  });

  console.log("Message sent: %s", info.messageId);
}

main().catch(console.error);
```

Error:
```
[root@moby test]# node test.js 
Error: Error upgrading connection with STARTTLS: 454 4.7.0 TLS not available due to local problem
    at SMTPConnection._actionSTARTTLS (/docker/rallly-mom/test/node_modules/nodemailer/lib/smtp-connection/index.js:1361:27)
    at SMTPConnection._processResponse (/docker/rallly-mom/test/node_modules/nodemailer/lib/smtp-connection/index.js:950:20)
    at SMTPConnection._onData (/docker/rallly-mom/test/node_modules/nodemailer/lib/smtp-connection/index.js:752:14)
    at Socket.SMTPConnection._onSocketData (/docker/rallly-mom/test/node_modules/nodemailer/lib/smtp-connection/index.js:191:44)
    at Socket.emit (node:events:520:28)
    at addChunk (node:internal/streams/readable:315:12)
    at readableAddChunk (node:internal/streams/readable:289:9)
    at Socket.Readable.push (node:internal/streams/readable:228:10)
    at TCP.onStreamRead (node:internal/stream_base_commons:190:23) {
  code: 'ETLS',
  response: '454 4.7.0 TLS not available due to local problem',
  responseCode: 454,
  command: 'STARTTLS'
}
```

I reviewed the documentation for nodemailer and added `ignoreTLS: true` to my configuration which fixed outgoing mail:
```
[root@moby test]# node test.js 
Message sent: <974f9135-4c0a-9e59-f7bb-fefdb06c8405@gec.im>
```