### PR TITLE
Adding AWS installation method to introduction.mdx

### DIFF
--- a/apps/docs/self-hosting/introduction.mdx
+++ b/apps/docs/self-hosting/introduction.mdx
@@ -37,17 +37,24 @@ please check out the [pricing](/self-hosting/pricing) page.
 
 ## Get Started
 
-Depending on how comfortable you are with technical things, you can either run Rallly on your own server or choose a managed hosting provider that will do it for you.
+Depending on how comfortable you are with technical things, you can either run Rallly on your own server, have it installed on your AWS account or choose a managed hosting provider that will do it for you.
 
-<CardGroup cols={2}>
-  <Card title="Docker Setup" icon="docker" href="/self-hosting/docker-compose">
-    Host your own instance of Rallly on your own server using Docker.
-  </Card>
-  <Card
-    icon="cloud"
-    title="Using a hosting provider"
-    href="/self-hosting/managed-hosting"
-  >
-    Choose a provider that will install and run an instance of Rallly for you.
-  </Card>
+<CardGroup cols={2}>  
+  <Card title="Docker Setup" icon="docker" href="/self-hosting/docker-compose">  
+    Host your own instance of Rallly on your own server using Docker.  
+  </Card>  
+  <Card  
+    icon="cloud"  
+    title="1-click AWS Install"  
+    href="https://klo.dev/stacksnap/apps/rallly/"   
+  >  
+    Install Rallly into your AWS account using Stacksnap.  
+  </Card>  
+  <Card  
+    icon="cloud"  
+    title="Using a hosting provider"  
+    href="/self-hosting/managed-hosting"  
+  >  
+    Choose a provider that will install and run an instance of Rallly for you.  
+  </Card>  
 </CardGroup>


### PR DESCRIPTION
Adding another way to install Rallly into AWS using the free Stacksnap cloud installer

## Description

**Replace me with a summary of the change and which issue is fixed. Please also include relevant motivation and context.**

## Checklist

Please check off all the following items with an "x" in the boxes before requesting a review.

- [x] I have performed a self-review of my code
- [x] My code follows the code style of this project
- [x] I have commented my code, particularly in hard-to-understand areas


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an option to install Rallly on an AWS account using Stacksnap.
  
- **Documentation**
  - Updated self-hosting introduction to include AWS installation instructions via Stacksnap.

- **Refactor**
  - Changed card title to "1-click AWS Install" and updated the link to point to Stacksnap for AWS installation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->