### PR TITLE
✨ Soft delete participants

### DIFF
--- a/packages/backend/trpc/routers/polls/participants.ts
+++ b/packages/backend/trpc/routers/polls/participants.ts
@@ -18,6 +18,7 @@ export const participants = router({
       const participants = await prisma.participant.findMany({
         where: {
           pollId,
+          deleted: false,
         },
         include: {
           votes: {
@@ -43,9 +44,13 @@ export const participants = router({
       }),
     )
     .mutation(async ({ input: { participantId } }) => {
-      await prisma.participant.delete({
+      await prisma.participant.update({
         where: {
           id: participantId,
+        },
+        data: {
+          deleted: true,
+          deletedAt: new Date(),
         },
       });
     }),

--- a/packages/database/prisma/migrations/20240704085250_soft_delete_participants/migration.sql
+++ b/packages/database/prisma/migrations/20240704085250_soft_delete_participants/migration.sql
@@ -1,0 +1,3 @@
+-- AlterTable
+ALTER TABLE "participants" ADD COLUMN     "deleted" BOOLEAN NOT NULL DEFAULT false,
+ADD COLUMN     "deleted_at" TIMESTAMP(3);

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -188,6 +188,8 @@ model Participant {
   votes     Vote[]
   createdAt DateTime  @default(now()) @map("created_at")
   updatedAt DateTime? @updatedAt @map("updated_at")
+  deleted   Boolean   @default(false)
+  deletedAt DateTime? @map("deleted_at")
 
   @@index([pollId], type: Hash)
   @@map("participants")


### PR DESCRIPTION
Switching to a soft delete policy for participant responses to allow us to keep track of the number of responses a user receives in a given period. This will also enable us to add the ability to "undo" a delete in the future.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a soft delete functionality for participants, allowing them to be marked as deleted without being permanently removed.

- **Database Updates**
  - Added `deleted` and `deleted_at` columns to the `participants` table for better tracking of removed participants.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->