### PR TITLE
🐛 Make identifier in verification tokens case insensitive

### DIFF
--- a/apps/web/tests/authentication.spec.ts
+++ b/apps/web/tests/authentication.spec.ts
@@ -96,12 +96,6 @@ test.describe.serial(() => {
       ).toBeVisible();
     });
 
-    test.describe("login", () => {
-      test.afterEach(async ({ page }) => {
-        await page.goto("/logout");
-      });
-    });
-
     test("can login with magic link", async ({ page }) => {
       await page.goto("/login");
 
@@ -140,6 +134,28 @@ test.describe.serial(() => {
       await page
         .getByPlaceholder("jessie.smith@example.com")
         .type(testUserEmail);
+
+      await page.getByRole("button", { name: "Continue" }).click();
+
+      const code = await getCode();
+
+      await page.getByPlaceholder("Enter your 6-digit code").type(code);
+
+      await page.getByRole("button", { name: "Continue" }).click();
+
+      await page.waitForURL("/polls");
+
+      await page.getByTestId("user-dropdown").click();
+
+      await expect(page.getByText("Test User")).toBeVisible();
+    });
+
+    test("allow using different case in email", async ({ page }) => {
+      await page.goto("/login");
+
+      await page
+        .getByPlaceholder("jessie.smith@example.com")
+        .type("Test@example.com");
 
       await page.getByRole("button", { name: "Continue" }).click();
 

--- a/packages/database/prisma/migrations/20231027074632_nextauth_ci_identifiers/migration.sql
+++ b/packages/database/prisma/migrations/20231027074632_nextauth_ci_identifiers/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "verification_tokens" ALTER COLUMN "identifier" SET DATA TYPE CITEXT;

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -228,7 +228,7 @@ model Comment {
 }
 
 model VerificationToken {
-  identifier String
+  identifier String   @db.Citext
   token      String   @unique
   expires    DateTime
 


### PR DESCRIPTION
The email identifier used in verification tokens would not match when using the 6-digit code login if the user types it in different to how it is stored in the database. To fix this, we modify the schema to make the identifier case insensitive.