### PR TITLE
🐛 Delete all comments when deleting account

### DIFF
--- a/packages/backend/trpc/routers/user.ts
+++ b/packages/backend/trpc/routers/user.ts
@@ -64,7 +64,7 @@ export const user = router({
         where: { userId: ctx.user.id },
       });
       await tx.comment.deleteMany({
-        where: { userId: ctx.user.id },
+        where: { OR: [{ pollId: { in: pollIds } }, { userId: ctx.user.id }] },
       });
       await tx.poll.deleteMany({
         where: { userId: ctx.user.id },


### PR DESCRIPTION
We need to delete all comments in polls belonging to a deleted user.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced comment deletion functionality: users can now delete comments associated with their user ID or linked to specific polls, increasing the flexibility of comment management.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->