### PR TITLE
🌐 Use single braces for message variables

### DIFF
--- a/apps/web/public/locales/da/app.json
+++ b/apps/web/public/locales/da/app.json
@@ -283,7 +283,7 @@
   "profileEmailAddressDescription": "Din e-mail adresse bruges til at logge ind på din konto",
   "emailAlreadyInUse": "Denne e-mail adresse er allerede tilknyttet en anden konto. Brug venligst en anden e-mail adresse.",
   "continueWith": "Fortsæt med {provider}",
-  "continueWithProvider": "Fortsæt med {{provider}}",
+  "continueWithProvider": "Fortsæt med {provider}",
   "loginFooter": "Har du ikke en konto? <a>Tilmeld dig</a>",
   "back": "Tilbage",
   "verifyEmail": "Bekræft din e-mail",

--- a/apps/web/public/locales/de/app.json
+++ b/apps/web/public/locales/de/app.json
@@ -283,7 +283,7 @@
   "profileEmailAddressDescription": "Deine E-Mail-Adresse wird verwendet, um dich bei deinem Konto anzumelden",
   "emailAlreadyInUse": "Diese E-Mail-Adresse ist bereits mit einem anderen Konto verknüpft. Bitte verwende eine andere E-Mail-Adresse.",
   "continueWith": "Weiter mit {provider}",
-  "continueWithProvider": "Weiter mit {{provider}}",
+  "continueWithProvider": "Weiter mit {provider}",
   "loginFooter": "Du hast noch kein Konto? <a>Registrieren</a>",
   "back": "Zurück",
   "verifyEmail": "Bestätige deine E-Mail-Adresse",

--- a/apps/web/public/locales/en/app.json
+++ b/apps/web/public/locales/en/app.json
@@ -283,7 +283,7 @@
   "profileEmailAddressDescription": "Your email address is used to log in to your account",
   "emailAlreadyInUse": "This email address is already associated with another account. Please use a different email address.",
   "continueWith": "Continue with {provider}",
-  "continueWithProvider": "Continue with {{provider}}",
+  "continueWithProvider": "Continue with {provider}",
   "loginFooter": "Don't have an account? <a>Sign up</a>",
   "back": "Back",
   "verifyEmail": "Verify your email",

--- a/apps/web/public/locales/fi/app.json
+++ b/apps/web/public/locales/fi/app.json
@@ -283,7 +283,7 @@
   "profileEmailAddressDescription": "Sähköpostiosoitettasi käytetään kirjautumaan sisään tilillesi",
   "emailAlreadyInUse": "Tämä sähköpostiosoite on jo liitetty toiseen tiliin. Ole hyvä ja käytä toista sähköpostiosoitetta.",
   "continueWith": "Jatka {provider}-tilillä",
-  "continueWithProvider": "Jatka {{provider}}-tilillä",
+  "continueWithProvider": "Jatka {provider}-tilillä",
   "loginFooter": "Eikö sinulla ole tiliä? <a>Rekisteröidy</a>",
   "back": "Takaisin",
   "verifyEmail": "Vahvista sähköpostiosoitteesi",

--- a/apps/web/public/locales/hu/app.json
+++ b/apps/web/public/locales/hu/app.json
@@ -282,7 +282,7 @@
   "profileEmailAddress": "Email cím",
   "profileEmailAddressDescription": "Az email címed használhatod a belépéshez",
   "continueWith": "Folytatás {provider} fiókkal",
-  "continueWithProvider": "Folytatás {{provider}} fiókkal",
+  "continueWithProvider": "Folytatás {provider} fiókkal",
   "loginFooter": "Nincs felhasználód? <a>Regisztrálj</a>",
   "back": "Vissza",
   "verifyEmail": "Hitelesítsd az email címed",

--- a/apps/web/public/locales/it/app.json
+++ b/apps/web/public/locales/it/app.json
@@ -283,7 +283,7 @@
   "profileEmailAddressDescription": "Il tuo indirizzo email viene utilizzato per accedere alla tua utenza",
   "emailAlreadyInUse": "Questo indirizzo email è già associato a un'altra utenza. Si prega di utilizzare un indirizzo email diverso.",
   "continueWith": "Continua con {provider}",
