### PR TITLE
fix: listen on all interfaces when running in docker

### DIFF
--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -53,5 +53,6 @@ COPY --from=installer --chown=nextjs:nodejs /app/apps/web/public ./apps/web/publ
 
 ARG SELF_HOSTED
 ENV NEXT_PUBLIC_SELF_HOSTED=$SELF_HOSTED
+ENV HOSTNAME=0.0.0.0
 
 CMD ["./docker-start.sh"]


### PR DESCRIPTION
## Description

This PR sets the `HOSTNAME` variable to make rallly listen on all interfaces by default. This is helpful in reverse-proxy deployments using docker compose, where the proxy network is different from the docker compose network.
Based on [this pr](https://github.com/vercel/next.js/pull/44627) it is enough to set the `HOSTNAME` env variable to `0.0.0.0`.

Resolves https://github.com/lukevella/rallly/issues/947

## Checklist

Please check off all the following items with an "x" in the boxes before requesting a review.

- [x] I have performed a self-review of my code
- [x] My code follows the code style of this project
- [x] I have commented my code, particularly in hard-to-understand areas


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the web application's Docker configuration to include the `HOSTNAME` environment variable set to `0.0.0.0`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->