### PR TITLE
Remove DATABASE_URL from Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,16 +12,14 @@ COPY . .
 
 RUN yarn build
 
-FROM node:alpine	
+FROM node:alpine
 
 ENV PORT 3000
 EXPOSE 3000
 
-ARG DATABASE_URL
-ENV DATABASE_URL $DATABASE_URL
-
 WORKDIR /usr/src/app
 
 COPY --from=build /app .
+COPY docker_start.sh .
 
-CMD sh -c "yarn prisma migrate deploy --schema prisma/schema.prisma && yarn start"
+ENTRYPOINT [ "./docker_start.sh" ]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: "3.3"
+version: "3.9"
 services:
   rallly_db:
     image: postgres:14.2
@@ -7,15 +7,20 @@ services:
       - db-data:/var/lib/postgresql/data
     environment:
       - POSTGRES_PASSWORD=postgres
+      - POSTGRES_DB=db
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
 
   rallly:
     build:
       context: .
-      args:
-        - DATABASE_URL=postgres://postgres:postgres@rallly_db:5432/db?pgbouncer=true
     restart: always
     depends_on:
-      - rallly_db
+      rallly_db:
+        condition: service_healthy
     ports:
       - 3000:3000
     environment:

--- a/docker_start.sh
+++ b/docker_start.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+yarn prisma migrate deploy --schema prisma/schema.prisma
+yarn start


### PR DESCRIPTION
Closes #170

This PR removes the `DATABASE_URL` from the Dockerfile and moves the CMD in the last line to a startup script.
Additionally, the docker compose performs a health check on the database container to wait until is fully functional to avoid refused connections that could sometims occur on the first run when the database was created.

I'm no Prisma expert but this seems to work without the need to override the `datasources` field in the `PrismaClient`. Prisma only complains when the env variable is not set upon startup.