### PR TITLE
🐛 Set poll branding in page loader to avoid color flash

### DIFF
--- a/apps/web/src/app/[locale]/(optional-space)/poll/[urlId]/admin-page-loader.tsx
+++ b/apps/web/src/app/[locale]/(optional-space)/poll/[urlId]/admin-page-loader.tsx
@@ -1,5 +1,6 @@
 "use client";
 import dynamic from "next/dynamic";
+import { PollBrandingFromContext } from "@/components/poll/poll-branding";
 
 const AdminPage = dynamic(
   () => import("./admin-page").then((mod) => mod.AdminPage),
@@ -7,5 +8,10 @@ const AdminPage = dynamic(
 );
 
 export function AdminPageLoader() {
-  return <AdminPage />;
+  return (
+    <>
+      <PollBrandingFromContext />
+      <AdminPage />
+    </>
+  );
 }

--- a/apps/web/src/app/[locale]/(optional-space)/poll/[urlId]/admin-page.tsx
+++ b/apps/web/src/app/[locale]/(optional-space)/poll/[urlId]/admin-page.tsx
@@ -1,7 +1,6 @@
 "use client";
 import Discussion from "@/components/discussion";
 import { EventCard } from "@/components/event-card";
-import { PollBranding } from "@/components/poll/poll-branding";
 import { PollFooter } from "@/components/poll/poll-footer";
 import { PollViewTracker } from "@/components/poll/poll-view-tracker";
 import { ResponsiveResults } from "@/components/poll/responsive-results";
@@ -15,9 +14,6 @@ export function AdminPage() {
 
   return (
     <div className="space-y-3 lg:space-y-4">
-      {poll.space?.showBranding && poll.space.primaryColor ? (
-        <PollBranding primaryColor={poll.space.primaryColor} />
-      ) : null}
       {/* Track poll views */}
       <PollViewTracker pollId={poll.id} />
       <GuestPollAlert />

--- a/apps/web/src/app/[locale]/invite/[urlId]/invite-page-loader.tsx
+++ b/apps/web/src/app/[locale]/invite/[urlId]/invite-page-loader.tsx
@@ -1,5 +1,6 @@
 "use client";
 import dynamic from "next/dynamic";
+import { PollBrandingFromContext } from "@/components/poll/poll-branding";
 
 const InvitePage = dynamic(
   () => import("./invite-page").then((mod) => mod.InvitePage),
@@ -7,5 +8,10 @@ const InvitePage = dynamic(
 );
 
 export function InvitePageLoader() {
-  return <InvitePage />;
+  return (
+    <>
+      <PollBrandingFromContext />
+      <InvitePage />
+    </>
+  );
 }

--- a/apps/web/src/app/[locale]/invite/[urlId]/invite-page.tsx
+++ b/apps/web/src/app/[locale]/invite/[urlId]/invite-page.tsx
@@ -4,7 +4,6 @@ import { ArrowUpRightIcon, CrownIcon } from "lucide-react";
 import Link from "next/link";
 import Discussion from "@/components/discussion";
 import { EventCard } from "@/components/event-card";
-import { PollBranding } from "@/components/poll/poll-branding";
 import { PollFooter } from "@/components/poll/poll-footer";
 import { PollViewTracker } from "@/components/poll/poll-view-tracker";
 import { ResponsiveResults } from "@/components/poll/responsive-results";
@@ -51,9 +50,6 @@ export function InvitePage() {
 
   return (
     <div className="page-bg-gray-100 h-dvh overflow-auto p-3 lg:p-6 dark:bg-gray-900">
-      {poll.space?.showBranding && poll.space.primaryColor ? (
-        <PollBranding primaryColor={poll.space.primaryColor} />
-      ) : null}
       <PollViewTracker pollId={poll.id} />
       <div className="mx-auto w-full max-w-4xl space-y-3">
         <GoToApp />

--- a/apps/web/src/components/poll/poll-branding.tsx
+++ b/apps/web/src/components/poll/poll-branding.tsx
@@ -1,6 +1,15 @@
 "use client";
 
+import { usePoll } from "@/contexts/poll";
 import { getPrimaryColorVars } from "@/features/branding/color";
+
+export function PollBrandingFromContext() {
+  const poll = usePoll();
+  if (!poll.space?.showBranding || !poll.space.primaryColor) {
+    return null;
+  }
+  return <PollBranding primaryColor={poll.space.primaryColor} />;
+}
 
 export function PollBranding({ primaryColor }: { primaryColor: string }) {
   const primaryColorVars = getPrimaryColorVars(primaryColor);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a context-driven poll branding component to render branding when appropriate.

* **Refactor**
  * Branding moved out of individual page layouts into the top-level loader output for admin and invite pages, preserving existing display conditions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->