### PR TITLE
🔒️ Harden rate limits on auth endpoints

### DIFF
--- a/apps/web/src/lib/auth.ts
+++ b/apps/web/src/lib/auth.ts
@@ -224,6 +224,16 @@ export const authLib = betterAuth({
   rateLimit: {
     enabled: isRateLimitEnabled,
     storage: isKvEnabled() ? "secondary-storage" : "memory",
+    customRules: {
+      "/sign-up/email": {
+        window: 60 * 60, // 1 hour
+        max: 5,
+      },
+      "/email-otp/send-verification-otp": {
+        window: 60 * 60, // 1 hour
+        max: 10,
+      },
+    },
   },
   account: {
     accountLinking: {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Rate limiting introduced to protect account creation and email OTP verification flows: sign-up attempts are limited to reduce abuse and email verification attempts are capped to prevent brute-force OTP usage. Users may see temporary blocks if limits are exceeded; normal usage remains unaffected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->