### PR TITLE
✨ Add tile descriptions

### DIFF
--- a/apps/web/public/locales/en/app.json
+++ b/apps/web/public/locales/en/app.json
@@ -340,5 +340,7 @@
   "homeActionsTitle": "Actions",
   "dismissFeedback": "Don't show again",
   "tooManyAttempts": "Too many attempts, please try again later.",
-  "unknownError": "Something went wrong"
+  "unknownError": "Something went wrong",
+  "livePollCount": "{count} live",
+  "upcomingEventCount": "{count} upcoming"
 }

--- a/apps/web/src/app/[locale]/(space)/page.tsx
+++ b/apps/web/src/app/[locale]/(space)/page.tsx
@@ -34,6 +34,7 @@ async function loadData() {
     };
   }
 
+  const now = new Date();
   const [livePollCount, upcomingEventCount] = await Promise.all([
     prisma.poll.count({
       where: {
@@ -45,7 +46,7 @@ async function loadData() {
       where: {
         userId: user.id,
         start: {
-          gte: new Date(),
+          gte: now,
         },
       },
     }),

--- a/apps/web/src/app/[locale]/(space)/page.tsx
+++ b/apps/web/src/app/[locale]/(space)/page.tsx
@@ -1,7 +1,6 @@
-import { Tile, TileGrid, TileTitle } from "@rallly/ui/tile";
+import { Tile, TileDescription, TileGrid, TileTitle } from "@rallly/ui/tile";
 import Link from "next/link";
 
-import type { Params } from "@/app/[locale]/types";
 import {
   BillingPageIcon,
   CreatePageIcon,
@@ -20,12 +19,46 @@ import {
 } from "@/app/components/page-layout";
 import { Trans } from "@/components/trans";
 import { IfCloudHosted } from "@/contexts/environment";
+import { getUser } from "@/data/get-user";
 import { getTranslation } from "@/i18n/server";
+import { prisma } from "@rallly/database";
 import { FeedbackAlert } from "./feedback-alert";
 
-export default async function Page(props: { params: Promise<Params> }) {
-  const params = await props.params;
-  await getTranslation(params.locale);
+async function loadData() {
+  const user = await getUser();
+
+  if (!user) {
+    return {
+      livePollCount: 0,
+      upcomingEventCount: 0,
+    };
+  }
+
+  const [livePollCount, upcomingEventCount] = await Promise.all([
+    prisma.poll.count({
+      where: {
+        userId: user.id,
+        status: "live",
+      },
+    }),
+    prisma.event.count({
+      where: {
+        userId: user.id,
+        start: {
+          gte: new Date(),
+        },
+      },
+    }),
+  ]);
+
+  return {
+    livePollCount,
+    upcomingEventCount,
+  };
+}
+
+export default async function Page() {
+  const { livePollCount, upcomingEventCount } = await loadData();
 
   return (
     <PageContainer>
@@ -71,6 +104,13 @@ export default async function Page(props: { params: Promise<Params> }) {
                 <TileTitle>
                   <Trans i18nKey="polls" defaults="Polls" />
                 </TileTitle>
+                <TileDescription>
+                  <Trans
+                    i18nKey="livePollCount"
+                    defaults="{count} live"
+                    values={{ count: livePollCount }}
+                  />
+                </TileDescription>
               </Link>
             </Tile>
 
@@ -80,6 +120,13 @@ export default async function Page(props: { params: Promise<Params> }) {
                 <TileTitle>
                   <Trans i18nKey="events" defaults="Events" />
                 </TileTitle>
+                <TileDescription>
+                  <Trans
+                    i18nKey="upcomingEventCount"
+                    defaults="{count} upcoming"
+                    values={{ count: upcomingEventCount }}
+                  />
+                </TileDescription>
               </Link>
             </Tile>
           </TileGrid>

--- a/packages/ui/src/tile.tsx
+++ b/packages/ui/src/tile.tsx
@@ -56,7 +56,7 @@ const TileDescription = React.forwardRef<
   <p
     ref={ref}
     className={cn(
-      "text-muted-foreground absolute right-3 top-3 text-sm",
+      "text-muted-foreground pointer-events-none absolute right-3 top-3 text-sm",
       className,
     )}
     {...props}

--- a/packages/ui/src/tile.tsx
+++ b/packages/ui/src/tile.tsx
@@ -18,7 +18,7 @@ const Tile = React.forwardRef<
     <Comp
       ref={ref}
       className={cn(
-        "text-card-foreground bg-background flex flex-col justify-end rounded-xl border p-3 shadow-sm transition-shadow hover:bg-gray-50 active:shadow-none",
+        "text-card-foreground relative bg-background flex flex-col justify-end rounded-xl border p-3 shadow-sm transition-shadow hover:bg-gray-50 active:shadow-none",
         className,
       )}
       {...props}
@@ -55,7 +55,10 @@ const TileDescription = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <p
     ref={ref}
-    className={cn("text-muted-foreground text-center text-sm", className)}
+    className={cn(
+      "text-muted-foreground absolute right-3 top-3 text-sm",
+      className,
+    )}
     {...props}
   />
 ));


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Live poll and upcoming event counts are now displayed on the main navigation tiles for Polls and Events.

- **Style**
  - Updated the layout of tile descriptions, positioning count overlays in the top-right corner of each tile for improved visibility.

- **Localization**
  - Added new localized strings to support dynamic display of live poll and upcoming event counts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->