### PR TITLE
✨ Add Reply-To headers to poll notification emails

### DIFF
--- a/apps/web/src/trpc/routers/polls/participants.ts
+++ b/apps/web/src/trpc/routers/polls/participants.ts
@@ -50,10 +50,12 @@ async function sendNewParticipantNotifcationEmail({
   pollId,
   pollTitle,
   participantName,
+  participantEmail,
 }: {
   pollId: string;
   pollTitle: string;
   participantName: string;
+  participantEmail?: string;
 }) {
   const watchers = await prisma.watcher.findMany({
     where: {
@@ -84,6 +86,7 @@ async function sendNewParticipantNotifcationEmail({
         const emailClient = await getEmailClient(watcherLocale);
         await emailClient.sendTemplate("NewParticipantEmail", {
           to: email,
+          replyTo: participantEmail,
           props: {
             participantName,
             pollUrl: absoluteUrl(`/poll/${pollId}`),
@@ -271,6 +274,11 @@ export const participants = router({
                 id: true,
                 title: true,
                 userId: true,
+                user: {
+                  select: {
+                    email: true,
+                  },
+                },
               },
             },
           },
@@ -287,6 +295,7 @@ export const participants = router({
 
           emailClient.queueTemplate("NewParticipantConfirmationEmail", {
             to: email,
+            replyTo: participant.poll.user?.email,
             props: {
               title: participant.poll.title,
               editSubmissionUrl: absoluteUrl(
@@ -301,6 +310,7 @@ export const participants = router({
             pollId,
             pollTitle: participant.poll.title,
             participantName: participant.name,
+            participantEmail: email,
           }),
         );
 

--- a/packages/emails/src/send-email.tsx
+++ b/packages/emails/src/send-email.tsx
@@ -16,6 +16,7 @@ type SendEmailOptions<T extends TemplateName> = {
     name: string;
     address: string;
   };
+  replyTo?: string;
   props: TemplateProps<T>;
   attachments?: Mail.Options["attachments"];
   icalEvent?: Mail.Options["icalEvent"];
@@ -116,6 +117,7 @@ export class EmailClient {
       await this.sendEmail({
         from: options.from || this.config.mail.from,
         to: options.to,
+        replyTo: options.replyTo,
         subject,
         html,
         text,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Email notifications now support reply-to addresses, allowing users to easily respond directly to poll participant notifications and communications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->