### PR TITLE
🚧 Add space branding to invite page

### DIFF
--- a/apps/web/src/app/[locale]/(optional-space)/poll/[urlId]/admin-page.tsx
+++ b/apps/web/src/app/[locale]/(optional-space)/poll/[urlId]/admin-page.tsx
@@ -1,13 +1,13 @@
 "use client";
 import Discussion from "@/components/discussion";
 import { EventCard } from "@/components/event-card";
+import { PollBranding } from "@/components/poll/poll-branding";
 import { PollFooter } from "@/components/poll/poll-footer";
 import { PollViewTracker } from "@/components/poll/poll-view-tracker";
 import { ResponsiveResults } from "@/components/poll/responsive-results";
 import { ScheduledEvent } from "@/components/poll/scheduled-event";
 import { VotingForm } from "@/components/poll/voting-form";
 import { usePoll } from "@/contexts/poll";
-
 import { GuestPollAlert } from "./guest-poll-alert";
 
 export function AdminPage() {
@@ -16,6 +16,9 @@ export function AdminPage() {
 
   return (
     <div className="space-y-3 lg:space-y-4">
+      {poll.space?.showBranding && poll.space.primaryColor ? (
+        <PollBranding primaryColor={poll.space.primaryColor} />
+      ) : null}
       {/* Track poll views */}
       <PollViewTracker pollId={poll.id} />
       <GuestPollAlert />

--- a/apps/web/src/app/[locale]/invite/[urlId]/invite-page.tsx
+++ b/apps/web/src/app/[locale]/invite/[urlId]/invite-page.tsx
@@ -4,6 +4,7 @@ import { ArrowUpRightIcon, CrownIcon } from "lucide-react";
 import Link from "next/link";
 import Discussion from "@/components/discussion";
 import { EventCard } from "@/components/event-card";
+import { PollBranding } from "@/components/poll/poll-branding";
 import { PollFooter } from "@/components/poll/poll-footer";
 import { PollViewTracker } from "@/components/poll/poll-view-tracker";
 import { ResponsiveResults } from "@/components/poll/responsive-results";
@@ -51,7 +52,9 @@ export function InvitePage() {
 
   return (
     <div className="page-bg-gray-100 h-dvh overflow-auto p-3 lg:p-6 dark:bg-gray-900">
-      <div className="page-bg-gray-100 hidden" />
+      {poll.space?.showBranding && poll.space.primaryColor ? (
+        <PollBranding primaryColor={poll.space.primaryColor} />
+      ) : null}
       <PollViewTracker pollId={poll.id} />
       <div className="mx-auto w-full max-w-4xl space-y-3">
         <GoToApp />

--- a/apps/web/src/components/poll/poll-branding.tsx
+++ b/apps/web/src/components/poll/poll-branding.tsx
@@ -1,0 +1,20 @@
+"use client";
+
+import { getPrimaryColorVars } from "@/features/branding/color";
+
+export function PollBranding({ primaryColor }: { primaryColor: string }) {
+  const primaryColorVars = getPrimaryColorVars(primaryColor);
+
+  return (
+    <style>{`
+          .light {
+            --primary: ${primaryColorVars.light};
+            --primary-foreground: ${primaryColorVars.lightForeground};
+          }
+          .dark {
+            --primary: ${primaryColorVars.dark};
+            --primary-foreground: ${primaryColorVars.darkForeground};
+          }
+        `}</style>
+  );
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Poll branding with custom primary colors now displays on admin and invite pages when enabled in space settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->