### PR TITLE
🐛 Handle legacy google and microsoft redirect uris

### DIFF
--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -62,6 +62,16 @@ const nextConfig = {
         destination: "/api/better-auth/oauth2/callback/oidc",
         permanent: false,
       },
+      {
+        source: "/api/auth/callback/google",
+        destination: "/api/better-auth/callback/google",
+        permanent: false,
+      },
+      {
+        source: "/api/auth/callback/microsoft-entra-id",
+        destination: "/api/better-auth/callback/microsoft",
+        permanent: false,
+      },
     ];
   },
   devIndicators: {

--- a/apps/web/src/lib/auth.ts
+++ b/apps/web/src/lib/auth.ts
@@ -149,6 +149,7 @@ export const authLib = betterAuth({
         ? {
             clientId: env.GOOGLE_CLIENT_ID,
             clientSecret: env.GOOGLE_CLIENT_SECRET,
+            redirectURI: absoluteUrl("/api/auth/callback/google"),
           }
         : undefined,
     microsoft:
@@ -157,6 +158,7 @@ export const authLib = betterAuth({
             tenantId: env.MICROSOFT_TENANT_ID,
             clientId: env.MICROSOFT_CLIENT_ID,
             clientSecret: env.MICROSOFT_CLIENT_SECRET,
+            redirectURI: absoluteUrl("/api/auth/callback/microsoft-entra-id"),
           }
         : undefined,
   },


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Add legacy OAuth callback redirects and update Google/Microsoft provider redirectURIs to use them.
> 
> - **Auth/OAuth**:
>   - Add redirects in `apps/web/next.config.js`:
>     - `GET /api/auth/callback/google` → `/api/better-auth/callback/google` (temporary)
>     - `GET /api/auth/callback/microsoft-entra-id` → `/api/better-auth/callback/microsoft` (temporary)
>   - Configure `socialProviders` in `apps/web/src/lib/auth.ts` to use these callback URLs via `redirectURI` for `google` and `microsoft`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c64acc5f455f3af0c49e1c5743ece77a026db825. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated OAuth provider configurations for Google and Microsoft authentication to properly route callback requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->