### PR TITLE
🐛 Don’t pass stripe event id as posthog uuid

### DIFF
--- a/apps/web/src/app/api/stripe/webhook/handlers/checkout/completed.ts
+++ b/apps/web/src/app/api/stripe/webhook/handlers/checkout/completed.ts
@@ -67,14 +67,13 @@ export async function onCheckoutSessionCompleted(event: Stripe.Event) {
     });
 
     posthog()?.capture({
-      uuid: event.id,
       distinctId: email,
       event: "license_purchase",
       properties: {
         licenseType,
         seats,
         version,
-        eventId: event.id,
+        stripeEventId: event.id,
         $set: {
           tier: licenseType,
         },

--- a/apps/web/src/app/api/stripe/webhook/handlers/customer-subscription/created.ts
+++ b/apps/web/src/app/api/stripe/webhook/handlers/customer-subscription/created.ts
@@ -101,7 +101,6 @@ export async function onCustomerSubscriptionCreated(event: Stripe.Event) {
 
   posthog()?.capture({
     distinctId: userId,
-    uuid: event.id,
     event: "subscription_create",
     properties: {
       interval,

--- a/apps/web/src/app/api/stripe/webhook/handlers/customer-subscription/updated.ts
+++ b/apps/web/src/app/api/stripe/webhook/handlers/customer-subscription/updated.ts
@@ -99,7 +99,6 @@ export async function onCustomerSubscriptionUpdated(event: Stripe.Event) {
 
   posthog()?.capture({
     distinctId: userId,
-    uuid: event.id,
     event: "subscription_update",
     properties: {
       interval,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated analytics data handling in Stripe webhook processes to refine event tracking parameters and remove redundant identifiers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->