### PR TITLE
🔥 Remove deprecated Watcher model and related mutations

### DIFF
--- a/apps/web/src/features/poll/mutations.ts
+++ b/apps/web/src/features/poll/mutations.ts
@@ -48,7 +48,6 @@ export const createPoll = async ({
       adminUrlId: nanoid(),
       participantUrlId: nanoid(),
       userId,
-      watchers: { create: { userId } },
       spaceId,
       options: { createMany: { data: options } },
     },

--- a/apps/web/src/trpc/routers/polls.ts
+++ b/apps/web/src/trpc/routers/polls.ts
@@ -192,13 +192,6 @@ export const polls = router({
           adminUrlId: adminToken,
           participantUrlId,
           userId: ctx.user.id,
-          watchers: !ctx.user.isGuest
-            ? {
-                create: {
-                  userId: ctx.user.id,
-                },
-              }
-            : undefined,
           options: {
             createMany: {
               data: input.options.map((option) => ({
@@ -529,86 +522,6 @@ export const polls = router({
       });
     }),
   // END LEGACY ROUTES
-  // @deprecated — replaced by global notification preferences in /settings/notifications
-  getWatchers: publicProcedure
-    .input(
-      z.object({
-        pollId: z.string(),
-      }),
-    )
-    .query(async ({ input: { pollId } }) => {
-      return await prisma.watcher.findMany({
-        where: {
-          pollId,
-        },
-        select: {
-          userId: true,
-        },
-      });
-    }),
-  // @deprecated — replaced by global notification preferences in /settings/notifications
-  watch: privateProcedure
-    .input(z.object({ pollId: z.string() }))
-    .mutation(async ({ input, ctx }) => {
-      const hasAccess = await hasPollAdminAccess(input.pollId, ctx.user.id);
-
-      if (!hasAccess) {
-        throw new TRPCError({
-          code: "FORBIDDEN",
-          message: "You are not allowed to watch this poll",
-        });
-      }
-
-      await prisma.watcher.create({
-        data: {
-          pollId: input.pollId,
-          userId: ctx.user.id,
-        },
-      });
-
-      // Track poll watch analytics
-      ctx.posthog?.capture({
-        event: "poll_watch",
-        distinctId: ctx.user.id,
-        properties: {
-          is_guest: ctx.user.isGuest,
-        },
-        groups: {
-          poll: input.pollId,
-        },
-      });
-    }),
-  // @deprecated — replaced by global notification preferences in /settings/notifications
-  unwatch: privateProcedure
-    .input(z.object({ pollId: z.string() }))
-    .mutation(async ({ input, ctx }) => {
-      const watcher = await prisma.watcher.findFirst({
-        where: {
-          pollId: input.pollId,
-          userId: ctx.user.id,
-        },
-        select: {
-          id: true,
-        },
-      });
-
-      if (watcher) {
-        await prisma.watcher.delete({
-          where: {
-            id: watcher.id,
-          },
-        });
-
-        // Track poll unwatch analytics
-        ctx.posthog?.capture({
-          event: "poll_unwatch",
-          distinctId: ctx.user.id,
-          groups: {
-            poll: input.pollId,
-          },
-        });
-      }
-    }),
   get: publicProcedure
     .input(
       z.object({
@@ -653,11 +566,6 @@ export const polls = router({
           userId: true,
           deleted: true,
           spaceId: true,
-          watchers: {
-            select: {
-              userId: true,
-            },
-          },
           scheduledEvent: {
             select: {
               id: true,
@@ -1181,11 +1089,6 @@ export const polls = router({
           disableComments: poll.disableComments,
           adminUrlId: nanoid(),
           participantUrlId: nanoid(),
-          watchers: {
-            create: {
-              userId: ctx.user.id,
-            },
-          },
           options: {
             create: poll.options,
           },

--- a/packages/database/prisma/migrations/20260309120531_remove_watcher_model/migration.sql
+++ b/packages/database/prisma/migrations/20260309120531_remove_watcher_model/migration.sql
@@ -1,0 +1,14 @@
+/*
+  Warnings:
+
+  - You are about to drop the `watchers` table. If the table is not empty, all the data it contains will be lost.
+
+*/
+-- DropForeignKey
+ALTER TABLE "watchers" DROP CONSTRAINT "watchers_poll_id_fkey";
+
+-- DropForeignKey
+ALTER TABLE "watchers" DROP CONSTRAINT "watchers_user_id_fkey";
+
+-- DropTable
+DROP TABLE "watchers";

--- a/packages/database/prisma/models/poll.prisma
+++ b/packages/database/prisma/models/poll.prisma
@@ -43,7 +43,6 @@ model Poll {
   scheduledEvent ScheduledEvent? @relation(fields: [scheduledEventId], references: [id], onDelete: SetNull)
   options        Option[]
   participants   Participant[]
-  watchers       Watcher[]
   comments       Comment[]
   votes          Vote[]
   views          PollView[]
@@ -54,19 +53,6 @@ model Poll {
   @@index([spaceId], type: Hash)
   @@index([userId], type: Hash)
   @@map("polls")
-}
-
-model Watcher {
-  id        Int      @id @default(autoincrement())
-  userId    String   @map("user_id")
-  pollId    String   @map("poll_id")
-  createdAt DateTime @default(now()) @map("created_at")
-
-  poll Poll @relation(fields: [pollId], references: [id], onDelete: Cascade)
-  user User @relation(fields: [userId], references: [id], onDelete: Cascade)
-
-  @@index([pollId], type: Hash)
-  @@map("watchers")
 }
 
 model Participant {

--- a/packages/database/prisma/models/user.prisma
+++ b/packages/database/prisma/models/user.prisma
@@ -59,7 +59,6 @@ model User {
 
   comments           Comment[]
   polls              Poll[]
-  watcher            Watcher[]
   notificationPreferences UserNotificationPreferences?
   accounts           Account[]
   participants       Participant[]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed poll watchers functionality. Users can no longer watch or unwatch polls, and the ability to view poll watchers has been removed. Automatic watcher tracking during poll creation has been discontinued.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->