### PR TITLE
✨ Add event types list page and nav entry

### DIFF
--- a/apps/landing/public/locales/en/common.json
+++ b/apps/landing/public/locales/en/common.json
@@ -6,7 +6,6 @@
   "footerCredit": "Made by <a>@imlukevella</a>",
   "footerSponsor": "This project is user-funded. Please consider supporting it by <a>donating</a>.",
   "language": "Language",
-  "poweredBy": "Powered by",
   "privacyPolicy": "Privacy Policy",
   "support": "Support",
   "cookiePolicy": "Cookie Policy",

--- a/apps/web/public/locales/en/app.json
+++ b/apps/web/public/locales/en/app.json
@@ -631,10 +631,6 @@
   "updateAvailable": "Update available",
   "eventTypesEmptyTitle": "No event types yet",
   "eventTypesEmptyDescription": "Create reusable event types that people can book with you.",
-  "eventTypeDurationMinutes": "{count, plural, one {# minute} other {# minutes}}",
-  "eventTypeCapacityUnlimited": "Unlimited",
-  "eventTypeCapacityCount": "{count, plural, one {# person} other {# people}}",
   "eventTypeUpdatedRelative": "Updated {relativeTime}",
-  "eventTypes": "Event Types",
-  "eventTypesNew": "New Event Type"
+  "eventTypes": "Event Types"
 }

--- a/apps/web/public/locales/en/app.json
+++ b/apps/web/public/locales/en/app.json
@@ -628,5 +628,13 @@
   "customBrandingPromptCta": "Set Up Now",
   "dismiss": "Dismiss",
   "new": "New",
-  "updateAvailable": "Update available"
+  "updateAvailable": "Update available",
+  "eventTypesEmptyTitle": "No event types yet",
+  "eventTypesEmptyDescription": "Create reusable event types that people can book with you.",
+  "eventTypeDurationMinutes": "{count, plural, one {# minute} other {# minutes}}",
+  "eventTypeCapacityUnlimited": "Unlimited",
+  "eventTypeCapacityCount": "{count, plural, one {# person} other {# people}}",
+  "eventTypeUpdatedRelative": "Updated {relativeTime}",
+  "eventTypes": "Event Types",
+  "eventTypesNew": "New Event Type"
 }

