### PR TITLE
✨ Add soft delete flow for event types (RAL-1186)

### DIFF
--- a/apps/web/public/locales/en/app.json
+++ b/apps/web/public/locales/en/app.json
@@ -656,6 +656,6 @@
   "locationDisplayTextPlaceholder": "Meeting link",
   "eventTypeActionsLabel": "Event type actions",
   "deleteEventTypeTitle": "Delete event type?",
-  "deleteEventTypeDescription": "<b>{name}</b> will be hidden from creation pickers. This cannot be undone.",
+  "deleteEventTypeDescription": "Existing bookings for <b>{name}</b> will not be affected, but no new bookings can be made.",
   "deleteEventTypeError": "Failed to delete event type"
 }

--- a/apps/web/public/locales/en/app.json
+++ b/apps/web/public/locales/en/app.json
@@ -653,5 +653,9 @@
   "maxAttendeesInvalid": "Must be a positive integer",
   "requiredField": "Required",
   "urlInvalid": "Must be a valid URL",
-  "locationDisplayTextPlaceholder": "Meeting link"
+  "locationDisplayTextPlaceholder": "Meeting link",
+  "eventTypeActionsLabel": "Event type actions",
+  "deleteEventTypeTitle": "Delete event type?",
+  "deleteEventTypeDescription": "<b>{name}</b> will be hidden from creation pickers. This cannot be undone.",
+  "deleteEventTypeError": "Failed to delete event type"
 }

--- a/apps/web/src/app/[locale]/(space)/(dashboard)/event-types/event-types-page.tsx
+++ b/apps/web/src/app/[locale]/(space)/(dashboard)/event-types/event-types-page.tsx
@@ -5,13 +5,23 @@ import { Button } from "@rallly/ui/button";
 import { CardTitle } from "@rallly/ui/card";
 import { useDialog } from "@rallly/ui/dialog";
 import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@rallly/ui/dropdown-menu";
+import { Icon } from "@rallly/ui/icon";
+import {
   ArmchairIcon,
   CalendarRangeIcon,
   ClockIcon,
   Link2Icon,
   MapPinIcon,
+  MoreVerticalIcon,
   PlusIcon,
+  Trash2Icon,
 } from "lucide-react";
