### PR TITLE
Fix: Ukrainian time zone spelling

### DIFF
--- a/apps/web/src/utils/supported-time-zones.ts
+++ b/apps/web/src/utils/supported-time-zones.ts
@@ -338,7 +338,7 @@ export const supportedTimeZones = [
   "Europe/Istanbul",
   "Europe/Jersey",
   "Europe/Kaliningrad",
-  "Europe/Kiev",
+  "Europe/Kyiv",
   "Europe/Kirov",
   "Europe/Lisbon",
   "Europe/Ljubljana",


### PR DESCRIPTION
## Description

Ukrainian time zone uses russian spelling. Source: https://en.wikipedia.org/wiki/KyivNotKiev

## Checklist

Please check off all the following items with an "x" in the boxes before requesting a review.

- [x] I have performed a self-review of my code
- [x] My code follows the code style of this project
- [x] I have commented my code, particularly in hard-to-understand areas


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated the time zone identifier from "Europe/Kiev" to "Europe/Kyiv" in the list of supported time zones.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->