-  "continueWithProvider": "Continua con {{provider}}",
+  "continueWithProvider": "Continua con {provider}",
   "loginFooter": "Non hai un'utenza? <a>Iscriviti</a>",
   "back": "Indietro",
   "verifyEmail": "Verifica la tua email",

--- a/apps/web/public/locales/nl/app.json
+++ b/apps/web/public/locales/nl/app.json
@@ -283,7 +283,7 @@
   "profileEmailAddressDescription": "Je e-mailadres wordt gebruikt om in te loggen op je account",
   "emailAlreadyInUse": "Dit e-mailadres is al gekoppeld aan een ander account. Gebruik een ander e-mailadres.",
   "continueWith": "Inloggen met {provider}",
-  "continueWithProvider": "Inloggen met {{provider}}",
+  "continueWithProvider": "Inloggen met {provider}",
   "loginFooter": "Heb je geen account? <a>Meld je aan</a>",
   "back": "Terug",
   "verifyEmail": "Verifieer je e-mailadres",

--- a/apps/web/public/locales/pt-BR/app.json
+++ b/apps/web/public/locales/pt-BR/app.json
@@ -283,7 +283,7 @@
   "profileEmailAddressDescription": "Seu endereço de email é usado para acessar sua conta",
   "emailAlreadyInUse": "Este endereço de e-mail já está associado a outra conta. Por favor, use um endereço de e-mail diferente.",
   "continueWith": "Continuar com {provider}",
-  "continueWithProvider": "Continuar com {{provider}}",
+  "continueWithProvider": "Continuar com {provider}",
   "loginFooter": "Não tem uma conta? <a>Cadastre-se</a>",
   "back": "Voltar",
   "verifyEmail": "Verifique seu e-mail",

--- a/apps/web/public/locales/sv/app.json
+++ b/apps/web/public/locales/sv/app.json
@@ -276,7 +276,7 @@
   "profileEmailAddressDescription": "Din mejladress används för att logga in på ditt konto",
   "emailAlreadyInUse": "Den här mejladressen är redan kopplad till ett annat konto. Använd en annan mejladress.",
   "continueWith": "Logga in med {provider}",
-  "continueWithProvider": "Logga in med {{provider}}",
+  "continueWithProvider": "Logga in med {provider}",
   "loginFooter": "Har du inte ett konto? <a>Skapa ett</a>",
   "back": "Tillbaka",
   "verifyEmail": "Verifiera din e-postadress",

--- a/apps/web/src/app/[locale]/(auth)/login/components/login-with-oidc.tsx
+++ b/apps/web/src/app/[locale]/(auth)/login/components/login-with-oidc.tsx
@@ -18,7 +18,7 @@ export async function LoginWithOIDC({ name }: { name: string }) {
         t={t}
         i18nKey="continueWithProvider"
         ns="app"
-        defaultValue="Login with {{provider}}"
+        defaultValue="Login with {provider}"
         values={{ provider: name }}
       />
     </Button>

--- a/apps/web/src/app/[locale]/(auth)/login/components/sso-provider.tsx
+++ b/apps/web/src/app/[locale]/(auth)/login/components/sso-provider.tsx
@@ -51,7 +51,7 @@ export function SSOProvider({
       aria-label={t("continueWithProvider", {
         provider: name,
         ns: "app",
-        defaultValue: "Continue with {{provider}}",
+        defaultValue: "Continue with {provider}",
       })}
       key={providerId}
       onClick={() => {
@@ -62,7 +62,7 @@ export function SSOProvider({
       <span>
         <Trans
           i18nKey="continueWithProvider"
-          defaults="Continue with {{provider}}"
+          defaults="Continue with {provider}"
           values={{ provider: name }}
         />
       </span>


### PR DESCRIPTION
Both double and single braces work but single braces seem to be standard.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Localization**
	- Updated localization strings across multiple languages to use consistent placeholder formatting for the "Continue with Provider" text
	- Modified provider placeholder syntax from `{{provider}}` to `{provider}` in Danish, German, English, Finnish, Hungarian, Italian, Dutch, Portuguese (Brazil), and Swedish localization files
	- Updated related UI components to match new string interpolation format

<!-- end of auto-generated comment: release notes by coderabbit.ai -->