### PR TITLE
🐛 Fix magic link consumed before user gets it

### DIFF
--- a/apps/web/src/utils/auth.ts
+++ b/apps/web/src/utils/auth.ts
@@ -19,11 +19,12 @@ import EmailProvider from "next-auth/providers/email";
 
 import { LegacyTokenProvider } from "@/utils/auth/legacy-token-provider";
 import { mergeGuestsIntoUser } from "@/utils/auth/merge-user";
+import { VerificationTokenFixAdapter } from "@/utils/auth/verification-token-fix";
 import { emailClient } from "@/utils/emails";
 
 const getAuthOptions = (...args: GetServerSessionParams) =>
   ({
-    adapter: PrismaAdapter(prisma),
+    adapter: VerificationTokenFixAdapter(PrismaAdapter(prisma)),
     secret: process.env.SECRET_PASSWORD,
     session: {
       strategy: "jwt",

--- a/apps/web/src/utils/auth.ts
+++ b/apps/web/src/utils/auth.ts
@@ -1,4 +1,3 @@
-import { PrismaAdapter } from "@auth/prisma-adapter";
 import { RegistrationTokenPayload } from "@rallly/backend";
 import { decryptToken } from "@rallly/backend/session";
 import { generateOtp, randomid } from "@rallly/backend/utils/nanoid";
@@ -17,14 +16,14 @@ import NextAuth, {
 import CredentialsProvider from "next-auth/providers/credentials";
 import EmailProvider from "next-auth/providers/email";
 
+import { CustomPrismaAdapter } from "@/utils/auth/custom-prisma-adapter";
 import { LegacyTokenProvider } from "@/utils/auth/legacy-token-provider";
 import { mergeGuestsIntoUser } from "@/utils/auth/merge-user";
-import { VerificationTokenFixAdapter } from "@/utils/auth/verification-token-fix";
 import { emailClient } from "@/utils/emails";
 
 const getAuthOptions = (...args: GetServerSessionParams) =>
   ({
-    adapter: VerificationTokenFixAdapter(PrismaAdapter(prisma)),
+    adapter: CustomPrismaAdapter(prisma),
     secret: process.env.SECRET_PASSWORD,
     session: {
       strategy: "jwt",

--- a/apps/web/src/utils/auth/custom-prisma-adapter.ts
+++ b/apps/web/src/utils/auth/custom-prisma-adapter.ts
@@ -22,9 +22,6 @@ export function CustomPrismaAdapter(prisma: PrismaClient): Adapter {
       return verificationToken;
     },
     async useVerificationToken(identifier_token) {
-      // NOTE: Some users have inboxes with spam filters that check all links before they are delivered.
-      // This means the verification link will be used before the user gets it. To get around this, we
-      // avoid deleting the verification token for now.
       try {
         const verificationToken = await prisma.verificationToken.findUnique({
           where: { identifier_token },

--- a/apps/web/src/utils/auth/custom-prisma-adapter.ts
+++ b/apps/web/src/utils/auth/custom-prisma-adapter.ts
@@ -1,14 +1,15 @@
-// NOTE: Some users have inboxes with spam filters that check all links before they are delivered.
-// This means the verification link will be used before the user gets it. To get around this, we
-// avoid deleting the verification token when it is used. Instead we delete all verification tokens
-// for an email address when a new verification token is created.
-
-import { Prisma, prisma } from "@rallly/database";
+import { PrismaAdapter } from "@auth/prisma-adapter";
+import { Prisma, PrismaClient } from "@prisma/client";
 import { Adapter } from "next-auth/adapters";
 
-export function VerificationTokenFixAdapter(adapter: Adapter): Adapter {
+export function CustomPrismaAdapter(prisma: PrismaClient): Adapter {
+  const adapter = PrismaAdapter(prisma);
   return {
     ...adapter,
+    // NOTE: Some users have inboxes with spam filters that check all links before they are delivered.
+    // This means the verification link will be used before the user gets it. To get around this, we
+    // avoid deleting the verification token when it is used. Instead we delete all verification tokens
+    // for an email address when a new verification token is created.
     async createVerificationToken(data) {
       await prisma.verificationToken.deleteMany({
         where: { identifier: data.identifier },

--- a/apps/web/src/utils/auth/verification-token-fix.ts
+++ b/apps/web/src/utils/auth/verification-token-fix.ts
@@ -1,0 +1,40 @@
+// NOTE: Some users have inboxes with spam filters that check all links before they are delivered.
+// This means the verification link will be used before the user gets it. To get around this, we
+// avoid deleting the verification token when it is used. Instead we delete all verification tokens
+// for an email address when a new verification token is created.
+
+import { Prisma, prisma } from "@rallly/database";
+import { Adapter } from "next-auth/adapters";
+
+export function VerificationTokenFixAdapter(adapter: Adapter): Adapter {
+  return {
+    ...adapter,
+    async createVerificationToken(data) {
+      await prisma.verificationToken.deleteMany({
+        where: { identifier: data.identifier },
+      });
+
+      const verificationToken = await prisma.verificationToken.create({
+        data,
+      });
+
+      return verificationToken;
+    },
+    async useVerificationToken(identifier_token) {
+      // NOTE: Some users have inboxes with spam filters that check all links before they are delivered.
+      // This means the verification link will be used before the user gets it. To get around this, we
+      // avoid deleting the verification token for now.
+      try {
+        const verificationToken = await prisma.verificationToken.findUnique({
+          where: { identifier_token },
+        });
+        return verificationToken;
+      } catch (error) {
+        // https://www.prisma.io/docs/reference/api-reference/error-reference#p2025
+        if ((error as Prisma.PrismaClientKnownRequestError).code === "P2025")
+          return null;
+        throw error;
+      }
+    },
+  };
+}


### PR DESCRIPTION
This changed address an issue that is being discussed here: https://github.com/nextauthjs/next-auth/discussions/4585

The issue:
Verification tokens can only be used once by default. This means that once a magic link is used the verification token is deleted. This causes issues for some users that have inboxes that checks links inside emails because the link ends up being consumed by the inbox which means the verification token is deleted by the time the user sees the email.

The solution:
We customize the prisma adapter such that the verification token is not deleted when it is used. To avoid accumulating verification tokens, we delete any existing verification tokens for the same identifier before creating new ones.

This is a temporary solution until a better one is found.

