### PR TITLE
📈 Capture participant email in posthog

### DIFF
--- a/apps/web/src/components/poll/mutations.ts
+++ b/apps/web/src/components/poll/mutations.ts
@@ -15,10 +15,11 @@ export const normalizeVotes = (
 
 export const useAddParticipantMutation = () => {
   return trpc.polls.participants.add.useMutation({
-    onSuccess: (_, { pollId, name }) => {
+    onSuccess: (_, { pollId, name, email }) => {
       posthog.capture("add participant", {
         pollId,
         name,
+        email,
       });
     },
   });


### PR DESCRIPTION
This will let us analyze how many participants choose to provide their email vs leaving it out.