### PR TITLE
🐛 Use dotenv in next config to load env vars from root

### DIFF
--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -8,6 +8,10 @@ const withBundleAnalyzer = require("@next/bundle-analyzer")({
   enabled: process.env.ANALYZE === "true",
 });
 
+require("dotenv").config({
+  path: "../../.env",
+});
+
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   output:


### PR DESCRIPTION
Fixes an issue where env vars are not accessible to the Next.js middleware during development until it is rebuilt.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced configuration to support loading environment variables, improving flexibility for environment-specific settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->