### PR TITLE
✨ Add edit event type dialog (RAL-1185)

### DIFF
--- a/apps/web/public/locales/en/app.json
+++ b/apps/web/public/locales/en/app.json
@@ -657,5 +657,8 @@
   "eventTypeActionsLabel": "Event type actions",
   "deleteEventTypeTitle": "Delete event type?",
   "deleteEventTypeDescription": "Existing bookings for <b>{name}</b> will not be affected, but no new bookings can be made.",
-  "deleteEventTypeError": "Failed to delete event type"
+  "deleteEventTypeError": "Failed to delete event type",
+  "edit": "Edit",
+  "editEventTypeTitle": "Edit Event Type",
+  "updateEventTypeError": "Failed to update event type"
 }

--- a/apps/web/src/app/[locale]/(space)/(dashboard)/event-types/event-types-page.tsx
+++ b/apps/web/src/app/[locale]/(space)/(dashboard)/event-types/event-types-page.tsx
@@ -18,6 +18,7 @@ import {
   Link2Icon,
   MapPinIcon,
   MoreVerticalIcon,
+  PencilIcon,
   PlusIcon,
   Trash2Icon,
 } from "lucide-react";
@@ -41,6 +42,8 @@ import { OptimizedAvatarImage } from "@/components/optimized-avatar-image";
 import { RandomGradientBar } from "@/components/random-gradient-bar";
 import { CreateEventTypeDialog } from "@/features/event-types/components/create-event-type-dialog";
 import { DeleteEventTypeDialog } from "@/features/event-types/components/delete-event-type-dialog";
+import { EditEventTypeDialog } from "@/features/event-types/components/edit-event-type-dialog";
+import type { EventTypeDTO } from "@/features/event-types/types";
 import { Trans } from "@/i18n/client";
 import { useLocale } from "@/lib/locale/client";
 import type { LocationType } from "@/lib/location";
