### PR TITLE
Make email placeholders RFC 2606 compliant

### DIFF
--- a/apps/web/public/locales/ca/app.json
+++ b/apps/web/public/locales/ca/app.json
@@ -37,7 +37,7 @@
   "editOptions": "Edita les opcions",
   "email": "Correu electrònic",
   "emailNotAllowed": "Aquest correu no està permès.",
-  "emailPlaceholder": "jessie.smith@email.com",
+  "emailPlaceholder": "jessie.smith@example.com",
   "endingGuestSessionNotice": "Un cop finalitzada una sessió no es pot reprendre. No podràs editar cap vot o comentari que hagis fet en aquesta sessió.",
   "endSession": "Finalitzar sessió",
   "expiredOrInvalidLink": "Aquest enllaç ha expirat o és invàlid. Si us plau, demana'n un de nou.",

--- a/apps/web/public/locales/cs/app.json
+++ b/apps/web/public/locales/cs/app.json
@@ -44,7 +44,7 @@
   "editVotes": "Upravit hlasy",
   "email": "E-mail",
   "emailNotAllowed": "Tento e-mail není povolen.",
-  "emailPlaceholder": "karel.novak@email.com",
+  "emailPlaceholder": "karel.novak@example.com",
   "endingGuestSessionNotice": "Jakmile relace hosta skončí, nelze ji obnovit. Nebudete moci upravovat žádné hlasy nebo komentáře, které jste v rámci relace zapracovali.",
   "endSession": "Ukončit relaci",
   "expiredOrInvalidLink": "Platnost odkazu vypršela nebo je neplatná. Požádejte o nový odkaz.",

--- a/apps/web/public/locales/de/app.json
+++ b/apps/web/public/locales/de/app.json
@@ -44,7 +44,7 @@
   "editVotes": "Stimmen bearbeiten",
   "email": "E-Mail",
   "emailNotAllowed": "Diese E-Mail ist nicht erlaubt.",
-  "emailPlaceholder": "max.mustermann@mail.de",
+  "emailPlaceholder": "max.mustermann@example.com",
   "endingGuestSessionNotice": "Sobald eine Gastsitzung beendet ist, kann sie nicht fortgesetzt werden. Du kannst weder Auswahl noch Kommentare bearbeiten, die Du mit dieser Sitzung gemacht hast.",
   "endSession": "Sitzung beenden",
   "expiredOrInvalidLink": "Dieser Link ist abgelaufen oder ungültig. Bitte fordere einen neuen Link an.",

--- a/apps/web/public/locales/en/app.json
+++ b/apps/web/public/locales/en/app.json
@@ -44,7 +44,7 @@
   "editVotes": "Edit votes",
   "email": "Email",
   "emailNotAllowed": "This email is not allowed.",
-  "emailPlaceholder": "jessie.smith@email.com",
+  "emailPlaceholder": "jessie.smith@example.com",
   "endingGuestSessionNotice": "Once a guest session ends it cannot be resumed. You will not be able to edit any votes or comments you've made with this session.",
   "endSession": "End session",
   "expiredOrInvalidLink": "This link is expired or invalid. Please request a new link.",

--- a/apps/web/public/locales/es/app.json
+++ b/apps/web/public/locales/es/app.json
@@ -39,7 +39,7 @@
   "editOptions": "Editar opciones",
   "email": "Correo electrónico",
   "emailNotAllowed": "Este correo electrónico no está permitido.",
-  "emailPlaceholder": "jessie.smith@email.com",
+  "emailPlaceholder": "jessie.smith@example.com",
   "endingGuestSessionNotice": "Una vez que finalices la sesión de visitante, no se puede reanudar. No podrás editar ningún voto o comentario que hayas hecho con esta sesión.",
   "endSession": "Cerrar Sesión",
   "exportToCsv": "Exportar a CSV",

--- a/apps/web/public/locales/fa/app.json
+++ b/apps/web/public/locales/fa/app.json
@@ -32,7 +32,7 @@
   "editDetails": "ویرایش جزئیات",
   "editOptions": "ویرایش گزینه‌ها",
   "email": "رایانامه",
