### PR TITLE
🐛 Exclude soft-deleted participants from finalize query

### DIFF
--- a/apps/web/src/trpc/routers/polls.ts
+++ b/apps/web/src/trpc/routers/polls.ts
@@ -719,6 +719,7 @@ export const polls = router({
             },
           },
           participants: {
+            where: { deleted: false },
             select: {
               id: true,
               name: true,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where deleted participants were incorrectly included in event creation and notifications. Only active participants are now considered for scheduling and related communications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->