### PR TITLE
♿️ Improve contrast for secondary text

### DIFF
--- a/apps/web/src/components/auth/login-form.tsx
+++ b/apps/web/src/components/auth/login-form.tsx
@@ -94,7 +94,7 @@ const VerifyCode: React.FunctionComponent<{
               {formState.errors.code.message}
             </p>
           ) : null}
-          <p className="mt-2 text-sm text-slate-400">
+          <p className="mt-2 text-sm text-slate-500">
             {t("verificationCodeHelp")}
           </p>
         </fieldset>

--- a/apps/web/src/components/compact-button.tsx
+++ b/apps/web/src/components/compact-button.tsx
@@ -17,7 +17,7 @@ const CompactButton: React.FunctionComponent<CompactButtonProps> = ({
   return (
     <button
       type="button"
-      className="inline-flex h-5 w-5 items-center justify-center rounded-full bg-slate-100 text-slate-400 transition-colors hover:bg-slate-200 active:bg-slate-300 active:text-slate-500"
+      className="inline-flex h-5 w-5 items-center justify-center rounded-full bg-slate-100 text-slate-500 transition-colors hover:bg-slate-200 active:bg-slate-300 active:text-slate-500"
       onClick={onClick}
     >
       {Icon ? <Icon className="h-3 w-3" /> : children}

--- a/apps/web/src/components/cookie-consent.tsx
+++ b/apps/web/src/components/cookie-consent.tsx
@@ -40,7 +40,7 @@ const CookieConsentPopover: React.FunctionComponent = () => {
           <div className="flex items-center space-x-6">
             <Link
               href="/privacy-policy"
-              className="hover:text-primary-500 text-slate-400"
+              className="hover:text-primary-500 text-slate-500"
             >
               Privacy Policy
             </Link>

--- a/apps/web/src/components/date-card.tsx
+++ b/apps/web/src/components/date-card.tsx
@@ -28,7 +28,7 @@ const DateCard: React.FunctionComponent<DateCardProps> = ({
       ) : null}
       <div>
         {dow ? (
-          <div className="-mt-3 bg-white text-center text-xs text-slate-400">
+          <div className="-mt-3 bg-white text-center text-xs text-slate-500">
             {dow}
           </div>
         ) : null}

--- a/apps/web/src/components/discussion/discussion.tsx
+++ b/apps/web/src/components/discussion/discussion.tsx
@@ -102,7 +102,7 @@ const Discussion: React.FunctionComponent = () => {
                     isYou={session.ownsObject(comment)}
                   />
                   <div className="mb-1">
-                    <span className="mr-1 text-slate-400">&bull;</span>
+                    <span className="mr-1 text-slate-500">&bull;</span>
                     <span className="text-sm text-slate-500">
                       {dayjs(new Date(comment.createdAt)).fromNow()}
                     </span>

--- a/apps/web/src/components/error-page.tsx
+++ b/apps/web/src/components/error-page.tsx
@@ -25,7 +25,7 @@ const ErrorPage: React.FunctionComponent<ComponentProps> = ({
       </Head>
       <div className="flex items-start">
         <div className="text-center">
-          <Icon className="mb-4 inline-block w-24 text-slate-400" />
+          <Icon className="mb-4 inline-block w-24 text-slate-500" />
           <div className="text-primary-500 mb-2 text-3xl font-bold ">
             {title}
           </div>

--- a/apps/web/src/components/forms/poll-options-form/month-calendar/month-calendar.tsx
+++ b/apps/web/src/components/forms/poll-options-form/month-calendar/month-calendar.tsx
@@ -104,7 +104,7 @@ const MonthCalendar: React.FunctionComponent<DateTimePickerProps> = ({
                 return (
                   <div
                     key={dayOfWeek}
-                    className="flex items-center justify-center pb-2 text-sm font-medium text-slate-400"
+                    className="flex items-center justify-center pb-2 text-sm font-medium text-slate-500"
                   >
                     {dayOfWeek.substring(0, 2)}
                   </div>
@@ -163,7 +163,7 @@ const MonthCalendar: React.FunctionComponent<DateTimePickerProps> = ({
                       className={clsx(
                         "relative flex h-full w-full items-center justify-center text-sm hover:bg-slate-50 focus:z-10 focus:rounded active:bg-slate-100",
                         {
-                          "bg-slate-50 text-slate-400": day.outOfMonth,
+                          "bg-slate-50 text-slate-500": day.outOfMonth,
                           "font-bold": day.today,
                           "text-primary-500": day.today && !day.selected,
                           "font-normal text-white after:absolute after:-z-0 after:h-8 after:w-8 after:rounded-full after:bg-green-500 after:content-['']":
@@ -192,7 +192,7 @@ const MonthCalendar: React.FunctionComponent<DateTimePickerProps> = ({
           <div className="flex items-center space-x-3 p-3 sm:p-4">
             <div className="grow">
               <div className="font-medium">{t("specifyTimes")}</div>
-              <div className="text-sm text-slate-400">
+              <div className="text-sm text-slate-500">
                 {t("specifyTimesDescription")}
               </div>
             </div>

--- a/apps/web/src/components/home/hero.tsx
+++ b/apps/web/src/components/home/hero.tsx
@@ -64,7 +64,7 @@ const Hero: React.FunctionComponent = () => {
                 transition={{ type: "spring", delay: 2 }}
               >
                 {t("perfect")} 🤩
-                <ScribbleArrow className="absolute -right-8 top-3 text-slate-400" />
+                <ScribbleArrow className="absolute -right-8 top-3 text-slate-500" />
               </m.div>
               <m.div
                 className="rounded-lg"

--- a/apps/web/src/components/layouts/page-layout.tsx
+++ b/apps/web/src/components/layouts/page-layout.tsx
@@ -69,7 +69,7 @@ const PageLayout: React.FunctionComponent<PageLayoutProps> = ({ children }) => {
               <Link className="inline-block rounded" href="/">
                 <Logo className="text-primary-500 w-40" alt="Rallly" />
               </Link>
-              <span className="absolute -bottom-6 right-0 text-sm text-slate-400 transition-colors">
+              <span className="absolute -bottom-6 right-0 text-sm text-slate-500 transition-colors">
                 <Trans t={t} i18nKey="3Ls" components={{ e: <em /> }} />
               </span>
             </div>

--- a/apps/web/src/components/layouts/page-layout/footer.tsx
+++ b/apps/web/src/components/layouts/page-layout/footer.tsx
@@ -21,8 +21,8 @@ const Footer: React.FunctionComponent = () => {
     <div className="mt-16 bg-gradient-to-b from-gray-50/0 via-gray-50 to-gray-50 ">
       <div className="mx-auto max-w-7xl space-y-8 p-8 lg:flex lg:space-x-16 lg:space-y-0">
         <div className=" lg:w-2/6">
-          <Logo className="w-32 text-slate-400" />
-          <div className="mb-8 mt-4 text-slate-400">
+          <Logo className="w-32 text-slate-500" />
+          <div className="mb-8 mt-4 text-slate-500">
             <p>
               <Trans
                 t={t}
@@ -30,7 +30,7 @@ const Footer: React.FunctionComponent = () => {
                 components={{
                   a: (
                     <a
-                      className="font-normal leading-loose text-slate-400 underline hover:text-slate-800 hover:underline"
+                      className="font-normal leading-loose text-slate-500 underline hover:text-slate-800 hover:underline"
                       href="https://www.paypal.com/donate/?hosted_button_id=7QXP2CUBLY88E"
                     />
                   ),
@@ -44,7 +44,7 @@ const Footer: React.FunctionComponent = () => {
                 components={{
                   a: (
                     <a
-                      className="font-normal leading-loose text-slate-400 underline hover:text-slate-800 hover:underline"
+                      className="font-normal leading-loose text-slate-500 underline hover:text-slate-800 hover:underline"
                       href="https://twitter.com/imlukevella"
                     />
                   ),
@@ -55,19 +55,19 @@ const Footer: React.FunctionComponent = () => {
           <div className="mb-8 flex items-center space-x-6">
             <a
               href="https://twitter.com/ralllyco"
-              className="hover:text-primary-500 text-sm text-slate-400 transition-colors hover:no-underline"
+              className="hover:text-primary-500 text-sm text-slate-500 transition-colors hover:no-underline"
             >
               <Twitter className="h-5 w-5" />
             </a>
             <a
               href="https://discord.gg/uzg4ZcHbuM"
-              className="hover:text-primary-500 text-sm text-slate-400 transition-colors hover:no-underline"
+              className="hover:text-primary-500 text-sm text-slate-500 transition-colors hover:no-underline"
             >
               <Discord className="h-5 w-5" />
             </a>
             <a
               href="https://github.com/lukevella/rallly"
-              className="hover:bg-primary-500 focus:ring-primary-500 active:bg-primary-600 inline-flex h-8 items-center rounded-full bg-slate-100 pl-2 pr-3 text-sm text-slate-400 transition-colors hover:text-white hover:no-underline focus:ring-2 focus:ring-offset-1"
+              className="hover:bg-primary-500 focus:ring-primary-500 active:bg-primary-600 inline-flex h-8 items-center rounded-full bg-slate-100 pl-2 pr-3 text-sm text-slate-500 transition-colors hover:text-white hover:no-underline focus:ring-2 focus:ring-offset-1"
             >
               <Star className="mr-2 inline-block w-5" />
               <span>{t("starOnGithub")}</span>
@@ -79,7 +79,7 @@ const Footer: React.FunctionComponent = () => {
           <ul className="space-y-2">
             <li>
               <a
-                className="inline-block font-normal text-slate-400 hover:text-slate-800 hover:no-underline"
+                className="inline-block font-normal text-slate-500 hover:text-slate-800 hover:no-underline"
                 href="https://github.com/lukevella/rallly/discussions"
               >
                 {t("discussions")}
@@ -88,7 +88,7 @@ const Footer: React.FunctionComponent = () => {
             <li>
               <Link
                 href="https://blog.rallly.co"
-                className="inline-block font-normal text-slate-400 hover:text-slate-800 hover:no-underline"
+                className="inline-block font-normal text-slate-500 hover:text-slate-800 hover:no-underline"
               >
                 {t("blog")}
               </Link>
@@ -96,7 +96,7 @@ const Footer: React.FunctionComponent = () => {
             <li>
               <a
                 href="https://support.rallly.co"
-                className="inline-block font-normal text-slate-400 hover:text-slate-800 hover:no-underline"
+                className="inline-block font-normal text-slate-500 hover:text-slate-800 hover:no-underline"
               >
                 {t("support")}
               </a>
@@ -104,7 +104,7 @@ const Footer: React.FunctionComponent = () => {
             <li>
               <Link
                 href="/privacy-policy"
-                className="inline-block font-normal text-slate-400 hover:text-slate-800 hover:no-underline"
+                className="inline-block font-normal text-slate-500 hover:text-slate-800 hover:no-underline"
               >
                 {t("privacyPolicy")}
               </Link>

--- a/apps/web/src/components/modal/modal.tsx
+++ b/apps/web/src/components/modal/modal.tsx
@@ -73,7 +73,7 @@ const Modal: React.FunctionComponent<ModalProps> = ({
                 {showClose ? (
                   <button
                     role="button"
-                    className="absolute top-1 right-1 z-10 rounded p-2 text-slate-400 transition-colors hover:bg-slate-500/10 hover:text-slate-500 focus:ring-0 focus:ring-offset-0 active:bg-slate-500/20"
+                    className="absolute top-1 right-1 z-10 rounded p-2 text-slate-500 transition-colors hover:bg-slate-500/10 hover:text-slate-500 focus:ring-0 focus:ring-offset-0 active:bg-slate-500/20"
                     onClick={onCancel}
                   >
                     <X className="h-4" />

--- a/apps/web/src/components/participant-dropdown.tsx
+++ b/apps/web/src/components/participant-dropdown.tsx
@@ -155,7 +155,7 @@ const ChangeNameModal = (props: {
         {errors.name ? (
           <div className="text-sm text-rose-500">{errors.name.message}</div>
         ) : null}
-        <div className="mt-2 text-sm text-slate-400">{t("changeNameInfo")}</div>
+        <div className="mt-2 text-sm text-slate-500">{t("changeNameInfo")}</div>
       </fieldset>
       <div className="flex gap-2 ">
         <Button disabled={formState.isSubmitting} onClick={props.onDone}>

--- a/apps/web/src/components/poll/desktop-poll/poll-header.tsx
+++ b/apps/web/src/components/poll/desktop-poll/poll-header.tsx
@@ -21,7 +21,7 @@ const TimeRange: React.FunctionComponent<{
       )}
     >
       <div>{startTime}</div>
-      <div className="text-slate-400">{endTime}</div>
+      <div className="text-slate-500">{endTime}</div>
     </div>
   );
 };

--- a/apps/web/src/components/poll/mobile-poll/poll-option.tsx
+++ b/apps/web/src/components/poll/mobile-poll/poll-option.tsx
@@ -93,7 +93,7 @@ const PollOptionVoteSummary: React.FunctionComponent<{ optionId: string }> = ({
     >
       <div>
         {noVotes ? (
-          <div className="rounded-lg bg-slate-50 p-2 text-center text-slate-400">
+          <div className="rounded-lg bg-slate-50 p-2 text-center text-slate-500">
             {t("noVotes")}
           </div>
         ) : (
@@ -190,7 +190,7 @@ const PollOption: React.FunctionComponent<PollOptionProps> = ({
   return (
     <div
       className={clsx("space-y-4 overflow-hidden p-3", {
-        "bg-slate-400/5": editable && active,
+        "bg-slate-500/5": editable && active,
       })}
       onTouchStart={() => setActive(editable)}
       onTouchEnd={() => setActive(false)}
@@ -218,7 +218,7 @@ const PollOption: React.FunctionComponent<PollOptionProps> = ({
               ) : null}
               <ChevronDown
                 className={clsx(
-                  "h-5 shrink-0 text-slate-400 transition-transform",
+                  "h-5 shrink-0 text-slate-500 transition-transform",
                   {
                     "-rotate-180": expanded,
                   },

--- a/apps/web/src/components/poll/mobile-poll/time-slot-option.tsx
+++ b/apps/web/src/components/poll/mobile-poll/time-slot-option.tsx
@@ -19,7 +19,7 @@ const TimeSlotOption: React.FunctionComponent<TimeSlotOptionProps> = ({
     <PollOption {...rest}>
       <div className="grow">
         <div className="h-7">{`${startTime}`}</div>
-        <div className="flex grow items-center text-sm text-slate-400">
+        <div className="flex grow items-center text-sm text-slate-500">
           <Clock className="leading- mr-1 inline w-4" />
           {duration}
         </div>

--- a/apps/web/src/components/poll/score-summary.tsx
+++ b/apps/web/src/components/poll/score-summary.tsx
@@ -37,7 +37,7 @@ export const ScoreSummary: React.FunctionComponent<PopularityScoreProps> =
           {
             "rounded-full bg-green-50 text-green-400": highlight,
           },
-          { "text-slate-400": !highlight },
+          { "text-slate-500": !highlight },
         )}
       >
         <CheckCircle className="-ml-1 inline-block h-4 transition-opacity" />

--- a/apps/web/src/components/poll/user-avatar.tsx
+++ b/apps/web/src/components/poll/user-avatar.tsx
@@ -30,7 +30,7 @@ const colors = [
   "bg-pink-400",
 ];
 
-const defaultColor = "bg-slate-400";
+const defaultColor = "bg-slate-500";
 
 export const UserAvatarProvider: React.FunctionComponent<{
   children?: React.ReactNode;

--- a/apps/web/src/components/sharing.tsx
+++ b/apps/web/src/components/sharing.tsx
@@ -36,7 +36,7 @@ const Sharing: React.FunctionComponent<SharingProps> = ({
         </div>
         <button
           onClick={onHide}
-          className="h-8 items-center justify-center rounded-md px-3 text-slate-400 transition-colors hover:bg-slate-500/10 hover:text-slate-500 active:bg-slate-500/20"
+          className="h-8 items-center justify-center rounded-md px-3 text-slate-500 transition-colors hover:bg-slate-500/10 hover:text-slate-500 active:bg-slate-500/20"
         >
           {t("hide")}
         </button>

--- a/apps/web/src/components/text-input.tsx
+++ b/apps/web/src/components/text-input.tsx
@@ -20,7 +20,7 @@ export const TextInput = React.forwardRef<HTMLInputElement, TextInputProps>(
         ref={ref}
         type="text"
         className={clsx(
-          "appearance-none rounded border border-gray-300 text-slate-700 placeholder:text-slate-400",
+          "appearance-none rounded border border-gray-300 text-slate-700 placeholder:text-slate-500",
           className,
           {
             "px-2 py-1": size === "md",

--- a/apps/web/style.css
+++ b/apps/web/style.css
@@ -57,7 +57,7 @@
     @apply mb-4;
   }
   .input {
-    @apply appearance-none border px-2 py-1 text-slate-700 placeholder:text-slate-400;
+    @apply appearance-none border px-2 py-1 text-slate-700 placeholder:text-slate-500;
   }
   input.input {
     @apply h-9;


### PR DESCRIPTION
turn text-slate-400 into text-slate-500
While text-slate-400 certainly looks elegant on a light background, it is difficult to read for people with limited vision. I have therefore replaced all places with text-slate-400 with text-slate-500. The visual change is minimal, but the contrast now meets a11y standards (see https://color.a11y.com/)