### PR TITLE
🐛 Set correct end date for all day events

### DIFF
--- a/apps/web/src/trpc/routers/polls.ts
+++ b/apps/web/src/trpc/routers/polls.ts
@@ -847,7 +847,10 @@ export const polls = router({
             id: eventId,
             uid: `${eventId}@rallly.co`,
             start: eventStart.toDate(),
-            end: eventStart.add(option.duration, "minute").toDate(),
+            end:
+              option.duration > 0
+                ? eventStart.add(option.duration, "minute").toDate()
+                : eventStart.add(1, "day").toDate(),
             title: poll.title,
             location: poll.location,
             timeZone: poll.timeZone,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Corrected end time for booked events with zero duration. These events now span one full day, preventing zero-length entries and ensuring consistent display across in-app views and exported calendar (ICS) files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->