### PR TITLE
🐛 Address PR feedback + persist cleared optional fields

### DIFF
--- a/apps/web/src/features/event-types/components/create-event-type-dialog.tsx
+++ b/apps/web/src/features/event-types/components/create-event-type-dialog.tsx
@@ -66,7 +66,7 @@ export function CreateEventTypeDialog({ open, onOpenChange }: DialogProps) {
       duration_minutes: input.duration,
       location_type: input.location?.type ?? "none",
       has_max_attendees: input.capacity !== null,
-      has_description: input.description !== undefined,
+      has_description: input.description !== null,
     });
     handleOpenChange(false);
   });

--- a/apps/web/src/features/event-types/components/edit-event-type-dialog.tsx
+++ b/apps/web/src/features/event-types/components/edit-event-type-dialog.tsx
@@ -65,6 +65,8 @@ export function EditEventTypeDialog({
   const handleOpenChange = (nextOpen: boolean) => {
     if (!nextOpen) {
       form.reset(initialValues);
+      setShowMaxAttendees(eventType.capacity !== null);
+      setShowDescription(eventType.description !== null);
     }
     onOpenChange?.(nextOpen);
   };
@@ -87,7 +89,7 @@ export function EditEventTypeDialog({
       duration_minutes: input.duration,
       location_type: input.location?.type ?? "none",
       has_max_attendees: input.capacity !== null,
-      has_description: input.description !== undefined,
+      has_description: input.description !== null,
     });
     handleOpenChange(false);
   });

