### PR TITLE
♻️ Use last selected to get active space

### DIFF
--- a/apps/web/src/auth/data.ts
+++ b/apps/web/src/auth/data.ts
@@ -33,98 +33,40 @@ export const getCurrentUserSpace = async () => {
     return null;
   }
 
-  if (user.activeSpaceId) {
-    const space = await prisma.space.findUnique({
-      where: {
-        id: user.activeSpaceId,
-      },
-      select: {
-        id: true,
-        name: true,
-        ownerId: true,
-        subscription: {
-          select: {
-            active: true,
-          },
-        },
-        members: {
-          where: {
-            userId: user.id,
-          },
-          select: {
-            role: true,
-            userId: true,
-          },
-        },
-      },
-    });
-
-    if (space) {
-      return {
-        user,
-        space: createSpaceDTO(user.id, space),
-      };
-    }
-
-    const defaultSpace = await prisma.space.findFirst({
-      where: {
-        ownerId: user.id,
-      },
-      select: {
-        id: true,
-        name: true,
-        ownerId: true,
-        subscription: {
-          select: {
-            active: true,
-          },
-        },
-        members: {
-          where: {
-            userId: user.id,
-          },
-          select: {
-            role: true,
-            userId: true,
-          },
-        },
-      },
-    });
-
-    if (defaultSpace) {
-      return {
-        user,
-        space: createSpaceDTO(user.id, defaultSpace),
-      };
-    }
-  }
-
-  const space = await prisma.space.findFirst({
+  // Get the most recently selected space via SpaceMember
+  const spaceMember = await prisma.spaceMember.findFirst({
     where: {
-      ownerId: user.id,
+      userId: user.id,
     },
-    select: {
-      id: true,
-      name: true,
-      ownerId: true,
-      subscription: {
+    orderBy: {
+      lastSelectedAt: "desc",
+    },
+    include: {
+      space: {
         select: {
-          active: true,
-        },
-      },
-      members: {
-        where: {
-          userId: user.id,
-        },
-        select: {
-          role: true,
-          userId: true,
+          id: true,
+          name: true,
+          ownerId: true,
+          subscription: {
+            select: {
+              active: true,
+            },
+          },
+          members: {
+            where: {
+              userId: user.id,
+            },
+            select: {
+              role: true,
+              userId: true,
+            },
+          },
         },
       },
     },
   });
 
-  if (!space) {
+  if (!spaceMember) {
     throw new AppError({
       code: "NOT_FOUND",
       message: "Space not found",
@@ -133,7 +75,7 @@ export const getCurrentUserSpace = async () => {
 
   return {
     user,
-    space: createSpaceDTO(user.id, space),
+    space: createSpaceDTO(user.id, spaceMember.space),
   };
 };
 
@@ -172,39 +114,29 @@ export const requireUser = cache(async () => {
 export const requireSpace = cache(async () => {
   const user = await requireUser();
 
-  if (user.activeSpaceId) {
-    const space = await prisma.space.findUnique({
-      where: {
-        id: user.activeSpaceId,
-      },
-      include: {
-        subscription: true,
-        members: true,
-      },
-    });
-
-    if (space) {
-      return createSpaceDTO(user.id, space);
-    }
-    console.error("Could not find user's active space");
-  }
-
-  const space = await prisma.space.findFirst({
+  const spaceMember = await prisma.spaceMember.findFirst({
     where: {
-      ownerId: user.id,
+      userId: user.id,
+    },
+    orderBy: {
+      lastSelectedAt: "desc",
     },
     include: {
-      subscription: true,
-      members: true,
+      space: {
+        include: {
+          subscription: true,
+          members: true,
+        },
+      },
     },
   });
 
-  if (!space) {
+  if (!spaceMember) {
     throw new AppError({
       code: "NOT_FOUND",
-      message: "User does not own any spaces",
+      message: "User does not belong to any spaces",
     });
   }
 
-  return createSpaceDTO(user.id, space);
+  return createSpaceDTO(user.id, spaceMember.space);
 });

--- a/apps/web/src/auth/data.ts
+++ b/apps/web/src/auth/data.ts
@@ -52,15 +52,6 @@ export const getCurrentUserSpace = async () => {
               active: true,
             },
           },
-          members: {
-            where: {
-              userId: user.id,
-            },
-            select: {
-              role: true,
-              userId: true,
-            },
-          },
         },
       },
     },
@@ -75,7 +66,13 @@ export const getCurrentUserSpace = async () => {
 
   return {
     user,
-    space: createSpaceDTO(user.id, spaceMember.space),
+    space: createSpaceDTO({
+      id: spaceMember.space.id,
+      ownerId: spaceMember.space.ownerId,
+      name: spaceMember.space.name,
+      subscription: spaceMember.space.subscription,
+      role: spaceMember.role,
+    }),
   };
 };
 
@@ -138,5 +135,11 @@ export const requireSpace = cache(async () => {
     });
   }
 
-  return createSpaceDTO(user.id, spaceMember.space);
+  return createSpaceDTO({
+    id: spaceMember.space.id,
+    ownerId: spaceMember.space.ownerId,
+    name: spaceMember.space.name,
+    subscription: spaceMember.space.subscription,
+    role: spaceMember.role,
+  });
 });

--- a/apps/web/src/auth/helpers/merge-user.ts
+++ b/apps/web/src/auth/helpers/merge-user.ts
@@ -1,48 +1,30 @@
-import { accessibleBy } from "@casl/prisma";
 import { prisma } from "@rallly/database";
 import { posthog } from "@rallly/posthog/server";
 import * as Sentry from "@sentry/nextjs";
-import { defineAbilityFor } from "@/features/user/ability";
-import { getUser } from "@/features/user/data";
 
 const getActiveSpaceForUser = async ({ userId }: { userId: string }) => {
-  const user = await getUser(userId);
-
-  if (!user) {
-    throw new Error(`User ${userId} not found`);
-  }
-
-  const ability = defineAbilityFor(user);
-
-  if (user.activeSpaceId) {
-    const space = await prisma.space.findFirst({
-      where: {
-        AND: [accessibleBy(ability).Space, { id: user.activeSpaceId }],
-      },
-    });
-
-    if (space) {
-      return space;
-    }
-  }
-
-  return await prisma.space.findFirst({
+  const spaceMember = await prisma.spaceMember.findFirst({
     where: {
-      ownerId: user.id,
+      userId,
+    },
+    select: {
+      spaceId: true,
     },
     orderBy: {
-      createdAt: "asc",
+      lastSelectedAt: "desc",
     },
   });
+
+  return spaceMember?.spaceId;
 };
 
 export const mergeGuestsIntoUser = async (
   userId: string,
   guestIds: string[],
 ) => {
-  const space = await getActiveSpaceForUser({ userId });
+  const spaceId = await getActiveSpaceForUser({ userId });
   const guestId = guestIds[0];
-  if (!space || !guestId) {
+  if (!spaceId || !guestId) {
     console.error(`User ${userId} has no active space or default space`);
     return;
   }
@@ -57,7 +39,7 @@ export const mergeGuestsIntoUser = async (
           data: {
             guestId: null,
             userId: userId,
-            spaceId: space.id,
+            spaceId,
           },
         }),
 

--- a/apps/web/src/features/space/actions.ts
+++ b/apps/web/src/features/space/actions.ts
@@ -67,7 +67,7 @@ export const createSpaceAction = authActionClient
     }),
   )
   .action(async ({ ctx, parsedInput }) => {
-    const space = await prisma.space.create({
+    await prisma.space.create({
       data: {
         name: parsedInput.name,
         ownerId: ctx.user.id,
@@ -75,23 +75,11 @@ export const createSpaceAction = authActionClient
           create: {
             userId: ctx.user.id,
             role: "ADMIN",
+            lastSelectedAt: new Date(),
           },
         },
       },
     });
-
-    try {
-      await prisma.user.update({
-        where: {
-          id: ctx.user.id,
-        },
-        data: {
-          activeSpaceId: space.id,
-        },
-      });
-    } catch (error) {
-      console.error(error);
-    }
   });
 
 export const deleteSpaceAction = authActionClient

--- a/apps/web/src/features/space/data.ts
+++ b/apps/web/src/features/space/data.ts
@@ -30,36 +30,21 @@ export async function getSpaceSeatCount(spaceId: string) {
   });
 }
 
-export function createSpaceDTO(
-  userId: string,
-  space: {
-    id: string;
-    ownerId: string;
-    name: string;
-    subscription: {
-      active: boolean;
-    } | null;
-    members: {
-      role: DBSpaceMemberRole;
-      userId: string;
-    }[];
-  },
-) {
-  const role = space.members.find((member) => member.userId === userId)?.role;
-
-  if (!role) {
-    throw new AppError({
-      code: "INTERNAL_SERVER_ERROR",
-      message: "User is not a member of the space",
-    });
-  }
-
+export function createSpaceDTO(space: {
+  id: string;
+  ownerId: string;
+  name: string;
+  role: DBSpaceMemberRole;
+  subscription: {
+    active: boolean;
+  } | null;
+}) {
   return {
     id: space.id,
     name: space.name,
     ownerId: space.ownerId,
     tier: getSpaceTier(space),
-    role: fromDBRole(role),
+    role: fromDBRole(space.role),
   } satisfies SpaceDTO;
 }
 

--- a/apps/web/src/features/space/data.ts
+++ b/apps/web/src/features/space/data.ts
@@ -11,7 +11,6 @@ import type { MemberRole } from "@/features/space/schema";
 import type { SpaceDTO } from "@/features/space/types";
 import { fromDBRole, toDBRole } from "@/features/space/utils";
 import { defineAbilityFor } from "@/features/user/ability";
-import { AppError } from "@/lib/errors";
 import { isSelfHosted } from "@/utils/constants";
 
 function getSpaceTier(space: {

--- a/apps/web/src/features/user/data.ts
+++ b/apps/web/src/features/user/data.ts
@@ -9,7 +9,6 @@ export const createUserDTO = (user: User): UserDTO => ({
   image: user.image ?? undefined,
   email: user.email,
   role: user.role,
-  activeSpaceId: user.activeSpaceId ?? undefined,
   timeZone: user.timeZone ?? undefined,
   timeFormat: user.timeFormat ?? undefined,
   locale: user.locale ?? undefined,

--- a/apps/web/src/features/user/mutations.ts
+++ b/apps/web/src/features/user/mutations.ts
@@ -47,17 +47,6 @@ export async function createUser({
         spaceId: space.id,
         userId: user.id,
         role: "ADMIN",
-      },
-    });
-
-    await tx.spaceMember.update({
-      where: {
-        spaceId_userId: {
-          spaceId: space.id,
-          userId: user.id,
-        },
-      },
-      data: {
         lastSelectedAt: new Date(),
       },
     });

--- a/apps/web/src/features/user/mutations.ts
+++ b/apps/web/src/features/user/mutations.ts
@@ -50,12 +50,15 @@ export async function createUser({
       },
     });
 
-    await tx.user.update({
+    await tx.spaceMember.update({
       where: {
-        id: user.id,
+        spaceId_userId: {
+          spaceId: space.id,
+          userId: user.id,
+        },
       },
       data: {
-        activeSpaceId: space.id,
+        lastSelectedAt: new Date(),
       },
     });
 
@@ -70,12 +73,15 @@ export async function setActiveSpace({
   userId: string;
   spaceId: string;
 }) {
-  return await prisma.user.update({
+  return await prisma.spaceMember.update({
     where: {
-      id: userId,
+      spaceId_userId: {
+        spaceId: spaceId,
+        userId: userId,
+      },
     },
     data: {
-      activeSpaceId: spaceId,
+      lastSelectedAt: new Date(),
     },
   });
 }

--- a/apps/web/src/features/user/schema.ts
+++ b/apps/web/src/features/user/schema.ts
@@ -12,7 +12,6 @@ export type UserDTO = {
   email: string;
   role: UserRole;
   isGuest: boolean;
-  activeSpaceId?: string;
   timeZone?: string;
   timeFormat?: TimeFormat;
   locale?: string;

--- a/packages/database/prisma/migrations/20250729143210_add_space_member_last_selected_at/migration.sql
+++ b/packages/database/prisma/migrations/20250729143210_add_space_member_last_selected_at/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "space_members" ADD COLUMN     "last_selected_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP;

--- a/packages/database/prisma/migrations/20250729144904_drop_user_active_space_id/migration.sql
+++ b/packages/database/prisma/migrations/20250729144904_drop_user_active_space_id/migration.sql
@@ -1,0 +1,11 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `active_space_id` on the `users` table. All the data in the column will be lost.
+
+*/
+-- DropForeignKey
+ALTER TABLE "users" DROP CONSTRAINT "users_active_space_id_fkey";
+
+-- AlterTable
+ALTER TABLE "users" DROP COLUMN "active_space_id";

--- a/packages/database/prisma/models/space.prisma
+++ b/packages/database/prisma/models/space.prisma
@@ -10,8 +10,7 @@ model Space {
   scheduledEvents ScheduledEvent[]
   subscription    Subscription?    @relation("SpaceToSubscription")
 
-  members        SpaceMember[]
-  activeForUsers User[]        @relation("UserActiveSpace")
+  members SpaceMember[]
 
   memberInvites SpaceMemberInvite[]
 
@@ -25,12 +24,13 @@ enum SpaceMemberRole {
 }
 
 model SpaceMember {
-  id        String          @id @default(uuid())
-  spaceId   String          @map("space_id")
-  userId    String          @map("user_id")
-  createdAt DateTime        @default(now()) @map("created_at")
-  updatedAt DateTime        @updatedAt @map("updated_at")
-  role      SpaceMemberRole @default(MEMBER)
+  id             String          @id @default(uuid())
+  spaceId        String          @map("space_id")
+  userId         String          @map("user_id")
+  createdAt      DateTime        @default(now()) @map("created_at")
+  updatedAt      DateTime        @updatedAt @map("updated_at")
+  role           SpaceMemberRole @default(MEMBER)
+  lastSelectedAt DateTime        @default(now()) @map("last_selected_at")
 
   space Space @relation(fields: [spaceId], references: [id], onDelete: Cascade)
   user  User  @relation(fields: [userId], references: [id], onDelete: Cascade)

--- a/packages/database/prisma/models/user.prisma
+++ b/packages/database/prisma/models/user.prisma
@@ -49,7 +49,6 @@ model User {
   bannedAt      DateTime?   @map("banned_at")
   banReason     String?     @map("ban_reason")
   role          UserRole    @default(user)
-  activeSpaceId String?     @map("active_space_id")
 
   comments           Comment[]
   polls              Poll[]
@@ -58,7 +57,6 @@ model User {
   participants       Participant[]
   paymentMethods     PaymentMethod[]
   subscription       Subscription?       @relation("UserToSubscription")
-  activeSpace        Space?              @relation("UserActiveSpace", fields: [activeSpaceId], references: [id], onDelete: SetNull)
   spaceMemberInvites SpaceMemberInvite[]
 
   spaces   Space[]       @relation("UserSpaces")

--- a/packages/database/prisma/seed/users.ts
+++ b/packages/database/prisma/seed/users.ts
@@ -61,13 +61,6 @@ async function createUser({
     },
   });
 
-  await prisma.user.update({
-    where: { id },
-    data: {
-      activeSpaceId: space.id,
-    },
-  });
-
   return user;
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The app now tracks a user's most recently selected space using a new "last selected" timestamp for each space membership.

* **Refactor**
  * The logic for determining a user's current space has been streamlined to use the most recently selected space membership, replacing previous methods based on user fields.
  * User-related data and actions now reference space membership activity instead of a dedicated "active space" field.
  * Simplified space data handling by directly using user roles in space information.

* **Database Changes**
  * Added a "last selected" timestamp column to space memberships.
  * Removed the "active space" field from user records and related schema.

* **API Changes**
  * The user data returned by the app no longer includes the "activeSpaceId" property.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->