### PR TITLE
♻️ Use revalidatePath instead of client side refresh

### DIFF
--- a/apps/web/src/app/[locale]/(space)/settings/profile/actions.ts
+++ b/apps/web/src/app/[locale]/(space)/settings/profile/actions.ts
@@ -1,6 +1,7 @@
 "use server";
 
 import { ActionError, authActionClient } from "@/features/safe-action/server";
+import { signOut } from "@/next-auth";
 import { subject } from "@casl/ability";
 import { prisma } from "@rallly/database";
 
@@ -32,6 +33,16 @@ export const deleteCurrentUserAction = authActionClient.action(
         id: userId,
       },
     });
+
+    ctx.posthog?.capture({
+      event: "delete_account",
+      distinctId: ctx.user.id,
+      properties: {
+        email: ctx.user.email,
+      },
+    });
+
+    await signOut();
 
     return {
       success: true,

--- a/apps/web/src/app/[locale]/(space)/settings/profile/delete-account-dialog.tsx
+++ b/apps/web/src/app/[locale]/(space)/settings/profile/delete-account-dialog.tsx
@@ -1,5 +1,4 @@
 "use client";
-import { usePostHog } from "@rallly/posthog/client";
 import { Button } from "@rallly/ui/button";
 import type { DialogProps } from "@rallly/ui/dialog";
 import {
@@ -13,7 +12,6 @@ import {
 } from "@rallly/ui/dialog";
 import { Form, FormField, FormItem, FormMessage } from "@rallly/ui/form";
 import { Input } from "@rallly/ui/input";
-import { signOut } from "next-auth/react";
 import { useForm } from "react-hook-form";
 
 import { Trans } from "@/components/trans";
@@ -34,16 +32,7 @@ export function DeleteAccountDialog({
     },
   });
 
-  const posthog = usePostHog();
-
-  const deleteUser = useSafeAction(deleteCurrentUserAction, {
-    onSuccess: () => {
-      posthog?.capture("delete account");
-      signOut({
-        redirectTo: "/login",
-      });
-    },
-  });
+  const deleteUser = useSafeAction(deleteCurrentUserAction);
   const { t } = useTranslation();
 
   return (

--- a/apps/web/src/app/[locale]/admin-setup/actions.ts
+++ b/apps/web/src/app/[locale]/admin-setup/actions.ts
@@ -3,6 +3,7 @@ import { authActionClient } from "@/features/safe-action/server";
 import { ActionError } from "@/features/safe-action/server";
 import { subject } from "@casl/ability";
 import { prisma } from "@rallly/database";
+import { redirect } from "next/navigation";
 
 export const makeMeAdminAction = authActionClient.action(async ({ ctx }) => {
   if (ctx.ability.cannot("update", subject("User", ctx.user), "role")) {
@@ -20,4 +21,6 @@ export const makeMeAdminAction = authActionClient.action(async ({ ctx }) => {
       role: "admin",
     },
   });
+
+  redirect("/control-panel");
 });

--- a/apps/web/src/app/[locale]/admin-setup/make-me-admin-button.tsx
+++ b/apps/web/src/app/[locale]/admin-setup/make-me-admin-button.tsx
@@ -3,16 +3,10 @@
 import { Trans } from "@/components/trans";
 import { useSafeAction } from "@/features/safe-action/client";
 import { Button } from "@rallly/ui/button";
-import { useRouter } from "next/navigation";
 import { makeMeAdminAction } from "./actions";
 
 export function MakeMeAdminButton() {
-  const router = useRouter();
-  const makeMeAdmin = useSafeAction(makeMeAdminAction, {
-    onSuccess: () => {
-      router.replace("/control-panel");
-    },
-  });
+  const makeMeAdmin = useSafeAction(makeMeAdminAction);
   return (
     <Button
       onClick={async () => {

--- a/apps/web/src/app/[locale]/control-panel/users/dialogs/delete-user-dialog.tsx
+++ b/apps/web/src/app/[locale]/control-panel/users/dialogs/delete-user-dialog.tsx
@@ -24,7 +24,6 @@ import {
   FormMessage,
 } from "@rallly/ui/form";
 import { Input } from "@rallly/ui/input";
-import { useRouter } from "next/navigation";
 import { useForm } from "react-hook-form";
 import { z } from "zod";
 
@@ -53,7 +52,6 @@ export function DeleteUserDialog({
   open: boolean;
   onOpenChange: (open: boolean) => void;
 }) {
-  const router = useRouter();
   const schema = useSchema(email);
   const form = useForm({
     resolver: zodResolver(schema),
@@ -64,7 +62,6 @@ export function DeleteUserDialog({
 
   const deleteUser = useSafeAction(deleteUserAction, {
     onSuccess: () => {
-      router.refresh();
       onOpenChange(false);
     },
   });

--- a/apps/web/src/app/[locale]/control-panel/users/user-row.tsx
+++ b/apps/web/src/app/[locale]/control-panel/users/user-row.tsx
@@ -23,7 +23,6 @@ import {
 } from "@rallly/ui/dropdown-menu";
 import { Icon } from "@rallly/ui/icon";
 import { MoreHorizontal, TrashIcon, UserPenIcon } from "lucide-react";
-import { useRouter } from "next/navigation";
 import { useTransition } from "react";
 import { DeleteUserDialog } from "./dialogs/delete-user-dialog";
 
@@ -40,12 +39,7 @@ export function UserRow({
   image?: string;
   role: "admin" | "user";
 }) {
-  const router = useRouter();
-  const changeRole = useSafeAction(changeRoleAction, {
-    onSuccess: () => {
-      router.refresh();
-    },
-  });
+  const changeRole = useSafeAction(changeRoleAction);
 
   const [isPending, startTransition] = useTransition();
   const { user } = useUser();

--- a/apps/web/src/features/user/actions.ts
+++ b/apps/web/src/features/user/actions.ts
@@ -2,6 +2,7 @@
 import { ActionError, authActionClient } from "@/features/safe-action/server";
 import { subject } from "@casl/ability";
 import { prisma } from "@rallly/database";
+import { revalidatePath } from "next/cache";
 import { z } from "zod";
 import { getUser } from "./queries";
 
@@ -46,6 +47,8 @@ export const changeRoleAction = authActionClient
         role,
       },
     });
+
+    revalidatePath("/control-panel");
   });
 
 export const deleteUserAction = authActionClient
@@ -82,6 +85,8 @@ export const deleteUserAction = authActionClient
         id: userId,
       },
     });
+
+    revalidatePath("/control-panel");
 
     return {
       success: true,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * After becoming an admin, users are now automatically redirected to the control panel.
  * The control panel now refreshes its data after user roles are changed or users are deleted.

* **Refactor**
  * Simplified account deletion and admin setup flows by removing client-side side effects such as sign-out, analytics tracking, and manual navigation refreshes. These actions are now handled on the server side where applicable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->