### PR TITLE
🐛 Fix issue that prevents space from being deleted

### DIFF
--- a/apps/web/src/features/space/actions.ts
+++ b/apps/web/src/features/space/actions.ts
@@ -145,7 +145,7 @@ export const deleteSpaceAction = spaceActionClient
     if (ctx.getMemberAbility().cannot("delete", subject("Space", space))) {
       throw new AppError({
         code: "FORBIDDEN",
-        message: "You do not have permission to delete to this space",
+        message: "You do not have permission to delete this space",
       });
     }
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Blocks deleting a space if it has active subscriptions and updates the permission error message for deletion.
> 
> - **Backend**
>   - **`deleteSpaceAction` (`apps/web/src/features/space/actions.ts`)**:
>     - Query active `subscriptions` when fetching a space.
>     - Replace tier-based check with an active subscription check before deletion.
>     - Update forbidden message to clarify lack of delete permission.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 99c51d6446abd98397e080ccdbb98259de9b739a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Clarified the permission error shown when users lack rights to delete a space ("You do not have permission to delete this space").

* **Refactor**
  * Space deletion now checks for active subscriptions and prevents deletion if any exist (replacing the previous tier-based restriction).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->