### PR TITLE
♻️ Move timezone change detector to dashboard layout

### DIFF
--- a/apps/web/src/app/[locale]/(space)/(dashboard)/layout.tsx
+++ b/apps/web/src/app/[locale]/(space)/(dashboard)/layout.tsx
@@ -18,6 +18,7 @@ import Link from "next/link";
 import { FeedbackMenuItem } from "@/app/[locale]/(space)/(dashboard)/components/feedback-menu-item";
 import { SpaceSidebarMenu } from "@/app/[locale]/(space)/(dashboard)/components/space-sidebar-menu";
 import { UpgradeMenuItem } from "@/app/[locale]/(space)/(dashboard)/components/upgrade-menu-item";
+import { TimeZoneChangeDetector } from "@/app/[locale]/timezone-change-detector";
 import { requireSpace, requireUser } from "@/auth/data";
 import { NavUser } from "@/components/nav-user";
 import { LicenseLimitWarning } from "@/features/licensing/components/license-limit-warning";
@@ -41,6 +42,7 @@ export default async function Layout({
 
   return (
     <SpaceSidebarProvider>
+      <TimeZoneChangeDetector />
       <CommandMenu />
       <Sidebar>
         <SidebarHeader>

--- a/apps/web/src/app/[locale]/layout.tsx
+++ b/apps/web/src/app/[locale]/layout.tsx
@@ -7,7 +7,6 @@ import { domAnimation, LazyMotion } from "motion/react";
 import type { Metadata, Viewport } from "next";
 import { Inter } from "next/font/google";
 import type React from "react";
-import { TimeZoneChangeDetector } from "@/app/[locale]/timezone-change-detector";
 import type { Params } from "@/app/[locale]/types";
 import { requireUser } from "@/auth/data";
 import { UserProvider } from "@/components/user-provider";
@@ -122,7 +121,6 @@ export default async function Root({
                             <TimezoneProvider initialTimezone={user?.timeZone}>
                               <ConnectedDayjsProvider>
                                 {children}
-                                <TimeZoneChangeDetector />
                               </ConnectedDayjsProvider>
                             </TimezoneProvider>
                           </PreferencesProvider>


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Small UI wiring change limited to where a client component mounts; low risk aside from potentially changing when/where users see the timezone prompt.
> 
> **Overview**
> Moves `TimeZoneChangeDetector` from the global `[locale]/layout.tsx` to the dashboard `(space)/(dashboard)/layout.tsx`, changing its scope from app-wide to dashboard-only.
> 
> This means timezone-change prompting/analytics will no longer trigger on non-dashboard pages and will mount alongside the dashboard sidebar layout instead.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 49d1519c227e47d688b4bcf7bc734b3a1e31ac6e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized timezone change detection to be scoped to the dashboard context instead of the application root level, improving code organization and specificity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->