### PR TITLE
CI/CD: Automatically publish Docker image

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -17,7 +17,7 @@ jobs:
           password: ${{ secrets.DOCKER_PASSWORD }}
       
       - name: Check out repository code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
  
       - name: Build and publish image
         uses: docker/build-push-action@v3

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,5 +1,4 @@
-name: Build and push Docker image
-
+name: Build and publish Docker image
 on:
   push:
     branches:
@@ -7,11 +6,11 @@ on:
   workflow_dispatch:
 
 jobs:
-  build-push:
-    name: Build and push image
+  publish:
+    name: Build and publish Docker image
     runs-on: ubuntu-latest
     steps: 
-      - name: Login to DockerHub
+      - name: Log in to Docker Hub
         uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
@@ -20,7 +19,7 @@ jobs:
       - name: Check out repository code
         uses: actions/checkout@v2
  
-      - name: Build and push image
+      - name: Build and publish image
         uses: docker/build-push-action@v3
         with:
           push: true

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,0 +1,29 @@
+name: Build and push Docker image
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  build-push:
+    name: Build and push image
+    runs-on: ubuntu-latest
+    steps: 
+      - name: Login to DockerHub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+      
+      - name: Check out repository code
+        uses: actions/checkout@v2
+ 
+      - name: Build and push image
+        uses: docker/build-push-action@v3
+        with:
+          push: true
+          tags: |
+            ${{ secrets.DOCKER_USERNAME }}/rallly:latest
+            ${{ secrets.DOCKER_USERNAME }}/rallly:${{ github.sha }}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,8 +15,7 @@ services:
       retries: 5
 
   rallly:
-    build:
-      context: .
+    image: lukevella/rallly:latest
     restart: always
     depends_on:
       rallly_db:


### PR DESCRIPTION
Now that #170 is fixed, we can add a CI/CD workflow to automatically push a Docker image to Dockerhub. Only thing you need to do is to add secrets for your Dockerhub credentials.
