### PR TITLE
🔒️ Ensure only users with admin privileges can perform admin actions

### DIFF
--- a/apps/web/src/trpc/routers/polls.ts
+++ b/apps/web/src/trpc/routers/polls.ts
@@ -26,6 +26,17 @@ import {
 import { comments } from "./polls/comments";
 import { participants } from "./polls/participants";
 
+const hasPollAdminAccess = async (pollId: string, userId: string) => {
+  const poll = await prisma.poll.findFirst({
+    where: {
+      id: pollId,
+      OR: [{ userId: userId }, { space: { members: { some: { userId } } } }],
+    },
+  });
+
+  return poll !== null;
+};
+
 const getPollIdFromAdminUrlId = async (urlId: string) => {
   const res = await prisma.poll.findUnique({
     select: {
@@ -556,6 +567,15 @@ export const polls = router({
   watch: privateProcedure
     .input(z.object({ pollId: z.string() }))
     .mutation(async ({ input, ctx }) => {
+      const hasAccess = await hasPollAdminAccess(input.pollId, ctx.user.id);
+
+      if (!hasAccess) {
+        throw new TRPCError({
+          code: "FORBIDDEN",
+          message: "You are not allowed to watch this poll",
+        });
+      }
+
       await prisma.watcher.create({
         data: {
           pollId: input.pollId,
@@ -723,6 +743,15 @@ export const polls = router({
       }),
     )
     .mutation(async ({ input, ctx }) => {
+      const hasAccess = await hasPollAdminAccess(input.pollId, ctx.user.id);
+
+      if (!hasAccess) {
+        throw new TRPCError({
+          code: "FORBIDDEN",
+          message: "You are not allowed to book a date for this poll",
+        });
+      }
+
       const poll = await prisma.poll.findUnique({
         where: {
           id: input.pollId,
@@ -1031,6 +1060,15 @@ export const polls = router({
       }),
     )
     .mutation(async ({ input, ctx }) => {
+      const hasAccess = await hasPollAdminAccess(input.pollId, ctx.user.id);
+
+      if (!hasAccess) {
+        throw new TRPCError({
+          code: "FORBIDDEN",
+          message: "You are not allowed to reopen this poll",
+        });
+      }
+
       await prisma.$transaction(async () => {
         const poll = await prisma.poll.update({
           where: {
@@ -1066,6 +1104,15 @@ export const polls = router({
     )
     .use(requireUserMiddleware)
     .mutation(async ({ input, ctx }) => {
+      const hasAccess = await hasPollAdminAccess(input.pollId, ctx.user.id);
+
+      if (!hasAccess) {
+        throw new TRPCError({
+          code: "FORBIDDEN",
+          message: "You are not allowed to pause this poll",
+        });
+      }
+
       await prisma.poll.update({
         where: {
           id: input.pollId,
@@ -1092,6 +1139,15 @@ export const polls = router({
       }),
     )
     .mutation(async ({ input, ctx }) => {
+      const hasAccess = await hasPollAdminAccess(input.pollId, ctx.user.id);
+
+      if (!hasAccess) {
+        throw new TRPCError({
+          code: "FORBIDDEN",
+          message: "You are not allowed to duplicate this poll",
+        });
+      }
+
       const poll = await prisma.poll.findUnique({
         where: {
           id: input.pollId,
@@ -1155,6 +1211,15 @@ export const polls = router({
     )
     .use(requireUserMiddleware)
     .mutation(async ({ input, ctx }) => {
+      const hasAccess = await hasPollAdminAccess(input.pollId, ctx.user.id);
+
+      if (!hasAccess) {
+        throw new TRPCError({
+          code: "FORBIDDEN",
+          message: "You are not allowed to resume this poll",
+        });
+      }
+
       await prisma.poll.update({
         where: {
           id: input.pollId,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds server-side admin permission checks to key poll admin mutations (watch, book, reopen, pause, duplicate, resume).
> 
> - **Backend/API (`apps/web/src/trpc/routers/polls.ts`)**
>   - **Access Control**: Introduce `hasPollAdminAccess(pollId, userId)` and gate admin operations with `FORBIDDEN` on failure.
>     - Affected mutations: `watch`, `book`, `reopen`, `pause`, `duplicate`, `resume`.
>   - Keeps existing logic intact; adds checks before performing actions and tracking analytics.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c95f4b7e1f953af8d531c13b079515386bf5b9dd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Added permission validation to poll operations. The following actions now require admin access: watching, booking dates, reopening, pausing, duplicating, and resuming polls. Users attempting these actions without proper permissions will receive a clear error message.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->