### PR TITLE
🐛 Fix issue where verification links would automatically get consumed by link checkers

### DIFF
--- a/apps/web/src/pages/api/auth/[...nextauth].ts
+++ b/apps/web/src/pages/api/auth/[...nextauth].ts
@@ -1,3 +1,11 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+
 import { AuthApiRoute } from "@/utils/auth";
 
-export default AuthApiRoute;
+export default async function auth(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method === "HEAD") {
+    return res.status(200).end();
+  }
+
+  return AuthApiRoute(req, res);
+}

--- a/apps/web/src/utils/auth.ts
+++ b/apps/web/src/utils/auth.ts
@@ -2,14 +2,12 @@ import { RegistrationTokenPayload } from "@rallly/backend";
 import { decryptToken } from "@rallly/backend/session";
 import { generateOtp, randomid } from "@rallly/backend/utils/nanoid";
 import { prisma } from "@rallly/database";
-import cookie from "cookie";
-import { IronSession, unsealData } from "iron-session";
 import {
   GetServerSidePropsContext,
   NextApiRequest,
   NextApiResponse,
 } from "next";
-import { NextAuthOptions, RequestInternal } from "next-auth";
+import { NextAuthOptions } from "next-auth";
 import NextAuth, {
   getServerSession as getServerSessionWithOptions,
 } from "next-auth/next";
@@ -317,35 +315,4 @@ export const isEmailBlocked = (email: string) => {
     }
   }
   return false;
-};
-
-export const legacySessionConfig = {
-  password: process.env.SECRET_PASSWORD ?? "",
-  cookieName: "rallly-session",
-  cookieOptions: {
-    secure: process.env.NEXT_PUBLIC_BASE_URL?.startsWith("https://") ?? false,
-  },
-  ttl: 60 * 60 * 24 * 30, // 30 days
-};
-
-export const getUserFromLegacySession = async (
-  req: Pick<RequestInternal, "headers">,
-) => {
-  const parsedCookie = cookie.parse(req.headers?.cookie);
-  if (parsedCookie[legacySessionConfig.cookieName]) {
-    try {
-      const session = await unsealData<IronSession>(
-        parsedCookie[legacySessionConfig.cookieName],
-        {
-          password: process.env.SECRET_PASSWORD,
-        },
-      );
-      if (session.user) {
-        return session.user;
-      }
-    } catch (e) {
-      return null;
-    }
-  }
-  return null;
 };


### PR DESCRIPTION
Follows the advice in the next-auth docs for handling HEAD requests in the `[...nextauth]` route.

See: https://next-auth.js.org/tutorials/avoid-corporate-link-checking-email-provider