### PR TITLE
💦 Temporarily disable arm64 builds

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -12,13 +12,6 @@ jobs:
       - name: Check out repository code
         uses: actions/checkout@v3
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
-
-      - name: Set up Docker Buildx
-        id: buildx
-        uses: docker/setup-buildx-action@v2
-
       - name: Docker meta
         id: meta
         uses: docker/metadata-action@v4
@@ -40,7 +33,7 @@ jobs:
         uses: docker/build-push-action@v4
         with:
           file: ./apps/web/Dockerfile
-          platforms: linux/arm64,linux/amd64
+          platforms: linux/amd64
           push: true
           cache-from: type=gha
           cache-to: type=gha,mode=max


### PR DESCRIPTION
The reason why this is necessary is because our pipeline is failing due to network timeouts. Unfortunately I am not aware of a solution to this problem but if we can find a way to build these images as part of our workflow we should reeanble this feature.