### PR TITLE
💬 Update annual benefit

### DIFF
--- a/apps/landing/public/locales/en/pricing.json
+++ b/apps/landing/public/locales/en/pricing.json
@@ -28,6 +28,6 @@
   "keepPollsIndefinitely": "Keep polls indefinitely",
   "whenPollInactive": "When does a poll become inactive?",
   "whenPollInactiveAnswer": "Polls become inactive when all date options are in the past AND the poll has not been accessed for over 30 days. Inactive polls are automatically deleted if you do not have a paid subscription.",
-  "discount": "Save {amount}",
-  "yearlyBillingDescription": "per year"
+  "yearlyBillingDescription": "per year",
+  "annualBenefit": "{count} months free"
 }

--- a/apps/landing/src/pages/pricing.tsx
+++ b/apps/landing/src/pages/pricing.tsx
@@ -72,15 +72,6 @@ const PriceTables = ({
           </TabsTrigger>
           <TabsTrigger value="yearly" className="inline-flex gap-x-2.5">
             <Trans i18nKey="pricing:billingPeriodYearly" defaults="Yearly" />
-            <Badge variant="green" className="inline-flex gap-2">
-              <Trans
-                i18nKey="pricing:annualBenefit"
-                defaults="{count} months free"
-                values={{
-                  count: 4,
-                }}
-              />
-            </Badge>
           </TabsTrigger>
         </TabsList>
       </div>
@@ -137,9 +128,20 @@ const PriceTables = ({
             </BillingPlanDescription>
           </BillingPlanHeader>
           <TabsContent value="yearly">
-            <BillingPlanPrice>
-              ${pricingData.yearly.amount / 100}
-            </BillingPlanPrice>
+            <div className="flex items-center gap-x-2">
+              <BillingPlanPrice>
+                ${pricingData.yearly.amount / 100}
+              </BillingPlanPrice>
+              <Badge variant="green" className="inline-flex gap-2">
+                <Trans
+                  i18nKey="pricing:annualBenefit"
+                  defaults="{count} months free!"
+                  values={{
+                    count: 4,
+                  }}
+                />
+              </Badge>
+            </div>
             <BillingPlanPeriod>
               <Trans
                 i18nKey="pricing:yearlyBillingDescription"

--- a/apps/landing/src/pages/pricing.tsx
+++ b/apps/landing/src/pages/pricing.tsx
@@ -74,10 +74,10 @@ const PriceTables = ({
             <Trans i18nKey="pricing:billingPeriodYearly" defaults="Yearly" />
             <Badge variant="green" className="inline-flex gap-2">
               <Trans
-                i18nKey="pricing:discount"
-                defaults="Save {amount}"
+                i18nKey="pricing:annualBenefit"
+                defaults="{count} months free"
                 values={{
-                  amount: `$${(pricingData.monthly.amount * 12 - pricingData.yearly.amount) / 100}`,
+                  count: 4,
                 }}
               />
             </Badge>

--- a/apps/web/public/locales/en/app.json
+++ b/apps/web/public/locales/en/app.json
@@ -262,7 +262,6 @@
   "pastEventsEmptyStateDescription": "When you schedule events, they will appear here.",
   "activePollCount": "{{activePollCount}} Live",
   "createPoll": "Create poll",
-  "yearlyDiscount": "Save {amount}",
   "yearlyBillingDescription": "per year",
   "addToCalendar": "Add to Calendar",
   "microsoft365": "Microsoft 365",
@@ -273,5 +272,6 @@
   "timeZoneChangeDetectorTitle": "Timezone Change Detected",
   "timeZoneChangeDetectorMessage": "Your timezone has changed to {currentTimeZone}. Do you want to update your preferences?",
   "yesUpdateTimezone": "Yes, update my timezone",
-  "noKeepCurrentTimezone": "No, keep the current timezone"
+  "noKeepCurrentTimezone": "No, keep the current timezone",
+  "annualBenefit": "{count} months free"
 }

--- a/apps/web/src/app/[locale]/(admin)/settings/billing/billing-plans.tsx
+++ b/apps/web/src/app/[locale]/(admin)/settings/billing/billing-plans.tsx
@@ -43,14 +43,10 @@ export const BillingPlans = ({ pricingData }: { pricingData: PricingData }) => {
               <Trans i18nKey="billingPeriodYearly" />
               <Badge variant="green">
                 <Trans
-                  i18nKey="yearlyDiscount"
-                  defaults="Save {amount}"
+                  i18nKey="annualBenefit"
+                  defaults="{count} months free"
                   values={{
-                    amount: `$${
-                      (pricingData.monthly.amount * 12 -
-                        pricingData.yearly.amount) /
-                      100
-                    }`,
+                    count: 4,
                   }}
                 />
               </Badge>

--- a/apps/web/src/app/[locale]/(admin)/settings/billing/billing-plans.tsx
+++ b/apps/web/src/app/[locale]/(admin)/settings/billing/billing-plans.tsx
@@ -41,15 +41,6 @@ export const BillingPlans = ({ pricingData }: { pricingData: PricingData }) => {
             </TabsTrigger>
             <TabsTrigger value="yearly" className="inline-flex gap-x-2.5">
               <Trans i18nKey="billingPeriodYearly" />
-              <Badge variant="green">
-                <Trans
-                  i18nKey="annualBenefit"
-                  defaults="{count} months free"
-                  values={{
-                    count: 4,
-                  }}
-                />
-              </Badge>
             </TabsTrigger>
           </TabsList>
         </div>
@@ -105,9 +96,21 @@ export const BillingPlans = ({ pricingData }: { pricingData: PricingData }) => {
             </div>
             <div className="flex">
               <TabsContent value="yearly">
-                <BillingPlanPrice>
-                  ${pricingData.yearly.amount / 100}
-                </BillingPlanPrice>
+                <div className="flex items-center gap-x-2">
+                  <BillingPlanPrice>
+                    ${pricingData.yearly.amount / 100}
+                  </BillingPlanPrice>
+                  <Badge variant="green">
+                    <Trans
+                      i18nKey="annualBenefit"
+                      defaults="{count} months free"
+                      values={{
+                        count: 4,
+                      }}
+                    />
+                  </Badge>
+                </div>
+
                 <BillingPlanPeriod>
                   <Trans
                     i18nKey="yearlyBillingDescription"


### PR DESCRIPTION
Updating the proposition for an annual subscription from "Save $28" to "x months free"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new promotional message highlighting "4 months free" with annual subscriptions.
	- Updated localization files to reflect the removal of discount messages and emphasize annual benefits.
- **Bug Fixes**
	- Corrected the displayed text in various components to align with the new annual benefit messaging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->