### PR TITLE
✨ Close expanded poll with esc key

### DIFF
--- a/apps/web/src/components/poll/desktop-poll.tsx
+++ b/apps/web/src/components/poll/desktop-poll.tsx
@@ -37,6 +37,24 @@ import ParticipantRow from "./desktop-poll/participant-row";
 import ParticipantRowForm from "./desktop-poll/participant-row-form";
 import PollHeader from "./desktop-poll/poll-header";
 
+function EscapeListener({ onEscape }: { onEscape: () => void }) {
+  React.useEffect(() => {
+    const handleEscape = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        onEscape();
+      }
+    };
+
+    document.addEventListener("keydown", handleEscape);
+
+    return () => {
+      document.removeEventListener("keydown", handleEscape);
+    };
+  }, [onEscape]);
+
+  return null;
+}
+
 const useIsOverflowing = <E extends Element | null>(
   ref: React.RefObject<E>,
 ) => {
@@ -204,6 +222,7 @@ const DesktopPoll: React.FunctionComponent = () => {
               </TooltipContent>
             </Tooltip>
           )}
+          {expanded ? <EscapeListener onEscape={collapse} /> : null}
         </div>
       </div>
     );


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced an `EscapeListener` component to allow users to collapse the poll by pressing the "Escape" key, enhancing accessibility and usability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->