-  "emailPlaceholder": "felan.felanzadeh@email.ir",
+  "emailPlaceholder": "felan.felanzadeh@example.com",
   "endingGuestSessionNotice": "زمانی که نشست میهمان تمام شود دیگر نمی‌تواند ادامه بیابد. شما نخواهید توانست هیچ‌یک از آراء یا دیدگاه‌های ساخته‌شده در این نشست را تغییر دهید.",
   "endSession": "پایان نشست",
   "exportToCsv": "خروجی CSV",

--- a/apps/web/public/locales/fi/app.json
+++ b/apps/web/public/locales/fi/app.json
@@ -44,7 +44,7 @@
   "editVotes": "Muokkaa ääniä",
   "email": "Sähköposti",
   "emailNotAllowed": "Tätä sähköpostia ei sallita.",
-  "emailPlaceholder": "maija.meikalainen@email.fi",
+  "emailPlaceholder": "maija.meikalainen@example.com",
   "endingGuestSessionNotice": "Vierasistuntoa ei voi jatkaa sen päätyttyä. Et voi muokata tämän istunnon aikana antamiasi ääniä tai kirjoittamiasi kommentteja.",
   "endSession": "Päätä istunto",
   "expiredOrInvalidLink": "Linkki on vanhentunut tai virheellinen. Pyydä uusi linkki.",

--- a/apps/web/public/locales/fr/app.json
+++ b/apps/web/public/locales/fr/app.json
@@ -44,7 +44,7 @@
   "editVotes": "Modifier les votes",
   "email": "Email",
   "emailNotAllowed": "Cet e-mail n'est pas autorisé.",
-  "emailPlaceholder": "jessie.smith@email.com",
+  "emailPlaceholder": "jessie.smith@example.com",
   "endingGuestSessionNotice": "Une fois que la session d'un invité est terminée, elle ne peut pas être reprise. Vous ne pourrez pas modifier les votes ou les commentaires que vous avez faits lors de cette session.",
   "endSession": "Fin de la session",
   "expiredOrInvalidLink": "Ce lien a expiré. Demandez un nouveau lien.",

--- a/apps/web/public/locales/hr/app.json
+++ b/apps/web/public/locales/hr/app.json
@@ -44,7 +44,7 @@
   "editVotes": "Uredi glasove",
   "email": "E-pošta",
   "emailNotAllowed": "Ova adresa pošte nije dozvoljena.",
-  "emailPlaceholder": "ime.prezime@email.com",
+  "emailPlaceholder": "ime.prezime@example.com",
   "endingGuestSessionNotice": "Nakon što vaša sesija kojom pristupate kao gost završi, ne može se nastaviti. Nećete moći uređivati glasove ili komentare koje ste dali tijekom ove sesije.",
   "endSession": "Završi sesiju",
   "expiredOrInvalidLink": "Ova poveznica je istekla ili nije valjana. Molimo zatražite novu poveznicu.",

--- a/apps/web/public/locales/hu/app.json
+++ b/apps/web/public/locales/hu/app.json
@@ -44,7 +44,7 @@
   "editVotes": "Szavazatok szerkesztése",
   "email": "E-mail",
   "emailNotAllowed": "Ez a email nem engedélyezett.",
-  "emailPlaceholder": "kovacs.anna@email.com",
+  "emailPlaceholder": "kovacs.anna@example.com",
   "endingGuestSessionNotice": "Egy vendég munkamenet befejezése nem visszavonható. Ezután nem tudod szerkeszteni a válaszaid vagy hozzászólásaid, amiket ebben a munkamenetben készítettél.",
   "endSession": "Munkamenet befejezése",
   "expiredOrInvalidLink": "A link érvénytelennek tűnik. Kérjük, igényeljen egy újat.",

