### PR TITLE
Fix event ICS download button file content

### DIFF
--- a/apps/web/src/components/add-to-calendar-button.tsx
+++ b/apps/web/src/components/add-to-calendar-button.tsx
@@ -119,13 +119,11 @@ export function AddToCalendarButton({
         <DropdownMenuSeparator />
         <DropdownMenuItem
           onClick={() => {
-            const res = ics(calendarEvent);
+            const data = ics(calendarEvent);
 
             // download the file
-            const blob = new Blob([res], { type: "text/calendar" });
-            const url = URL.createObjectURL(blob);
             const link = document.createElement("a");
-            link.setAttribute("href", url);
+            link.setAttribute("href", data);
             link.setAttribute(
               "download",
               `${title.toLocaleLowerCase().replace(/\s/g, "-")}.ics`,


### PR DESCRIPTION
**Solves #1389:** 

**Summary:**
The content of the ICS file generated by the download button in `apps/web/src/components/add-to-calendar-button.tsx` is URL-encoded, preventing it from being imported into calendar apps. This PR fixes this.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved the ICS file download functionality for the Add to Calendar button, streamlining the process for users.
	- Continued support for adding events to Google Calendar, Microsoft 365, Outlook, and Yahoo.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->