### PR TITLE
🐛 Fix escaped values in emails

### DIFF
--- a/packages/emails/src/templates/finalized-host.tsx
+++ b/packages/emails/src/templates/finalized-host.tsx
@@ -39,7 +39,6 @@ const FinalizeHostEmail = ({
         ns: "emails",
         defaultValue:
           "Final date booked! We've notified participants and sent them calendar invites.",
-        title,
       })}
     >
       <Heading>
@@ -55,6 +54,7 @@ const FinalizeHostEmail = ({
           i18nKey="finalizeHost_content"
           ns="emails"
           values={{ title }}
+          shouldUnescape={true}
           components={{
             b: <strong />,
           }}
@@ -126,6 +126,9 @@ FinalizeHostEmail.getSubject = (
     defaultValue: "Date booked for {{title}}",
     title: props.title,
     ns: "emails",
+    interpolation: {
+      escapeValue: false,
+    },
   });
 };
 

--- a/packages/emails/src/templates/finalized-participant.tsx
+++ b/packages/emails/src/templates/finalized-participant.tsx
@@ -53,6 +53,7 @@ const FinalizeParticipantEmail = ({
           ns="emails"
           defaults="<b>{{hostName}}</b> has booked <b>{{title}}</b> for the following date:"
           values={{ hostName, title }}
+          shouldUnescape={true}
           components={{
             b: <strong />,
           }}
@@ -117,6 +118,9 @@ FinalizeParticipantEmail.getSubject = (
     defaultValue: "Date booked for {{title}}",
     title: props.title,
     ns: "emails",
+    interpolation: {
+      escapeValue: false,
+    },
   });
 };
 

--- a/packages/emails/src/templates/new-comment.tsx
+++ b/packages/emails/src/templates/new-comment.tsx
@@ -42,6 +42,7 @@ const NewCommentEmail = ({
           ns="emails"
           i18nKey="newComment_content"
           defaults="<b>{{authorName}}</b> has commented on <b>{{title}}</b>."
+          shouldUnescape={true}
           components={{
             b: <strong />,
           }}
@@ -64,6 +65,9 @@ NewCommentEmail.getSubject = (
     defaultValue: "{{authorName}} has commented on {{title}}",
     authorName: props.authorName,
     title: props.title,
+    interpolation: {
+      escapeValue: false,
+    },
   });
 };
 

--- a/packages/emails/src/templates/new-participant.tsx
+++ b/packages/emails/src/templates/new-participant.tsx
@@ -69,6 +69,9 @@ NewParticipantEmail.getSubject = (
     name: props.participantName,
     title: props.title,
     ns: "emails",
+    interpolation: {
+      escapeValue: false,
+    },
   });
 };
 

--- a/packages/emails/src/templates/new-poll.tsx
+++ b/packages/emails/src/templates/new-poll.tsx
@@ -46,6 +46,7 @@ export const NewPollEmail = ({
           i18nKey="newPoll_content"
           ns="emails"
           values={{ title }}
+          shouldUnescape={true}
           components={{
             b: <strong />,
           }}
@@ -71,6 +72,9 @@ NewPollEmail.getSubject = (props: NewPollEmailProps, ctx: EmailContext) => {
   return ctx.t("newPoll_subject", {
     defaultValue: "Let's find a date for {{title}}!",
     title: props.title,
+    interpolation: {
+      escapeValue: false,
+    },
     ns: "emails",
   });
 };


### PR DESCRIPTION
Fixes an issue where special characters like "&" would appear as "&amp;" in emails because i18next escapes these characters by default.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced email components to support HTML rendering in translations and subject lines.
	- Introduced `shouldUnescape` property for correct HTML tag interpretation.
	- Added `interpolation` option for unescaped values in subject lines.

- **Bug Fixes**
	- Improved dynamic content handling in email templates for better formatting and display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->