### PR TITLE
💬 Add missing i18n string

### DIFF
--- a/apps/web/public/locales/en/app.json
+++ b/apps/web/public/locales/en/app.json
@@ -102,6 +102,7 @@
   "timeZoneSelect__defaultValue": "Select time zone…",
   "timeZoneSelect__noOption": "No option found",
   "timeZoneSelect__inputPlaceholder": "Search…",
+  "timeZonePicker__ignore": "Ignore time zone",
   "poweredByRallly": "Powered by <a>{name}</a>",
   "participants": "Participants",
   "language": "Language",

--- a/apps/web/src/components/time-zone-picker/time-zone-picker.tsx
+++ b/apps/web/src/components/time-zone-picker/time-zone-picker.tsx
@@ -8,6 +8,7 @@ import {
 import { Combobox } from "@headlessui/react";
 import clsx from "clsx";
 import { ChevronDownIcon } from "lucide-react";
+import { useTranslation } from "next-i18next";
 import React from "react";
 import spacetime from "spacetime";
 import soft from "timezone-soft";
@@ -124,6 +125,7 @@ const TimeZonePicker: React.FunctionComponent<{
   style?: React.CSSProperties;
   disabled?: boolean;
 }> = ({ value, onChange, onBlur, className, style, disabled }) => {
+  const { t } = useTranslation();
   const { options, findFuzzyTz } = useTimeZones();
 
   const { reference, floating, x, y, strategy, refs } = useFloating({
@@ -147,12 +149,14 @@ const TimeZonePicker: React.FunctionComponent<{
     () => [
       {
         value: "",
-        label: "Ignore time zone",
+        label: t("timeZonePicker__ignore", {
+          defaultValue: "Ignore time zone",
+        }),
         offset: 0,
       },
       ...options,
     ],
-    [options],
+    [options, t],
   );
 
   const selectedTimeZone = React.useMemo(


### PR DESCRIPTION
## Description

Converts a hardcoded string of the time zone picker ("Ignore time zone") to a translatable string:

![image](https://github.com/lukevella/rallly/assets/682310/ae814932-4ee1-4f2f-8487-92bdd9f60294)

## Checklist

Please check off all the following items with an "x" in the boxes before requesting a review.

- [x] I have performed a self-review of my code
- [x] My code follows the code style of this project
- [x] I have commented my code, particularly in hard-to-understand areas


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Enhancements**
  - Localized the "Ignore time zone" label in the TimeZonePicker for better international support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->