### PR TITLE
💄 Hide comment dropdown menu when unavailable to user

### DIFF
--- a/apps/web/src/components/discussion/discussion.tsx
+++ b/apps/web/src/components/discussion/discussion.tsx
@@ -120,7 +120,6 @@ const Discussion: React.FunctionComponent = () => {
                       <DropdownItem
                         icon={Trash}
                         label={t("deleteComment")}
-                        disabled={!canDelete}
                         onClick={() => {
                           deleteComment.mutate({
                             commentId: comment.id,

--- a/apps/web/src/components/discussion/discussion.tsx
+++ b/apps/web/src/components/discussion/discussion.tsx
@@ -112,22 +112,24 @@ const Discussion: React.FunctionComponent = () => {
                       {dayjs(new Date(comment.createdAt)).fromNow()}
                     </span>
                   </div>
-                  <Dropdown
-                    placement="bottom-start"
-                    trigger={<CompactButton icon={DotsHorizontal} />}
-                  >
-                    <DropdownItem
-                      icon={Trash}
-                      label={t("deleteComment")}
-                      disabled={!canDelete}
-                      onClick={() => {
-                        deleteComment.mutate({
-                          commentId: comment.id,
-                          pollId,
-                        });
-                      }}
-                    />
-                  </Dropdown>
+                  {canDelete &&
+                    <Dropdown
+                      placement="bottom-start"
+                      trigger={<CompactButton icon={DotsHorizontal} />}
+                    >
+                      <DropdownItem
+                        icon={Trash}
+                        label={t("deleteComment")}
+                        disabled={!canDelete}
+                        onClick={() => {
+                          deleteComment.mutate({
+                            commentId: comment.id,
+                            pollId,
+                          });
+                        }}
+                      />
+                    </Dropdown>
+                  }
                 </div>
                 <div className="w-fit whitespace-pre-wrap">
                   <TruncatedLinkify>{comment.content}</TruncatedLinkify>


### PR DESCRIPTION
Currently, each comment has a menu, with a button to delete the comment. If the user is not allowed to delete the comment, the button is disabled (see first screenshot).
With this pull request the menu button is only shown if necessary. This reduces clutter and improves the user experience.

Before:
![image](https://user-images.githubusercontent.com/64426524/225133385-43d11861-2572-4345-a462-9e66860f6942.png)

After:
![image](https://user-images.githubusercontent.com/64426524/225133465-b33b9fd4-dead-4d7d-bb01-132ebac60610.png)
