### PR TITLE
✨ Add server-side upload proxy for self-hosted S3 (RAL-1150)

### DIFF
--- a/apps/web/src/app/api/storage/[...key]/route.ts
+++ b/apps/web/src/app/api/storage/[...key]/route.ts
@@ -116,6 +116,10 @@ export async function PUT(
     return new NextResponse("Payload too large", { status: 413 });
   }
 
+  if (arrayBuffer.byteLength !== contentLength) {
+    return new NextResponse("Content length mismatch", { status: 400 });
+  }
+
   try {
     await s3Client.send(
       new PutObjectCommand({

--- a/apps/web/src/app/api/storage/[...key]/route.ts
+++ b/apps/web/src/app/api/storage/[...key]/route.ts
@@ -1,12 +1,17 @@
-import { GetObjectCommand } from "@aws-sdk/client-s3";
+import { GetObjectCommand, PutObjectCommand } from "@aws-sdk/client-s3";
 import { createLogger } from "@rallly/logger";
 import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
 
 import { env } from "@/env";
+import { verifyUploadToken } from "@/lib/storage/image-upload";
 import { getS3Client } from "@/lib/storage/s3";
+import { isSelfHosted } from "@/utils/constants";
 
 const logger = createLogger("api/storage");
+
+const MAX_UPLOAD_BYTES = 2 * 1024 * 1024;
+const ALLOWED_UPLOAD_CONTENT_TYPES = new Set(["image/jpeg", "image/png"]);
 
 async function getAvatar(key: string) {
   const s3Client = getS3Client();
@@ -60,4 +65,74 @@ export async function GET(
       { status: 500 },
     );
   }
+}
+
+export async function PUT(
+  req: NextRequest,
+  context: { params: Promise<{ key: string[] }> },
+) {
+  if (!isSelfHosted) {
+    return new NextResponse("Not found", { status: 404 });
+  }
+
+  const keyParts = (await context.params).key;
+
+  if (keyParts[0] !== "upload" || keyParts.length < 2) {
+    return new NextResponse("Not found", { status: 404 });
+  }
+
+  const key = keyParts.slice(1).join("/");
+  const token = req.nextUrl.searchParams.get("token");
+
+  if (!token || !verifyUploadToken(key, token)) {
+    return new NextResponse("Invalid token", { status: 401 });
+  }
+
+  const contentType = req.headers.get("content-type") ?? "";
+
+  if (!ALLOWED_UPLOAD_CONTENT_TYPES.has(contentType)) {
+    return new NextResponse("Unsupported content type", { status: 415 });
+  }
+
+  const contentLength = Number(req.headers.get("content-length"));
+
+  if (
+    !Number.isFinite(contentLength) ||
+    contentLength <= 0 ||
+    contentLength > MAX_UPLOAD_BYTES
+  ) {
+    return new NextResponse("Invalid content length", { status: 413 });
+  }
+
+  const s3Client = getS3Client();
+
+  if (!s3Client) {
+    return new NextResponse("Storage not configured", { status: 500 });
+  }
+
+  const arrayBuffer = await req.arrayBuffer();
+
+  if (arrayBuffer.byteLength > MAX_UPLOAD_BYTES) {
+    return new NextResponse("Payload too large", { status: 413 });
+  }
+
+  try {
+    await s3Client.send(
+      new PutObjectCommand({
+        Bucket: env.S3_BUCKET_NAME,
+        Key: key,
+        ContentType: contentType,
+        ContentLength: arrayBuffer.byteLength,
+        Body: new Uint8Array(arrayBuffer),
+      }),
+    );
+  } catch (error) {
+    logger.error({ error, key }, "Failed to upload object to storage");
+    return NextResponse.json(
+      { error: "Failed to upload object" },
+      { status: 500 },
+    );
+  }
+
+  return new NextResponse(null, { status: 200 });
 }

--- a/apps/web/src/lib/storage/image-upload.ts
+++ b/apps/web/src/lib/storage/image-upload.ts
@@ -2,24 +2,40 @@ import "server-only";
 import crypto from "node:crypto";
 import { DeleteObjectCommand, PutObjectCommand } from "@aws-sdk/client-s3";
 import { getSignedUrl } from "@aws-sdk/s3-request-presigner";
-
 import { env } from "@/env";
 import { AppError } from "@/lib/errors";
 import { isSelfHosted } from "@/utils/constants";
 import { getS3Client } from "./s3";
 
-export function signUploadKey(key: string) {
+const UPLOAD_TOKEN_TTL_SECONDS = 3600;
+
+function computeSignature(payload: string) {
   return crypto
     .createHmac("sha256", env.SECRET_PASSWORD)
-    .update(key)
+    .update(payload)
     .digest("hex");
 }
 
+export function signUploadKey(key: string) {
+  const expiry = Math.floor(Date.now() / 1000) + UPLOAD_TOKEN_TTL_SECONDS;
+  const signature = computeSignature(`${key}:${expiry}`);
+  return `${expiry}.${signature}`;
+}
+
 export function verifyUploadToken(key: string, token: string) {
-  const expected = signUploadKey(key);
+  const parts = token.split(".");
+  if (parts.length !== 2) return false;
+  const [expiryStr, signature] = parts;
+  const expiry = Number(expiryStr);
+  if (!Number.isInteger(expiry)) return false;
+  if (expiry <= Math.floor(Date.now() / 1000)) return false;
+
+  const expected = computeSignature(`${key}:${expiry}`);
   const expectedBuf = Buffer.from(expected, "hex");
-  const tokenBuf = Buffer.from(token, "hex");
-  if (expectedBuf.length !== tokenBuf.length) return false;
+  const tokenBuf = Buffer.from(signature, "hex");
+  if (expectedBuf.length === 0 || expectedBuf.length !== tokenBuf.length) {
+    return false;
+  }
   return crypto.timingSafeEqual(expectedBuf, tokenBuf);
 }
 

--- a/apps/web/src/lib/storage/image-upload.ts
+++ b/apps/web/src/lib/storage/image-upload.ts
@@ -1,10 +1,27 @@
 import "server-only";
+import crypto from "node:crypto";
 import { DeleteObjectCommand, PutObjectCommand } from "@aws-sdk/client-s3";
 import { getSignedUrl } from "@aws-sdk/s3-request-presigner";
 
 import { env } from "@/env";
 import { AppError } from "@/lib/errors";
+import { isSelfHosted } from "@/utils/constants";
 import { getS3Client } from "./s3";
+
+export function signUploadKey(key: string) {
+  return crypto
+    .createHmac("sha256", env.SECRET_PASSWORD)
+    .update(key)
+    .digest("hex");
+}
+
+export function verifyUploadToken(key: string, token: string) {
+  const expected = signUploadKey(key);
+  const expectedBuf = Buffer.from(expected, "hex");
+  const tokenBuf = Buffer.from(token, "hex");
+  if (expectedBuf.length !== tokenBuf.length) return false;
+  return crypto.timingSafeEqual(expectedBuf, tokenBuf);
+}
 
 const mimeToExtension = {
   "image/jpeg": "jpg",
@@ -41,6 +58,18 @@ export async function getImageUploadUrl({
   }
 
   const key = `${keyPrefix}/${entityId}-${Date.now()}.${mimeToExtension[fileType]}`;
+
+  if (isSelfHosted) {
+    const token = signUploadKey(key);
+    const url = `/api/storage/upload/${key}?token=${token}`;
+    return {
+      success: true,
+      url,
+      fields: {
+        key,
+      },
+    } as const;
+  }
 
   const command = new PutObjectCommand({
     Bucket: env.S3_BUCKET_NAME,


### PR DESCRIPTION
Pre-signed S3 URLs fail with self-hosted Garage behind Traefik's StripPrefix middleware. When self-hosted, proxy uploads through the app using an HMAC-signed URL instead of pre-signing against S3.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added self-hosted image upload support using token-based upload URLs.
  * Uploads accept JPEG/PNG only and enforce a 2 MiB maximum.
  * Client-facing upload URL generation now returns a self-hosted upload endpoint and token when enabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->