### PR TITLE
🔥 Remove unused input schema

### DIFF
--- a/apps/web/src/app/api/stripe/checkout/route.ts
+++ b/apps/web/src/app/api/stripe/checkout/route.ts
@@ -15,7 +15,6 @@ import { getSession } from "@/lib/auth";
 
 const inputSchema = z.object({
   period: z.enum(["monthly", "yearly"]).optional(),
-  success_path: z.string().optional(),
   return_path: z.string().optional(),
 });
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed the optional `success_path` parameter from the Stripe checkout endpoint. If you were using this parameter in requests, it will no longer be accepted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->