### PR TITLE
🐛 Fix automatic timezone change on poll update

### DIFF
--- a/apps/web/src/components/forms/poll-options-form/month-calendar/month-calendar.tsx
+++ b/apps/web/src/components/forms/poll-options-form/month-calendar/month-calendar.tsx
@@ -52,6 +52,8 @@ const MonthCalendar: React.FunctionComponent<DateTimePickerProps> = ({
 
   const form = useFormContext<NewEventData>();
 
+  const [preservedTimeZone, setPreservedTimeZone] = React.useState<string | null>(null);
+
   const optionsByDay = React.useMemo(() => {
     const res: Record<
       string,
@@ -224,7 +226,7 @@ const MonthCalendar: React.FunctionComponent<DateTimePickerProps> = ({
                 checked={isTimedEvent}
                 onCheckedChange={(checked) => {
                   if (checked) {
-                    form.setValue("timeZone", getBrowserTimeZone());
+                    form.setValue("timeZone", preservedTimeZone ?? form.getValues("timeZone") ?? getBrowserTimeZone());
                     // convert dates to time slots
                     onChange(
                       options.map<DateTimeOption>((option) => {
@@ -246,6 +248,8 @@ const MonthCalendar: React.FunctionComponent<DateTimePickerProps> = ({
                       }),
                     );
                   } else {
+                    const currentTimeZone = form.getValues("timeZone");
+                    if (currentTimeZone) setPreservedTimeZone(currentTimeZone);
                     form.setValue("timeZone", "");
                     onChange(
                       datepicker.selection.map((date) => ({


### PR DESCRIPTION
## Description

**Bug Fix**
Fixes issue: [#1218](https://github.com/lukevella/rallly/issues/1218)
Fixes a bug where the timezone resets to the browser’s timezone when all poll options are removed using the "Edit Options" path or when toggling the "Specify times" option off and on again.

Previously, when all time options were deleted from a poll or when the "Specify times" option was disabled and re-enabled, the timezone would revert to the user's current (browser) timezone. This PR ensures that the originally selected timezone is preserved in these cases.

### QA Instructions:

**On Poll Creation**:
1. Enable the "Specify times" option.
2. Verify that the browser’s timezone is shown by default.
3. Select a different timezone.
4. Disable and re-enable the "Specify times" option — the selected timezone should remain unchanged.
5. With "Specify times" disabled, go to week view and add a new time — the selected timezone should still be preserved.
6. Toggling the "Automatic Time Zone Conversion" option should reset the timezone to the browser’s timezone (this is expected behavior).

**On Poll Update**:
1. Open an existing poll with a timezone different from your current browser timezone.
2. Delete all poll options.
3. Add a new option.
4. Enable the "Specify times" option.
5. The originally selected timezone should be preserved and remain editable.


## Checklist

Please check off all the following items with an "x" in the boxes before requesting a review.

- [ ] I have performed a self-review of my code
- [ ] My code follows the code style of this project
- [ ] I have commented my code, particularly in hard-to-understand areas


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved time zone management in the poll scheduling form. When toggling the time specification option, the interface now preserves your previously selected time zone for a more consistent experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->