### PR TITLE
fix: add servername to SMTP TLS options for SNI support

### DIFF
--- a/packages/emails/src/send-email.tsx
+++ b/packages/emails/src/send-email.tsx
@@ -208,6 +208,7 @@ export class EmailClient {
             : undefined,
           tls: {
             rejectUnauthorized,
+            servername: process.env.SMTP_HOST,
           },
         });
         break;


### PR DESCRIPTION
## Problem
Some SMTP servers (like delivery.qboxmail.com) require SNI (Server Name Indication) during the TLS handshake to return the correct certificate. Without explicitly setting the `servername` option in nodemailer's TLS configuration, the server may present a default certificate (e.g., `*.smtpfy.com`) instead of the expected one (e.g., `*.qboxmail.com`), causing TLS certificate validation errors.

**Error example:**
```
Error: Hostname/IP does not match certificate's altnames: 
Host: delivery.qboxmail.com. is not in the cert's altnames: 
DNS:*.smtpfy.com, DNS:smtpfy.com
```

## Solution
Add `servername: process.env.SMTP_HOST` to the TLS options when creating the SMTP transport. This ensures the correct SNI hostname is sent during the TLS handshake, allowing the SMTP server to return the appropriate certificate.

## Changes
- `packages/emails/src/send-email.tsx`: Added `servername: process.env.SMTP_HOST` to TLS options

## Testing
- Verified `servername` is a standard Node.js TLS socket option supported by nodemailer
- This is a minimal, backward-compatible change
- Works with nodemailer ^6.9.9 (current dependency)

## References
- [Node.js TLS documentation](https://nodejs.org/api/tls.html#tlsconnectoptions-callback)
- [nodemailer SMTP transport options](https://nodemailer.com/smtp/)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced SMTP configuration for improved email delivery reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->