### PR TITLE
🔨  Remove postinstall script

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ The following instructions are for running the project locally for development.
 
 2. Install dependencies
 
-   ```
+   ```bash
    yarn
    ```
 
@@ -51,19 +51,25 @@ The following instructions are for running the project locally for development.
 
    **Note:** `.env.development` is preconfigured with default values for development. You can leave these as is for local development.
 
-4. Setup database
+4. Generate Prisma client
+
+   ```bash
+   yarn db:generate
+   ```
+
+5. Setup database
 
    You will need to have [Docker](https://docs.docker.com/get-docker/) installed and running to run the database using the provided docker-compose file.
 
    To start the database, run:
 
-   ```
+   ```bash
    yarn docker:up
    ```
 
    Next run the following command to setup the database:
 
-   ```
+   ```bash
    yarn db:reset
    ```
 
@@ -73,9 +79,9 @@ The following instructions are for running the project locally for development.
    - run migrations to create a new database schema
    - seed the database with test users and random data
 
-5. Start the Next.js server
+6. Start the Next.js server
 
-   ```
+   ```bash
    yarn dev
    ```
 

--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -42,7 +42,7 @@ COPY --from=builder --chown=nextjs:nodejs /app/packages/database/prisma ./prisma
 COPY --from=installer /app/apps/web/next.config.js .
 COPY --from=installer /app/apps/web/package.json .
 
-ENV PORT 3000
+ENV PORT=3000
 EXPOSE 3000
 
 # Automatically leverage output traces to reduce image size

--- a/package.json
+++ b/package.json
@@ -3,7 +3,6 @@
   "private": true,
   "version": "3.9.0",
   "scripts": {
-    "postinstall": "yarn db:generate",
     "dev": "turbo dev --filter=@rallly/web",
     "dev:emails": "turbo dev --filter=@rallly/emails",
     "dev:landing": "dotenv -c development turbo dev --filter=@rallly/landing",


### PR DESCRIPTION
The postinstall script which generated the prisma client automatically was causing out docker version release action to fail:

https://github.com/lukevella/rallly/actions/runs/10556238820

To fix this, we're removing the postinstall script and updating the README to run the prisma client generation manually by running `yarn db:generate`.