### PR TITLE
🔒️ Ignore user input author name

### DIFF
--- a/apps/web/src/trpc/routers/polls/comments.ts
+++ b/apps/web/src/trpc/routers/polls/comments.ts
@@ -95,7 +95,7 @@ export const comments = router({
 
         if (!user) {
           throw new TRPCError({
-            code: "UNAUTHORIZED",
+            code: "INTERNAL_SERVER_ERROR",
             message: "User not found",
           });
         }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Authenticated commenters’ author names are now taken from their account profile (ignoring input), with a user lookup and error if missing.
> 
> - **Backend (poll comments)**
>   - Update `add` mutation in `apps/web/src/trpc/routers/polls/comments.ts` to ignore provided `authorName` for authenticated users and use `user.name` from the database.
>   - Add user validation: lookup by `ctx.user.id`; throw `INTERNAL_SERVER_ERROR` if not found.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2f4e53581c1b82669570061b9852a066eb7efd1c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Authenticated users' poll comments now display the registered profile name instead of any manually entered name, ensuring consistent author identification.
  * Added stronger validation for authenticated comment submissions to prevent creation of comments by nonexistent or unauthorized accounts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->