### PR TITLE
📝 Add link to status page

### DIFF
--- a/apps/landing/public/locales/en/common.json
+++ b/apps/landing/public/locales/en/common.json
@@ -23,5 +23,6 @@
   "getStarted": "Get started",
   "availabilityPoll": "Availability Poll",
   "solutions": "Solutions",
-  "howItWorks": "How it Works"
+  "howItWorks": "How it Works",
+  "status": "Status"
 }

--- a/apps/landing/src/components/layouts/page-layout/footer.tsx
+++ b/apps/landing/src/components/layouts/page-layout/footer.tsx
@@ -161,6 +161,14 @@ const Footer: React.FunctionComponent = () => {
                 <Trans i18nKey="support" defaults="Support" />
               </Link>
             </li>
+            <li>
+              <Link
+                href="https://rallly.openstatus.dev"
+                className="inline-block font-normal text-gray-500 hover:text-gray-800 hover:no-underline"
+              >
+                <Trans i18nKey="status" defaults="Status" />
+              </Link>
+            </li>
           </ul>
         </div>
         <div className="lg:w-1/6">


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a "Status" link in the footer directing users to "https://rallly.openstatus.dev" for service status updates.
  
- **Content Updates**
  - Updated the locale for the "en" language by adding the "status" key and modifying the "howItWorks" key.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->