### PR TITLE
🩹 Fix incorrect auth client base url

### DIFF
--- a/packages/utils/src/absolute-url.ts
+++ b/packages/utils/src/absolute-url.ts
@@ -22,6 +22,7 @@ export function absoluteUrl(
   const baseUrl =
     process.env.NEXT_PUBLIC_BASE_URL ??
     getVercelUrl() ??
+    (typeof window !== "undefined" ? window.location.origin : null) ??
     `http://localhost:${port}`;
 
   const url = new URL(subpath, baseUrl);


### PR DESCRIPTION
The base url used in the auth client is resolving at build time. This is problematic for self-hosters since the base url is only known at run-time. This is a temporary fix that resolved to using `window.location.origin` instead of defaulting to `http://localhost:3000`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved base URL detection in browser environments by adding a fallback to the browser's origin when configuration variables are unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->