### PR TITLE
Add web proxy example

### DIFF
--- a/apps/docs/self-hosting/docker-compose.mdx
+++ b/apps/docs/self-hosting/docker-compose.mdx
@@ -98,7 +98,13 @@ This command will:
 
 ## Using a Reverse Proxy
 
-By default the app will run unencrypted on port 3000. If you want to serve the app over HTTPS you will need to use a reverse proxy.
+By default the app will run unencrypted on port 3000. If you want to serve the app over HTTPS you will need to use a reverse proxy. For example, using Apache you would put something similar to the following in your web site's configuration:
+
+```
+ ProxyPreserveHost On
+ ProxyPass / http://localhost:3000/
+ ProxyPassReverse / http://localhost:3000/
+```
 
 After setting up a reverse proxy be sure to change this line `- 3000:3000` to - `127.0.0.1:3000:3000` in `docker-compose.yml` and restart the container for it to apply the changes. This prevents Rallly from being accessed remotely using HTTP on port 3000 which is a security concern.
 


### PR DESCRIPTION
Helping people orientate on what to do in order to proxy the UI.

- [x] I have performed a self-review of my code
- [x] My code follows the code style of this project
- [ ] I have commented my code, particularly in hard-to-understand areas


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added instructions for setting up a reverse proxy with Apache to serve the app over HTTPS in the Docker Compose self-hosting guide.
  - Updated Docker Compose configuration to enhance security by preventing remote access via HTTP on port 3000.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->