### PR TITLE
🌐 Add gb locale

### DIFF
--- a/apps/web/src/utils/dayjs.tsx
+++ b/apps/web/src/utils/dayjs.tsx
@@ -39,6 +39,11 @@ const dayjsLocales: Record<
     timeFormat: "hours12",
     import: () => import("dayjs/locale/en"),
   },
+  "en-GB": {
+    weekStart: 1,
+    timeFormat: "hours24",
+    import: () => import("dayjs/locale/en-gb"),
+  },
   es: {
     weekStart: 1,
     timeFormat: "hours24",

--- a/packages/languages/languages.json
+++ b/packages/languages/languages.json
@@ -5,6 +5,7 @@
   "da": "Dansk",
   "de": "Deutsch",
   "en": "English",
+  "en-GB": "English (UK)",
   "es": "Español",
   "fr": "Français",
   "hr": "Hrvatski",


### PR DESCRIPTION
Adding en-gb locale to 24-hour clock for gb users.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added support for British English localization, including week start on Monday and 24-hour time format.
	- Introduced a distinct language entry for British English in the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->