### PR TITLE
🐛 Don’t return metadata if poll is deleted

### DIFF
--- a/apps/web/src/app/[locale]/invite/[urlId]/layout.tsx
+++ b/apps/web/src/app/[locale]/invite/[urlId]/layout.tsx
@@ -20,7 +20,7 @@ export default async function Layout({
     trpc.polls.comments.list.prefetch({ pollId: params.urlId }),
   ]);
 
-  if (!poll) {
+  if (!poll || poll.deleted) {
     notFound();
   }
 

--- a/apps/web/src/app/[locale]/invite/[urlId]/page.tsx
+++ b/apps/web/src/app/[locale]/invite/[urlId]/page.tsx
@@ -52,6 +52,7 @@ export async function generateMetadata({
     select: {
       id: true,
       title: true,
+      deleted: true,
       user: {
         select: {
           name: true,
@@ -62,7 +63,7 @@ export async function generateMetadata({
 
   const { t } = await getTranslation(locale);
 
-  if (!poll) {
+  if (!poll || poll.deleted) {
     notFound();
   }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Enhanced the invitation experience by ensuring that if a poll is deleted or unavailable, users are presented with the correct error page for a non-existent resource.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->