### PR TITLE
♻️ Migrate small-table hash indexes to btree

### DIFF
--- a/packages/database/prisma/migrations/20260514165732_migrate_hash_indexes_to_btree_small_tables/migration.sql
+++ b/packages/database/prisma/migrations/20260514165732_migrate_hash_indexes_to_btree_small_tables/migration.sql
@@ -1,0 +1,62 @@
+-- DropIndex
+DROP INDEX "comments_poll_id_idx";
+
+-- DropIndex
+DROP INDEX "polls_guest_id_idx";
+
+-- DropIndex
+DROP INDEX "polls_space_id_idx";
+
+-- DropIndex
+DROP INDEX "polls_user_id_idx";
+
+-- DropIndex
+DROP INDEX "scheduled_events_space_id_idx";
+
+-- DropIndex
+DROP INDEX "scheduled_events_user_id_idx";
+
+-- DropIndex
+DROP INDEX "space_member_invites_space_id_idx";
+
+-- DropIndex
+DROP INDEX "space_members_space_id_idx";
+
+-- DropIndex
+DROP INDEX "space_members_user_id_idx";
+
+-- DropIndex
+DROP INDEX "spaces_owner_id_idx";
+
+-- DropIndex
+DROP INDEX "subscriptions_space_id_idx";
+
+-- DropIndex
+DROP INDEX "subscriptions_user_id_idx";
+
+-- CreateIndex
+CREATE INDEX "comments_poll_id_idx" ON "comments"("poll_id");
+
+-- CreateIndex
+CREATE INDEX "polls_space_id_idx" ON "polls"("space_id");
+
+-- CreateIndex
+CREATE INDEX "polls_user_id_idx" ON "polls"("user_id");
+
+-- CreateIndex
+CREATE INDEX "scheduled_events_space_id_idx" ON "scheduled_events"("space_id");
+
+-- CreateIndex
+CREATE INDEX "scheduled_events_user_id_idx" ON "scheduled_events"("user_id");
+
+-- CreateIndex
+CREATE INDEX "space_members_user_id_idx" ON "space_members"("user_id");
+
+-- CreateIndex
+CREATE INDEX "spaces_owner_id_idx" ON "spaces"("owner_id");
+
+-- CreateIndex
+CREATE INDEX "subscriptions_user_id_idx" ON "subscriptions"("user_id");
+
+-- CreateIndex
+CREATE INDEX "subscriptions_space_id_idx" ON "subscriptions"("space_id");

--- a/packages/database/prisma/models/billing.prisma
+++ b/packages/database/prisma/models/billing.prisma
@@ -18,8 +18,8 @@ model Subscription {
   user  User  @relation("UserToSubscription", fields: [userId], references: [id], onDelete: Cascade)
   space Space @relation("SpaceToSubscription", fields: [spaceId], references: [id], onDelete: Cascade)
 
-  @@index([userId], type: Hash)
-  @@index([spaceId], type: Hash)
+  @@index([userId])
+  @@index([spaceId])
   @@map("subscriptions")
 }
 

--- a/packages/database/prisma/models/event.prisma
+++ b/packages/database/prisma/models/event.prisma
@@ -39,8 +39,8 @@ model ScheduledEvent {
   invites          ScheduledEventInvite[]
   polls            Poll[]
 
-  @@index([spaceId], type: Hash)
-  @@index([userId], type: Hash)
+  @@index([spaceId])
+  @@index([userId])
   @@map("scheduled_events")
 }
 

--- a/packages/database/prisma/models/poll.prisma
+++ b/packages/database/prisma/models/poll.prisma
@@ -57,9 +57,8 @@ model Poll {
   space          Space?          @relation(fields: [spaceId], references: [id], onDelete: SetNull)
   spaceId        String?         @map("space_id")
 
-  @@index([guestId], type: Hash)
-  @@index([spaceId], type: Hash)
-  @@index([userId], type: Hash)
+  @@index([spaceId])
+  @@index([userId])
   @@map("polls")
 }
 
@@ -141,7 +140,7 @@ model Comment {
   poll Poll  @relation(fields: [pollId], references: [id], onDelete: Cascade)
   user User? @relation(fields: [userId], references: [id], onDelete: Cascade)
 
-  @@index([pollId], type: Hash)
+  @@index([pollId])
   @@map("comments")
 }
 

--- a/packages/database/prisma/models/space.prisma
+++ b/packages/database/prisma/models/space.prisma
@@ -21,7 +21,7 @@ model Space {
 
   apiKeys SpaceApiKey[]
 
-  @@index([ownerId], type: Hash)
+  @@index([ownerId])
   @@map("spaces")
 }
 
@@ -50,8 +50,7 @@ model SpaceMember {
   user  User  @relation(fields: [userId], references: [id], onDelete: Cascade)
 
   @@unique([spaceId, userId])
-  @@index([spaceId], type: Hash, map: "space_members_space_id_idx")
-  @@index([userId], type: Hash, map: "space_members_user_id_idx")
+  @@index([userId])
   @@map("space_members")
 }
 
@@ -68,7 +67,6 @@ model SpaceMemberInvite {
   space     Space @relation(fields: [spaceId], references: [id], onDelete: Cascade)
 
   @@unique([spaceId, email])
-  @@index([spaceId], type: Hash, map: "space_member_invites_space_id_idx")
   @@map("space_member_invites")
 }
 


### PR DESCRIPTION
## Summary

- Convert hash indexes to btree on small tables (`polls`, `spaces`, `space_members`, `space_member_invites`, `comments`, `scheduled_events`, `subscriptions`) for schema consistency and to unblock future composite/partial indexes
- Drop two redundant indexes covered by unique constraints (`space_members.spaceId`, `space_member_invites.spaceId`)
- Drop one dead index on a deprecated field (`polls.guestId`)
- Remove redundant `map:` args that matched Prisma's default naming
- Large tables (`votes`, `options`, `poll_views`, `participants`) deliberately excluded — may be restructured under the EventType/Sheets direction

Closes [RAL-1188](https://linear.app/rallly/issue/RAL-1188/migrate-hash-indexes-to-btree-small-tables).

## Test plan

- [x] `pnpm db:migrate` applies cleanly locally
- [x] Verified all in-scope tables now use btree (`pg_indexes` + `pg_am`)
- [x] Verified out-of-scope tables (`votes`, `options`, `poll_views`, `participants`) hash indexes untouched
- [x] No renames in the generated SQL — `map:` removal was a true no-op
- [x] Confirm `prisma migrate deploy` runs cleanly in staging/prod

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated database indexing structure across multiple tables to optimize backend performance and query efficiency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lukevella/rallly/pull/2379)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->