### PR TITLE
Set supportEmail when rendering login template

### DIFF
--- a/src/server/routers/login.ts
+++ b/src/server/routers/login.ts
@@ -30,6 +30,7 @@ export const login = createRouter().mutation("login", {
       templateVars: {
         loginUrl,
         homePageUrl,
+        supportEmail: process.env.SUPPORT_EMAIL,
       },
     });
   },


### PR DESCRIPTION
The contact link is rendered as "mailto:undefined" in the magic link emails