### PR TITLE
🐛 Redirect to admin setup when initial admin is detected

### DIFF
--- a/apps/web/src/auth/data.ts
+++ b/apps/web/src/auth/data.ts
@@ -8,6 +8,7 @@ import { createSpaceDTO } from "@/features/space/data";
 import { createUserDTO } from "@/features/user/data";
 import { AppError } from "@/lib/errors";
 import { auth } from "@/next-auth";
+import { isInitialAdmin } from "@/utils/is-initial-admin";
 
 export const getCurrentUser = async () => {
   const session = await auth();
@@ -144,6 +145,10 @@ export const requireAdmin = cache(async () => {
   const user = await requireUser();
 
   if (user.role !== "admin") {
+    if (isInitialAdmin(user.email)) {
+      return redirect("/admin-setup");
+    }
+
     notFound();
   }
 });


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Initial admins without the "admin" role are now redirected to the admin setup page instead of receiving a 404 error.

* **Bug Fixes**
  * Improved handling for initial admin users during the admin access process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->