### PR TITLE
Remove transition-all to remove weird transition

### DIFF
--- a/apps/web/src/components/layouts/standard-layout/mobile-navigation.tsx
+++ b/apps/web/src/components/layouts/standard-layout/mobile-navigation.tsx
@@ -46,7 +46,7 @@ export const MobileNavigation = (props: { className?: string }) => {
   return (
     <div
       className={clsx(
-        "sticky top-0 z-40 flex w-full shrink-0 items-center justify-between border-b p-2 transition-all",
+        "sticky top-0 z-40 flex w-full shrink-0 items-center justify-between border-b p-2",
         {
           "bg-gray-50 shadow-sm sm:bg-gray-50/75 sm:backdrop-blur-md ":
             isPinned,


### PR DESCRIPTION
## Description

Currently when you scroll and the header gets sticky, there is a weird transition going on:

https://user-images.githubusercontent.com/1368405/227801805-c5f5f506-6949-44fe-be8c-f05db04dfc51.mp4

This PR removes the `transition-all` class to make the switching between sticky and non sticky smoother:

https://user-images.githubusercontent.com/1368405/227801873-e5992d31-e2be-4d5f-be73-b9163f97526c.mp4



## Checklist

Please check off all the following items with an "x" in the boxes before requesting a review.

- [x] I have performed a self-review of my code
- [x] My code follows the code style of this project
- [x] I have commented my code, particularly in hard-to-understand areas