+import React from "react";
 import {
   PageContainer,
   PageContent,
@@ -30,6 +40,7 @@ import {
 import { OptimizedAvatarImage } from "@/components/optimized-avatar-image";
 import { RandomGradientBar } from "@/components/random-gradient-bar";
 import { CreateEventTypeDialog } from "@/features/event-types/components/create-event-type-dialog";
+import { DeleteEventTypeDialog } from "@/features/event-types/components/delete-event-type-dialog";
 import { Trans } from "@/i18n/client";
 import { useLocale } from "@/lib/locale/client";
 import type { LocationType } from "@/lib/location";
@@ -69,6 +80,7 @@ function EventTypeCard({
   hostImage,
   locationType,
   locationLabel,
+  onDelete,
 }: {
   name: string;
   duration: number;
@@ -77,13 +89,37 @@ function EventTypeCard({
   hostImage?: string;
   locationType: LocationType | null;
   locationLabel: string | null;
+  onDelete: () => void;
 }) {
   const { locale } = useLocale();
   return (
     <div className="flex flex-col overflow-hidden rounded-2xl border border-card-border bg-card">
       <RandomGradientBar />
       <div className="p-3">
-        <OptimizedAvatarImage size="lg" src={hostImage} name={hostName} />
+        <div className="flex items-start justify-between gap-2">
+          <OptimizedAvatarImage size="lg" src={hostImage} name={hostName} />
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button variant="ghost" size="icon">
+                <Icon>
+                  <MoreVerticalIcon />
+                </Icon>
+                <span className="sr-only">
+                  <Trans
+                    i18nKey="eventTypeActionsLabel"
+                    defaults="Event type actions"
+                  />
+                </span>
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end">
+              <DropdownMenuItem variant="destructive" onClick={onDelete}>
+                <Trash2Icon className="size-4" />
+                <Trans i18nKey="delete" defaults="Delete" />
+              </DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
+        </div>
         <p className="mt-2 font-medium text-muted-foreground text-sm">
           {hostName}
         </p>
@@ -119,7 +155,12 @@ function EventTypeCard({
 
 export function EventTypesPage() {
   const [{ eventTypes }] = trpc.eventTypes.list.useSuspenseQuery();
-  const dialog = useDialog();
+  const createDialog = useDialog();
+  const deleteDialog = useDialog();
+  const [selectedEventType, setSelectedEventType] = React.useState<{
+    id: string;
+    name: string;
+  } | null>(null);
 
   return (
     <PageContainer>
@@ -130,7 +171,7 @@ export function EventTypesPage() {
           </PageTitle>
         </PageHeaderContent>
         <PageHeaderActions>
-          <Button variant="primary" onClick={() => dialog.trigger()}>
+          <Button variant="primary" onClick={() => createDialog.trigger()}>
             <PlusIcon data-icon="inline-start" />
             <Trans i18nKey="newEventType" defaults="New Event Type" />
           </Button>
@@ -138,7 +179,7 @@ export function EventTypesPage() {
       </PageHeader>
       <PageContent>
         {eventTypes.length === 0 ? (
-          <EventTypesEmptyState onCreate={() => dialog.trigger()} />
+          <EventTypesEmptyState onCreate={() => createDialog.trigger()} />
         ) : (
           <div className="@container">
             <div className="grid @4xl:grid-cols-3 @md:grid-cols-2 grid-cols-1 gap-4">
@@ -158,13 +199,27 @@ export function EventTypesPage() {
                         : (eventType.location.text ?? eventType.location.url)
                       : null
                   }
+                  onDelete={() => {
+                    setSelectedEventType({
+                      id: eventType.id,
+                      name: eventType.name,
+                    });
+                    deleteDialog.trigger();
+                  }}
                 />
               ))}
             </div>
           </div>
         )}
       </PageContent>
-      <CreateEventTypeDialog {...dialog.dialogProps} />
+      <CreateEventTypeDialog {...createDialog.dialogProps} />
+      {selectedEventType ? (
+        <DeleteEventTypeDialog
+          {...deleteDialog.dialogProps}
+          eventTypeId={selectedEventType.id}
+          eventTypeName={selectedEventType.name}
+        />
+      ) : null}
     </PageContainer>
   );
 }

--- a/apps/web/src/features/event-types/components/delete-event-type-dialog.tsx
+++ b/apps/web/src/features/event-types/components/delete-event-type-dialog.tsx
@@ -1,0 +1,86 @@
+"use client";
+
+import { usePostHog } from "@rallly/posthog/client";
+import { Button } from "@rallly/ui/button";
+import type { DialogProps } from "@rallly/ui/dialog";
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@rallly/ui/dialog";
+import { toast } from "@rallly/ui/sonner";
+import { Trans, useTranslation } from "@/i18n/client";
+import { trpc } from "@/trpc/client";
+
+export function DeleteEventTypeDialog({
+  eventTypeId,
+  eventTypeName,
+  open,
+  onOpenChange,
+}: DialogProps & {
+  eventTypeId: string;
+  eventTypeName: string;
+}) {
+  const { t } = useTranslation();
+  const posthog = usePostHog();
+  const softDelete = trpc.eventTypes.softDelete.useMutation();
+
+  const handleDelete = async () => {
+    try {
+      await softDelete.mutateAsync({ id: eventTypeId });
+    } catch {
+      toast.error(
+        t("deleteEventTypeError", {
+          defaultValue: "Failed to delete event type",
+        }),
+      );
+      return;
+    }
+    posthog?.capture("event_type_deletion:confirm");
+    onOpenChange?.(false);
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent size="sm">
+        <DialogHeader>
+          <DialogTitle>
+            <Trans
+              i18nKey="deleteEventTypeTitle"
+              defaults="Delete event type?"
+            />
+          </DialogTitle>
+          <DialogDescription>
+            <Trans
+              i18nKey="deleteEventTypeDescription"
+              defaults="<b>{name}</b> will be hidden from creation pickers. This cannot be undone."
+              values={{ name: eventTypeName }}
+              components={{
+                b: <b className="font-semibold text-foreground" />,
+              }}
+            />
+          </DialogDescription>
+        </DialogHeader>
+        <DialogFooter>
+          <DialogClose asChild>
+            <Button type="button" disabled={softDelete.isPending}>
+              <Trans i18nKey="cancel" defaults="Cancel" />
+            </Button>
+          </DialogClose>
+          <Button
+            type="button"
+            variant="destructive"
+            onClick={handleDelete}
+            loading={softDelete.isPending}
+          >
+            <Trans i18nKey="delete" defaults="Delete" />
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}


### PR DESCRIPTION
## Summary
- Adds a per-row dropdown menu on each event type card with a destructive `Delete` action
- Confirmation dialog calls `eventTypes.softDelete` and fires `event_type_deletion:confirm` on success
- Deleted records disappear from the list via the global mutation invalidation in the trpc client
- Edit dialog entry point (per RAL-1185) is not in scope here — the dialog accepts a `DialogProps`-shaped API so the future edit dialog can mount it the same way

## Test plan
- [x] Open the dropdown on a card; click `Delete`
- [x] Confirmation dialog shows the event type name in the description
- [x] Clicking `Cancel` or dismissing the dialog leaves the record intact
- [x] Clicking `Delete` removes the card from the list, button shows loading state, dialog closes on success
- [x] Confirm `event_type_deletion:confirm` fires in PostHog
- [x] Reload the page — deleted record stays hidden

Closes RAL-1186

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added delete functionality for event types via an actions menu on each card
  * Added confirmation dialog to prevent accidental deletions
  * Error notifications shown if deletion fails

* **Localization**
  * Added English locale strings for event type UI, actions, and delete-confirmation dialog (including interpolated name and error text)

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lukevella/rallly/pull/2386?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->