### PR TITLE
💄 Fix desktop poll styling

### DIFF
--- a/apps/web/src/components/poll/desktop-poll.tsx
+++ b/apps/web/src/components/poll/desktop-poll.tsx
@@ -95,7 +95,7 @@ const DesktopPoll: React.FunctionComponent = () => {
 
   const goToNextPage = () => {
     if (scrollRef.current) {
-      scrollRef.current.scrollLeft += 240;
+      scrollRef.current.scrollLeft += 235;
     }
   };
 
@@ -114,7 +114,7 @@ const DesktopPoll: React.FunctionComponent = () => {
 
   const goToPreviousPage = () => {
     if (scrollRef.current) {
-      scrollRef.current.scrollLeft -= 240;
+      scrollRef.current.scrollLeft -= 235;
     }
   };
   const { t } = useTranslation();
@@ -287,7 +287,7 @@ const DesktopPoll: React.FunctionComponent = () => {
                 <div
                   aria-hidden="true"
                   className={cn(
-                    "pointer-events-none absolute bottom-0 left-[240px] top-0 z-30 w-4 border-l bg-gradient-to-r from-gray-800/5 via-transparent to-transparent transition-opacity",
+                    "pointer-events-none absolute bottom-0 left-[235] top-0 z-30 w-4 border-l bg-gradient-to-r from-gray-800/5 via-transparent to-transparent transition-opacity",
                     x > 0 ? "opacity-100" : "opacity-0",
                   )}
                 />
@@ -345,7 +345,7 @@ const DesktopPoll: React.FunctionComponent = () => {
                     </tbody>
                   </table>
                   {mode === "new" ? (
-                    <div className="sticky left-[240px] flex w-[calc(100%-240px)] items-center justify-between gap-4 border-l border-t bg-gray-50 p-3">
+                    <div className="sticky left-[235] flex w-[calc(100%-235)] items-center justify-between gap-4 border-t bg-gray-50 p-3">
                       <Button
                         onClick={() => {
                           votingForm.cancel();

--- a/apps/web/src/components/poll/desktop-poll/participant-row-form.tsx
+++ b/apps/web/src/components/poll/desktop-poll/participant-row-form.tsx
@@ -56,7 +56,7 @@ const ParticipantRowForm = ({
   return (
     <tr className={cn("group", className)}>
       <td
-        style={{ minWidth: 240, maxWidth: 240 }}
+        style={{ minWidth: 235, maxWidth: 235 }}
         className="sticky left-0 z-10 h-12 bg-white px-4"
       >
         <div className="flex items-center justify-between gap-x-2.5">

--- a/apps/web/src/components/poll/desktop-poll/participant-row.tsx
+++ b/apps/web/src/components/poll/desktop-poll/participant-row.tsx
@@ -47,7 +47,7 @@ export const ParticipantRowView: React.FunctionComponent<{
       className={cn("group", className)}
     >
       <td
-        style={{ minWidth: 240, maxWidth: 240 }}
+        style={{ minWidth: 235, maxWidth: 235 }}
         className="sticky left-0 z-10 h-12 bg-white px-4"
       >
         <div className="flex max-w-full items-center justify-between gap-x-2">

--- a/apps/web/src/components/poll/desktop-poll/poll-header.tsx
+++ b/apps/web/src/components/poll/desktop-poll/poll-header.tsx
@@ -48,7 +48,7 @@ const TimelineRow = ({
   return (
     <tr>
       <th
-        style={{ minWidth: 240, top }}
+        style={{ minWidth: 235, top }}
         className="sticky left-0 z-30 bg-white pl-4 pr-4"
       />
       {children}
@@ -77,7 +77,7 @@ const PollHeader: React.FunctionComponent = () => {
               style={{ height: monthRowHeight }}
               className={cn(
                 "sticky top-0 space-y-3 bg-gray-50",
-                firstOfMonth ? "left-[240px] z-20 border-l" : "z-10",
+                firstOfMonth ? "left-[235px] z-20 border-l" : "z-10",
               )}
             >
               <div className="flex">
@@ -111,7 +111,7 @@ const PollHeader: React.FunctionComponent = () => {
                 minWidth: 80,
                 width: 80,
                 height: dayRowHeight,
-                left: firstOfDay && !lastOfDay ? 240 : 0,
+                left: firstOfDay && !lastOfDay ? 235 : 0,
                 top: monthRowHeight,
               }}
               className={cn(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Adjusted table and header cell widths and positioning from 240px to 235px for improved alignment in the poll interface.
  - Updated horizontal scroll increment to match new sizing.
  - Refined sticky footer and header positioning for consistency.
  - Removed border styling from the sticky footer for a cleaner appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->