### PR TITLE
✨ Include participant email in notification if provided

### DIFF
--- a/apps/web/src/trpc/routers/polls/participants.ts
+++ b/apps/web/src/trpc/routers/polls/participants.ts
@@ -50,10 +50,12 @@ async function sendNewParticipantNotifcationEmail({
   pollId,
   pollTitle,
   participantName,
+  participantEmail,
 }: {
   pollId: string;
   pollTitle: string;
   participantName: string;
+  participantEmail?: string;
 }) {
   const watchers = await prisma.watcher.findMany({
     where: {
@@ -86,6 +88,7 @@ async function sendNewParticipantNotifcationEmail({
           to: email,
           props: {
             participantName,
+            participantEmail,
             pollUrl: absoluteUrl(`/poll/${pollId}`),
             disableNotificationsUrl: absoluteUrl(
               `/api/notifications/unsubscribe?token=${token}`,
@@ -301,6 +304,7 @@ export const participants = router({
             pollId,
             pollTitle: participant.poll.title,
             participantName: participant.name,
+            participantEmail: email,
           }),
         );
 

--- a/packages/emails/locales/ca/emails.json
+++ b/packages/emails/locales/ca/emails.json
@@ -28,7 +28,7 @@
   "newParticipantConfirmation_preview": "Per editar la teva resposta, utilitza l'enllaç a continuació",
   "newParticipantConfirmation_heading": "Confirmació de Resposta de l'Enquesta",
   "newParticipantConfirmation_subject": "Gràcies per respondre a {title}",
-  "newParticipant_content": "<b>{name}</b> ha respost a <b>{title}</b>.",
+  "newParticipant_content": "<b>{name}</b><email /> ha respost a <b>{title}</b>.",
   "newParticipant_content2": "Ves a la teva enquesta per veure la nova resposta.",
   "newParticipant_preview": "Ves a la teva enquesta per veure la nova resposta.",
   "newParticipant_heading": "Nova Resposta",

--- a/packages/emails/locales/cs/emails.json
+++ b/packages/emails/locales/cs/emails.json
@@ -22,7 +22,7 @@
   "newParticipantConfirmation_preview": "K úpravě své reakce použijte níže uvedený odkaz",
   "newParticipantConfirmation_heading": "Potvrzení reakce na anketu",
   "newParticipantConfirmation_subject": "Děkujeme za reakci na {title}",
-  "newParticipant_content": "<b>{name}</b> reagoval na <b>{title}</b>.",
+  "newParticipant_content": "<b>{name}</b><email /> reagoval na <b>{title}</b>.",
   "newParticipant_content2": "Přejděte na svou anketu, abyste viděli novou reakci.",
   "newParticipant_preview": "Přejděte na svou anketu, abyste viděli novou reakci.",
   "newParticipant_heading": "Nová reakce",

--- a/packages/emails/locales/da/emails.json
+++ b/packages/emails/locales/da/emails.json
@@ -22,7 +22,7 @@
   "newParticipantConfirmation_preview": "For at redigere dit svar, skal du bruge linket nedenfor",
   "newParticipantConfirmation_heading": "Bekræftelse på afgivelse af svar",
   "newParticipantConfirmation_subject": "Tak for at svare på {title}",
-  "newParticipant_content": "<b>{name}</b> har svaret på <b>{title}</b>.",
+  "newParticipant_content": "<b>{name}</b><email /> har svaret på <b>{title}</b>.",
   "newParticipant_content2": "Gå til din afstemning, for at se det nye svar.",
   "newParticipant_preview": "Gå til din afstemning for at se det nye svar.",
   "newParticipant_heading": "Ny besvarelse",

--- a/packages/emails/locales/de/emails.json
+++ b/packages/emails/locales/de/emails.json
@@ -22,7 +22,7 @@
   "newParticipantConfirmation_preview": "Um deine Antwort zu bearbeiten, verwende den Link unten stehenden Link",
   "newParticipantConfirmation_heading": "Bestätigung der Umfrageantwort",
   "newParticipantConfirmation_subject": "Vielen Dank für die Antwort auf {title}",
-  "newParticipant_content": "<b>{name}</b> hat auf <b>{title}</b> geantwortet.",
+  "newParticipant_content": "<b>{name}</b><email /> hat auf <b>{title}</b> geantwortet.",
   "newParticipant_content2": "Gehe zu deiner Umfrage, um die neue Antwort zu sehen.",
   "newParticipant_preview": "Gehe zu deiner Umfrage, um die neue Antwort zu sehen.",
   "newParticipant_heading": "Neue Antwort",

--- a/packages/emails/locales/en/emails.json
+++ b/packages/emails/locales/en/emails.json
@@ -22,7 +22,7 @@
   "newParticipantConfirmation_preview": "To edit your response use the link below",
   "newParticipantConfirmation_heading": "Poll Response Confirmation",
   "newParticipantConfirmation_subject": "Thanks for responding to {title}",
-  "newParticipant_content": "<b>{name}</b> has responded to <b>{title}</b>.",
+  "newParticipant_content": "<b>{name}</b><email /> has responded to <b>{title}</b>.",
   "newParticipant_content2": "Go to your poll to see the new response.",
   "newParticipant_preview": "Go to your poll to see the new response.",
   "newParticipant_heading": "New Response",

--- a/packages/emails/locales/es/emails.json
+++ b/packages/emails/locales/es/emails.json
@@ -22,7 +22,7 @@
   "newParticipantConfirmation_preview": "Para editar tu respuesta utiliza el siguiente enlace",
   "newParticipantConfirmation_heading": "Confirmación de respuesta a encuesta",
   "newParticipantConfirmation_subject": "Gracias por responder a {title}",
-  "newParticipant_content": "<b>{name}</b> ha respondido a <b>{title}</b>.",
+  "newParticipant_content": "<b>{name}</b><email /> ha respondido a <b>{title}</b>.",
   "newParticipant_content2": "Ve a tu encuesta para ver la nueva respuesta.",
   "newParticipant_preview": "Ve a tu encuesta para ver la nueva respuesta.",
   "newParticipant_heading": "Nueva respuesta",

--- a/packages/emails/locales/eu/emails.json
+++ b/packages/emails/locales/eu/emails.json
@@ -28,7 +28,7 @@
   "newParticipantConfirmation_preview": "Zure erantzuna editatzeko, erabili beheko esteka",
   "newParticipantConfirmation_heading": "Inkestaren erantzunaren berrespena",
   "newParticipantConfirmation_subject": "Eskerrik asko {title}-ri erantzuteagatik",
-  "newParticipant_content": "<b>{name}</b>-k erantzun dio <b>{title}</b>ri.",
+  "newParticipant_content": "<b>{name}</b><email />-k erantzun dio <b>{title}</b>ri.",
   "newParticipant_content2": "Joan zure inkestara erantzun berria ikusteko.",
   "newParticipant_preview": "Joan zure inkestara erantzun berria ikusteko.",
   "newParticipant_heading": "Erantzun berria",

--- a/packages/emails/locales/fi/emails.json
+++ b/packages/emails/locales/fi/emails.json
@@ -22,7 +22,7 @@
   "newParticipantConfirmation_preview": "Käytä alla olevaa linkkiä muokataksesi vastaustasi",
   "newParticipantConfirmation_heading": "Kyselyn vastausvahvistus",
   "newParticipantConfirmation_subject": "Kiitos vastauksestasi kyselyyn {title}",
-  "newParticipant_content": "<b>{name}</b> on vastannut <b>{title}</b>.",
+  "newParticipant_content": "<b>{name}</b><email /> on vastannut <b>{title}</b>.",
   "newParticipant_content2": "Siirry kyselyysi nähdäksesi uusi vastaus.",
   "newParticipant_preview": "Siirry kyselyysi nähdäksesi uusi vastaus.",
   "newParticipant_heading": "Uusi vastaus",

--- a/packages/emails/locales/fr/emails.json
+++ b/packages/emails/locales/fr/emails.json
@@ -22,7 +22,7 @@
   "newParticipantConfirmation_preview": "Pour modifier votre réponse, utilisez le lien ci-dessous",
   "newParticipantConfirmation_heading": "Confirmation de réponse au sondage",
   "newParticipantConfirmation_subject": "Merci d'avoir répondu à {title}",
-  "newParticipant_content": "<b>{name}</b> a répondu à <b>{title}</b>.",
+  "newParticipant_content": "<b>{name}</b><email /> a répondu à <b>{title}</b>.",
   "newParticipant_content2": "Allez à votre sondage pour voir la nouvelle réponse.",
   "newParticipant_preview": "Allez à votre sondage pour voir la nouvelle réponse.",
   "newParticipant_heading": "Nouvelle réponse",

--- a/packages/emails/locales/hr/emails.json
+++ b/packages/emails/locales/hr/emails.json
@@ -28,7 +28,7 @@
   "newParticipantConfirmation_preview": "Za uređivanje svog odgovora upotrijebite vezu u nastavku",
   "newParticipantConfirmation_heading": "Potvrda odgovora na anketu",
   "newParticipantConfirmation_subject": "Hvala na odgovaranju na {title}",
-  "newParticipant_content": "<b>{name}</b> je odgovorio na <b>{title}</b>.",
+  "newParticipant_content": "<b>{name}</b><email /> je odgovorio na <b>{title}</b>.",
   "newParticipant_content2": "Idite na svoju anketu i pogledajte novi odgovor.",
   "newParticipant_preview": "Idite na svoju anketu i pogledajte novi odgovor.",
   "newParticipant_heading": "Novi odgovor",

--- a/packages/emails/locales/hu/emails.json
+++ b/packages/emails/locales/hu/emails.json
@@ -22,7 +22,7 @@
   "newParticipantConfirmation_preview": "A válaszod szerkesztéséhez használd az alábbi hivatkozást",
   "newParticipantConfirmation_heading": "Szavazat megerősítés",
   "newParticipantConfirmation_subject": "Köszönjük a válaszod erre: {title}",
-  "newParticipant_content": "<b>{name}</b> szavazott erre: <b>{title}</b>.",
+  "newParticipant_content": "<b>{name}</b><email /> szavazott erre: <b>{title}</b>.",
   "newParticipant_content2": "Irány a szavazás, hogy láthasd az új szavazatokat.",
   "newParticipant_preview": "Irány a szavazás, hogy láthasd az új szavazatokat.",
   "newParticipant_heading": "Új szavazat",

--- a/packages/emails/locales/it/emails.json
+++ b/packages/emails/locales/it/emails.json
@@ -22,7 +22,7 @@
   "newParticipantConfirmation_preview": "Per modificare la tua risposta usa il link qui sotto",
   "newParticipantConfirmation_heading": "Conferma Risposta al Sondaggio",
   "newParticipantConfirmation_subject": "Grazie per aver risposto a {title}",
-  "newParticipant_content": "<b>{name}</b> ha risposto a <b>{title}</b>.",
+  "newParticipant_content": "<b>{name}</b><email /> ha risposto a <b>{title}</b>.",
   "newParticipant_content2": "Vai al tuo sondaggio per vedere la nuova risposta.",
   "newParticipant_preview": "Vai al tuo sondaggio per vedere la nuova risposta.",
   "newParticipant_heading": "Nuova Risposta",

--- a/packages/emails/locales/ja/emails.json
+++ b/packages/emails/locales/ja/emails.json
@@ -28,7 +28,7 @@
   "newParticipantConfirmation_preview": "回答を編集するには、以下のリンクを使用してください",
   "newParticipantConfirmation_heading": "アンケート回答の確認",
   "newParticipantConfirmation_subject": "{title} への回答ありがとうございます",
-  "newParticipant_content": "<b>{name}</b> が <b>{title}</b> に回答しました。",
+  "newParticipant_content": "<b>{name}</b><email /> が <b>{title}</b> に回答しました。",
   "newParticipant_content2": "新しい回答を表示するには、アンケートにアクセスしてください。",
   "newParticipant_preview": "新しい回答を表示するには、アンケートにアクセスしてください。",
   "newParticipant_heading": "新しい回答",

--- a/packages/emails/locales/nl/emails.json
+++ b/packages/emails/locales/nl/emails.json
@@ -22,7 +22,7 @@
   "newParticipantConfirmation_preview": "Gebruik de onderstaande link om je reactie te bewerken",
   "newParticipantConfirmation_heading": "Bevestiging van reactie op poll",
   "newParticipantConfirmation_subject": "Bedankt voor je reactie op {title}",
-  "newParticipant_content": "<b>{name}</b> heeft gereageerd op <b>{title}</b>.",
+  "newParticipant_content": "<b>{name}</b><email /> heeft gereageerd op <b>{title}</b>.",
   "newParticipant_content2": "Ga naar je poll om de nieuwe reactie te bekijken.",
   "newParticipant_preview": "Ga naar je poll om de nieuwe reactie te bekijken.",
   "newParticipant_heading": "Nieuwe reactie",

--- a/packages/emails/locales/no/emails.json
+++ b/packages/emails/locales/no/emails.json
@@ -22,7 +22,7 @@
   "newParticipantConfirmation_preview": "For å redigere svaret ditt, bruk lenken under",
   "newParticipantConfirmation_heading": "Bekreftelse av avstemningsrespons",
   "newParticipantConfirmation_subject": "Takk for at du svarte på {title}",
-  "newParticipant_content": "<b>{name}</b> har besvart <b>{title}</b>.",
+  "newParticipant_content": "<b>{name}</b><email /> har besvart <b>{title}</b>.",
   "newParticipant_content2": "Gå til avstemningen din for å se det nye svaret.",
   "newParticipant_preview": "Gå til avstemningen din for å se det nye svaret.",
   "newParticipant_heading": "Ny respons",

--- a/packages/emails/locales/pl/emails.json
+++ b/packages/emails/locales/pl/emails.json
@@ -22,7 +22,7 @@
   "newParticipantConfirmation_preview": "Aby edytować swoją odpowiedź, użyj linku poniżej",
   "newParticipantConfirmation_heading": "Potwierdzenie odpowiedzi w ankiecie",
   "newParticipantConfirmation_subject": "Dziękujemy za odpowiedź na {title}",
-  "newParticipant_content": "<b>{name}</b> odpowiedział na <b>{title}</b>.",
+  "newParticipant_content": "<b>{name}</b><email /> odpowiedział na <b>{title}</b>.",
   "newParticipant_content2": "Przejdź do swojej ankiety, aby zobaczyć nową odpowiedź.",
   "newParticipant_preview": "Przejdź do swojej ankiety, aby zobaczyć nową odpowiedź.",
   "newParticipant_heading": "Nowa odpowiedź",

--- a/packages/emails/locales/pt-BR/emails.json
+++ b/packages/emails/locales/pt-BR/emails.json
@@ -22,7 +22,7 @@
   "newParticipantConfirmation_preview": "Para editar sua resposta, use o link abaixo",
   "newParticipantConfirmation_heading": "Confirmação de Resposta da Enquete",
   "newParticipantConfirmation_subject": "Obrigado por responder a {title}",
-  "newParticipant_content": "<b>{name}</b> respondeu a <b>{title}</b>.",
+  "newParticipant_content": "<b>{name}</b><email /> respondeu a <b>{title}</b>.",
   "newParticipant_content2": "Vá para a sua enquete para ver a nova resposta.",
   "newParticipant_preview": "Vá para a sua enquete para ver a nova resposta.",
   "newParticipant_heading": "Nova Resposta",

--- a/packages/emails/locales/pt/emails.json
+++ b/packages/emails/locales/pt/emails.json
@@ -28,7 +28,7 @@
   "newParticipantConfirmation_preview": "Para editar a sua resposta, use a hiperligação abaixo",
   "newParticipantConfirmation_heading": "Confirmação de Resposta da Votação",
   "newParticipantConfirmation_subject": "Obrigado por responder a {title}",
-  "newParticipant_content": "<b>{name}</b> respondeu a <b>{title}</b>.",
+  "newParticipant_content": "<b>{name}</b><email /> respondeu a <b>{title}</b>.",
   "newParticipant_content2": "Vá para a sua votação para ver a nova resposta.",
   "newParticipant_preview": "Vá para a sua votação para ver a nova resposta.",
   "newParticipant_heading": "Nova Resposta",

--- a/packages/emails/locales/ru/emails.json
+++ b/packages/emails/locales/ru/emails.json
@@ -22,7 +22,7 @@
   "newParticipantConfirmation_preview": "Чтобы изменить свой ответ, используйте ссылку ниже",
   "newParticipantConfirmation_heading": "Подтверждение ответа на опрос",
   "newParticipantConfirmation_subject": "Спасибо за ответ на {title}",
-  "newParticipant_content": "<b>{name}</b> ответил на <b>{title}</b>.",
+  "newParticipant_content": "<b>{name}</b><email /> ответил на <b>{title}</b>.",
   "newParticipant_content2": "Перейдите к своему опросу, чтобы увидеть новый ответ.",
   "newParticipant_preview": "Перейдите к своему опросу, чтобы увидеть новый ответ.",
   "newParticipant_heading": "Новый ответ",

--- a/packages/emails/locales/sk/emails.json
+++ b/packages/emails/locales/sk/emails.json
@@ -28,7 +28,7 @@
   "newParticipantConfirmation_preview": "Na úpravu svojej odpovede použite odkaz nižšie",
   "newParticipantConfirmation_heading": "Potvrdenie o odpovedi na anketu",
   "newParticipantConfirmation_subject": "Ďakujeme za odpoveď na {title}",
-  "newParticipant_content": "<b>{name}</b> odpovedal na <b>{title}</b>.",
+  "newParticipant_content": "<b>{name}</b><email /> odpovedal na <b>{title}</b>.",
   "newParticipant_content2": "Choďte na svoju anketu, aby ste videli novú odpoveď.",
   "newParticipant_preview": "Choďte na svoju anketu, aby ste videli novú odpoveď.",
   "newParticipant_heading": "Nová odpoveď",

--- a/packages/emails/locales/sv/emails.json
+++ b/packages/emails/locales/sv/emails.json
@@ -22,7 +22,7 @@
   "newParticipantConfirmation_preview": "För att redigera ditt svar använd länken nedan",
   "newParticipantConfirmation_heading": "Bekräftelse på förfrågan",
   "newParticipantConfirmation_subject": "Tack för att du svarade på {title}",
-  "newParticipant_content": "<b>{name}</b> har svarat på <b>{title}</b>.",
+  "newParticipant_content": "<b>{name}</b><email /> har svarat på <b>{title}</b>.",
   "newParticipant_content2": "Gå till din förfrågan för att se det senaste svaret.",
   "newParticipant_preview": "Gå till din förfrågan för att se det senaste svaret.",
   "newParticipant_heading": "Nytt svar",

--- a/packages/emails/locales/tr/emails.json
+++ b/packages/emails/locales/tr/emails.json
@@ -28,7 +28,7 @@
   "newParticipantConfirmation_preview": "Yanıtınızı düzenlemek için aşağıdaki bağlantıyı kullanın",
   "newParticipantConfirmation_heading": "Anket Yanıtı Onayı",
   "newParticipantConfirmation_subject": "{title} için yanıt verdiğiniz için teşekkürler",
-  "newParticipant_content": "<b>{name}</b>, <b>{title}</b> üzerine yanıt verdi.",
+  "newParticipant_content": "<b>{name}</b><email />, <b>{title}</b> üzerine yanıt verdi.",
   "newParticipant_content2": "Yeni yanıtı görmek için anketinize gidin.",
   "newParticipant_preview": "Yeni yanıtı görmek için anketinize gidin.",
   "newParticipant_heading": "Yeni Yanıt",

--- a/packages/emails/locales/zh-Hant/emails.json
+++ b/packages/emails/locales/zh-Hant/emails.json
@@ -28,7 +28,7 @@
   "newParticipantConfirmation_preview": "要編輯您的回覆，請使用以下鏈接",
   "newParticipantConfirmation_heading": "投票回覆確認",
   "newParticipantConfirmation_subject": "感謝您對 {title} 做出回覆",
-  "newParticipant_content": "<b>{name}</b> 已對 <b>{title}</b> 做出回覆。",
+  "newParticipant_content": "<b>{name}</b><email /> 已對 <b>{title}</b> 做出回覆。",
   "newParticipant_content2": "前往您的投票以查看新的回覆。",
   "newParticipant_preview": "前往您的投票以查看新的回覆。",
   "newParticipant_heading": "新回覆",

--- a/packages/emails/locales/zh/emails.json
+++ b/packages/emails/locales/zh/emails.json
@@ -22,7 +22,7 @@
   "newParticipantConfirmation_preview": "要编辑您的回复，请使用以下链接",
   "newParticipantConfirmation_heading": "投票回复确认",
   "newParticipantConfirmation_subject": "感谢您回复{title}",
-  "newParticipant_content": "<b>{name}</b> 已经对<b>{title}</b>进行了回复。",
+  "newParticipant_content": "<b>{name}</b><email /> 已经对<b>{title}</b>进行了回复。",
   "newParticipant_content2": "前往您的投票以查看新回复。",
   "newParticipant_preview": "前往您的投票以查看新回复。",
   "newParticipant_heading": "新回复",

--- a/packages/emails/src/templates/new-participant.tsx
+++ b/packages/emails/src/templates/new-participant.tsx
@@ -1,5 +1,5 @@
+import { Link } from "@react-email/components";
 import { Trans } from "react-i18next/TransWithoutContext";
-
 import type { NotificationBaseProps } from "../components/notification-email";
 import NotificationEmail from "../components/notification-email";
 import { Heading, Text } from "../components/styled-components";
@@ -7,11 +7,13 @@ import type { EmailContext } from "../types";
 
 export interface NewParticipantEmailProps extends NotificationBaseProps {
   participantName: string;
+  participantEmail?: string;
 }
 
 const NewParticipantEmail = ({
   title,
   participantName,
+  participantEmail,
   pollUrl,
   disableNotificationsUrl,
   ctx,
@@ -39,9 +41,21 @@ const NewParticipantEmail = ({
           t={ctx.t}
           i18nKey="newParticipant_content"
           ns="emails"
-          defaults="<b>{name}</b> has responded to <b>{title}</b>."
+          defaults="<b>{name}</b><email /> has responded to <b>{title}</b>."
           components={{
             b: <strong />,
+            email: participantEmail ? (
+              <span>
+                &nbsp;(
+                <Link href={`mailto:${participantEmail}`}>
+                  {participantEmail}
+                </Link>
+                )
+              </span>
+            ) : (
+              // biome-ignore lint/complexity/noUselessFragments: <explanation>
+              <></>
+            ),
           }}
           values={{ name: participantName, title }}
         />


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
- Participant email addresses are now displayed in new participant notification emails across all supported languages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->