### PR TITLE
Run docker workflow once a week

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,9 +1,8 @@
 name: Build and publish Docker image
 on:
-  push:
-    branches:
-      - main
   workflow_dispatch:
+  schedule:
+    - cron: "0 6 * * 1" # Every Monday at 6:00am UTC
 
 jobs:
   publish:


### PR DESCRIPTION
Since updating the workflow to support arm architectures this workflow now takes around an hour to finish. I'm assuming that it is a bit overkill to publish an image for every commit here. So instead moving to a weekly build whereby an image is published every Monday at 06:00 am UTC instead.