### PR TITLE
🔨  Use node:20-slim as runner

### DIFF
--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -26,7 +26,16 @@ ENV NEXT_PUBLIC_SELF_HOSTED=$SELF_HOSTED
 
 RUN SKIP_ENV_VALIDATION=1 yarn build
 
-FROM node:20 AS runner
+FROM node:20-slim AS runner
+
+# prisma requirements
+# (see https://www.prisma.io/docs/orm/reference/system-requirements)
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends \
+    openssl \
+    zlib1g \
+    libgcc-s1 \
+  && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app
 


### PR DESCRIPTION
## Description

Use `node:20-slim` as runner image
Install Prisma requirements (openssl is not in node slim image)

Discussion #1349 

## Checklist

Please check off all the following items with an "x" in the boxes before requesting a review.

- [x] I have performed a self-review of my code
- [x] My code follows the code style of this project
- [x] I have commented my code, particularly in hard-to-understand areas


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Improved the build environment for the Node.js application by switching to a lighter base image.
	- Added installation of essential system dependencies for enhanced functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->