### PR TITLE
✨ Add NEXT_PUBLIC_CDN_BASE_URL to serve stored assets directly

### DIFF
--- a/apps/web/.env.sample
+++ b/apps/web/.env.sample
@@ -32,6 +32,8 @@ S3_BUCKET_NAME=rallly
 S3_ENDPOINT=http://0.0.0.0:9000
 S3_ACCESS_KEY_ID=minio
 S3_SECRET_ACCESS_KEY=minio123
+# Optional: serve stored assets directly from a CDN instead of proxying through /api/storage/
+# NEXT_PUBLIC_CDN_BASE_URL=https://example.cloudfront.net
 
 # KV (Redis) (optional)
 # Defaults below are configured for the local Redis instance (see docker-compose.dev.yml)

--- a/apps/web/src/components/optimized-avatar-image.tsx
+++ b/apps/web/src/components/optimized-avatar-image.tsx
@@ -3,8 +3,8 @@ import { cn } from "@rallly/ui";
 import { Avatar, AvatarFallback, AvatarImage } from "@rallly/ui/avatar";
 import { Icon } from "@rallly/ui/icon";
 import { UserIcon } from "lucide-react";
-import Image from "next/image";
 import React from "react";
+import { resolveStorageUrl } from "@/utils/storage";
 
 async function getGravatarUrl(email: string): Promise<string | null> {
   if (typeof crypto === "undefined" || !crypto.subtle) {
@@ -35,7 +35,6 @@ export function OptimizedAvatarImage({
   className?: string;
   email?: string;
 }) {
-  const [isLoaded, setLoaded] = React.useState(false);
   const [gravatarUrl, setGravatarUrl] = React.useState<string | null>(null);
 
   React.useEffect(() => {
@@ -62,32 +61,17 @@ export function OptimizedAvatarImage({
   return (
     <Avatar className={cn("rounded-full", className)} size={size}>
       {imageSrc ? (
-        imageSrc.startsWith("https") || imageSrc.startsWith("data:") ? (
-          <AvatarImage src={imageSrc} alt={name} />
+        <AvatarImage src={resolveStorageUrl(imageSrc)} alt={name} />
+      ) : null}
+      <AvatarFallback seed={name} className={cn("shrink-0")}>
+        {/^\p{L}+$/u.test(initials) ? (
+          initials
         ) : (
-          <Image
-            src={`/api/storage/${imageSrc}`}
-            width={128}
-            height={128}
-            alt={name}
-            style={{ objectFit: "cover" }}
-            onLoad={() => {
-              setLoaded(true);
-            }}
-          />
-        )
-      ) : null}
-      {!imageSrc || !isLoaded ? (
-        <AvatarFallback seed={name} className={cn("shrink-0")}>
-          {/^\p{L}+$/u.test(initials) ? (
-            initials
-          ) : (
-            <Icon>
-              <UserIcon />
-            </Icon>
-          )}
-        </AvatarFallback>
-      ) : null}
+          <Icon>
+            <UserIcon />
+          </Icon>
+        )}
+      </AvatarFallback>
     </Avatar>
   );
 }

--- a/apps/web/src/env.ts
+++ b/apps/web/src/env.ts
@@ -167,6 +167,13 @@ export const env = createEnv({
      * If not set, the Turnstile widget is not rendered.
      */
     NEXT_PUBLIC_TURNSTILE_SITE_KEY: z.string().optional(),
+    /**
+     * Public CDN base URL for serving stored assets directly (e.g. a CloudFront distribution or
+     * a public MinIO bucket URL). When set, image URLs are constructed as
+     * `${NEXT_PUBLIC_CDN_BASE_URL}/${key}` instead of routing through the `/api/storage/` proxy.
+     * If not set, assets are proxied through Next.js (current behaviour).
+     */
+    NEXT_PUBLIC_CDN_BASE_URL: z.url().optional(),
   },
   /*
    * Due to how Next.js bundles environment variables on Edge and Client,
@@ -237,6 +244,7 @@ export const env = createEnv({
     RATE_LIMIT_ENABLED: process.env.RATE_LIMIT_ENABLED,
     TURNSTILE_SECRET_KEY: process.env.TURNSTILE_SECRET_KEY,
     NEXT_PUBLIC_TURNSTILE_SITE_KEY: process.env.NEXT_PUBLIC_TURNSTILE_SITE_KEY,
+    NEXT_PUBLIC_CDN_BASE_URL: process.env.NEXT_PUBLIC_CDN_BASE_URL,
   },
   skipValidation: !!process.env.SKIP_ENV_VALIDATION,
 });

--- a/apps/web/src/features/space/components/space-icon.tsx
+++ b/apps/web/src/features/space/components/space-icon.tsx
@@ -2,8 +2,8 @@
 
 import { cn } from "@rallly/ui";
 import type { AvatarProps } from "@rallly/ui/avatar";
-import { Avatar, AvatarFallback } from "@rallly/ui/avatar";
-import Image from "next/image";
+import { Avatar, AvatarFallback, AvatarImage } from "@rallly/ui/avatar";
+import { resolveStorageUrl } from "@/utils/storage";
 
 type SpaceIconProps = {
   name: string;
@@ -14,19 +14,10 @@ type SpaceIconProps = {
 export function SpaceIcon({ name, src, className, size }: SpaceIconProps) {
   return (
     <Avatar className={cn(className)} size={size}>
-      {src ? (
-        <Image
-          src={`/api/storage/${src}`}
-          width={128}
-          height={128}
-          alt={name}
-          style={{ objectFit: "cover" }}
-        />
-      ) : (
-        <AvatarFallback seed={name}>
-          {name.slice(0, 2).toUpperCase()}
-        </AvatarFallback>
-      )}
+      {src ? <AvatarImage src={resolveStorageUrl(src)} alt={name} /> : null}
+      <AvatarFallback seed={name}>
+        {name.slice(0, 2).toUpperCase()}
+      </AvatarFallback>
     </Avatar>
   );
 }

--- a/apps/web/src/trpc/routers/polls/participants.ts
+++ b/apps/web/src/trpc/routers/polls/participants.ts
@@ -9,6 +9,7 @@ import { posthog } from "@/features/analytics/posthog";
 import { getNotificationRecipient } from "@/features/notifications/queries";
 import { hasPollAdminAccess } from "@/features/poll/query";
 import { getEmailClient } from "@/utils/emails";
+import { resolveStorageUrl } from "@/utils/storage";
 import {
   createRateLimitMiddleware,
   publicProcedure,
@@ -312,7 +313,7 @@ export const participants = router({
               ? {
                   primaryColor: space.primaryColor ?? undefined,
                   logoUrl: space.image
-                    ? absoluteUrl(`/api/storage/${space.image}`)
+                    ? resolveStorageUrl(space.image)
                     : undefined,
                 }
               : {}),

--- a/apps/web/src/utils/storage.ts
+++ b/apps/web/src/utils/storage.ts
@@ -1,0 +1,28 @@
+import { absoluteUrl } from "@rallly/utils/absolute-url";
+import { env } from "@/env";
+
+/**
+ * Resolves a storage key to an absolute URL.
+ *
+ * 1. If the key is already an absolute URL (e.g. OAuth avatars) or a data URI → returned as-is.
+ * 2. If `NEXT_PUBLIC_CDN_BASE_URL` is set → served directly from the CDN/bucket.
+ * 3. Otherwise → proxied through `/api/storage/`.
+ */
+export function resolveStorageUrl(key: string): string {
+  if (
+    key.startsWith("https://") ||
+    key.startsWith("http://") ||
+    key.startsWith("data:")
+  ) {
+    return key;
+  }
+
+  const normalizedKey = key.replace(/^\/+/, "");
+
+  if (env.NEXT_PUBLIC_CDN_BASE_URL) {
+    const base = env.NEXT_PUBLIC_CDN_BASE_URL.replace(/\/+$/, "");
+    return `${base}/${normalizedKey}`;
+  }
+
+  return absoluteUrl(`/api/storage/${normalizedKey}`);
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional CDN integration: configure a public CDN base URL to serve images and files directly instead of proxying through the app.
  * Asset URL resolution now uses the CDN when configured for emails, avatars, and space icons.

* **Chores**
  * Simplified image rendering and consistent fallback behavior for avatars and icons.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->