### PR TITLE
🐛 Fix broken compatibility with previous oidc redirect uri

### DIFF
--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -57,6 +57,11 @@ const nextConfig = {
         destination: "/api/notifications/unsubscribe",
         permanent: true,
       },
+      {
+        source: "/api/auth/callback/oidc",
+        destination: "/api/better-auth/oauth2/callback/oidc",
+        permanent: false,
+      },
     ];
   },
   devIndicators: {

--- a/apps/web/src/lib/auth.ts
+++ b/apps/web/src/lib/auth.ts
@@ -48,6 +48,7 @@ if (env.OIDC_CLIENT_ID && env.OIDC_CLIENT_SECRET && env.OIDC_DISCOVERY_URL) {
           clientId: env.OIDC_CLIENT_ID,
           clientSecret: env.OIDC_CLIENT_SECRET,
           scopes: ["openid", "profile", "email"],
+          redirectURI: absoluteUrl("/api/auth/callback/oidc"),
           mapProfileToUser(profile) {
             return {
               name: getValueByPath(profile, env.OIDC_NAME_CLAIM_PATH) as string,


### PR DESCRIPTION
Fix #2010 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Restores OIDC callback compatibility by adding a redirect from `/api/auth/callback/oidc` to the BetterAuth callback and setting `redirectURI` to the legacy path.
> 
> - **Auth/OIDC**:
>   - Set `redirectURI` to `absoluteUrl("/api/auth/callback/oidc")` in `genericOAuth` config in `apps/web/src/lib/auth.ts`.
> - **Next.js config**:
>   - Add redirect from `"/api/auth/callback/oidc"` to `"/api/better-auth/oauth2/callback/oidc"` (non-permanent) in `apps/web/next.config.js`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 03e35835059a765fab0e2d6651c16b6b52459d68. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated OpenID Connect authentication callback configuration to ensure proper OAuth redirect routing for user login flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->