### PR TITLE
🐛 Fix participant count

### DIFF
--- a/apps/web/public/locales/en/app.json
+++ b/apps/web/public/locales/en/app.json
@@ -455,7 +455,7 @@
   "loading": "Loading...",
   "endOfList": "You've reached the end of the list",
   "attendeeCount": "{count, plural, =0 {No attendees} one {1 attendee} other {# attendees}}",
-  "participantCount": "{count, plural, one {1 participant} other {# participants}}",
+  "participantCount": "{count, plural, =0 {No participants} one {1 participant} other {# participants}}",
   "imageCropDialogTitle": "Crop Image",
   "cropPreview": "Crop preview",
   "annualSavings": "Save {amount} with yearly billing",

--- a/apps/web/src/features/poll/components/poll-list.tsx
+++ b/apps/web/src/features/poll/components/poll-list.tsx
@@ -5,7 +5,6 @@ import { OptimizedAvatarImage } from "@/components/optimized-avatar-image";
 import { StackedList, StackedListItem } from "@/components/stacked-list";
 import { Trans } from "@/components/trans";
 import { PollStatusIcon } from "@/features/poll/components/poll-status-icon";
-
 import type { PollStatus } from "../schema";
 
 export const PollList = StackedList;
@@ -44,7 +43,7 @@ export function PollListItem({
               <span className="cursor-help text-muted-foreground text-sm">
                 <Trans
                   i18nKey="participantCount"
-                  defaults="{count, plural, one {1 participant} other {# participants}}"
+                  defaults="{count, plural, =0 {No participants} =1 {1 participant} other {# participants}}"
                   values={{ count: participants.length }}
                 />
               </span>
@@ -70,8 +69,8 @@ export function PollListItem({
           <span className="text-muted-foreground text-sm">
             <Trans
               i18nKey="participantCount"
-              defaults="{count, plural, one {1 participant} other {# participants}}"
-              values={{ count: 0 }}
+              defaults="{count, plural, =0 {No participants} =1 {1 participant} other {# participants}}"
+              values={{ count: participants.length }}
             />
           </span>
         )}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Participant count text updated with explicit zero-case handling. Polls with 0 participants now display “No participants” instead of “0 participants.”
  * Singular and plural forms remain accurate: “1 participant” and “# participants” for counts above one.
  * Applied across poll list views to ensure consistent display of participant counts.
  * English language strings updated to support the new zero-case wording.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->