### PR TITLE
✨ Set default calendar

### DIFF
--- a/apps/web/public/locales/en/app.json
+++ b/apps/web/public/locales/en/app.json
@@ -521,5 +521,8 @@
   "calendarSelectionSetError": "Failed to set calendar selection",
   "connectCalendar": "Connect Calendar",
   "connectGoogleCalendar": "Google Calendar",
-  "connectMicrosoftCalendar": "Microsoft Calendar"
+  "connectMicrosoftCalendar": "Microsoft Calendar",
+  "settingDefaultCalendar": "Setting default calendar...",
+  "defaultCalendarSetSuccess": "Default calendar set successfully",
+  "defaultCalendarSetError": "Failed to set default calendar"
 }

--- a/apps/web/src/app/[locale]/(space)/settings/calendars/components/default-calendar-select.tsx
+++ b/apps/web/src/app/[locale]/(space)/settings/calendars/components/default-calendar-select.tsx
@@ -9,20 +9,49 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@rallly/ui/select";
+import { toast } from "@rallly/ui/sonner";
 import { Trans } from "@/components/trans";
+import { useTranslation } from "@/i18n/client";
 import { trpc } from "@/trpc/client";
+
+const NONE_VALUE = "none";
 
 export function DefaultCalendarSelect() {
   const { data: defaultCalendar } = trpc.calendars.getDefault.useQuery();
   const { data: connections } = trpc.calendars.list.useQuery();
 
+  const setDefaultCalendar = trpc.calendars.setDefault.useMutation();
+  const { t } = useTranslation();
+  const onValueChange = (value: string) => {
+    toast.promise(
+      setDefaultCalendar.mutateAsync({
+        calendarId: value === NONE_VALUE ? null : value,
+      }),
+      {
+        loading: t("settingDefaultCalendar", {
+          defaultValue: "Setting default calendar...",
+        }),
+        success: t("defaultCalendarSetSuccess", {
+          defaultValue: "Default calendar set successfully",
+        }),
+        error: t("defaultCalendarSetError", {
+          defaultValue: "Failed to set default calendar",
+        }),
+      },
+    );
+  };
+
   return (
-    <Select value={defaultCalendar?.defaultDestinationCalendarId ?? "none"}>
+    <Select
+      defaultValue={defaultCalendar?.defaultDestinationCalendarId ?? NONE_VALUE}
+      onValueChange={onValueChange}
+      disabled={setDefaultCalendar.isPending}
+    >
       <SelectTrigger>
         <SelectValue />
       </SelectTrigger>
       <SelectContent>
-        <SelectItem value="none">
+        <SelectItem value={NONE_VALUE}>
           <Trans
             i18nKey="defaultCalendarNone"
             defaults="No calendar selected"

--- a/apps/web/src/app/[locale]/(space)/settings/calendars/page.tsx
+++ b/apps/web/src/app/[locale]/(space)/settings/calendars/page.tsx
@@ -33,7 +33,10 @@ export default async function CalendarsPage() {
 
   const trpc = await createSSRHelper();
 
-  await trpc.calendars.list.prefetch();
+  await Promise.all([
+    trpc.calendars.list.prefetch(),
+    trpc.calendars.getDefault.prefetch(),
+  ]);
 
   return (
     <HydrationBoundary state={dehydrate(trpc.queryClient)}>

--- a/apps/web/src/features/calendars/mutations.ts
+++ b/apps/web/src/features/calendars/mutations.ts
@@ -204,3 +204,41 @@ export const setCalendarSelection = async (params: {
 
   return { success: true };
 };
+
+export const setDefaultCalendar = async ({
+  userId,
+  calendarId,
+}: {
+  userId: string;
+  calendarId: string | null;
+}) => {
+  if (calendarId) {
+    const calendar = await prisma.providerCalendar.findFirst({
+      where: { id: calendarId },
+      select: {
+        calendarConnectionId: true,
+        calendarConnection: {
+          select: { userId: true },
+        },
+      },
+    });
+
+    if (!calendar) {
+      return { success: false, error: "Calendar not found" as const };
+    }
+
+    if (calendar.calendarConnection.userId !== userId) {
+      return {
+        success: false,
+        error: "Calendar does not belong to user" as const,
+      };
+    }
+  }
+
+  await prisma.user.update({
+    where: { id: userId },
+    data: { defaultDestinationCalendarId: calendarId },
+  });
+
+  return { success: true };
+};

--- a/apps/web/src/trpc/routers/calendars.ts
+++ b/apps/web/src/trpc/routers/calendars.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 import {
   disconnectCalendarConnection,
   setCalendarSelection,
+  setDefaultCalendar,
   syncCalendars,
 } from "@/features/calendars/mutations";
 import { getCalendars, getDefaultCalendar } from "@/features/calendars/queries";
@@ -24,6 +25,14 @@ export const calendars = router({
   getDefault: privateProcedure.query(async ({ ctx }) => {
     return getDefaultCalendar(ctx.user.id);
   }),
+  setDefault: privateProcedure
+    .input(z.object({ calendarId: z.string().nullable() }))
+    .mutation(async ({ ctx, input }) => {
+      return setDefaultCalendar({
+        userId: ctx.user.id,
+        calendarId: input.calendarId,
+      });
+    }),
   setSelection: privateProcedure
     .input(
       z.object({


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Choose a default calendar (or “none”) in Settings with instant feedback via notifications.

- Improvements
  - Faster Calendars page load through parallel data fetching.
  - Localized loading, success, and error messages when updating the default calendar.
  - Disabled input while saving to prevent duplicate changes.
  - Clearer user feedback if the selected calendar is unavailable or not accessible.

- Bug Fixes
  - Fixed localization formatting so new messages display properly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->