--- a/apps/web/public/locales/it/app.json
+++ b/apps/web/public/locales/it/app.json
@@ -44,7 +44,7 @@
   "editVotes": "Modifica voti",
   "email": "Email",
   "emailNotAllowed": "Questa email non è consentita.",
-  "emailPlaceholder": "jessie.smith@email.com",
+  "emailPlaceholder": "jessie.smith@example.com",
   "endingGuestSessionNotice": "Una volta terminata la sessione ospite, la sessione non può essere ripresa. Non sarà possibile modificare alcun voto o commento fatto con questa sessione.",
   "endSession": "Termina sessione",
   "expiredOrInvalidLink": "Questo link è scaduto. Richiedine uno nuovo.",

--- a/apps/web/public/locales/nl/app.json
+++ b/apps/web/public/locales/nl/app.json
@@ -44,7 +44,7 @@
   "editVotes": "Stemmen bewerken",
   "email": "E-mail",
   "emailNotAllowed": "Dit e-mailadres is niet toegelaten.",
-  "emailPlaceholder": "jessie.smith@email.com",
+  "emailPlaceholder": "jessie.smith@example.com",
   "endingGuestSessionNotice": "Zodra een gastsessie is beëindigd, kan deze niet worden hervat. Je kan geen stemmen of opmerkingen bewerken die je tijdens deze sessie hebt gemaakt.",
   "endSession": "Sessie beëindigen",
   "expiredOrInvalidLink": "Deze link is verlopen of ongeldig. Vraag een nieuwe link aan.",

--- a/apps/web/public/locales/pl/app.json
+++ b/apps/web/public/locales/pl/app.json
@@ -31,7 +31,7 @@
   "edit": "Edytuj",
   "editDetails": "Edytuj szczegóły",
   "editOptions": "Edytuj opcje",
-  "emailPlaceholder": "jan.kowalski@email.com",
+  "emailPlaceholder": "jan.kowalski@example.com",
   "endingGuestSessionNotice": "Po zakończeniu sesji gościa nie można jej wznowić. Nie będzie można edytować żadnych głosów ani komentarzy dodanych podczas tej sesji.",
   "endSession": "Zakończ sesję",
   "exportToCsv": "Eksport do CSV",

--- a/apps/web/public/locales/pt-BR/app.json
+++ b/apps/web/public/locales/pt-BR/app.json
@@ -44,7 +44,7 @@
   "editVotes": "Editar votos",
   "email": "E-mail",
   "emailNotAllowed": "Este email não é permitido.",
-  "emailPlaceholder": "fulano@email.com.br",
+  "emailPlaceholder": "fulano@example.com.br",
   "endingGuestSessionNotice": "Uma vez que uma sessão de convidado termine, ela não poderá ser retomada. Você não poderá editar nenhum voto ou comentário que tenha feito nesta sessão.",
   "endSession": "Encerrar sessão",
   "expiredOrInvalidLink": "Este link está expirado ou inválido. Por favor, solicite um novo link.",

--- a/apps/web/public/locales/pt/app.json
+++ b/apps/web/public/locales/pt/app.json
@@ -37,7 +37,7 @@
   "editOptions": "Editar opções",
   "email": "E-mail",
   "emailNotAllowed": "Este endereço de e-mail não é permitido.",
-  "emailPlaceholder": "antonio.silva@email.pt",
+  "emailPlaceholder": "antonio.silva@example.com",
   "endingGuestSessionNotice": "Uma vez que uma sessão de convidado termine, ela não poderá ser retomada. Não poderá editar nenhum voto ou comentário que tenha feito nesta sessão.",
   "endSession": "Terminar sessão",
   "expiredOrInvalidLink": "Este link expirou ou é inválido. Por favor, solicite um novo link.",

--- a/apps/web/public/locales/ru/app.json
+++ b/apps/web/public/locales/ru/app.json
@@ -43,7 +43,7 @@
   "editVotes": "Редактировать голоса",
   "email": "Email",
   "emailNotAllowed": "Такой email недопустим.",
