### PR TITLE
🐛 Fix floating times in ICS

### DIFF
--- a/apps/web/src/trpc/routers/polls.ts
+++ b/apps/web/src/trpc/routers/polls.ts
@@ -818,19 +818,17 @@ export const polls = router({
           email: a.email as string,
         }));
 
-      const eventEnd =
-        option.duration > 0
-          ? eventStart.add(option.duration, "minutes")
-          : eventStart.add(1, "day");
-
       const event = createIcsEvent({
         uid,
         sequence: 0,
         title: poll.title,
         location: poll.location ?? undefined,
         description: poll.description ?? undefined,
-        start: eventStart.toDate(),
-        end: eventEnd.toDate(),
+        start: option.startTime,
+        end:
+          option.duration > 0
+            ? dayjs(option.startTime).add(option.duration, "minute").toDate()
+            : dayjs(option.startTime).add(1, "day").toDate(),
         allDay: option.duration === 0,
         timeZone: poll.timeZone ?? undefined,
         organizer: {

--- a/apps/web/src/utils/ics.test.ts
+++ b/apps/web/src/utils/ics.test.ts
@@ -95,6 +95,8 @@ describe("createIcsEvent", () => {
       expect(result.error).toBeFalsy();
       expect(result.value).toContain("DTSTART:20240315T120000");
       expect(result.value).toContain("DTEND:20240315T130000");
+      expect(result.value).not.toContain("DTSTART:20240315T120000Z");
+      expect(result.value).not.toContain("DTEND:20240315T130000Z");
     });
 
     it("should treat empty string timezone as floating", () => {
@@ -110,6 +112,8 @@ describe("createIcsEvent", () => {
       expect(result.error).toBeFalsy();
       expect(result.value).toContain("DTSTART:20240315T120000");
       expect(result.value).toContain("DTEND:20240315T130000");
+      expect(result.value).not.toContain("DTSTART:20240315T120000Z");
+      expect(result.value).not.toContain("DTEND:20240315T130000Z");
     });
   });
 

--- a/apps/web/src/utils/ics.ts
+++ b/apps/web/src/utils/ics.ts
@@ -28,78 +28,61 @@ export interface CreateIcsEventOptions {
  * Creates an ICS event with proper date/time handling
  * Handles all-day events, timezone conversions, and floating time automatically
  */
-export function createIcsEvent(options: CreateIcsEventOptions): {
+export function createIcsEvent({
+  uid,
+  start,
+  end,
+  allDay,
+  timeZone,
+  sequence = 0,
+  title,
+  description,
+  location,
+  organizer,
+  attendees,
+  method = "request",
+  status = "CONFIRMED",
+}: CreateIcsEventOptions): {
   error?: Error;
   value?: string;
 } {
-  const {
+  return ics.createEvent({
     uid,
-    start,
-    end,
-    allDay,
-    timeZone,
-    sequence = 0,
+    productId,
+    sequence,
     title,
     description,
     location,
     organizer,
     attendees,
-    method = "request",
-    status = "CONFIRMED",
-  } = options;
-
-  let eventAttributes: ics.EventAttributes;
-
-  if (allDay) {
-    // All-day events: use date-only format (3 values)
-    eventAttributes = {
-      uid,
-      productId,
-      sequence,
-      title,
-      description,
-      location,
-      organizer,
-      attendees,
-      method,
-      status,
-      start: [
-        start.getUTCFullYear(),
-        start.getUTCMonth() + 1,
-        start.getUTCDate(),
-      ],
-      end: [end.getUTCFullYear(), end.getUTCMonth() + 1, end.getUTCDate()],
-    };
-  } else {
-    // Timezone-aware events: convert to UTC
-    eventAttributes = {
-      uid,
-      productId,
-      sequence,
-      title,
-      description,
-      location,
-      organizer,
-      attendees,
-      method,
-      status,
-      start: [
-        start.getUTCFullYear(),
-        start.getUTCMonth() + 1,
-        start.getUTCDate(),
-        start.getUTCHours(),
-        start.getUTCMinutes(),
-      ],
-      end: [
-        end.getUTCFullYear(),
-        end.getUTCMonth() + 1,
-        end.getUTCDate(),
-        end.getUTCHours(),
-        end.getUTCMinutes(),
-      ],
-      startInputType: timeZone ? "utc" : "local",
-    };
-  }
-
-  return ics.createEvent(eventAttributes);
+    method,
+    status,
+    startInputType: timeZone ? "utc" : "local",
+    startOutputType: timeZone ? "utc" : "local",
+    ...(allDay
+      ? {
+          start: [
+            start.getUTCFullYear(),
+            start.getUTCMonth() + 1,
+            start.getUTCDate(),
+          ],
+          end: [end.getUTCFullYear(), end.getUTCMonth() + 1, end.getUTCDate()],
+        }
+      : {
+          start: [
+            start.getUTCFullYear(),
+            start.getUTCMonth() + 1,
+            start.getUTCDate(),
+            start.getUTCHours(),
+            start.getUTCMinutes(),
+          ],
+          end: [
+            end.getUTCFullYear(),
+            end.getUTCMonth() + 1,
+            end.getUTCDate(),
+            end.getUTCHours(),
+            end.getUTCMinutes(),
+          ],
+        }),
+  });
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Bug Fixes
  - ICS invites now use each option's explicit start time and compute end times consistently (zero-duration options span one day).

- Improvements
  - Simplified and unified ICS generation for more consistent payloads and better calendar interoperability; ICS creation API updated for cleaner inputs.

- Tests
  - Floating-time tests use fixed UTC timestamps for deterministic, timezone-agnostic DTSTART/DTEND expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->