### PR TITLE
✨ Build update-check module with in-memory cache (RAL-1159)

### DIFF
--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -78,6 +78,10 @@ ENV PORT=3000
 ENV HOSTNAME=0.0.0.0
 ENV LOG_LEVEL=warn
 
+# Rallly cloud API base URL. Set here so only self-hosted images phone home;
+# local dev and cloud builds leave it unset and skip outbound calls entirely.
+ENV API_BASE_URL=https://api.rallly.co
+
 ARG SELF_HOSTED
 ENV NEXT_PUBLIC_SELF_HOSTED=$SELF_HOSTED
 

--- a/apps/web/src/env.ts
+++ b/apps/web/src/env.ts
@@ -150,6 +150,13 @@ export const env = createEnv({
      * If not set, Turnstile verification is disabled.
      */
     TURNSTILE_SECRET_KEY: z.string().optional(),
+    /**
+     * Base URL of the Rallly cloud API (e.g. https://api.rallly.co).
+     * Set by the self-hosted Docker image so the instance can phone home for
+     * update checks. Unset elsewhere — the features that depend on it no-op
+     * when it's missing.
+     */
+    API_BASE_URL: z.url().optional(),
   },
   /*
    * Environment variables available on the client (and server).
@@ -241,6 +248,7 @@ export const env = createEnv({
     HIDE_ATTRIBUTION: process.env.HIDE_ATTRIBUTION,
     RATE_LIMIT_ENABLED: process.env.RATE_LIMIT_ENABLED,
     TURNSTILE_SECRET_KEY: process.env.TURNSTILE_SECRET_KEY,
+    API_BASE_URL: process.env.API_BASE_URL,
     NEXT_PUBLIC_TURNSTILE_SITE_KEY: process.env.NEXT_PUBLIC_TURNSTILE_SITE_KEY,
     NEXT_PUBLIC_CDN_BASE_URL: process.env.NEXT_PUBLIC_CDN_BASE_URL,
   },

--- a/apps/web/src/features/update-check/get-update-status.ts
+++ b/apps/web/src/features/update-check/get-update-status.ts
@@ -1,0 +1,83 @@
+import "server-only";
+
+import { prisma } from "@rallly/database";
+import { env } from "@/env";
+import { appVersion, isSelfHosted } from "@/utils/constants";
+import { isNewer } from "./is-newer";
+
+const CACHE_TTL_MS = 24 * 60 * 60 * 1000;
+const FETCH_TIMEOUT_MS = 5000;
+
+type CachedResponse = {
+  latest: string;
+  url: string;
+  fetchedAt: number;
+};
+
+type UpstreamResponse = {
+  latest: string;
+  url: string;
+  publishedAt: string;
+};
+
+export type UpdateStatus =
+  | { checkDisabled: true }
+  | {
+      checkDisabled: false;
+      currentVersion: string | undefined;
+      latestVersion: string | null;
+      updateAvailable: boolean;
+      releaseUrl: string | null;
+    };
+
+let cache: CachedResponse | null = null;
+let inFlight: Promise<void> | null = null;
+
+async function getInstanceId() {
+  const settings = await prisma.instanceSettings.upsert({
+    where: { id: 1 },
+    create: { id: 1 },
+    update: {},
+    select: { instanceId: true },
+  });
+  return settings.instanceId;
+}
+
+async function refreshCache() {
+  if (!appVersion || !env.API_BASE_URL) return;
+  const instanceId = await getInstanceId();
+  const url = `${env.API_BASE_URL}/updates?version=${encodeURIComponent(appVersion)}&instanceId=${encodeURIComponent(instanceId)}`;
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+  try {
+    const res = await fetch(url, { signal: controller.signal });
+    if (!res.ok) return;
+    const data = (await res.json()) as UpstreamResponse;
+    cache = { latest: data.latest, url: data.url, fetchedAt: Date.now() };
+  } catch {
+    // Swallow: receiver unreachable, timeout, malformed response.
+    // Leave `cache` as-is so the next trigger retries.
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+export async function getUpdateStatus(): Promise<UpdateStatus> {
+  if (!isSelfHosted || !env.API_BASE_URL) return { checkDisabled: true };
+
+  const fresh = cache && Date.now() - cache.fetchedAt < CACHE_TTL_MS;
+  if (!fresh && !inFlight) {
+    inFlight = refreshCache().finally(() => {
+      inFlight = null;
+    });
+  }
+
+  return {
+    checkDisabled: false,
+    currentVersion: appVersion,
+    latestVersion: cache?.latest ?? null,
+    updateAvailable:
+      cache && appVersion ? isNewer(cache.latest, appVersion) : false,
+    releaseUrl: cache?.url ?? null,
+  };
+}

--- a/apps/web/src/features/update-check/get-update-status.ts
+++ b/apps/web/src/features/update-check/get-update-status.ts
@@ -1,6 +1,7 @@
 import "server-only";
 
 import { prisma } from "@rallly/database";
+import * as z from "zod";
 import { env } from "@/env";
 import { appVersion, isSelfHosted } from "@/utils/constants";
 import { isNewer } from "./is-newer";
@@ -14,11 +15,10 @@ type CachedResponse = {
   fetchedAt: number;
 };
 
-type UpstreamResponse = {
-  latest: string;
-  url: string;
-  publishedAt: string;
-};
+const upstreamResponseSchema = z.object({
+  latest: z.string().min(1),
+  url: z.string().min(1),
+});
 
 export type UpdateStatus =
   | { checkDisabled: true }
@@ -52,8 +52,13 @@ async function refreshCache() {
   try {
     const res = await fetch(url, { signal: controller.signal });
     if (!res.ok) return;
-    const data = (await res.json()) as UpstreamResponse;
-    cache = { latest: data.latest, url: data.url, fetchedAt: Date.now() };
+    const parsed = upstreamResponseSchema.safeParse(await res.json());
+    if (!parsed.success) return;
+    cache = {
+      latest: parsed.data.latest,
+      url: parsed.data.url,
+      fetchedAt: Date.now(),
+    };
   } catch {
     // Swallow: receiver unreachable, timeout, malformed response.
     // Leave `cache` as-is so the next trigger retries.

--- a/apps/web/src/features/update-check/is-newer.test.ts
+++ b/apps/web/src/features/update-check/is-newer.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import { isNewer } from "./is-newer";
+
+describe("isNewer", () => {
+  it("returns true when latest has a higher patch", () => {
+    expect(isNewer("1.2.4", "1.2.3")).toBe(true);
+  });
+
+  it("returns false when versions are equal", () => {
+    expect(isNewer("1.2.3", "1.2.3")).toBe(false);
+  });
+
+  it("returns false when latest is older", () => {
+    expect(isNewer("1.2.3", "1.2.4")).toBe(false);
+  });
+
+  it("handles double-digit segments without lexicographic bugs", () => {
+    expect(isNewer("1.10.0", "1.9.0")).toBe(true);
+    expect(isNewer("1.9.0", "1.10.0")).toBe(false);
+  });
+
+  it("strips a leading 'v' from either operand", () => {
+    expect(isNewer("v1.2.4", "1.2.3")).toBe(true);
+    expect(isNewer("1.2.4", "v1.2.3")).toBe(true);
+  });
+
+  it("treats missing segments as zero", () => {
+    expect(isNewer("1.2", "1.2.0")).toBe(false);
+    expect(isNewer("1.3", "1.2.5")).toBe(true);
+  });
+});

--- a/apps/web/src/features/update-check/is-newer.ts
+++ b/apps/web/src/features/update-check/is-newer.ts
@@ -3,7 +3,9 @@ export function isNewer(latest: string, current: string) {
     v
       .replace(/^v/, "")
       .split(".")
-      .map((part) => Number.parseInt(part, 10));
+      .map((part) =>
+        /^\d+$/.test(part) ? Number.parseInt(part, 10) : Number.NaN,
+      );
   const a = parse(latest);
   const b = parse(current);
   const length = Math.max(a.length, b.length);

--- a/apps/web/src/features/update-check/is-newer.ts
+++ b/apps/web/src/features/update-check/is-newer.ts
@@ -1,0 +1,18 @@
+export function isNewer(latest: string, current: string) {
+  const parse = (v: string) =>
+    v
+      .replace(/^v/, "")
+      .split(".")
+      .map((part) => Number.parseInt(part, 10));
+  const a = parse(latest);
+  const b = parse(current);
+  const length = Math.max(a.length, b.length);
+  for (let i = 0; i < length; i++) {
+    const x = a[i] ?? 0;
+    const y = b[i] ?? 0;
+    if (Number.isNaN(x) || Number.isNaN(y)) return false;
+    if (x > y) return true;
+    if (x < y) return false;
+  }
+  return false;
+}


### PR DESCRIPTION
Server-side module that fetches the latest Rallly release from api.rallly.co on behalf of admin pages. 24h in-memory cache with an in-flight promise guard to prevent stampedes. getUpdateStatus() is a no-op on cloud and fails quiet when the receiver is unreachable.

The instanceId is read directly from the InstanceSettings singleton, upserted on first read (Postgres fills the UUID via its default).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Adds update checking for self-hosted instances with release info and update availability shown.
  * Allows configuring the update server endpoint via an environment setting.

* **Bug Fixes**
  * Improves version comparison logic to correctly handle multi-digit and prefixed versions.

* **Tests**
  * Adds tests validating the version-comparison behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->