### PR TITLE
Fix docs images being scrollable

### DIFF
--- a/apps/docs/contribute/documentation.mdx
+++ b/apps/docs/contribute/documentation.mdx
@@ -7,8 +7,7 @@ description: Help us maintain and improve our documentation
 If you have a [Github](https://github.com) account, you can make changes or report issues using the links that appear at the top of each page.
 
 <Frame caption="Links to edit a page or open an issue on Github">
-  ![Edit Documentation
-  Links](/images/contribute/documentation/edit-documentation.png)
+  <img src="/images/contribute/documentation/edit-documentation.png" alt="Edit Documentation Links"/>
 </Frame>
 
 ## Submitting a Pull Request

--- a/apps/docs/contribute/translations.mdx
+++ b/apps/docs/contribute/translations.mdx
@@ -20,8 +20,7 @@ Once you've joined the project:
 3. Start translating!
 
 <Frame>
-  ![Crowdin
-  Project](https://user-images.githubusercontent.com/676849/180199933-4e507c8e-0e9a-498a-99c8-a7ad44cb7ded.png)
+  <img src="https://user-images.githubusercontent.com/676849/180199933-4e507c8e-0e9a-498a-99c8-a7ad44cb7ded.png" alt="Crowdin Project"/>
 </Frame>
 
 ## Tips for Translators
@@ -99,8 +98,7 @@ If your language requires more than one plural form, you can add additional rule
 ```
 
 <Frame caption="Crowdin let's you preview your message to make sure it works">
-  ![Using ICU Message Format on
-  Crowdin](/images/contribute/translations/icu-message-format.png)
+  <img src="/images/contribute/translations/icu-message-format.png" alt="Using ICU Message Format on Corwdin"/>
 </Frame>
 
 ### Register

--- a/apps/docs/guide/participant-guide.mdx
+++ b/apps/docs/guide/participant-guide.mdx
@@ -14,7 +14,9 @@ description: "How to respond to a Rallly poll"
 
     <Note>If you leave an option unselected, it will be counted as a **No** vote.</Note>
 
-    <Frame>![Submit a Response](/images/voting-in-progress.png)</Frame>
+    <Frame>
+      <img src="/images/voting-in-progress.png" alt="Submit a Response"/>
+    </Frame>
 
     When you're done, click **Continue**.
 
@@ -24,14 +26,18 @@ description: "How to respond to a Rallly poll"
 
     <Tip>To ensure you don't lose the ability to edit your response, enter your email address to receive a confirmation email with a magic link that identifies you .</Tip>
 
-    <Frame>![Submit a Response](/images/voting-submitting.png)</Frame>
+    <Frame>
+      <img src="/images/voting-submitting.png" alt="Submittting a Response"/>
+    </Frame>
 
   </Step>
   <Step title="Done!">
     
     If you need to make changes, you can use the dropdown menu next to your name.
 
-    <Frame>![Submit a Response](/images/voting-submitted.png)</Frame>
+    <Frame>
+      <img src="/images/voting-submitted.png" alt="Vote Submitted"/>
+    </Frame>
 
   </Step>
 </Steps>

--- a/apps/docs/introduction.mdx
+++ b/apps/docs/introduction.mdx
@@ -4,7 +4,9 @@ title: "Introduction"
 description: "Welcome to the official documentation for Rallly."
 ---
 
-<Frame>![Rallly Splash Image](/images/self-hosting/splash.png)</Frame>
+<Frame>
+  <img src="/images/self-hosting/splash.png" alt="Rallly Splash Image"/>
+</Frame>
 
 ## What is Rallly?
 

--- a/apps/docs/self-hosting/introduction.mdx
+++ b/apps/docs/self-hosting/introduction.mdx
@@ -7,7 +7,9 @@ description: How to Self-Host Rallly
 Rallly is 100% open-source and available under the [GNU Affero General Public License v3.0 (AGPL-3.0)](https://github.com/lukevella/rallly/blob/main/LICENSE)
 which allows you to run your own instance of Rallly for free for both personal and commercial use.
 
-<Frame>![Rallly Splash Image](/images/self-hosting/splash.png)</Frame>
+<Frame>
+  <img src="/images/self-hosting/splash.png" alt="Rallly Splash Image"/>
+</Frame>
 
 ## Official Docker Image
 

--- a/apps/docs/workflow/create.mdx
+++ b/apps/docs/workflow/create.mdx
@@ -12,7 +12,9 @@ on [New Poll](https://app.rallly.co/new).
     Enter the title of your poll. You can also add a description to your poll if
     you want to give your participants more information about the event.
 
-    <Frame>![New Poll Page](/images/new-poll-page.png)</Frame>
+    <Frame>
+      <img src="/images/new-poll-page.png" alt="New Poll Page"/>
+    </Frame>
 
   </Step>
   <Step title="Select Dates or Times">
@@ -20,12 +22,12 @@ on [New Poll](https://app.rallly.co/new).
     <Tabs>
       <Tab title="Month View">
         <Frame caption="Use Month View to select dates or create repeating time slots">
-          ![Month View](/images/month-view.png)
+          <img src="/images/month-view.png" alt="Month View"/>
         </Frame>
       </Tab>
       <Tab title="Week View">
         <Frame caption="Use Week View to draw time slot options on a calendar">
-          ![Week View](/images/week-view.png)
+          <img src="/images/week-view.png" alt="Week View"/>
         </Frame>
       </Tab>
     </Tabs>

--- a/apps/docs/workflow/finalize.mdx
+++ b/apps/docs/workflow/finalize.mdx
@@ -8,20 +8,24 @@ description: "Pick a final date for your event"
   <Step title="Review your results">
     Click **Manage** and select **Finalize** from the dropdown menu.
 
-    <Frame>![Finalize](/images/finalize.png)</Frame>
+    <Frame>
+      <img src="/images/finalize.png" alt="Finalize a poll"/>
+    </Frame>
 
   </Step>
   <Step title="Finalize">
-Select your preferred date from the list and click **Finalize**.
+    Select your preferred date from the list and click **Finalize**.
 
-This will:
+    This will:
 
-1. Send an email to you with a calendar invite for the selected date
-2. Send an email to the attendees with the calendar invite.
-3. Close the poll and prevent any further votes.
+    1. Send an email to you with a calendar invite for the selected date
+    2. Send an email to the attendees with the calendar invite.
+    3. Close the poll and prevent any further votes.
 
-The selected date will be displayed on your finalized poll for everyone to see.
+    The selected date will be displayed on your finalized poll for everyone to see.
 
-<Frame>![Finalized Poll](/images/finalized.png)</Frame>
+    <Frame>
+      <img src="/images/finalized.png" alt="Finalized Poll"/>
+    </Frame>
   </Step>
 </Steps>

--- a/apps/docs/workflow/invite.mdx
+++ b/apps/docs/workflow/invite.mdx
@@ -9,7 +9,7 @@ description: "Collect responses from your participants by sharing your invite li
     Click the **Share** button to open the dialog containing your **Invite
     Link**.
     <Frame caption="Hint: You can copy the link by clicking on it">
-      ![Share Dialog](/images/invite-link.png)
+      <img src="/images/invite-link.png" alt="Share Dialog"/>
     </Frame>
   </Step>
   <Step title="Wait for participants to vote">
@@ -17,11 +17,15 @@ description: "Collect responses from your participants by sharing your invite li
     
     <Note>Have a look at the [Participant Guide](/guide/participant-guide) for details on how participants can vote.</Note>
 
-    <Frame>![Voting](/images/voting.png)</Frame>
+    <Frame>
+      <img src="/images/voting.png" alt="Voting"/>
+    </Frame>
 
     As participants respond, you can review the results to see which dates are preferred.
 
-    <Frame>![Voting](/images/review.png)</Frame>
+    <Frame>
+      <img src="/images/review.png" alt="Voting"/>
+    </Frame>
 
   </Step>
 </Steps>


### PR DESCRIPTION
## Description

Sometimes images inside a ``Frame`` component showed a scrollbar, allowing users to scroll the image out of the bounds of the frame.  

By using the HTML ``img`` element inside a ``Frame`` component (as shown in the [docs](https://mintlify.com/docs/content/components/frame)) instead of Markdown images the issue gets fixed with no noticeable changes.

## Checklist

- [x] I have performed a self-review of my code
- [x] My code follows the code style of this project
- [x] I have commented my code, particularly in hard-to-understand areas
