### PR TITLE
🗑️ Deprecate touchedAt

### DIFF
--- a/apps/web/src/trpc/routers/polls.ts
+++ b/apps/web/src/trpc/routers/polls.ts
@@ -365,22 +365,6 @@ export const polls = router({
         data: { deleted: true, deletedAt: new Date() },
       });
     }),
-  touch: publicProcedure
-    .input(
-      z.object({
-        pollId: z.string(),
-      }),
-    )
-    .mutation(async ({ input: { pollId } }) => {
-      await prisma.poll.update({
-        where: {
-          id: pollId,
-        },
-        data: {
-          touchedAt: new Date(),
-        },
-      });
-    }),
   // END LEGACY ROUTES
   getWatchers: publicProcedure
     .input(

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -152,7 +152,7 @@ model Poll {
   status                  PollStatus @default(live)
   deleted                 Boolean    @default(false)
   deletedAt               DateTime?  @map("deleted_at")
-  touchedAt               DateTime   @default(now()) @map("touched_at")
+  touchedAt               DateTime   @default(now()) @map("touched_at") // @deprecated
   participantUrlId        String     @unique @map("participant_url_id")
   adminUrlId              String     @unique @map("admin_url_id")
   eventId                 String?    @unique @map("event_id")


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Removed the functionality that updated poll interaction timestamps, streamlining poll data handling.
  - Deprecated the poll’s activity timestamp field to signal upcoming adjustments.
  - These changes contribute to a cleaner system architecture and lay the groundwork for future improvements, ensuring users experience enhanced consistency during poll interactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->