### PR TITLE
fix: improve mobile poll layout for narrow screens

### DIFF
--- a/apps/web/src/components/poll/mobile-poll/poll-option.tsx
+++ b/apps/web/src/components/poll/mobile-poll/poll-option.tsx
@@ -130,9 +130,9 @@ const PollOption: React.FunctionComponent<PollOptionProps> = ({
         selectorRef.current?.click();
       }}
     >
-      <div className="flex h-7 items-center justify-between gap-x-4">
-        <div className="shrink-0">{children}</div>
-        <div className="flex items-center gap-x-4">
+      <div className="flex h-7 min-w-0 items-center justify-between gap-x-4">
+        <div className="min-w-0 shrink">{children}</div>
+        <div className="flex shrink-0 items-center gap-x-4">
           {role === "participant" && poll.hideParticipants ? (
             <ConnectedScoreSummary optionId={optionId} />
           ) : (
@@ -152,7 +152,7 @@ const PollOption: React.FunctionComponent<PollOptionProps> = ({
           )}
 
           {showVotes ? (
-            <div className="relative flex size-7 items-center justify-center">
+            <div className="relative flex size-7 shrink-0 items-center justify-center">
               {editable ? (
                 <VoteSelector
                   ref={selectorRef}

--- a/apps/web/src/components/poll/mobile-poll/time-slot-option.tsx
+++ b/apps/web/src/components/poll/mobile-poll/time-slot-option.tsx
@@ -17,11 +17,11 @@ const TimeSlotOption: React.FunctionComponent<TimeSlotOptionProps> = ({
 }) => {
   return (
     <PollOption {...rest}>
-      <div className="flex items-center gap-x-4 text-sm">
-        <div>{startTime}</div>
-        <div className="flex items-center gap-x-1.5 opacity-50">
-          <ClockIcon className="size-4" />
-          {duration}
+      <div className="flex min-w-0 items-center gap-x-2 text-sm sm:gap-x-4">
+        <div className="shrink-0">{startTime}</div>
+        <div className="flex min-w-0 items-center gap-x-1 opacity-50 sm:gap-x-1.5">
+          <ClockIcon className="size-4 shrink-0" />
+          <span className="truncate">{duration}</span>
         </div>
       </div>
     </PollOption>


### PR DESCRIPTION
## Summary
Fixes layout issues on mobile devices with narrow screens (<300px) where the vote selector button would get cut off when time slot options have long duration labels (e.g., "1h 30m").

## Problem
On devices with low screen widths, the vote selector button becomes partially or fully hidden when polls display date options with extended duration text. Users cannot access the voting functionality on very narrow screens.

## Solution
Instead of adding horizontal scrolling (which may not be intuitive for users), this fix uses CSS flexbox properties to ensure proper content sizing:

### Changes in `poll-option.tsx`:
- Add `min-w-0` to flex containers to allow children to shrink below content size
- Add `shrink-0` to the vote selector container to prevent it from being cut off
- Change children container from `shrink-0` to `shrink` with `min-w-0` to allow graceful shrinking

### Changes in `time-slot-option.tsx`:
- Add `min-w-0` to allow the time slot content to shrink
- Add `shrink-0` to keep start time always visible
- Add `truncate` to duration text for graceful text overflow
- Reduce gaps on mobile (`gap-x-2`, `gap-x-1`) with larger gaps on `sm+` screens (`sm:gap-x-4`, `sm:gap-x-1.5`)

## Test Plan
- [ ] Test on viewport width of 300px or less
- [ ] Test with time slot options with extended durations (1h 30m, 2h 15m, etc.)
- [ ] Verify vote selector button is always accessible
- [ ] Test on both editable and view-only modes
- [ ] Test on different mobile browsers (Safari, Chrome)

## Screenshots
Testing should be done on narrow viewports - the vote button should remain visible and accessible.

Fixes #1437

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced mobile poll display with refined layout spacing and improved text handling to prevent overflow on poll options and time slot selections.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->