### PR TITLE
🔧 Allow sentry config when env vars are missing

### DIFF
--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -95,6 +95,7 @@ const sentryWebpackPluginOptions = {
 const withBundleAnalyzerConfig = withBundleAnalyzer(nextConfig);
 // Make sure adding Sentry options is the last code to run before exporting, to
 // ensure that your source maps include changes from all other Webpack plugins
-module.exports = process.env.SENTRY_AUTH_TOKEN
-  ? withSentryConfig(withBundleAnalyzerConfig, sentryWebpackPluginOptions)
-  : withBundleAnalyzerConfig;
+module.exports = withSentryConfig(
+  withBundleAnalyzerConfig,
+  sentryWebpackPluginOptions,
+);


### PR DESCRIPTION
FIxes annoying warnings in development

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Simplified the Next.js configuration for Sentry integration, ensuring consistent inclusion of Sentry options with the bundle analyzer.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->