### PR TITLE
fix ics download button

### DIFF
--- a/apps/web/src/components/add-to-calendar-button.tsx
+++ b/apps/web/src/components/add-to-calendar-button.tsx
@@ -57,24 +57,7 @@ export function AddToCalendarButton({
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
-        <Button
-          onClick={() => {
-            const res = ics(calendarEvent);
-
-            // download the file
-            const blob = new Blob([res], { type: "text/calendar" });
-            const url = URL.createObjectURL(blob);
-            const link = document.createElement("a");
-            link.setAttribute("href", url);
-            link.setAttribute(
-              "download",
-              `${title.toLocaleLowerCase().replace(/\s/g, "-")}.ics`,
-            );
-            document.body.appendChild(link);
-            link.click();
-            document.body.removeChild(link);
-          }}
-        >
+        <Button>
           <Icon>
             <PlusIcon />
           </Icon>
@@ -134,7 +117,24 @@ export function AddToCalendarButton({
           <Trans i18nKey="yahoo" defaults="Yahoo" />
         </DropdownMenuItem>
         <DropdownMenuSeparator />
-        <DropdownMenuItem>
+        <DropdownMenuItem
+          onClick={() => {
+            const res = ics(calendarEvent);
+
+            // download the file
+            const blob = new Blob([res], { type: "text/calendar" });
+            const url = URL.createObjectURL(blob);
+            const link = document.createElement("a");
+            link.setAttribute("href", url);
+            link.setAttribute(
+              "download",
+              `${title.toLocaleLowerCase().replace(/\s/g, "-")}.ics`,
+            );
+            document.body.appendChild(link);
+            link.click();
+            document.body.removeChild(link);
+          }}
+        >
           <Icon>
             <DownloadIcon />
           </Icon>


### PR DESCRIPTION
## Description
The download button for the ICS file currently has no effect. The code for downloading the ICS file was attached to the `DropDownMenuTrigger` instead of the actual `DropdownMenuItem`. With this PR I am moving the `onClick` code to the actual `DropdownMenuItem` that should be responsible for the ICS download.

resolves #1380

## Checklist

Please check off all the following items with an "x" in the boxes before requesting a review.

- [X] I have performed a self-review of my code: I did a visual review on the code and looked up the documentation of the `calendar-link` library that is used. Unfortunately I wasn't able to actually test it locally as I wasn't able to find out how to login with the seeded users without setting up a SMTP catcher locally.
- [X] My code follows the code style of this project
- [X] I have commented my code, particularly in hard-to-understand areas: Not needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced the `Add to Calendar` functionality with a dedicated dropdown menu for downloading ICS files.
	- Improved user interface by separating the calendar addition action from the download action.

- **Bug Fixes**
	- Resolved previous confusion by clearly defining button and download functionalities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->