### PR TITLE
🔥 Remove unused admin prop from legacy poll context

### DIFF
--- a/apps/web/src/components/poll-context.tsx
+++ b/apps/web/src/components/poll-context.tsx
@@ -17,7 +17,6 @@ import { useRequiredContext } from "./use-required-context";
 type PollContextValue = {
   poll: GetPollApiResponse;
   urlId: string;
-  admin: boolean;
   highScore: number;
   optionIds: string[];
   getScore: (optionId: string) => {
@@ -41,9 +40,8 @@ export const usePoll = () => {
 export const PollContextProvider: React.FunctionComponent<{
   poll: GetPollApiResponse;
   urlId: string;
-  admin: boolean;
   children?: React.ReactNode;
-}> = ({ poll, urlId, admin, children }) => {
+}> = ({ poll, urlId, children }) => {
   const { t } = useTranslation();
   const { participants } = useParticipants();
 
@@ -86,7 +84,6 @@ export const PollContextProvider: React.FunctionComponent<{
       optionIds,
       poll,
       urlId,
-      admin,
       highScore,
       getVote: (participantId, optionId) => {
         const vote = participants
@@ -96,7 +93,7 @@ export const PollContextProvider: React.FunctionComponent<{
       },
       getScore,
     };
-  }, [admin, getScore, participants, poll, urlId]);
+  }, [getScore, participants, poll, urlId]);
 
   if (poll.deleted) {
     return (

--- a/apps/web/src/components/poll/poll-context-provider.tsx
+++ b/apps/web/src/components/poll/poll-context-provider.tsx
@@ -13,7 +13,7 @@ export const LegacyPollContextProvider = (props: React.PropsWithChildren) => {
   }
 
   return (
-    <PollContextProvider poll={poll} urlId={poll.id} admin={false}>
+    <PollContextProvider poll={poll} urlId={poll.id}>
       <ModalProvider>
         <OptionsProvider>{props.children}</OptionsProvider>
       </ModalProvider>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified internal context configuration by removing an unused property from the poll context provider.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->