### PR TITLE
Enable zooming and scaling

### DIFF
--- a/apps/web/src/pages/_app.tsx
+++ b/apps/web/src/pages/_app.tsx
@@ -91,7 +91,7 @@ const MyApp: NextPage<AppPropsWithLayout> = ({ Component, pageProps }) => {
       <Head>
         <meta
           name="viewport"
-          content="width=device-width, initial-scale=1, minimum-scale=1, maximum-scale=1, user-scalable=no"
+          content="width=device-width, initial-scale=1, minimum-scale=1, maximum-scale=5, user-scalable=yes"
         />
       </Head>
       <Toaster />


### PR DESCRIPTION
According to a11y standards, zooming and scaling must not be disabled, because people with low vision rely on screen magnifiers to properly see the contents of a web page.
see https://dequeuniversity.com/rules/axe/4.4/meta-viewport

I see no reason to disable zooming and scaling, so I've modified this accordingly.