### PR TITLE
✨ Add SessionRefresher to keep cookieCache warm in space layout

### DIFF
--- a/apps/web/src/app/[locale]/(space)/layout.tsx
+++ b/apps/web/src/app/[locale]/(space)/layout.tsx
@@ -1,5 +1,6 @@
 import { dehydrate, HydrationBoundary } from "@tanstack/react-query";
 import { redirect } from "next/navigation";
+import { SessionRefresher } from "@/components/session-refresher";
 import { PreferencesProvider } from "@/contexts/preferences";
 import { BillingProvider } from "@/features/billing/client";
 import { SpaceProvider } from "@/features/space/client";
@@ -27,6 +28,7 @@ export default async function Layout({
 
   return (
     <HydrationBoundary state={dehydrate(helpers.queryClient)}>
+      <SessionRefresher />
       <PreferencesProvider>
         <SpaceProvider>
           <BillingProvider>{children}</BillingProvider>

--- a/apps/web/src/components/session-refresher.tsx
+++ b/apps/web/src/components/session-refresher.tsx
@@ -1,0 +1,15 @@
+"use client";
+
+import { authClient } from "@/lib/auth-client";
+
+// Fires /get-session on mount (and on tab focus, via better-auth defaults)
+// so the cookieCache Set-Cookie reaches the browser. Without this, the
+// session_data cookie only ever propagates at sign-in and every request
+// past its 5-min lifetime falls back to a DB lookup.
+//
+// Only mount inside authenticated layouts — using this on public layouts
+// would trigger a /get-session call for every anonymous poll viewer.
+export function SessionRefresher() {
+  authClient.useSession();
+  return null;
+}


### PR DESCRIPTION
Mounts a client component that calls authClient.useSession() inside the authenticated space layout so the better-auth cookieCache Set-Cookie reaches the browser on mount and tab focus. Prevents the session_data cookie from expiring after 5 minutes and falling back to a DB lookup on every request.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Sessions now automatically refresh when switching between browser tabs and on page load, ensuring consistent authentication state across multiple tabs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lukevella/rallly/pull/2376)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->