-  "emailPlaceholder": "jessie.smith@email.com",
+  "emailPlaceholder": "jessie.smith@example.com",
   "endingGuestSessionNotice": "Как только гостевая сессия завершится, она не сможет быть возобновлена. Вы не сможете исправить ответы или комментарии, сделанные в этой сессии.",
   "endSession": "Завершить сессию",
   "expiredOrInvalidLink": "Эта ссылка устарела или недействительна. Пожалуйста, запросите новую.",

--- a/apps/web/public/locales/sk/app.json
+++ b/apps/web/public/locales/sk/app.json
@@ -44,7 +44,7 @@
   "editVotes": "Upraviť hlasy",
   "email": "Email",
   "emailNotAllowed": "Tento email nie je povolený.",
-  "emailPlaceholder": "jan.slovak@email.com",
+  "emailPlaceholder": "jan.slovak@example.com",
   "endingGuestSessionNotice": "Keď relácia hosťa skončí, nie je možné ju obnoviť. Nebudete môcť upravovať žiadne hlasy alebo komentáre, ktoré ste v rámci relácie zapracovali.",
   "endSession": "Ukončiť reláciu",
   "expiredOrInvalidLink": "Platnosť odkazu vypršala alebo je odkaz nefunkčný. ",

--- a/apps/web/public/locales/sv/app.json
+++ b/apps/web/public/locales/sv/app.json
@@ -44,7 +44,7 @@
   "editVotes": "Ändra röster",
   "email": "E-post",
   "emailNotAllowed": "Den här e-postadressen är inte tillåten.",
-  "emailPlaceholder": "olle.jonsson@email.com",
+  "emailPlaceholder": "olle.jonsson@example.com",
   "endingGuestSessionNotice": "När en gäst session avslutas kan den inte återupptas. Du kommer inte att kunna redigera några röster eller kommentarer som du har gjort med denna session.",
   "endSession": "Avsluta session",
   "expiredOrInvalidLink": "Denna länk är ogiltig eller har löpt ut. Vänligen begär en ny länk.",

--- a/apps/web/public/locales/vi/app.json
+++ b/apps/web/public/locales/vi/app.json
@@ -43,7 +43,7 @@
   "editVotes": "Chỉnh sửa bầu chọn",
   "email": "Địa chỉ email",
   "emailNotAllowed": "Địa chỉ email này không được phép sử dụng.",
-  "emailPlaceholder": "nguyenvana@email.com",
+  "emailPlaceholder": "nguyenvana@example.com",
   "endingGuestSessionNotice": "Một khi phiên tạm thời kết thúc, nó không thể được tiếp tục. Bạn sẽ không thể chỉnh sửa bất kỳ phiếu bầu hoặc nhận xét nào bạn đã thực hiện với phiên này.",
   "endSession": "Kết thúc phiên",
   "expiredOrInvalidLink": "Đường dẫn này đã hết hạn hoặc vô hiệu lực. Hãy yêu cầu đường dẫn mới.",

--- a/apps/web/public/locales/zh/app.json
+++ b/apps/web/public/locales/zh/app.json
@@ -35,7 +35,7 @@
   "editDetails": "编辑详细信息",
   "editOptions": "编辑选项",
   "email": "电子邮件",
-  "emailPlaceholder": "jessi.smith@email.com",
+  "emailPlaceholder": "jessi.smith@example.com",
   "endingGuestSessionNotice": "访客会话结束后无法恢复。你将无法编辑你在会话中的任何投票或评论。",
   "endSession": "结束会话",
   "exportToCsv": "导出为 CSV文件",


### PR DESCRIPTION
## Description

Firstly, thank you! This project is AMAZING!

I'm submitting a change to make all email placeholders [RFC 2606 compliant](https://www.rfc-editor.org/rfc/rfc2606) by using example.com as the email domain.

## Checklist

Please check off all the following items with an "x" in the boxes before requesting a review.

- [x] I have performed a self-review of my code
- [x] My code follows the code style of this project
- [x] I have commented my code, particularly in hard-to-understand areas
