### PR TITLE
🐛 Fix account linking when using SSO

### DIFF
--- a/apps/web/src/utils/auth.ts
+++ b/apps/web/src/utils/auth.ts
@@ -222,7 +222,7 @@ const getAuthOptions = (...args: GetServerSessionParams) =>
         } else {
           // merge guest user into newly logged in user
           const session = await getServerSession(...args);
-          if (session && session.user.email === null) {
+          if (session && user.email && session.user.email === null) {
             await mergeGuestsIntoUser(user.email, [session.user.id]);
           }
 

--- a/apps/web/src/utils/auth.ts
+++ b/apps/web/src/utils/auth.ts
@@ -223,7 +223,7 @@ const getAuthOptions = (...args: GetServerSessionParams) =>
           // merge guest user into newly logged in user
           const session = await getServerSession(...args);
           if (session && session.user.email === null) {
-            await mergeGuestsIntoUser(user.id, [session.user.id]);
+            await mergeGuestsIntoUser(user.email, [session.user.id]);
           }
 
           posthog?.capture({

--- a/apps/web/src/utils/auth/merge-user.ts
+++ b/apps/web/src/utils/auth/merge-user.ts
@@ -1,9 +1,17 @@
 import { prisma } from "@rallly/database";
 
 export const mergeGuestsIntoUser = async (
-  userId: string,
+  email: string,
   guestIds: string[],
 ) => {
+  const user = await prisma.user.findUnique({
+    where: {
+      email: email,
+    },
+  });
+
+  const userId = user?.id;
+
   await prisma.poll.updateMany({
     where: {
       userId: {

--- a/apps/web/src/utils/auth/merge-user.ts
+++ b/apps/web/src/utils/auth/merge-user.ts
@@ -1,4 +1,5 @@
 import { prisma } from "@rallly/database";
+import * as Sentry from "@sentry/node";
 
 export const mergeGuestsIntoUser = async (
   email: string,
@@ -11,6 +12,11 @@ export const mergeGuestsIntoUser = async (
   });
 
   const userId = user?.id;
+
+  if (!userId) {
+    Sentry.captureMessage("Could not find user to merge guests into.");
+    return;
+  }
 
   await prisma.poll.updateMany({
     where: {


### PR DESCRIPTION
When using SSO the user id returned is the provider account id which means guest users are not linked to the right account. This change users the email address to get the correct user id.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Updated authentication process to identify users by email instead of user ID for merging guest data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->