### PR TITLE
🐛 Fix delete order

### DIFF
--- a/apps/web/src/trpc/routers/user.ts
+++ b/apps/web/src/trpc/routers/user.ts
@@ -59,8 +59,12 @@ export const user = router({
         where: { userId: ctx.user.id },
       });
       const pollIds = polls.map((poll) => poll.id);
-      await tx.comment.deleteMany({
+
+      await tx.vote.deleteMany({
         where: { pollId: { in: pollIds } },
+      });
+      await tx.comment.deleteMany({
+        where: { OR: [{ pollId: { in: pollIds } }, { userId: ctx.user.id }] },
       });
       await tx.option.deleteMany({
         where: { pollId: { in: pollIds } },
@@ -71,14 +75,8 @@ export const user = router({
       await tx.watcher.deleteMany({
         where: { OR: [{ pollId: { in: pollIds } }, { userId: ctx.user.id }] },
       });
-      await tx.vote.deleteMany({
-        where: { pollId: { in: pollIds } },
-      });
       await tx.event.deleteMany({
         where: { userId: ctx.user.id },
-      });
-      await tx.comment.deleteMany({
-        where: { OR: [{ pollId: { in: pollIds } }, { userId: ctx.user.id }] },
       });
       await tx.poll.deleteMany({
         where: { userId: ctx.user.id },


### PR DESCRIPTION
We need to delete votes first before we can delete options.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved the user data deletion process by restructuring the order of operations, enhancing data integrity during deletions.
	- Expanded comment deletion logic to include comments made by the user, ensuring a more comprehensive cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->