### PR TITLE
💄 Use dynamic height for mobile

### DIFF
--- a/apps/web/src/app/[locale]/(auth)/layout.tsx
+++ b/apps/web/src/app/[locale]/(auth)/layout.tsx
@@ -14,7 +14,7 @@ export default async function Layout({
   children: React.ReactNode;
 }) {
   return (
-    <div className="relative flex h-screen flex-col items-center justify-center bg-gray-100 p-2 lg:p-4">
+    <div className="relative flex h-dvh flex-col items-center justify-center bg-gray-100 p-2 lg:p-4">
       <div className="z-10 flex w-full max-w-7xl flex-1 rounded-xl border bg-white shadow-sm lg:max-h-[720px] lg:p-2">
         <div className="flex flex-1 flex-col gap-4 p-6 lg:p-16">
           <div className="py-8">


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
	- Updated viewport height styling to use `dvh` (dynamic viewport height) instead of `screen` for improved responsiveness across different devices and screen sizes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->