### PR TITLE
Fix malformed RFC 2606 tweak

### DIFF
--- a/apps/web/public/locales/pt-BR/app.json
+++ b/apps/web/public/locales/pt-BR/app.json
@@ -44,7 +44,7 @@
   "editVotes": "Editar votos",
   "email": "E-mail",
   "emailNotAllowed": "Este email não é permitido.",
-  "emailPlaceholder": "fulano@example.com.br",
+  "emailPlaceholder": "fulano@example.com",
   "endingGuestSessionNotice": "Uma vez que uma sessão de convidado termine, ela não poderá ser retomada. Você não poderá editar nenhum voto ou comentário que tenha feito nesta sessão.",
   "endSession": "Encerrar sessão",
   "expiredOrInvalidLink": "Este link está expirado ou inválido. Por favor, solicite um novo link.",


### PR DESCRIPTION
My "find and replace for email.com" failed to consider second-level domains with something after the `.com` (in this case it was `.com.br`.

## Description

**Replace me with a summary of the change and which issue is fixed. Please also include relevant motivation and context.**

## Checklist

Please check off all the following items with an "x" in the boxes before requesting a review.

- [x] I have performed a self-review of my code
- [x] My code follows the code style of this project
- [x] I have commented my code, particularly in hard-to-understand areas
