### PR TITLE
Change french translation for createdTime

### DIFF
--- a/apps/web/public/locales/fr/app.json
+++ b/apps/web/public/locales/fr/app.json
@@ -149,7 +149,7 @@
   "notificationsGuestTooltip": "Créez un compte ou connectez-vous pour acheter un abonnement",
   "planFree": "Gratuit",
   "dateAndTimeDescription": "Changez vos paramètres de date et d'heure préférés",
-  "createdTime": "Créé le {relativeTime}",
+  "createdTime": "Créé {relativeTime}",
   "permissionDeniedParticipant": "Si vous n'êtes pas le créateur du sondage, vous devriez aller à la page d'invitation.",
   "goToInvite": "Accéder à la page d'invitation",
   "planPro": "Pro",


### PR DESCRIPTION
Since the app uses relative time, it shouldn't read "Créé le il y a 15 minutes". "le" should only be used for a date.

## Description

Correcting the translation to make sense in french.

## Checklist

Please check off all the following items with an "x" in the boxes before requesting a review.

- [x] I have performed a self-review of my code
- [x] My code follows the code style of this project
- [x] I have commented my code, particularly in hard-to-understand areas
