### PR TITLE
🐛 Fix timezone warning

### DIFF
--- a/apps/web/src/lib/timezone/client/context.tsx
+++ b/apps/web/src/lib/timezone/client/context.tsx
@@ -4,7 +4,7 @@ import dayjs from "dayjs";
 import timezone from "dayjs/plugin/timezone";
 import * as React from "react";
 
-import { getBrowserTimeZone } from "@/utils/date-time-utils";
+import { getBrowserTimeZone, normalizeTimeZone } from "@/utils/date-time-utils";
 
 dayjs.extend(timezone);
 
@@ -24,19 +24,14 @@ export const TimezoneProvider = ({
   children,
   initialTimezone,
 }: TimezoneProviderProps) => {
-  const [timezone, setTimezone] = React.useState(() => {
+  const [timezone, setTimezone] = React.useState<string>(() => {
     if (initialTimezone) {
-      try {
-        dayjs().tz(initialTimezone);
-        return initialTimezone;
-      } catch (error) {
-        console.warn(error);
-      }
+      return normalizeTimeZone(initialTimezone);
     }
-
     return getBrowserTimeZone();
   });
 
+  console.log("timezone", timezone);
   const value = React.useMemo(() => ({ timezone, setTimezone }), [timezone]);
 
   return (


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Normalize initial timezone on load, type the timezone state explicitly, and add a debug log in the timezone context.
> 
> - **Timezone Context (`apps/web/src/lib/timezone/client/context.tsx`)**:
>   - Normalize `initialTimezone` using `normalizeTimeZone` instead of `dayjs().tz` try/catch.
>   - Explicitly type React state as `string`.
>   - Retain fallback to `getBrowserTimeZone()`.
>   - Add `console.log` for current `timezone`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit be7a39edce2b92e314f479f8c7eea3c0eb8efa7b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved timezone initialization and normalization logic for more consistent timezone handling across the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->