### PR TITLE
Improve time slot start times

### DIFF
--- a/src/components/forms/poll-options-form/month-calendar/month-calendar.tsx
+++ b/src/components/forms/poll-options-form/month-calendar/month-calendar.tsx
@@ -330,7 +330,7 @@ const MonthCalendar: React.VoidFunctionComponent<DateTimePickerProps> = ({
                               const lastOption = expectTimeOption(
                                 optionsForDay[optionsForDay.length - 1].option,
                               );
-                              const startTime = lastOption.start;
+                              const startTime = lastOption.end;
 
                               onChange([
                                 ...options,


### PR DESCRIPTION
Set start time of new time slot to end of previous slot

Currently, the time slots all start at the same time. This is cumbersome and creates additional effort when creating polls.
This pull request sets the start time of the new time slot to the end time of the previous time slot. This allows users to create successive time slots with just a few clicks.

see https://github.com/lukevella/rallly/discussions/138