@@ -80,6 +83,7 @@ function EventTypeCard({
   hostImage,
   locationType,
   locationLabel,
+  onEdit,
   onDelete,
 }: {
   name: string;
@@ -89,6 +93,7 @@ function EventTypeCard({
   hostImage?: string;
   locationType: LocationType | null;
   locationLabel: string | null;
+  onEdit: () => void;
   onDelete: () => void;
 }) {
   const { locale } = useLocale();
@@ -113,6 +118,10 @@ function EventTypeCard({
               </Button>
             </DropdownMenuTrigger>
             <DropdownMenuContent align="end">
+              <DropdownMenuItem onClick={onEdit}>
+                <PencilIcon className="size-4" />
+                <Trans i18nKey="edit" defaults="Edit" />
+              </DropdownMenuItem>
               <DropdownMenuItem variant="destructive" onClick={onDelete}>
                 <Trash2Icon className="size-4" />
                 <Trans i18nKey="delete" defaults="Delete" />
@@ -156,11 +165,10 @@ function EventTypeCard({
 export function EventTypesPage() {
   const [{ eventTypes }] = trpc.eventTypes.list.useSuspenseQuery();
   const createDialog = useDialog();
+  const editDialog = useDialog();
   const deleteDialog = useDialog();
-  const [selectedEventType, setSelectedEventType] = React.useState<{
-    id: string;
-    name: string;
-  } | null>(null);
+  const [selectedEventType, setSelectedEventType] =
+    React.useState<EventTypeDTO | null>(null);
 
   return (
     <PageContainer>
@@ -199,11 +207,12 @@ export function EventTypesPage() {
                         : (eventType.location.text ?? eventType.location.url)
                       : null
                   }
+                  onEdit={() => {
+                    setSelectedEventType(eventType);
+                    editDialog.trigger();
+                  }}
                   onDelete={() => {
-                    setSelectedEventType({
-                      id: eventType.id,
-                      name: eventType.name,
-                    });
+                    setSelectedEventType(eventType);
                     deleteDialog.trigger();
                   }}
                 />
@@ -214,11 +223,17 @@ export function EventTypesPage() {
       </PageContent>
       <CreateEventTypeDialog {...createDialog.dialogProps} />
       {selectedEventType ? (
-        <DeleteEventTypeDialog
-          {...deleteDialog.dialogProps}
-          eventTypeId={selectedEventType.id}
-          eventTypeName={selectedEventType.name}
-        />
+        <>
+          <EditEventTypeDialog
+            {...editDialog.dialogProps}
+            eventType={selectedEventType}
+          />
+          <DeleteEventTypeDialog
+            {...deleteDialog.dialogProps}
+            eventTypeId={selectedEventType.id}
+            eventTypeName={selectedEventType.name}
+          />
+        </>
       ) : null}
     </PageContainer>
   );

--- a/apps/web/src/features/event-types/components/edit-event-type-dialog.tsx
+++ b/apps/web/src/features/event-types/components/edit-event-type-dialog.tsx
@@ -8,7 +8,6 @@ import {
   Dialog,
   DialogClose,
   DialogContent,
-  DialogDescription,
   DialogFooter,
   DialogHeader,
   DialogTitle,
@@ -20,31 +19,52 @@ import { useForm } from "react-hook-form";
 import {
   buildEventTypeFormSchema,
   EventTypeFormFields,
-  eventTypeFormDefaults,
+  eventTypeToFormValues,
   eventTypeValuesToInput,
 } from "@/features/event-types/components/event-type-form";
+import type { EventTypeDTO } from "@/features/event-types/types";
 import { Trans, useTranslation } from "@/i18n/client";
 import { trpc } from "@/trpc/client";
 
-export function CreateEventTypeDialog({ open, onOpenChange }: DialogProps) {
+export function EditEventTypeDialog({
+  eventType,
+  open,
+  onOpenChange,
+}: DialogProps & {
+  eventType: EventTypeDTO;
+}) {
   const { t } = useTranslation();
   const posthog = usePostHog();
-  const createEventType = trpc.eventTypes.create.useMutation();
-  const [showMaxAttendees, setShowMaxAttendees] = React.useState(false);
-  const [showDescription, setShowDescription] = React.useState(false);
+  const updateEventType = trpc.eventTypes.update.useMutation();
+
+  const initialValues = React.useMemo(
+    () => eventTypeToFormValues(eventType),
+    [eventType],
+  );
+
+  const [showMaxAttendees, setShowMaxAttendees] = React.useState(
+    eventType.capacity !== null,
+  );
+  const [showDescription, setShowDescription] = React.useState(
+    eventType.description !== null,
+  );
 
   const formSchema = React.useMemo(() => buildEventTypeFormSchema(t), [t]);
 
   const form = useForm({
     resolver: zodResolver(formSchema),
-    defaultValues: eventTypeFormDefaults,
+    defaultValues: initialValues,
   });
+
+  React.useEffect(() => {
+    form.reset(initialValues);
+    setShowMaxAttendees(eventType.capacity !== null);
+    setShowDescription(eventType.description !== null);
+  }, [eventType.capacity, eventType.description, form, initialValues]);
 
   const handleOpenChange = (nextOpen: boolean) => {
     if (!nextOpen) {
-      form.reset(eventTypeFormDefaults);
-      setShowMaxAttendees(false);
-      setShowDescription(false);
+      form.reset(initialValues);
     }
     onOpenChange?.(nextOpen);
   };
@@ -53,16 +73,17 @@ export function CreateEventTypeDialog({ open, onOpenChange }: DialogProps) {
     const input = eventTypeValuesToInput(values);
 
     try {
-      await createEventType.mutateAsync(input);
+      await updateEventType.mutateAsync({ id: eventType.id, ...input });
     } catch {
       toast.error(
-        t("createEventTypeError", {
-          defaultValue: "Failed to create event type",
+        t("updateEventTypeError", {
+          defaultValue: "Failed to update event type",
         }),
       );
       return;
     }
-    posthog?.capture("event_type_creation:form_submit", {
+    posthog?.capture("event_type_edit:form_submit", {
+      event_type_id: eventType.id,
       duration_minutes: input.duration,
       location_type: input.location?.type ?? "none",
       has_max_attendees: input.capacity !== null,
@@ -76,17 +97,8 @@ export function CreateEventTypeDialog({ open, onOpenChange }: DialogProps) {
       <DialogContent size="lg">
         <DialogHeader>
           <DialogTitle>
-            <Trans
-              i18nKey="createEventTypeTitle"
-              defaults="Create Event Type"
-            />
+            <Trans i18nKey="editEventTypeTitle" defaults="Edit Event Type" />
           </DialogTitle>
-          <DialogDescription>
-            <Trans
-              i18nKey="createEventTypeDescription"
-              defaults="Set up a reusable event type that people can book with you."
-            />
-          </DialogDescription>
         </DialogHeader>
         <Form {...form}>
           <form onSubmit={onSubmit} className="space-y-5">
@@ -99,16 +111,16 @@ export function CreateEventTypeDialog({ open, onOpenChange }: DialogProps) {
             />
             <DialogFooter className="pt-2">
               <DialogClose asChild>
-                <Button type="button" disabled={createEventType.isPending}>
+                <Button type="button" disabled={updateEventType.isPending}>
                   <Trans i18nKey="cancel" defaults="Cancel" />
                 </Button>
               </DialogClose>
               <Button
                 type="submit"
                 variant="primary"
-                loading={createEventType.isPending}
+                loading={updateEventType.isPending}
               >
-                <Trans i18nKey="create" defaults="Create" />
+                <Trans i18nKey="save" defaults="Save" />
               </Button>
             </DialogFooter>
           </form>

--- a/apps/web/src/features/event-types/components/event-type-form.tsx
+++ b/apps/web/src/features/event-types/components/event-type-form.tsx
@@ -1,0 +1,451 @@
+"use client";
+
+import { Button } from "@rallly/ui/button";
+import {
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@rallly/ui/form";
+import { Input } from "@rallly/ui/input";
+import { RadioGroup, RadioGroupItem } from "@rallly/ui/radio-group";
+import { Textarea } from "@rallly/ui/textarea";
+import { Link2Icon, MapPinIcon, PlusIcon } from "lucide-react";
+import React from "react";
+import type { UseFormReturn } from "react-hook-form";
+import { z } from "zod";
+import type { EventTypeDTO } from "@/features/event-types/types";
+import { Trans, useTranslation } from "@/i18n/client";
+import type { Location } from "@/lib/location";
+
+export function buildEventTypeFormSchema(
+  t: (key: string, opts: { defaultValue: string }) => string,
+) {
+  return z
+    .object({
+      name: z.string().min(1).max(255),
+      duration: z.number().int().positive(),
+      maxAttendees: z.string().optional(),
+      description: z.string().max(2000).optional(),
+      locationType: z.enum(["", "in_person", "custom_link"]),
+      locationAddress: z.string().optional(),
+      locationUrl: z.string().optional(),
+      locationText: z.string().optional(),
+    })
+    .superRefine((data, ctx) => {
+      if (data.maxAttendees) {
+        const parsed = Number(data.maxAttendees);
+        if (!Number.isInteger(parsed) || parsed <= 0) {
+          ctx.addIssue({
+            path: ["maxAttendees"],
+            code: "custom",
+            message: t("maxAttendeesInvalid", {
+              defaultValue: "Must be a positive integer",
+            }),
+          });
+        }
+      }
+      if (data.locationType === "in_person") {
+        if (!data.locationAddress?.trim()) {
+          ctx.addIssue({
+            path: ["locationAddress"],
+            code: "custom",
+            message: t("requiredField", { defaultValue: "Required" }),
+          });
+        }
+      } else if (data.locationType === "custom_link") {
+        if (!data.locationUrl?.trim()) {
+          ctx.addIssue({
+            path: ["locationUrl"],
+            code: "custom",
+            message: t("requiredField", { defaultValue: "Required" }),
+          });
+        } else {
+          try {
+            new URL(data.locationUrl);
+          } catch {
+            ctx.addIssue({
+              path: ["locationUrl"],
+              code: "custom",
+              message: t("urlInvalid", {
+                defaultValue: "Must be a valid URL",
+              }),
+            });
+          }
+        }
+      }
+    });
+}
+
+export type EventTypeFormValues = z.infer<
+  ReturnType<typeof buildEventTypeFormSchema>
+>;
+
+export const eventTypeFormDefaults: EventTypeFormValues = {
+  name: "",
+  duration: 60,
+  maxAttendees: "",
+  description: "",
+  locationType: "",
+  locationAddress: "",
+  locationUrl: "",
+  locationText: "",
+};
+
+export function eventTypeToFormValues(
+  eventType: EventTypeDTO,
+): EventTypeFormValues {
+  const location = eventType.location;
+  return {
+    name: eventType.name,
+    duration: eventType.duration,
+    maxAttendees: eventType.capacity !== null ? String(eventType.capacity) : "",
+    description: eventType.description ?? "",
+    locationType: location?.type ?? "",
+    locationAddress: location?.type === "in_person" ? location.address : "",
+    locationUrl: location?.type === "custom_link" ? location.url : "",
+    locationText: location?.type === "custom_link" ? (location.text ?? "") : "",
+  };
+}
+
+type EventTypeInput = {
+  name: string;
+  duration: number;
+  capacity: number | null;
+  description: string | undefined;
+  location: Location | undefined;
+};
+
+export function eventTypeValuesToInput(
+  values: EventTypeFormValues,
+): EventTypeInput {
+  const capacity = values.maxAttendees ? Number(values.maxAttendees) : null;
+  const description = values.description?.trim() || undefined;
+  const location: Location | undefined =
+    values.locationType === "in_person" && values.locationAddress
+      ? { type: "in_person", address: values.locationAddress.trim() }
+      : values.locationType === "custom_link" && values.locationUrl
+        ? {
+            type: "custom_link",
+            url: values.locationUrl.trim(),
+            text: values.locationText?.trim() || undefined,
+          }
+        : undefined;
+  return {
+    name: values.name.trim(),
+    duration: values.duration,
+    capacity,
+    description,
+    location,
+  };
+}
+
+export function EventTypeFormFields({
+  form,
+  showMaxAttendees,
+  setShowMaxAttendees,
+  showDescription,
+  setShowDescription,
+}: {
+  form: UseFormReturn<EventTypeFormValues>;
+  showMaxAttendees: boolean;
+  setShowMaxAttendees: (value: boolean) => void;
+  showDescription: boolean;
+  setShowDescription: (value: boolean) => void;
+}) {
+  const { t } = useTranslation();
+  const locationType = form.watch("locationType");
+
+  const handleRemoveMaxAttendees = () => {
+    setShowMaxAttendees(false);
+    form.setValue("maxAttendees", "");
+    form.clearErrors("maxAttendees");
+  };
+
+  const handleRemoveDescription = () => {
+    setShowDescription(false);
+    form.setValue("description", "");
+    form.clearErrors("description");
+  };
+
+  return (
+    <>
+      <div className="grid gap-4 sm:grid-cols-[1fr_8rem]">
+        <FormField
+          control={form.control}
+          name="name"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>
+                <Trans i18nKey="name" defaults="Name" />
+              </FormLabel>
+              <FormControl>
+                <Input
+                  {...field}
+                  autoFocus
+                  placeholder={t("eventTypeNamePlaceholder", {
+                    defaultValue: "Discovery call",
+                  })}
+                />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+        <FormField
+          control={form.control}
+          name="duration"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>
+                <Trans i18nKey="durationLabel" defaults="Duration" />
+              </FormLabel>
+              <FormControl>
+                <div className="relative">
+                  <Input
+                    type="number"
+                    min={1}
+                    step={1}
+                    className="pr-10"
+                    {...field}
+                    onChange={(event) => {
+                      const value = event.target.value;
+                      field.onChange(value === "" ? "" : Number(value));
+                    }}
+                  />
+                  <span className="pointer-events-none absolute inset-y-0 right-2.5 flex items-center text-muted-foreground text-sm">
+                    <Trans i18nKey="minutesAbbreviation" defaults="min" />
+                  </span>
+                </div>
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+      </div>
+
+      <FormField
+        control={form.control}
+        name="locationType"
+        render={({ field }) => (
+          <FormItem>
+            <FormLabel>
+              <Trans i18nKey="location" defaults="Location" />
+            </FormLabel>
+            <FormControl>
+              <RadioGroup
+                value={field.value}
+                onValueChange={(value) => {
+                  field.onChange(value);
+                  form.clearErrors(["locationAddress", "locationUrl"]);
+                }}
+                className="grid grid-cols-2 gap-2"
+              >
+                <RadioCardOption
+                  value="in_person"
+                  icon={<MapPinIcon className="size-4" />}
+                  label={t("locationInPerson", { defaultValue: "In person" })}
+                />
+                <RadioCardOption
+                  value="custom_link"
+                  icon={<Link2Icon className="size-4" />}
+                  label={t("locationCustomLink", {
+                    defaultValue: "Custom link",
+                  })}
+                />
+              </RadioGroup>
+            </FormControl>
+          </FormItem>
+        )}
+      />
+
+      {locationType === "in_person" ? (
+        <FormField
+          control={form.control}
+          name="locationAddress"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>
+                <Trans i18nKey="address" defaults="Address" />
+              </FormLabel>
+              <FormControl>
+                <Input
+                  {...field}
+                  placeholder={t("addressPlaceholder", {
+                    defaultValue: "123 Main Street",
+                  })}
+                />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+      ) : null}
+
+      {locationType === "custom_link" ? (
+        <div className="grid gap-3 sm:grid-cols-2">
+          <FormField
+            control={form.control}
+            name="locationUrl"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>
+                  <Trans i18nKey="url" defaults="URL" />
+                </FormLabel>
+                <FormControl>
+                  <Input type="url" {...field} placeholder="https://" />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+          <FormField
+            control={form.control}
+            name="locationText"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel className="flex items-center gap-1.5">
+                  <Trans
+                    i18nKey="locationDisplayText"
+                    defaults="Display text"
+                  />
+                  <span className="text-muted-foreground">
+                    <Trans i18nKey="optionalLabel" defaults="(Optional)" />
+                  </span>
+                </FormLabel>
+                <FormControl>
+                  <Input
+                    {...field}
+                    placeholder={t("locationDisplayTextPlaceholder", {
+                      defaultValue: "Meeting link",
+                    })}
+                  />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+        </div>
+      ) : null}
+
+      {showMaxAttendees ? (
+        <FormField
+          control={form.control}
+          name="maxAttendees"
+          render={({ field }) => (
+            <FormItem>
+              <div className="flex items-center justify-between">
+                <FormLabel>
+                  <Trans i18nKey="maxAttendees" defaults="Max attendees" />
+                </FormLabel>
+                <RemoveOptionalButton onClick={handleRemoveMaxAttendees} />
+              </div>
+              <FormControl>
+                <Input type="number" min={1} step={1} {...field} />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+      ) : null}
+
+      {showDescription ? (
+        <FormField
+          control={form.control}
+          name="description"
+          render={({ field }) => (
+            <FormItem>
+              <div className="flex items-center justify-between">
+                <FormLabel>
+                  <Trans i18nKey="description" defaults="Description" />
+                </FormLabel>
+                <RemoveOptionalButton onClick={handleRemoveDescription} />
+              </div>
+              <FormControl>
+                <Textarea
+                  {...field}
+                  rows={3}
+                  placeholder={t("eventTypeDescriptionPlaceholder", {
+                    defaultValue: "What is this event about?",
+                  })}
+                />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+      ) : null}
+
+      {!showMaxAttendees || !showDescription ? (
+        <div className="flex flex-wrap items-center gap-1">
+          {!showMaxAttendees ? (
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              onClick={() => {
+                setShowMaxAttendees(true);
+                form.setValue("maxAttendees", "1");
+              }}
+              className="text-muted-foreground"
+            >
+              <PlusIcon data-icon="inline-start" />
+              <Trans i18nKey="setMaxAttendees" defaults="Set max attendees" />
+            </Button>
+          ) : null}
+          {!showDescription ? (
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              onClick={() => setShowDescription(true)}
+              className="text-muted-foreground"
+            >
+              <PlusIcon data-icon="inline-start" />
+              <Trans i18nKey="addDescription" defaults="Add description" />
+            </Button>
+          ) : null}
+        </div>
+      ) : null}
+    </>
+  );
+}
+
+function RadioCardOption({
+  value,
+  icon,
+  label,
+}: {
+  value: string;
+  icon: React.ReactNode;
+  label: string;
+}) {
+  const id = React.useId();
+  return (
+    <label
+      htmlFor={id}
+      className="group flex cursor-pointer items-center gap-2.5 rounded-lg border border-input bg-card px-3 py-2.5 text-sm transition-colors hover:bg-accent has-data-[state=checked]:border-primary has-data-[state=checked]:bg-primary/5"
+    >
+      <RadioGroupItem id={id} value={value} />
+      <span className="flex items-center gap-1.5 font-medium text-foreground">
+        <span className="text-muted-foreground group-has-data-[state=checked]:text-primary">
+          {icon}
+        </span>
+        {label}
+      </span>
+    </label>
+  );
+}
+
+function RemoveOptionalButton({ onClick }: { onClick: () => void }) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className="font-normal text-muted-foreground text-sm underline-offset-2 hover:text-foreground hover:underline"
+    >
+      <Trans i18nKey="remove" defaults="Remove" />
+    </button>
+  );
+}


### PR DESCRIPTION
## Summary
- Adds an `Edit` action to the per-row dropdown menu alongside `Delete`
- New `EditEventTypeDialog` prefills the form from the selected event type, submits via `eventTypes.update`, and fires `event_type_edit:form_submit` (with `event_type_id` + the same shape of properties as the create event)
- Form body extracted into `event-type-form.tsx` (schema, defaults, fields, value↔input converters) now that both create and edit consume it. `CreateEventTypeDialog` is rewired to use the shared module — no behaviour change for create
- Host stays read-only in this phase

## Test plan
- [ ] Open the row dropdown; click `Edit` — dialog opens prefilled with the current values
- [ ] Editing fields and clicking `Save` updates the record; the list reflects the change after the global invalidation
- [ ] Optional fields hide/show correctly: if the record has no max attendees, the `Set max attendees` button appears; same for description
- [ ] Toggling location type (none → in person → custom link) shows the right inputs and validates them
- [ ] Cancel / dismiss discards changes; reopening the dialog re-prefills from the latest record
- [ ] Confirm `event_type_edit:form_submit` fires in PostHog with the expected properties
- [ ] Create flow still works end to end (regression)

Closes RAL-1185

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Users can now edit existing event types directly from the event types dashboard
  * Added comprehensive form validation for event type modifications with error handling
  * Updated localization for edit operations

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lukevella/rallly/pull/2387?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->