### PR TITLE
Fix time slot checkbox being pushed out of viewport

### DIFF
--- a/apps/web/src/components/poll/mobile-poll/time-slot-option.tsx
+++ b/apps/web/src/components/poll/mobile-poll/time-slot-option.tsx
@@ -1,6 +1,6 @@
 import { ClockIcon } from "lucide-react";
 import * as React from "react";
-
+import { createBreakpoint } from "react-use";
 import PollOption, { PollOptionProps } from "./poll-option";
 
 export interface TimeSlotOptionProps extends PollOptionProps {
@@ -9,20 +9,33 @@ export interface TimeSlotOptionProps extends PollOptionProps {
   duration: string;
 }
 
+const useBreakpoint = createBreakpoint({
+  hideDuration: 320,
+  showDuration: 380,
+});
+
 const TimeSlotOption: React.FunctionComponent<TimeSlotOptionProps> = ({
   startTime,
   endTime,
   duration,
   ...rest
 }) => {
+  const breakpoint = useBreakpoint();
+  const showVotes = !!(rest.selectedParticipantId || rest.editable);
+  const showDuration =
+    breakpoint === "showDuration" ||
+    (breakpoint !== "showDuration" && !showVotes);
+
   return (
     <PollOption {...rest}>
       <div className="flex items-center gap-x-4 text-sm">
         <div>{`${startTime} - ${endTime}`}</div>
-        <div className="flex items-center gap-x-1.5 opacity-50">
-          <ClockIcon className="size-4" />
-          {duration}
-        </div>
+        {showDuration && (
+          <div className="flex items-center gap-x-1.5 opacity-50">
+            <ClockIcon className="size-4" />
+            {duration}
+          </div>
+        )}
       </div>
     </PollOption>
   );


### PR DESCRIPTION
## Description

This PR fixes #1407; the vote checkboxes being hidden on smaller viewports when both time and duration is shown, pushing the checkbox out of the viewport. By hiding the duration while the user fills in availability, the checkboxes remain in the viewport.

## Checklist

- [x] I have performed a self-review of my code
- [x] My code follows the code style of this project
- [x] I have commented my code, particularly in hard-to-understand areas