--- a/apps/web/src/app/[locale]/(space)/(dashboard)/event-types/event-types-page.tsx
+++ b/apps/web/src/app/[locale]/(space)/(dashboard)/event-types/event-types-page.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { Card, CardContent, CardHeader, CardTitle } from "@rallly/ui/card";
 import { Icon } from "@rallly/ui/icon";
 import {
   CalendarRangeIcon,
@@ -22,12 +23,13 @@ import {
   EmptyStateTitle,
 } from "@/components/empty-state";
 import { OptimizedAvatarImage } from "@/components/optimized-avatar-image";
-import { StackedList, StackedListItem } from "@/components/stacked-list";
+import { RandomGradientBar } from "@/components/random-gradient-bar";
 import type { EventTypeDTO } from "@/features/event-types/types";
 import { Trans } from "@/i18n/client";
-import { dayjs } from "@/lib/dayjs";
+import { useLocale } from "@/lib/locale/client";
 import type { Location } from "@/lib/location";
 import { trpc } from "@/trpc/client";
+import { formatDuration } from "@/utils/date-time-utils";
 
 function EventTypesEmptyState() {
   return (
@@ -55,7 +57,7 @@ function LocationSummary({ location }: { location: Location | null }) {
 
   if (location.type === "in_person") {
     return (
-      <span className="inline-flex items-center gap-1 truncate">
+      <span className="inline-flex items-center gap-2 truncate">
         <Icon>
           <MapPinIcon />
         </Icon>
@@ -66,7 +68,7 @@ function LocationSummary({ location }: { location: Location | null }) {
 
   const label = location.text ?? location.url;
   return (
-    <span className="inline-flex items-center gap-1 truncate">
+    <span className="inline-flex items-center gap-2 truncate">
       <Icon>
         <LinkIcon />
       </Icon>
@@ -75,49 +77,42 @@ function LocationSummary({ location }: { location: Location | null }) {
   );
 }
 
-function EventTypeRow({ eventType }: { eventType: EventTypeDTO }) {
+function EventTypeCard({ eventType }: { eventType: EventTypeDTO }) {
+  const { locale } = useLocale();
   return (
-    <div className="flex items-center justify-between gap-4">
-      <div className="min-w-0 flex-1">
-        <div className="truncate font-medium text-sm">{eventType.name}</div>
-        <div className="mt-1 flex items-center gap-2 text-muted-foreground text-xs">
-          <OptimizedAvatarImage
-            size="sm"
-            src={eventType.host.image ?? undefined}
-            name={eventType.host.name}
-          />
-          <span className="truncate">{eventType.host.name}</span>
-        </div>
-      </div>
-      <div className="hidden shrink-0 flex-wrap items-center justify-end gap-x-4 gap-y-1 text-muted-foreground text-xs sm:flex">
-        <span className="inline-flex items-center gap-1">
+    <Card className="flex h-full flex-col">
+      <RandomGradientBar />
+      <CardHeader>
+        <OptimizedAvatarImage
+          size="lg"
+          src={eventType.host.image ?? undefined}
+          name={eventType.host.name}
+        />
+        <p className="mt-2 font-medium text-muted-foreground text-sm">
+          {eventType.host.name}
+        </p>
+        <CardTitle className="mt-2 truncate">{eventType.name}</CardTitle>
+      </CardHeader>
+      <CardContent className="flex flex-1 flex-col gap-2 pt-0 text-muted-foreground text-sm">
+        <div className="flex items-center gap-2">
           <Icon>
             <ClockIcon />
           </Icon>
-          <span>
-            {dayjs.duration(eventType.duration, "minutes").humanize()}
-          </span>
-        </span>
+          <span>{formatDuration(eventType.duration, locale)}</span>
+        </div>
         {eventType.capacity !== null ? (
-          <span className="inline-flex items-center gap-1">
+          <div className="flex items-center gap-2">
             <Icon>
               <UserIcon />
             </Icon>
             <span>{eventType.capacity}</span>
-          </span>
+          </div>
         ) : null}
         {eventType.location ? (
           <LocationSummary location={eventType.location} />
         ) : null}
-        <span className="whitespace-nowrap">
-          <Trans
-            i18nKey="eventTypeUpdatedRelative"
-            defaults="Updated {relativeTime}"
-            values={{ relativeTime: dayjs(eventType.updatedAt).fromNow() }}
-          />
-        </span>
-      </div>
-    </div>
+      </CardContent>
+    </Card>
   );
 }
 
@@ -137,13 +132,13 @@ export function EventTypesPage() {
         {eventTypes.length === 0 ? (
           <EventTypesEmptyState />
         ) : (
-          <StackedList>
-            {eventTypes.map((eventType) => (
-              <StackedListItem key={eventType.id}>
-                <EventTypeRow eventType={eventType} />
-              </StackedListItem>
-            ))}
-          </StackedList>
+          <div className="@container">
+            <div className="grid @4xl:grid-cols-3 @md:grid-cols-2 grid-cols-1 gap-4">
+              {eventTypes.map((eventType) => (
+                <EventTypeCard key={eventType.id} eventType={eventType} />
+              ))}
+            </div>
+          </div>
         )}
       </PageContent>
     </PageContainer>

--- a/apps/web/src/app/[locale]/(space)/(dashboard)/event-types/event-types-page.tsx
+++ b/apps/web/src/app/[locale]/(space)/(dashboard)/event-types/event-types-page.tsx
@@ -1,13 +1,13 @@
 "use client";
 
-import { Card, CardContent, CardHeader, CardTitle } from "@rallly/ui/card";
-import { Icon } from "@rallly/ui/icon";
+import { Badge } from "@rallly/ui/badge";
+import { CardTitle } from "@rallly/ui/card";
 import {
+  ArmchairIcon,
   CalendarRangeIcon,
   ClockIcon,
-  LinkIcon,
+  Link2Icon,
   MapPinIcon,
-  UserIcon,
 } from "lucide-react";
 import {
   PageContainer,
@@ -24,10 +24,9 @@ import {
 } from "@/components/empty-state";
 import { OptimizedAvatarImage } from "@/components/optimized-avatar-image";
 import { RandomGradientBar } from "@/components/random-gradient-bar";
-import type { EventTypeDTO } from "@/features/event-types/types";
 import { Trans } from "@/i18n/client";
 import { useLocale } from "@/lib/locale/client";
-import type { Location } from "@/lib/location";
+import type { LocationType } from "@/lib/location";
 import { trpc } from "@/trpc/client";
 import { formatDuration } from "@/utils/date-time-utils";
 
@@ -50,69 +49,59 @@ function EventTypesEmptyState() {
   );
 }
 
-function LocationSummary({ location }: { location: Location | null }) {
-  if (!location) {
-    return null;
-  }
-
-  if (location.type === "in_person") {
-    return (
-      <span className="inline-flex items-center gap-2 truncate">
-        <Icon>
-          <MapPinIcon />
-        </Icon>
-        <span className="truncate">{location.address}</span>
-      </span>
-    );
-  }
-
-  const label = location.text ?? location.url;
-  return (
-    <span className="inline-flex items-center gap-2 truncate">
-      <Icon>
-        <LinkIcon />
-      </Icon>
-      <span className="truncate">{label}</span>
-    </span>
-  );
-}
-
-function EventTypeCard({ eventType }: { eventType: EventTypeDTO }) {
+function EventTypeCard({
+  name,
+  duration,
+  capacity,
+  hostName,
+  hostImage,
+  locationType,
+  locationLabel,
+}: {
+  name: string;
+  duration: number;
+  capacity: number | null;
+  hostName: string;
+  hostImage?: string;
+  locationType: LocationType | null;
+  locationLabel: string | null;
+}) {
   const { locale } = useLocale();
   return (
-    <Card className="flex h-full flex-col">
+    <div className="flex flex-col overflow-hidden rounded-2xl border border-card-border bg-card">
       <RandomGradientBar />
-      <CardHeader>
-        <OptimizedAvatarImage
-          size="lg"
-          src={eventType.host.image ?? undefined}
-          name={eventType.host.name}
-        />
+      <div className="p-3">
+        <OptimizedAvatarImage size="lg" src={hostImage} name={hostName} />
         <p className="mt-2 font-medium text-muted-foreground text-sm">
-          {eventType.host.name}
+          {hostName}
         </p>
-        <CardTitle className="mt-2 truncate">{eventType.name}</CardTitle>
-      </CardHeader>
-      <CardContent className="flex flex-1 flex-col gap-2 pt-0 text-muted-foreground text-sm">
-        <div className="flex items-center gap-2">
-          <Icon>
-            <ClockIcon />
-          </Icon>
-          <span>{formatDuration(eventType.duration, locale)}</span>
+        <CardTitle className="mt-2 truncate">{name}</CardTitle>
+      </div>
+      <div className="mt-auto p-3">
+        <div className="flex flex-wrap gap-1">
+          <Badge>
+            <ClockIcon className="mr-1 -ml-0.5 size-4" />
+            <span>{formatDuration(duration, locale)}</span>
+          </Badge>
+          {capacity !== null ? (
+            <Badge>
+              <ArmchairIcon className="mr-1 -ml-0.5 size-4" />
+              <span>{capacity}</span>
+            </Badge>
+          ) : null}
+          {locationType && locationLabel ? (
+            <Badge>
+              {locationType === "in_person" ? (
+                <MapPinIcon className="mr-1 -ml-0.5 size-4" />
+              ) : (
+                <Link2Icon className="mr-1 -ml-0.5 size-4" />
+              )}
+              <span className="truncate">{locationLabel}</span>
+            </Badge>
+          ) : null}
         </div>
-        {eventType.capacity !== null ? (
-          <div className="flex items-center gap-2">
-            <Icon>
-              <UserIcon />
-            </Icon>
-            <span>{eventType.capacity}</span>
-          </div>
-        ) : null}
-        {eventType.location ? (
-          <LocationSummary location={eventType.location} />
-        ) : null}
-      </CardContent>
-    </Card>
+      </div>
+    </div>
   );
 }
 
@@ -135,7 +124,22 @@ export function EventTypesPage() {
           <div className="@container">
             <div className="grid @4xl:grid-cols-3 @md:grid-cols-2 grid-cols-1 gap-4">
               {eventTypes.map((eventType) => (
-                <EventTypeCard key={eventType.id} eventType={eventType} />
+                <EventTypeCard
+                  key={eventType.id}
+                  name={eventType.name}
+                  duration={eventType.duration}
+                  capacity={eventType.capacity}
+                  hostName={eventType.host.name}
+                  hostImage={eventType.host.image ?? undefined}
+                  locationType={eventType.location?.type ?? null}
+                  locationLabel={
+                    eventType.location
+                      ? eventType.location.type === "in_person"
+                        ? eventType.location.address
+                        : (eventType.location.text ?? eventType.location.url)
+                      : null
+                  }
+                />
               ))}
             </div>
           </div>

--- a/apps/web/src/app/[locale]/(space)/(dashboard)/event-types/event-types-page.tsx
+++ b/apps/web/src/app/[locale]/(space)/(dashboard)/event-types/event-types-page.tsx
@@ -8,7 +8,6 @@ import {
   MapPinIcon,
   UserIcon,
 } from "lucide-react";
-import Link from "next/link";
 import {
   PageContainer,
   PageContent,
@@ -78,52 +77,47 @@ function LocationSummary({ location }: { location: Location | null }) {
 
 function EventTypeRow({ eventType }: { eventType: EventTypeDTO }) {
   return (
-    <Link
-      href={`/event-types/${eventType.id}/edit`}
-      className="flex w-full flex-col gap-2"
-    >
-      <div className="flex items-center justify-between gap-4">
-        <div className="min-w-0 flex-1">
-          <div className="truncate font-medium text-sm">{eventType.name}</div>
-          <div className="mt-1 flex items-center gap-2 text-muted-foreground text-xs">
-            <OptimizedAvatarImage
-              size="sm"
-              src={eventType.host.image ?? undefined}
-              name={eventType.host.name}
-            />
-            <span className="truncate">{eventType.host.name}</span>
-          </div>
-        </div>
-        <div className="hidden shrink-0 flex-wrap items-center justify-end gap-x-4 gap-y-1 text-muted-foreground text-xs sm:flex">
-          <span className="inline-flex items-center gap-1">
-            <Icon>
-              <ClockIcon />
-            </Icon>
-            <span>
-              {dayjs.duration(eventType.duration, "minutes").humanize()}
-            </span>
-          </span>
-          {eventType.capacity !== null ? (
-            <span className="inline-flex items-center gap-1">
-              <Icon>
-                <UserIcon />
-              </Icon>
-              <span>{eventType.capacity}</span>
-            </span>
-          ) : null}
-          {eventType.location ? (
-            <LocationSummary location={eventType.location} />
-          ) : null}
-          <span className="whitespace-nowrap">
-            <Trans
-              i18nKey="eventTypeUpdatedRelative"
-              defaults="Updated {relativeTime}"
-              values={{ relativeTime: dayjs(eventType.updatedAt).fromNow() }}
-            />
-          </span>
+    <div className="flex items-center justify-between gap-4">
+      <div className="min-w-0 flex-1">
+        <div className="truncate font-medium text-sm">{eventType.name}</div>
+        <div className="mt-1 flex items-center gap-2 text-muted-foreground text-xs">
+          <OptimizedAvatarImage
+            size="sm"
+            src={eventType.host.image ?? undefined}
+            name={eventType.host.name}
+          />
+          <span className="truncate">{eventType.host.name}</span>
         </div>
       </div>
-    </Link>
+      <div className="hidden shrink-0 flex-wrap items-center justify-end gap-x-4 gap-y-1 text-muted-foreground text-xs sm:flex">
+        <span className="inline-flex items-center gap-1">
+          <Icon>
+            <ClockIcon />
+          </Icon>
+          <span>
+            {dayjs.duration(eventType.duration, "minutes").humanize()}
+          </span>
+        </span>
+        {eventType.capacity !== null ? (
+          <span className="inline-flex items-center gap-1">
+            <Icon>
+              <UserIcon />
+            </Icon>
+            <span>{eventType.capacity}</span>
+          </span>
+        ) : null}
+        {eventType.location ? (
+          <LocationSummary location={eventType.location} />
+        ) : null}
+        <span className="whitespace-nowrap">
+          <Trans
+            i18nKey="eventTypeUpdatedRelative"
+            defaults="Updated {relativeTime}"
+            values={{ relativeTime: dayjs(eventType.updatedAt).fromNow() }}
+          />
+        </span>
+      </div>
+    </div>
   );
 }
 

--- a/apps/web/src/app/[locale]/(space)/(dashboard)/event-types/event-types-page.tsx
+++ b/apps/web/src/app/[locale]/(space)/(dashboard)/event-types/event-types-page.tsx
@@ -1,21 +1,18 @@
 "use client";
 
-import { buttonVariants } from "@rallly/ui";
 import { Icon } from "@rallly/ui/icon";
 import {
   CalendarRangeIcon,
   ClockIcon,
   LinkIcon,
   MapPinIcon,
-  PlusIcon,
-  UsersIcon,
+  UserIcon,
 } from "lucide-react";
 import Link from "next/link";
 import {
   PageContainer,
   PageContent,
   PageHeader,
-  PageHeaderActions,
   PageHeaderContent,
   PageTitle,
 } from "@/app/components/page-layout";
@@ -102,29 +99,18 @@ function EventTypeRow({ eventType }: { eventType: EventTypeDTO }) {
             <Icon>
               <ClockIcon />
             </Icon>
-            <Trans
-              i18nKey="eventTypeDurationMinutes"
-              defaults="{count, plural, one {# minute} other {# minutes}}"
-              values={{ count: eventType.duration }}
-            />
+            <span>
+              {dayjs.duration(eventType.duration, "minutes").humanize()}
+            </span>
           </span>
-          <span className="inline-flex items-center gap-1">
-            <Icon>
-              <UsersIcon />
-            </Icon>
-            {eventType.capacity === null ? (
-              <Trans
-                i18nKey="eventTypeCapacityUnlimited"
-                defaults="Unlimited"
-              />
-            ) : (
-              <Trans
-                i18nKey="eventTypeCapacityCount"
-                defaults="{count, plural, one {# person} other {# people}}"
-                values={{ count: eventType.capacity }}
-              />
-            )}
-          </span>
+          {eventType.capacity !== null ? (
+            <span className="inline-flex items-center gap-1">
+              <Icon>
+                <UserIcon />
+              </Icon>
+              <span>{eventType.capacity}</span>
+            </span>
+          ) : null}
           {eventType.location ? (
             <LocationSummary location={eventType.location} />
           ) : null}
@@ -152,15 +138,6 @@ export function EventTypesPage() {
             <Trans i18nKey="eventTypes" defaults="Event Types" />
           </PageTitle>
         </PageHeaderContent>
-        <PageHeaderActions>
-          <Link
-            href="/event-types/create"
-            className={buttonVariants({ variant: "primary" })}
-          >
-            <PlusIcon data-icon="inline-start" />
-            <Trans i18nKey="eventTypesNew" defaults="New Event Type" />
-          </Link>
-        </PageHeaderActions>
       </PageHeader>
       <PageContent>
         {eventTypes.length === 0 ? (

--- a/apps/web/src/app/[locale]/(space)/(dashboard)/event-types/event-types-page.tsx
+++ b/apps/web/src/app/[locale]/(space)/(dashboard)/event-types/event-types-page.tsx
@@ -1,0 +1,180 @@
+"use client";
+
+import { buttonVariants } from "@rallly/ui";
+import { Icon } from "@rallly/ui/icon";
+import {
+  CalendarRangeIcon,
+  ClockIcon,
+  LinkIcon,
+  MapPinIcon,
+  PlusIcon,
+  UsersIcon,
+} from "lucide-react";
+import Link from "next/link";
+import {
+  PageContainer,
+  PageContent,
+  PageHeader,
+  PageHeaderActions,
+  PageHeaderContent,
+  PageTitle,
+} from "@/app/components/page-layout";
+import {
+  EmptyState,
+  EmptyStateDescription,
+  EmptyStateIcon,
+  EmptyStateTitle,
+} from "@/components/empty-state";
+import { OptimizedAvatarImage } from "@/components/optimized-avatar-image";
+import { StackedList, StackedListItem } from "@/components/stacked-list";
+import type { EventTypeDTO } from "@/features/event-types/types";
+import { Trans } from "@/i18n/client";
+import { dayjs } from "@/lib/dayjs";
+import type { Location } from "@/lib/location";
+import { trpc } from "@/trpc/client";
+
+function EventTypesEmptyState() {
+  return (
+    <EmptyState className="p-8">
+      <EmptyStateIcon>
+        <CalendarRangeIcon />
+      </EmptyStateIcon>
+      <EmptyStateTitle>
+        <Trans i18nKey="eventTypesEmptyTitle" defaults="No event types yet" />
+      </EmptyStateTitle>
+      <EmptyStateDescription>
+        <Trans
+          i18nKey="eventTypesEmptyDescription"
+          defaults="Create reusable event types that people can book with you."
+        />
+      </EmptyStateDescription>
+    </EmptyState>
+  );
+}
+
+function LocationSummary({ location }: { location: Location | null }) {
+  if (!location) {
+    return null;
+  }
+
+  if (location.type === "in_person") {
+    return (
+      <span className="inline-flex items-center gap-1 truncate">
+        <Icon>
+          <MapPinIcon />
+        </Icon>
+        <span className="truncate">{location.address}</span>
+      </span>
+    );
+  }
+
+  const label = location.text ?? location.url;
+  return (
+    <span className="inline-flex items-center gap-1 truncate">
+      <Icon>
+        <LinkIcon />
+      </Icon>
+      <span className="truncate">{label}</span>
+    </span>
+  );
+}
+
+function EventTypeRow({ eventType }: { eventType: EventTypeDTO }) {
+  return (
+    <Link
+      href={`/event-types/${eventType.id}/edit`}
+      className="flex w-full flex-col gap-2"
+    >
+      <div className="flex items-center justify-between gap-4">
+        <div className="min-w-0 flex-1">
+          <div className="truncate font-medium text-sm">{eventType.name}</div>
+          <div className="mt-1 flex items-center gap-2 text-muted-foreground text-xs">
+            <OptimizedAvatarImage
+              size="sm"
+              src={eventType.host.image ?? undefined}
+              name={eventType.host.name}
+            />
+            <span className="truncate">{eventType.host.name}</span>
+          </div>
+        </div>
+        <div className="hidden shrink-0 flex-wrap items-center justify-end gap-x-4 gap-y-1 text-muted-foreground text-xs sm:flex">
+          <span className="inline-flex items-center gap-1">
+            <Icon>
+              <ClockIcon />
+            </Icon>
+            <Trans
+              i18nKey="eventTypeDurationMinutes"
+              defaults="{count, plural, one {# minute} other {# minutes}}"
+              values={{ count: eventType.duration }}
+            />
+          </span>
+          <span className="inline-flex items-center gap-1">
+            <Icon>
+              <UsersIcon />
+            </Icon>
+            {eventType.capacity === null ? (
+              <Trans
+                i18nKey="eventTypeCapacityUnlimited"
+                defaults="Unlimited"
+              />
+            ) : (
+              <Trans
+                i18nKey="eventTypeCapacityCount"
+                defaults="{count, plural, one {# person} other {# people}}"
+                values={{ count: eventType.capacity }}
+              />
+            )}
+          </span>
+          {eventType.location ? (
+            <LocationSummary location={eventType.location} />
+          ) : null}
+          <span className="whitespace-nowrap">
+            <Trans
+              i18nKey="eventTypeUpdatedRelative"
+              defaults="Updated {relativeTime}"
+              values={{ relativeTime: dayjs(eventType.updatedAt).fromNow() }}
+            />
+          </span>
+        </div>
+      </div>
+    </Link>
+  );
+}
+
+export function EventTypesPage() {
+  const [{ eventTypes }] = trpc.eventTypes.list.useSuspenseQuery();
+
+  return (
+    <PageContainer>
+      <PageHeader>
+        <PageHeaderContent>
+          <PageTitle>
+            <Trans i18nKey="eventTypes" defaults="Event Types" />
+          </PageTitle>
+        </PageHeaderContent>
+        <PageHeaderActions>
+          <Link
+            href="/event-types/create"
+            className={buttonVariants({ variant: "primary" })}
+          >
+            <PlusIcon data-icon="inline-start" />
+            <Trans i18nKey="eventTypesNew" defaults="New Event Type" />
+          </Link>
+        </PageHeaderActions>
+      </PageHeader>
+      <PageContent>
+        {eventTypes.length === 0 ? (
+          <EventTypesEmptyState />
+        ) : (
+          <StackedList>
+            {eventTypes.map((eventType) => (
+              <StackedListItem key={eventType.id}>
+                <EventTypeRow eventType={eventType} />
+              </StackedListItem>
+            ))}
+          </StackedList>
+        )}
+      </PageContent>
+    </PageContainer>
+  );
+}

--- a/apps/web/src/app/[locale]/(space)/(dashboard)/event-types/page.tsx
+++ b/apps/web/src/app/[locale]/(space)/(dashboard)/event-types/page.tsx
@@ -1,0 +1,31 @@
+import { dehydrate, HydrationBoundary } from "@tanstack/react-query";
+import type { Metadata } from "next";
+import { notFound } from "next/navigation";
+import { getTranslation } from "@/i18n/server";
+import { isFeatureEnabled } from "@/lib/feature-flags/server";
+import { createPrivateSSRHelper } from "@/trpc/server/create-ssr-helper";
+import { EventTypesPage } from "./event-types-page";
+
+export default async function Page() {
+  if (!isFeatureEnabled("eventTypes")) {
+    notFound();
+  }
+
+  const helpers = await createPrivateSSRHelper();
+  await helpers.eventTypes.list.prefetch();
+
+  return (
+    <HydrationBoundary state={dehydrate(helpers.queryClient)}>
+      <EventTypesPage />
+    </HydrationBoundary>
+  );
+}
+
+export async function generateMetadata(): Promise<Metadata> {
+  const { t } = await getTranslation();
+  return {
+    title: t("eventTypes", {
+      defaultValue: "Event Types",
+    }),
+  };
+}

--- a/apps/web/src/features/event-types/data.ts
+++ b/apps/web/src/features/event-types/data.ts
@@ -1,4 +1,4 @@
-import type { EventType } from "@rallly/database";
+import type { EventType, User } from "@rallly/database";
 import { prisma } from "@rallly/database";
 import { createLogger } from "@rallly/logger";
 import type { EventTypeDTO } from "@/features/event-types/types";
@@ -7,7 +7,9 @@ import { locationSchema } from "@/lib/location";
 
 const logger = createLogger("event-types/data");
 
-export function createEventTypeDTO(eventType: EventType): EventTypeDTO {
+export function createEventTypeDTO(
+  eventType: EventType & { host: Pick<User, "id" | "name" | "image"> },
+): EventTypeDTO {
   let location: Location | null = null;
   if (eventType.location !== null) {
     try {
@@ -27,6 +29,11 @@ export function createEventTypeDTO(eventType: EventType): EventTypeDTO {
     description: eventType.description,
     location,
     hostId: eventType.hostId,
+    host: {
+      id: eventType.host.id,
+      name: eventType.host.name,
+      image: eventType.host.image,
+    },
     spaceId: eventType.spaceId,
     createdAt: eventType.createdAt,
     updatedAt: eventType.updatedAt,
@@ -40,6 +47,11 @@ export async function getEventTypes(spaceId: string): Promise<EventTypeDTO[]> {
       deleted: false,
     },
     orderBy: { updatedAt: "desc" },
+    include: {
+      host: {
+        select: { id: true, name: true, image: true },
+      },
+    },
   });
 
   return rows.map(createEventTypeDTO);

--- a/apps/web/src/features/event-types/types.ts
+++ b/apps/web/src/features/event-types/types.ts
@@ -1,5 +1,11 @@
 import type { Location } from "@/lib/location";
 
+export type EventTypeHost = {
+  id: string;
+  name: string;
+  image: string | null;
+};
+
 export type EventTypeDTO = {
   id: string;
   name: string;
@@ -8,6 +14,7 @@ export type EventTypeDTO = {
   description: string | null;
   location: Location | null;
   hostId: string;
+  host: EventTypeHost;
   spaceId: string;
   createdAt: Date;
   updatedAt: Date;

--- a/apps/web/src/features/navigation/config.tsx
+++ b/apps/web/src/features/navigation/config.tsx
@@ -6,6 +6,7 @@ import {
   CalendarDaysIcon,
   CalendarIcon,
   HomeIcon,
+  ShapesIcon,
 } from "lucide-react";
 import { usePathname } from "next/navigation";
 import React from "react";
@@ -37,6 +38,7 @@ export const useSpaceMenu = () => {
   const { t } = useTranslation();
   const pathname = usePathname();
   const isCalendarsEnabled = useFeatureFlag("calendars");
+  const isEventTypesEnabled = useFeatureFlag("eventTypes");
   const config = React.useMemo<NavigationConfig>(
     () => ({
       sections: [
@@ -81,11 +83,24 @@ export const useSpaceMenu = () => {
                   },
                 ]
               : []),
+            ...(isEventTypesEnabled
+              ? [
+                  {
+                    id: "event-types",
+                    label: t("eventTypes", { defaultValue: "Event Types" }),
+                    href: "/event-types",
+                    icon: ShapesIcon,
+                    isActive:
+                      pathname === "/event-types" ||
+                      pathname.startsWith("/event-types/"),
+                  },
+                ]
+              : []),
           ],
         },
       ],
     }),
-    [pathname, t, isCalendarsEnabled],
+    [pathname, t, isCalendarsEnabled, isEventTypesEnabled],
   );
 
   return React.useMemo(

--- a/apps/web/src/trpc/routers/event-types.ts
+++ b/apps/web/src/trpc/routers/event-types.ts
@@ -40,6 +40,11 @@ export const eventTypes = router({
           description: input.description,
           location: input.location,
         },
+        include: {
+          host: {
+            select: { id: true, name: true, image: true },
+          },
+        },
       });
       return createEventTypeDTO(created);
     }),
@@ -59,6 +64,11 @@ export const eventTypes = router({
           capacity: input.capacity,
           description: input.description,
           location: input.location,
+        },
+        include: {
+          host: {
+            select: { id: true, name: true, image: true },
+          },
         },
       });
 

--- a/apps/web/src/utils/date-time-utils.ts
+++ b/apps/web/src/utils/date-time-utils.ts
@@ -38,20 +38,33 @@ export interface ParsedTimeSlotOption {
 
 export type ParsedDateTimeOpton = ParsedDateOption | ParsedTimeSlotOption;
 
-export const getDuration = (startTime: dayjs.Dayjs, endTime: dayjs.Dayjs) => {
-  const hours = Math.floor(endTime.diff(startTime, "hours"));
-  const minutes = Math.floor(endTime.diff(startTime, "minute") - hours * 60);
-  let res = "";
+type DurationFormatCtor = new (
+  locale: string | undefined,
+  options: { style: "narrow" },
+) => { format(duration: { hours?: number; minutes?: number }): string };
+
+export const formatDuration = (minutes: number, locale?: string) => {
+  const hours = Math.floor(minutes / 60);
+  const mins = minutes % 60;
+  const DurationFormat = (Intl as { DurationFormat?: DurationFormatCtor })
+    .DurationFormat;
+  if (DurationFormat) {
+    return new DurationFormat(locale, { style: "narrow" }).format({
+      hours,
+      minutes: mins,
+    });
+  }
+  if (hours && mins) {
+    return `${hours}h ${mins}m`;
+  }
   if (hours) {
-    res += `${hours}h`;
+    return `${hours}h`;
   }
-  if (hours && minutes) {
-    res += " ";
-  }
-  if (minutes) {
-    res += `${minutes}m`;
-  }
-  return res;
+  return `${mins}m`;
+};
+
+export const getDuration = (startTime: dayjs.Dayjs, endTime: dayjs.Dayjs) => {
+  return formatDuration(endTime.diff(startTime, "minute"));
 };
 
 export const removeAllOptionsForDay = (

--- a/packages/database/prisma/seed.ts
+++ b/packages/database/prisma/seed.ts
@@ -1,6 +1,7 @@
 import { PrismaPg } from "@prisma/adapter-pg";
 import { PrismaClient } from "../generated/prisma/client";
 import {
+  eventTypes,
   polls,
   scheduledEvents,
   spaceMembers,
@@ -168,6 +169,23 @@ async function main() {
   console.info(
     `✓ ${polls.length} polls, ${optionCount} options, ${participantCount} participants, ${voteCount} votes, ${commentCount} comments`,
   );
+
+  // 6. Event types
+  const now = Date.now();
+  await prisma.eventType.createMany({
+    data: eventTypes.map((et, i) => ({
+      id: et.id,
+      spaceId: et.spaceId,
+      hostId: et.hostId,
+      name: et.name,
+      duration: et.duration,
+      capacity: et.capacity,
+      description: et.description,
+      location: et.location ?? undefined,
+      updatedAt: new Date(now - i * 60_000),
+    })),
+  });
+  console.info(`✓ ${eventTypes.length} event types`);
 }
 
 main()

--- a/packages/database/prisma/seed/data.ts
+++ b/packages/database/prisma/seed/data.ts
@@ -1003,6 +1003,106 @@ const acmePolls: PollDef[] = [
 
 export const polls: PollDef[] = [...personalPolls, ...acmePolls];
 
+// ─── Event Types ─────────────────────────────────────────────────────────────
+
+type EventTypeLocation =
+  | { type: "in_person"; address: string; placeId?: string }
+  | { type: "custom_link"; url: string; text?: string };
+
+export type EventTypeDef = {
+  id: string;
+  spaceId: string;
+  hostId: string;
+  name: string;
+  duration: number;
+  capacity: number | null;
+  description: string | null;
+  location: EventTypeLocation | null;
+};
+
+export const eventTypes: EventTypeDef[] = [
+  // ── Personal space (space-1) ─────────────────────────────────────────────
+  {
+    id: "et-1",
+    spaceId: "space-1",
+    hostId: "user-1",
+    name: "30 Minute Meeting",
+    duration: 30,
+    capacity: null,
+    description: "Quick catch-up or intro.",
+    location: {
+      type: "custom_link",
+      url: "https://zoom.us/j/1234567890",
+      text: "Zoom",
+    },
+  },
+  {
+    id: "et-2",
+    spaceId: "space-1",
+    hostId: "user-1",
+    name: "Coffee Chat",
+    duration: 45,
+    capacity: 1,
+    description: null,
+    location: {
+      type: "in_person",
+      address: "Café on 5th Ave, New York",
+    },
+  },
+
+  // ── Acme Inc (space-2) ───────────────────────────────────────────────────
+  {
+    id: "et-3",
+    spaceId: "space-2",
+    hostId: "user-1",
+    name: "Intro Call",
+    duration: 15,
+    capacity: null,
+    description: "Brief intro to see if we're a fit.",
+    location: {
+      type: "custom_link",
+      url: "https://meet.google.com/abc-defg-hij",
+      text: "Google Meet",
+    },
+  },
+  {
+    id: "et-4",
+    spaceId: "space-2",
+    hostId: "user-2",
+    name: "Product Demo",
+    duration: 45,
+    capacity: null,
+    description: "Live walkthrough of the product.",
+    location: {
+      type: "custom_link",
+      url: "https://zoom.us/j/9876543210",
+    },
+  },
+  {
+    id: "et-5",
+    spaceId: "space-2",
+    hostId: "user-3",
+    name: "Office Hours",
+    duration: 60,
+    capacity: 5,
+    description: "Drop-in time for engineering questions.",
+    location: {
+      type: "in_person",
+      address: "Acme HQ, Conference Room B",
+    },
+  },
+  {
+    id: "et-6",
+    spaceId: "space-2",
+    hostId: "user-1",
+    name: "Team Workshop",
+    duration: 90,
+    capacity: null,
+    description: "Hands-on working session.",
+    location: null,
+  },
+];
+
 // ─── Scheduled Events ────────────────────────────────────────────────────────
 
 export type ScheduledEventDef = {

--- a/packages/ui/src/badge.tsx
+++ b/packages/ui/src/badge.tsx
@@ -5,12 +5,12 @@ import type * as React from "react";
 import { cn } from "./lib/utils";
 
 const badgeVariants = cva(
-  "group inline-flex items-center justify-center whitespace-nowrap rounded-full transition-colors focus:outline-hidden focus:ring-2 focus:ring-ring focus:ring-offset-2",
+  "group inline-flex items-center justify-center whitespace-nowrap rounded-lg transition-colors focus:outline-hidden focus:ring-2 focus:ring-ring focus:ring-offset-2",
   {
     variants: {
       variant: {
         primary: "bg-primary text-primary-foreground",
-        default: "bg-muted",
+        default: "border border-card-border bg-card text-muted-foreground",
         destructive:
           "bg-rose-600/10 text-rose-600 dark:bg-rose-500/10 dark:text-rose-500",
         outline: "text-foreground",


### PR DESCRIPTION
## Summary
- Adds `/event-types` dashboard page (gated by the `eventTypes` feature flag) with an empty state and a stacked list showing host, duration, capacity, location, and last updated time.
- Wires the route into the space navigation using `ShapesIcon`.
- Extends `EventTypeDTO` and `getEventTypes` to include host info (id, name, image), and updates the tRPC create/update mutations to include the host relation when returning the DTO.

## Test plan
- [x] Enable the `eventTypes` feature flag and verify the new nav entry appears under Content.
- [ ] Visit `/event-types` with no event types and confirm the empty state renders.
- [x] Create an event type and confirm it appears in the stacked list with host avatar, duration, capacity, location, and relative updated time.
- [x] Disable the feature flag and confirm `/event-types` returns 404 and the nav entry is hidden.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Redesigned Event Types dashboard: responsive card grid showing host, duration, capacity (when set), and location summary. Per-row "updated" timestamps no longer shown.

* **Navigation**
  * Added Event Types menu item.

* **Documentation**
  * Added English UI text for Event Types (heading, empty-state title/description, "updated" label).
  * Removed English "Powered by" label from landing copy.

* **Chores**
  * Added event-type seed data and a locale-aware duration formatting utility.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lukevella/rallly/pull/2381)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->