--- a/apps/web/src/features/event-types/components/event-type-form.tsx
+++ b/apps/web/src/features/event-types/components/event-type-form.tsx
@@ -55,7 +55,8 @@ export function buildEventTypeFormSchema(
           });
         }
       } else if (data.locationType === "custom_link") {
-        if (!data.locationUrl?.trim()) {
+        const trimmedUrl = data.locationUrl?.trim();
+        if (!trimmedUrl) {
           ctx.addIssue({
             path: ["locationUrl"],
             code: "custom",
@@ -63,7 +64,7 @@ export function buildEventTypeFormSchema(
           });
         } else {
           try {
-            new URL(data.locationUrl);
+            new URL(trimmedUrl);
           } catch {
             ctx.addIssue({
               path: ["locationUrl"],
@@ -113,16 +114,16 @@ type EventTypeInput = {
   name: string;
   duration: number;
   capacity: number | null;
-  description: string | undefined;
-  location: Location | undefined;
+  description: string | null;
+  location: Location | null;
 };
 
 export function eventTypeValuesToInput(
   values: EventTypeFormValues,
 ): EventTypeInput {
   const capacity = values.maxAttendees ? Number(values.maxAttendees) : null;
-  const description = values.description?.trim() || undefined;
-  const location: Location | undefined =
+  const description = values.description?.trim() || null;
+  const location: Location | null =
     values.locationType === "in_person" && values.locationAddress
       ? { type: "in_person", address: values.locationAddress.trim() }
       : values.locationType === "custom_link" && values.locationUrl
@@ -131,7 +132,7 @@ export function eventTypeValuesToInput(
             url: values.locationUrl.trim(),
             text: values.locationText?.trim() || undefined,
           }
-        : undefined;
+        : null;
   return {
     name: values.name.trim(),
     duration: values.duration,
@@ -183,6 +184,7 @@ export function EventTypeFormFields({
               <FormControl>
                 <Input
                   {...field}
+                  name="eventTypeName"
                   autoFocus
                   placeholder={t("eventTypeNamePlaceholder", {
                     defaultValue: "Discovery call",
@@ -230,9 +232,22 @@ export function EventTypeFormFields({
         name="locationType"
         render={({ field }) => (
           <FormItem>
-            <FormLabel>
-              <Trans i18nKey="location" defaults="Location" />
-            </FormLabel>
+            <div className="flex items-center justify-between">
+              <FormLabel>
+                <Trans i18nKey="location" defaults="Location" />
+              </FormLabel>
+              {field.value !== "" ? (
+                <RemoveOptionalButton
+                  onClick={() => {
+                    form.setValue("locationType", "");
+                    form.setValue("locationAddress", "");
+                    form.setValue("locationUrl", "");
+                    form.setValue("locationText", "");
+                    form.clearErrors(["locationAddress", "locationUrl"]);
+                  }}
+                />
+              ) : null}
+            </div>
             <FormControl>
               <RadioGroup
                 value={field.value}
@@ -425,15 +440,13 @@ function RadioCardOption({
   return (
     <label
       htmlFor={id}
-      className="group flex cursor-pointer items-center gap-2.5 rounded-lg border border-input bg-card px-3 py-2.5 text-sm transition-colors hover:bg-accent has-data-[state=checked]:border-primary has-data-[state=checked]:bg-primary/5"
+      className="group flex cursor-pointer items-center gap-2 rounded-lg border border-input bg-card px-3 py-2.5 text-sm transition-colors hover:bg-accent has-data-[state=checked]:border-primary has-data-[state=checked]:bg-primary/5"
     >
-      <RadioGroupItem id={id} value={value} />
-      <span className="flex items-center gap-1.5 font-medium text-foreground">
-        <span className="text-muted-foreground group-has-data-[state=checked]:text-primary">
-          {icon}
-        </span>
-        {label}
+      <span className="text-muted-foreground group-has-data-[state=checked]:text-primary">
+        {icon}
       </span>
+      <span className="flex-1 font-normal">{label}</span>
+      <RadioGroupItem className="hidden" id={id} value={value} />
     </label>
   );
 }

--- a/apps/web/src/features/event-types/schema.ts
+++ b/apps/web/src/features/event-types/schema.ts
@@ -5,8 +5,8 @@ export const eventTypeInputSchema = z.object({
   name: z.string().min(1).max(255),
   duration: z.number().int().positive(),
   capacity: z.number().int().positive().nullable().optional(),
-  description: z.string().max(2000).optional(),
-  location: locationSchema.optional(),
+  description: z.string().max(2000).nullable().optional(),
+  location: locationSchema.nullable().optional(),
 });
 
 export type EventTypeInput = z.infer<typeof eventTypeInputSchema>;

--- a/apps/web/src/trpc/routers/event-types.ts
+++ b/apps/web/src/trpc/routers/event-types.ts
@@ -1,4 +1,4 @@
-import { prisma } from "@rallly/database";
+import { Prisma, prisma } from "@rallly/database";
 import { TRPCError } from "@trpc/server";
 import { z } from "zod";
 import { isEventTypesEnabled } from "@/features/event-types/constants";
@@ -38,7 +38,7 @@ export const eventTypes = router({
           duration: input.duration,
           capacity: input.capacity,
           description: input.description,
-          location: input.location,
+          location: input.location ?? Prisma.JsonNull,
         },
         include: {
           host: {
@@ -63,7 +63,7 @@ export const eventTypes = router({
           duration: input.duration,
           capacity: input.capacity,
           description: input.description,
-          location: input.location,
+          location: input.location ?? Prisma.JsonNull,
         },
         include: {
           host: {

--- a/packages/database/src/client.ts
+++ b/packages/database/src/client.ts
@@ -2,6 +2,7 @@ import { PrismaPg } from "@prisma/adapter-pg";
 import { PrismaClient } from "../generated/prisma/client";
 
 export type * from "../generated/prisma/client";
+export { Prisma } from "../generated/prisma/client";
 
 const globalForPrisma = globalThis as unknown as {
   prisma?: PrismaClient;


### PR DESCRIPTION
## Summary
Follow-up to #2387 that landed late. Covers the CodeRabbit feedback that was posted just before the merge plus a related bug we caught afterwards.

- Reset `showMaxAttendees` and `showDescription` when the edit dialog closes so reopening the same record shows the correct sections
- Trim the custom link URL before parsing it; submit already trimmed
- Add a `Remove` link next to the `Location` label so the location can be cleared once a type is picked
- **Persist cleared optional fields on update** — previously, clearing description or location only zeroed out the form state; the API received `undefined` so Prisma left the column unchanged. Schema now accepts `null` for both, the form converter returns `null`, and the trpc router maps `null` location to `Prisma.JsonNull` (required for Json? columns)
- Re-export `Prisma` at runtime from `@rallly/database` so the router can reach `Prisma.JsonNull` (server-only package, no client bundle impact)
- Set `name="eventTypeName"` on the event type name input to keep password managers from autofilling it

## Test plan
- [x] Edit an event type with a description, click Remove, Save → reopen: description is gone in the DB and the dialog shows no description
- [x] Edit an event type with a location, click Remove on the Location row, Save → reopen: location is null, dialog shows no selection
- [x] Validate URL with leading/trailing whitespace; passes when only padded
- [x] Open the edit dialog, toggle `Add description`, cancel → reopen the same record: description toggle is back to initial state
- [x] 1Password / LastPass no longer offer to autofill the event type name input

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a "Remove" button in the location type selector for clearing location selections

* **Bug Fixes**
  * Improved custom link URL validation with automatic whitespace trimming
  * Enhanced handling of empty description and location fields in event type forms

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lukevella/rallly/pull/2388?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->