### PR TITLE
🐛 Default to pro space when self-hosting

### DIFF
--- a/apps/web/src/features/space/mutations.ts
+++ b/apps/web/src/features/space/mutations.ts
@@ -1,16 +1,21 @@
+import type { SpaceTier } from "@rallly/database";
 import { prisma } from "@rallly/database";
+import { isSelfHosted } from "@/utils/constants";
 
 export async function createSpace({
   name = "Personal",
   ownerId,
+  tier = isSelfHosted ? "pro" : "hobby",
 }: {
   name?: string;
   ownerId: string;
+  tier?: SpaceTier;
 }) {
   const space = await prisma.space.create({
     data: {
       name,
       ownerId,
+      tier,
       members: {
         create: {
           userId: ownerId,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Spaces are now assigned a tier level automatically, defaulting to "pro" for self-hosted deployments and "hobby" otherwise.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->