### PR TITLE
🐛 Handle data uri as user avatar

### DIFF
--- a/apps/web/src/components/optimized-avatar-image.tsx
+++ b/apps/web/src/components/optimized-avatar-image.tsx
@@ -30,7 +30,7 @@ export function OptimizedAvatarImage({
       style={{ width: sizeToWidth[size], height: sizeToWidth[size] }}
     >
       {src ? (
-        src.startsWith("https") ? (
+        src.startsWith("https") || src.startsWith("data:") ? (
           <AvatarImage src={src} alt={name} />
         ) : (
           <Image


### PR DESCRIPTION
Microsoft accounts send data uris as profile pictures. This is a temporary fix and we should probably be uploading the pictures to s3 during account creation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced avatar image rendering to support data URLs along with HTTPS URLs, offering more flexibility for image sources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->