### PR TITLE
🔒️ Check poll admin privilage before mutation

### DIFF
--- a/apps/web/src/trpc/routers/polls.ts
+++ b/apps/web/src/trpc/routers/polls.ts
@@ -391,6 +391,13 @@ export const polls = router({
     .mutation(async ({ input, ctx }) => {
       const pollId = await getPollIdFromAdminUrlId(input.urlId);
 
+      if (!(await hasPollAdminAccess(pollId, ctx.user.id))) {
+        throw new TRPCError({
+          code: "FORBIDDEN",
+          message: "You do not have permission to update this poll",
+        });
+      }
+
       if (input.optionsToDelete && input.optionsToDelete.length > 0) {
         await prisma.option.deleteMany({
           where: {
@@ -579,6 +586,14 @@ export const polls = router({
     .use(requireUserMiddleware)
     .mutation(async ({ input: { urlId }, ctx }) => {
       const pollId = await getPollIdFromAdminUrlId(urlId);
+
+      if (!(await hasPollAdminAccess(pollId, ctx.user.id))) {
+        throw new TRPCError({
+          code: "FORBIDDEN",
+          message: "You do not have permission to delete this poll",
+        });
+      }
+
       await prisma.poll.update({
         where: { id: pollId },
         data: { deleted: true, deletedAt: new Date() },


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved poll access control by enforcing authorization checks during update and delete operations.
  * Unauthorized users attempting to modify or delete a poll will now receive a proper error response instead of proceeding with the operation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->