### PR TITLE
🐛 Send poll response confirmation email in respondent's locale

### DIFF
--- a/apps/web/src/trpc/routers/polls/participants.ts
+++ b/apps/web/src/trpc/routers/polls/participants.ts
@@ -308,7 +308,7 @@ export const participants = router({
 
           const space = participant.poll.space;
           const emailClient = await getEmailClient({
-            locale: ctx.user.locale ?? undefined,
+            locale: ctx.locale,
             ...(space?.showBranding
               ? {
                   primaryColor: space.primaryColor ?? undefined,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed an issue where confirmation emails sent to new poll participants may not have been displayed in the correct language. The system now properly uses the participant's locale preference when sending these notifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->