### PR TITLE
fix: center profile image properly with object-center

### DIFF
--- a/apps/web/src/components/optimized-avatar-image.tsx
+++ b/apps/web/src/components/optimized-avatar-image.tsx
@@ -27,7 +27,7 @@ export function OptimizedAvatarImage({
             width={128}
             height={128}
             alt={name}
-            style={{ objectFit: "cover" }}
+            className="object-cover object-center"
             onLoad={() => {
               setLoaded(true);
             }}

--- a/packages/ui/src/avatar.tsx
+++ b/packages/ui/src/avatar.tsx
@@ -41,7 +41,10 @@ const AvatarImage = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <AvatarPrimitive.Image
     ref={ref}
-    className={cn("aspect-square h-full w-full", className)}
+    className={cn(
+      "aspect-square h-full w-full object-cover object-center",
+      className,
+    )}
     {...props}
   />
 ));


### PR DESCRIPTION
## Summary
- Add `object-cover` and `object-center` classes to ensure profile images are properly centered within their container
- Fix applied to both `OptimizedAvatarImage` component (Next.js Image) and `AvatarImage` component for consistency

## Problem
After uploading and cropping an image that appears centered in the crop dialog, the final rendered image displays slightly shifted to the right instead of being centered.

## Solution
The issue was that the image elements were missing explicit `object-position: center` CSS. While `object-fit: cover` was applied, the default object-position can vary across browsers. Adding `object-center` (Tailwind class for `object-position: center`) ensures consistent centering.

## Changes
- `apps/web/src/components/optimized-avatar-image.tsx`: Replace `style={{ objectFit: "cover" }}` with `className="object-cover object-center"`
- `packages/ui/src/avatar.tsx`: Add `object-cover object-center` to AvatarImage component

## Test Plan
- [ ] Upload a profile image with distinct center content
- [ ] Verify the image appears centered in the avatar display
- [ ] Test on different browsers (Safari, Chrome, Firefox)

Fixes #2014

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated avatar components to use Tailwind CSS utilities for image positioning and sizing, replacing inline style approaches while maintaining consistent visual behavior across avatar elements.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->