### PR TITLE
🐛 Fix issue where user cannot be deleted

### DIFF
--- a/apps/web/src/features/user/ability.ts
+++ b/apps/web/src/features/user/ability.ts
@@ -51,9 +51,9 @@ function defineAbilityForUser(
 
   // Cannot delete user if they have active subscriptions
   cannot("delete", "User", {
-    spaces: {
+    subscriptions: {
       some: {
-        tier: "pro",
+        active: true,
       },
     },
   });

--- a/apps/web/src/features/user/actions.ts
+++ b/apps/web/src/features/user/actions.ts
@@ -64,9 +64,9 @@ export const deleteUserAction = adminActionClient
     const user = await prisma.user.findUnique({
       where: { id: userId },
       include: {
-        spaces: {
+        subscriptions: {
           select: {
-            tier: true,
+            active: true,
           },
         },
       },


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated user deletion permission so account removal now checks whether a user has an active subscription. The system uses subscription active status (instead of the previous space-tier criterion) when determining if an account may be deleted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->