### PR TITLE
🐛 Fix timezone-dependent test failures in generateTimeSlots

### DIFF
--- a/apps/web/src/app/api/private/utils/time-slots.ts
+++ b/apps/web/src/app/api/private/utils/time-slots.ts
@@ -74,12 +74,9 @@ export const generateTimeSlots = (
 
   const allowed = new Set(generator.daysOfWeek.map((d) => dayMap[d]));
 
-  const startDay = timeZone
-    ? dayjs(generator.startDate).tz(timeZone, true).startOf("day")
-    : dayjs(generator.startDate).utc(true).startOf("day");
-  const endDay = timeZone
-    ? dayjs(generator.endDate).tz(timeZone, true).startOf("day")
-    : dayjs(generator.endDate).utc(true).startOf("day");
+  // Use UTC for date iteration to avoid local timezone interference
+  const startDay = dayjs.utc(generator.startDate).startOf("day");
+  const endDay = dayjs.utc(generator.endDate).startOf("day");
 
   const from = parseLocalDateTimeInTimeZone(
     generator.startDate,
@@ -102,11 +99,12 @@ export const generateTimeSlots = (
     cursor.isSameOrBefore(endDay, "day");
     cursor = cursor.add(1, "day")
   ) {
-    if (!allowed.has(cursor.day())) {
+    const date = cursor.format("YYYY-MM-DD");
+    // Get day of week in the target timezone
+    const dayInTz = timeZone ? dayjs.tz(date, timeZone).day() : cursor.day();
+    if (!allowed.has(dayInTz)) {
       continue;
     }
-
-    const date = cursor.format("YYYY-MM-DD");
     const windowStart = parseLocalDateTimeInTimeZone(
       date,
       generator.fromTime,


### PR DESCRIPTION
### The problem
`dayjs.tz()` and `dayjs().add(1, 'day')` were being affected by the local system timezone. When adding 1 day to a UTC midnight timestamp in a non-UTC timezone, dayjs was incorrectly calculating the next day.

### The fix

Use `dayjs.utc()` for the date iteration loop (which is purely about iterating over calendar dates) and only apply the target timezone when checking the day of week and generating actual time slots. This makes the date iteration timezone-agnostic

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed time slot availability calculation to properly consider the specified time zone when filtering days of the week. This ensures time slots are correctly displayed based on the target time zone rather than local settings.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->