### PR TITLE
🐛 Fix date grouping

### DIFF
--- a/apps/web/src/components/poll/desktop-poll/poll-header.tsx
+++ b/apps/web/src/components/poll/desktop-poll/poll-header.tsx
@@ -68,7 +68,9 @@ const PollHeader: React.FunctionComponent = () => {
       <TimelineRow top={0}>
         {options.map((option, i) => {
           const firstOfMonth =
-            i === 0 || options[i - 1]?.month !== option.month;
+            i === 0 ||
+            options[i - 1]?.month !== option.month ||
+            options[i - 1]?.year !== option.year;
 
           return (
             <th
@@ -101,10 +103,14 @@ const PollHeader: React.FunctionComponent = () => {
           const firstOfDay =
             i === 0 ||
             options[i - 1]?.day !== option.day ||
-            options[i - 1]?.month !== option.month;
+            options[i - 1]?.month !== option.month ||
+            options[i - 1]?.year !== option.year;
 
           const lastOfDay =
-            i === options.length - 1 || options[i + 1]?.day !== option.day;
+            i === options.length - 1 ||
+            options[i + 1]?.day !== option.day ||
+            options[i + 1]?.month !== option.month ||
+            options[i + 1]?.year !== option.year;
           return (
             <th
               key={option.optionId}

--- a/apps/web/src/components/poll/mobile-poll.tsx
+++ b/apps/web/src/components/poll/mobile-poll.tsx
@@ -184,7 +184,7 @@ const MobilePoll: React.FunctionComponent = () => {
         editable={isEditing}
         group={(option) => {
           if (option.type === "timeSlot") {
-            return `${option.dow} ${option.day} ${option.month}`;
+            return `${option.dow} ${option.day} ${option.month} ${option.year}`;
           }
           return `${option.month} ${option.year}`;
         }}


### PR DESCRIPTION
The date grouping logic only compared month names without considering the year. So "Apr 2026", "Apr 2027", and "Apr 2028" all resolved to the same group — making it look like there was only one date. Fixed by including the year in all month/day boundary comparisons on both desktop and mobile views.

Fix #2278

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved date/year display in poll headers to correctly handle scheduling across year boundaries. Poll time slot labels now include year information, and date grouping properly respects year boundaries to prevent date confusion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->