### PR TITLE
🐛 Dynamically render login page

### DIFF
--- a/apps/web/src/app/[locale]/(auth)/login/page.tsx
+++ b/apps/web/src/app/[locale]/(auth)/login/page.tsx
@@ -7,6 +7,8 @@ import { getTranslation } from "@/app/i18n";
 import { AuthCard } from "@/components/auth/auth-layout";
 import { isOIDCEnabled, oidcName } from "@/utils/constants";
 
+export const dynamic = "force-dynamic";
+
 export default async function LoginPage({ params }: { params: Params }) {
   const { t } = await getTranslation(params.locale);
   return (


### PR DESCRIPTION
Make sure the login page is dynamically rendered to use runtime values for OIDC config. Fix for #697.