### PR TITLE
🐛 Fix allowed email address matcher

### DIFF
--- a/packages/backend/trpc/routers/auth.ts
+++ b/packages/backend/trpc/routers/auth.ts
@@ -52,7 +52,11 @@ const isEmailBlocked = (email: string) => {
     const allowedEmails = process.env.ALLOWED_EMAILS.split(",");
     // Check whether the email matches enough of the patterns specified in ALLOWED_EMAILS
     const isAllowed = allowedEmails.some((allowedEmail) => {
-      const regex = new RegExp(allowedEmail.trim().replace("*", ".*"), "i");
+      const regex = new RegExp(
+        `^${allowedEmail
+          .replace(/[.+?^${}()|[\]\\]/g, "\\$&")
+          .replaceAll(/[*]/g, ".*")}$`,
+      );
       return regex.test(email);
     });
 


### PR DESCRIPTION
The matcher was not escaping special characters which may have caused it to work in unexpected ways. This change escapes all special regex characters except for "*" which is converted to ".*" to act as a wildcard character.

This might fix #859 