### PR TITLE
💄 Use dvh on quick create page

### DIFF
--- a/apps/web/src/app/[locale]/quick-create/page.tsx
+++ b/apps/web/src/app/[locale]/quick-create/page.tsx
@@ -17,7 +17,7 @@ export default async function QuickCreatePage() {
 
   const { t } = await getTranslation();
   return (
-    <div className="flex min-h-screen p-2">
+    <div className="flex h-dvh p-2">
       <div className="flex flex-1 flex-col gap-6 rounded-xl border bg-white p-6">
         <div className="mx-auto w-full max-w-md flex-1">
           <div className="space-y-8">


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
	- Updated page styling for the Quick Create page, adjusting the height property to use a dynamic viewport height (`h-dvh`) instead of the minimum screen height.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->