### PR TITLE
Add ability to hide attendees from calendar hit

### DIFF
--- a/apps/web/public/locales/en/app.json
+++ b/apps/web/public/locales/en/app.json
@@ -202,6 +202,7 @@
   "requireParticipantEmailLabel": "Make email address required for participants",
   "hideParticipantsLabel": "Hide participant list from other participants",
   "hideScoresLabel": "Hide scores until after a participant has voted",
+  "bccAttendeesLabel": "Hide attendee list from finalized email",
   "authErrorTitle": "Login Error",
   "authErrorDescription": "There was an error logging you in. Please try again.",
   "authErrorCta": "Go to login page",

--- a/apps/web/src/app/[locale]/poll/[urlId]/edit-settings/page.tsx
+++ b/apps/web/src/app/[locale]/poll/[urlId]/edit-settings/page.tsx
@@ -33,6 +33,7 @@ const Page = () => {
       hideScores: poll.hideScores,
       disableComments: poll.disableComments,
       requireParticipantEmail: poll.requireParticipantEmail,
+      bccAttendees: poll.bccAttendees,
     },
   });
 

--- a/apps/web/src/components/create-poll.tsx
+++ b/apps/web/src/components/create-poll.tsx
@@ -49,6 +49,7 @@ export const CreatePoll: React.FunctionComponent = () => {
       view: "month",
       options: [],
       hideScores: false,
+      bccAttendees: false,
       hideParticipants: false,
       disableComments: false,
       duration: 60,
@@ -86,6 +87,7 @@ export const CreatePoll: React.FunctionComponent = () => {
               hideParticipants: formData?.hideParticipants,
               disableComments: formData?.disableComments,
               hideScores: formData?.hideScores,
+              bccAttendees: formData?.bccAttendees,
               requireParticipantEmail: formData?.requireParticipantEmail,
               options: required(formData?.options).map((option) => ({
                 startDate: option.type === "date" ? option.date : option.start,

--- a/apps/web/src/components/forms/poll-settings.tsx
+++ b/apps/web/src/components/forms/poll-settings.tsx
@@ -21,6 +21,7 @@ export type PollSettingsFormData = {
   hideParticipants: boolean;
   hideScores: boolean;
   disableComments: boolean;
+  bccAttendees: boolean;
 };
 
 const SettingContent = ({ children }: React.PropsWithChildren) => {
@@ -173,6 +174,31 @@ export const PollSettingsForm = ({ children }: React.PropsWithChildren) => {
                     <Trans
                       i18nKey="hideScoresLabel"
                       defaults="Hide scores until after a participant has voted"
+                    />
+                  </SettingTitle>
+                </SettingContent>
+                <Switch
+                  id={field.name}
+                  disabled={isFree}
+                  checked={field.value}
+                  onCheckedChange={(checked) => {
+                    field.onChange(checked);
+                  }}
+                />
+              </Setting>
+            )}
+          />
+          <FormField
+            control={form.control}
+            name="bccAttendees"
+            render={({ field }) => (
+              <Setting disabled={isFree}>
+                <EyeIcon className="size-5 shrink-0 translate-y-0.5" />
+                <SettingContent>
+                  <SettingTitle htmlFor={field.name} pro>
+                    <Trans
+                      i18nKey="bccAttendeesLabel"
+                      defaults="Hide attendee list from finalized email"
                     />
                   </SettingTitle>
                 </SettingContent>

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,6 +1,6 @@
 services:
   rallly_db:
-    image: postgres:14.2
+    image: docker.io/library/postgres:14.2
     restart: always
     ports:
       - "5450:5432"

--- a/packages/backend/trpc/routers/polls.ts
+++ b/packages/backend/trpc/routers/polls.ts
@@ -156,6 +156,7 @@ export const polls = router({
         description: z.string().optional(),
         hideParticipants: z.boolean().optional(),
         hideScores: z.boolean().optional(),
+        bccAttendees: z.boolean().optional(),
         disableComments: z.boolean().optional(),
         requireParticipantEmail: z.boolean().optional(),
         options: z
@@ -217,6 +218,7 @@ export const polls = router({
           hideParticipants: input.hideParticipants,
           disableComments: input.disableComments,
           hideScores: input.hideScores,
+          bccAttendees: input.bccAttendees,
           requireParticipantEmail: input.requireParticipantEmail,
         },
       });
@@ -263,6 +265,7 @@ export const polls = router({
         hideParticipants: z.boolean().optional(),
         disableComments: z.boolean().optional(),
         hideScores: z.boolean().optional(),
+        bccAttendees: z.boolean().optional(),
         requireParticipantEmail: z.boolean().optional(),
       }),
     )
@@ -324,6 +327,7 @@ export const polls = router({
           timeZone: input.timeZone,
           closed: input.closed,
           hideScores: input.hideScores,
+          bccAttendees: input.bccAttendees,
           hideParticipants: input.hideParticipants,
           disableComments: input.disableComments,
           requireParticipantEmail: input.requireParticipantEmail,
@@ -469,6 +473,7 @@ export const polls = router({
           hideParticipants: true,
           disableComments: true,
           hideScores: true,
+          bccAttendees: true,
           requireParticipantEmail: true,
           options: {
             select: {
@@ -734,6 +739,7 @@ export const polls = router({
           title: true,
           location: true,
           description: true,
+          bccAttendees: true,
           user: {
             select: {
               name: true,
@@ -838,7 +844,7 @@ export const polls = router({
           name: poll.user.name,
           email: poll.user.email,
         },
-        attendees: icsAttendees,
+        attendees: poll.bccAttendees ? [] : icsAttendees,
         ...(option.duration > 0
           ? {
               start: [
@@ -1035,6 +1041,7 @@ export const polls = router({
           timeZone: true,
           hideParticipants: true,
           hideScores: true,
+          bccAttendees: true,
           disableComments: true,
           options: {
             select: {
@@ -1062,6 +1069,7 @@ export const polls = router({
           description: poll.description,
           hideParticipants: poll.hideParticipants,
           hideScores: poll.hideScores,
+          bccAttendees: poll.bccAttendees,
           disableComments: poll.disableComments,
           adminUrlId: nanoid(),
           participantUrlId: nanoid(),

--- a/packages/database/prisma/migrations/20240717162653_bcc_attendees/migration.sql
+++ b/packages/database/prisma/migrations/20240717162653_bcc_attendees/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "polls" ADD COLUMN     "bccAttendees" BOOLEAN NOT NULL DEFAULT false;

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -116,34 +116,35 @@ enum PollStatus {
 }
 
 model Poll {
-  id                      String        @id @unique @map("id")
-  createdAt               DateTime      @default(now()) @map("created_at")
-  updatedAt               DateTime      @updatedAt @map("updated_at")
+  id                      String     @id @unique @map("id")
+  createdAt               DateTime   @default(now()) @map("created_at")
+  updatedAt               DateTime   @updatedAt @map("updated_at")
   deadline                DateTime?
   title                   String
   description             String?
   location                String?
-  userId                  String        @map("user_id")
-  timeZone                String?       @map("time_zone")
-  closed                  Boolean       @default(false) // @deprecated
-  status                  PollStatus    @default(live)
-  deleted                 Boolean       @default(false)
-  deletedAt               DateTime?     @map("deleted_at")
-  touchedAt               DateTime      @default(now()) @map("touched_at")
-  participantUrlId        String        @unique @map("participant_url_id")
-  adminUrlId              String        @unique @map("admin_url_id")
-  eventId                 String?       @unique @map("event_id")
-  hideParticipants        Boolean       @default(false) @map("hide_participants")
-  hideScores              Boolean       @default(false) @map("hide_scores")
-  disableComments         Boolean       @default(false) @map("disable_comments")
-  requireParticipantEmail Boolean       @default(false) @map("require_participant_email")
+  userId                  String     @map("user_id")
+  timeZone                String?    @map("time_zone")
+  closed                  Boolean    @default(false) // @deprecated
+  status                  PollStatus @default(live)
+  deleted                 Boolean    @default(false)
+  deletedAt               DateTime?  @map("deleted_at")
+  touchedAt               DateTime   @default(now()) @map("touched_at")
+  participantUrlId        String     @unique @map("participant_url_id")
+  adminUrlId              String     @unique @map("admin_url_id")
+  eventId                 String?    @unique @map("event_id")
+  hideParticipants        Boolean    @default(false) @map("hide_participants")
+  hideScores              Boolean    @default(false) @map("hide_scores")
+  bccAttendees            Boolean    @default(false) @map("bccAttendees")
+  disableComments         Boolean    @default(false) @map("disable_comments")
+  requireParticipantEmail Boolean    @default(false) @map("require_participant_email")
 
-  user                    User?         @relation(fields: [userId], references: [id])
-  event                   Event?        @relation(fields: [eventId], references: [id])
-  options                 Option[]
-  participants            Participant[]
-  watchers                Watcher[]
-  comments                Comment[]
+  user         User?         @relation(fields: [userId], references: [id])
+  event        Event?        @relation(fields: [eventId], references: [id])
+  options      Option[]
+  participants Participant[]
+  watchers     Watcher[]
+  comments     Comment[]
 
   @@index([userId], type: Hash)
   @@map("polls")
@@ -159,7 +160,7 @@ model Event {
   duration  Int      @default(0) @map("duration_minutes")
   createdAt DateTime @default(now()) @map("created_at")
 
-  poll      Poll?
+  poll Poll?
 
   @@index([userId], type: Hash)
   @@map("events")
@@ -197,7 +198,7 @@ model Participant {
 
 model Option {
   id        String   @id @default(cuid())
-  startTime DateTime @db.Timestamp(0) @map("start_time")
+  startTime DateTime @map("start_time") @db.Timestamp(0)
   duration  Int      @default(0) @map("duration_minutes")
   pollId    String   @map("poll_id")
   poll      Poll     @relation(fields: [pollId], references: [id])


### PR DESCRIPTION
## Description

Adds the ability to hide attendees from the `.ics` calendar hits that are sent to event attendees. Keeps the organizer's email.

I've been using Rallly for a few organizations and one of the problems with a large attendee list is that it shares every responder's email with other responders when finalizing the event. This might unintentionally doxx some users.

Under the hood I've added a settings flag called `bccAttendees`, which doesn't actually "bcc" in the traditional sense, but instead just sets the `ics` attendees list to an empty array if the event's `bccAttendees` setting is configured to `true` (I'm open to changing this btw)

Any other changes included in this pull request are formatting changes (such as in the prisma schema) or adding the fully qualified domain in the docker compose dev file for podman compatibility (I can remove this change if requested).

## Checklist

Please check off all the following items with an "x" in the boxes before requesting a review.

- [x] I have performed a self-review of my code
- [x] My code follows the code style of this project
- [x] I have commented my code, particularly in hard-to-understand areas


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new option to hide the attendee list from finalized emails in poll settings.

- **Chores**
  - Updated PostgreSQL image source in `docker-compose` for development environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->