### PR TITLE
📌 Pin prisma to v6 in Dockerfile

### DIFF
--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -58,7 +58,7 @@ RUN apt-get update \
 WORKDIR /app
 
 # Install prisma globally needed for runtime operations like migrations
-RUN pnpm add -g prisma
+RUN pnpm add -g prisma@6
 
 # Don't run production as root
 RUN addgroup --system nodejs \


### PR DESCRIPTION
Pin prisma to v6 to avoid pulling v7 which isn't fully supported yet. See #2028 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Prisma dependency to version 6 in the container runtime environment to ensure consistent versioning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->