### PR TITLE
:construction_worker: add multiarch builds (`amd64` and `arm64`)

### DIFF
--- a/.github/workflows/docker-image-manual.yml
+++ b/.github/workflows/docker-image-manual.yml
@@ -27,11 +27,17 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Build and publish image
         uses: docker/build-push-action@v5
         with:
           file: ./apps/web/Dockerfile
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/docker-image-version-release.yml
+++ b/.github/workflows/docker-image-version-release.yml
@@ -29,11 +29,17 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Build and publish image
         uses: docker/build-push-action@v5
         with:
           file: ./apps/web/Dockerfile
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
## Description

Currently only `amd64` builds are done, for running on cheaper hardware an `arm64` build would be awesome.

## Checklist

Please check off all the following items with an "x" in the boxes before requesting a review.

- [x] I have performed a self-review of my code
- [x] My code follows the code style of this project
- [x] I have commented my code, particularly in hard-to-understand areas


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Enhanced Docker image publishing workflows to support multi-platform builds, enabling images for both AMD64 and ARM64 architectures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->