### PR TITLE
✨ Add Sheet schema + extend ScheduledEvent for bookings (RAL-1189)

### DIFF
--- a/apps/web/src/trpc/routers/polls.ts
+++ b/apps/web/src/trpc/routers/polls.ts
@@ -851,6 +851,7 @@ export const polls = router({
                 data: poll.participants
                   .filter((p) => !!p.email)
                   .map((p) => ({
+                    uid: nanoid(),
                     inviteeName: p.name,
                     inviteeEmail: p.email as string,
                     inviteeTimeZone:

--- a/packages/database/prisma/migrations/20260518184939_add_sheet_and_extend_scheduled_event/migration.sql
+++ b/packages/database/prisma/migrations/20260518184939_add_sheet_and_extend_scheduled_event/migration.sql
@@ -1,0 +1,84 @@
+-- AlterTable: extend ScheduledEventInvite with locale and per-invite uid
+ALTER TABLE "scheduled_event_invites" ADD COLUMN "invitee_locale" TEXT;
+ALTER TABLE "scheduled_event_invites" ADD COLUMN "uid" TEXT;
+
+-- Backfill uid for existing rows using the row id (already unique)
+UPDATE "scheduled_event_invites" SET "uid" = "id" WHERE "uid" IS NULL;
+
+-- Enforce NOT NULL after backfill
+ALTER TABLE "scheduled_event_invites" ALTER COLUMN "uid" SET NOT NULL;
+
+-- AlterTable: extend ScheduledEvent with sheet/event-type provenance and capacity
+ALTER TABLE "scheduled_events" ADD COLUMN "capacity" INTEGER,
+ADD COLUMN "event_type_id" TEXT,
+ADD COLUMN "sheet_slot_id" TEXT;
+
+-- CreateTable
+CREATE TABLE "sheets" (
+    "id" TEXT NOT NULL,
+    "space_id" TEXT NOT NULL,
+    "host_id" TEXT NOT NULL,
+    "title" TEXT NOT NULL,
+    "description" TEXT,
+    "url_id" TEXT NOT NULL,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+    "deleted" BOOLEAN NOT NULL DEFAULT false,
+    "deleted_at" TIMESTAMP(3),
+
+    CONSTRAINT "sheets_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "sheet_slots" (
+    "id" TEXT NOT NULL,
+    "sheet_id" TEXT NOT NULL,
+    "event_type_id" TEXT NOT NULL,
+    "start_time" TIMESTAMP(3) NOT NULL,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "sheet_slots_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "sheets_url_id_key" ON "sheets"("url_id");
+
+-- CreateIndex
+CREATE INDEX "sheets_space_id_idx" ON "sheets"("space_id");
+
+-- CreateIndex
+CREATE INDEX "sheets_host_id_idx" ON "sheets"("host_id");
+
+-- CreateIndex
+CREATE INDEX "sheet_slots_sheet_id_start_time_idx" ON "sheet_slots"("sheet_id", "start_time");
+
+-- CreateIndex
+CREATE INDEX "sheet_slots_event_type_id_idx" ON "sheet_slots"("event_type_id");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "scheduled_event_invites_uid_key" ON "scheduled_event_invites"("uid");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "scheduled_events_sheet_slot_id_key" ON "scheduled_events"("sheet_slot_id");
+
+-- CreateIndex
+CREATE INDEX "scheduled_events_event_type_id_idx" ON "scheduled_events"("event_type_id");
+
+-- AddForeignKey
+ALTER TABLE "scheduled_events" ADD CONSTRAINT "scheduled_events_event_type_id_fkey" FOREIGN KEY ("event_type_id") REFERENCES "event_types"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "scheduled_events" ADD CONSTRAINT "scheduled_events_sheet_slot_id_fkey" FOREIGN KEY ("sheet_slot_id") REFERENCES "sheet_slots"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "sheets" ADD CONSTRAINT "sheets_space_id_fkey" FOREIGN KEY ("space_id") REFERENCES "spaces"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "sheets" ADD CONSTRAINT "sheets_host_id_fkey" FOREIGN KEY ("host_id") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "sheet_slots" ADD CONSTRAINT "sheet_slots_sheet_id_fkey" FOREIGN KEY ("sheet_id") REFERENCES "sheets"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "sheet_slots" ADD CONSTRAINT "sheet_slots_event_type_id_fkey" FOREIGN KEY ("event_type_id") REFERENCES "event_types"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/packages/database/prisma/models/event-type.prisma
+++ b/packages/database/prisma/models/event-type.prisma
@@ -13,8 +13,10 @@ model EventType {
   deleted   Boolean   @default(false)
   deletedAt DateTime? @map("deleted_at")
 
-  space Space @relation(fields: [spaceId], references: [id], onDelete: Cascade)
-  host  User  @relation(fields: [hostId], references: [id], onDelete: Cascade)
+  space           Space            @relation(fields: [spaceId], references: [id], onDelete: Cascade)
+  host            User             @relation(fields: [hostId], references: [id], onDelete: Cascade)
+  slots           SheetSlot[]
+  scheduledEvents ScheduledEvent[]
 
   @@index([spaceId])
   @@index([hostId])

--- a/packages/database/prisma/models/event.prisma
+++ b/packages/database/prisma/models/event.prisma
@@ -19,9 +19,12 @@ model ScheduledEvent {
   id          String               @id @default(cuid())
   userId      String               @map("user_id")
   spaceId     String               @map("space_id")
+  eventTypeId String?              @map("event_type_id")
+  sheetSlotId String?              @unique @map("sheet_slot_id")
   title       String
   description String?
   location    String?
+  capacity    Int?
   createdAt   DateTime             @default(now()) @map("created_at")
   updatedAt   DateTime             @updatedAt @map("updated_at")
   status      ScheduledEventStatus @default(confirmed)
@@ -35,12 +38,15 @@ model ScheduledEvent {
 
   user             User                   @relation(fields: [userId], references: [id], onDelete: Cascade)
   space            Space                  @relation(fields: [spaceId], references: [id], onDelete: Cascade)
+  eventType        EventType?             @relation(fields: [eventTypeId], references: [id], onDelete: SetNull)
+  sheetSlot        SheetSlot?             @relation(fields: [sheetSlotId], references: [id], onDelete: SetNull)
   rescheduledDates RescheduledEventDate[]
   invites          ScheduledEventInvite[]
   polls            Poll[]
 
   @@index([spaceId])
   @@index([userId])
+  @@index([eventTypeId])
   @@map("scheduled_events")
 }
 
@@ -60,11 +66,13 @@ model RescheduledEventDate {
 
 model ScheduledEventInvite {
   id               String                     @id @default(cuid())
+  uid              String                     @unique
   scheduledEventId String                     @map("scheduled_event_id")
   inviteeName      String                     @map("invitee_name")
   inviteeEmail     String                     @map("invitee_email")
   inviteeId        String?                    @map("invitee_id")
   inviteeTimeZone  String?                    @map("invitee_time_zone")
+  inviteeLocale    String?                    @map("invitee_locale")
   status           ScheduledEventInviteStatus @default(pending)
   createdAt        DateTime                   @default(now()) @map("created_at")
   updatedAt        DateTime                   @updatedAt @map("updated_at")

--- a/packages/database/prisma/models/sheet.prisma
+++ b/packages/database/prisma/models/sheet.prisma
@@ -1,0 +1,39 @@
+model Sheet {
+  id          String  @id @default(cuid())
+  spaceId     String  @map("space_id")
+  hostId      String  @map("host_id")
+  title       String
+  description String?
+  urlId       String  @unique @map("url_id")
+
+  createdAt DateTime  @default(now()) @map("created_at")
+  updatedAt DateTime  @updatedAt @map("updated_at")
+  deleted   Boolean   @default(false)
+  deletedAt DateTime? @map("deleted_at")
+
+  space Space       @relation(fields: [spaceId], references: [id], onDelete: Cascade)
+  host  User        @relation(fields: [hostId], references: [id], onDelete: Cascade)
+  slots SheetSlot[]
+
+  @@index([spaceId])
+  @@index([hostId])
+  @@map("sheets")
+}
+
+model SheetSlot {
+  id          String   @id @default(cuid())
+  sheetId     String   @map("sheet_id")
+  eventTypeId String   @map("event_type_id")
+  startTime   DateTime @map("start_time")
+
+  createdAt DateTime @default(now()) @map("created_at")
+  updatedAt DateTime @updatedAt @map("updated_at")
+
+  sheet          Sheet           @relation(fields: [sheetId], references: [id], onDelete: Cascade)
+  eventType      EventType       @relation(fields: [eventTypeId], references: [id], onDelete: Restrict)
+  scheduledEvent ScheduledEvent?
+
+  @@index([sheetId, startTime])
+  @@index([eventTypeId])
+  @@map("sheet_slots")
+}

--- a/packages/database/prisma/models/space.prisma
+++ b/packages/database/prisma/models/space.prisma
@@ -13,6 +13,7 @@ model Space {
   polls           Poll[]
   scheduledEvents ScheduledEvent[]
   eventTypes      EventType[]
+  sheets          Sheet[]
   subscriptions   Subscription[]   @relation("SpaceToSubscription")
 
   members SpaceMember[]

--- a/packages/database/prisma/models/user.prisma
+++ b/packages/database/prisma/models/user.prisma
@@ -73,6 +73,7 @@ model User {
   scheduledEvents       ScheduledEvent[]
   scheduledEventInvites ScheduledEventInvite[]
   hostedEventTypes      EventType[]
+  hostedSheets          Sheet[]
 
   calendarConnections CalendarConnection[]
   credentials         Credential[]

--- a/packages/database/prisma/seed.ts
+++ b/packages/database/prisma/seed.ts
@@ -57,15 +57,19 @@ async function main() {
 
     if (evt.invites?.length) {
       await prisma.scheduledEventInvite.createMany({
-        data: evt.invites.map((inv) => ({
-          id: nextId(),
-          scheduledEventId: eventId,
-          inviteeName: inv.inviteeName,
-          inviteeEmail: inv.inviteeEmail,
-          inviteeTimeZone: inv.inviteeTimeZone,
-          inviteeId: inv.inviteeId,
-          status: inv.status,
-        })),
+        data: evt.invites.map((inv) => {
+          const inviteId = nextId();
+          return {
+            id: inviteId,
+            uid: inviteId,
+            scheduledEventId: eventId,
+            inviteeName: inv.inviteeName,
+            inviteeEmail: inv.inviteeEmail,
+            inviteeTimeZone: inv.inviteeTimeZone,
+            inviteeId: inv.inviteeId,
+            status: inv.status,
+          };
+        }),
       });
       inviteCount += evt.invites.length;
     }


### PR DESCRIPTION
## Summary

First deliverable for the Sign-up Sheets project. Introduces the `Sheet` and `SheetSlot` models and extends `ScheduledEvent` / `ScheduledEventInvite` so sheet bookings reuse the existing booking machinery rather than running on a parallel `Booking` model.

## Schema changes

**New models:**
- `Sheet` — sign-up sheet container (host, space, title, urlId, soft delete)
- `SheetSlot` — offered time on a sheet, lightweight `(sheetId, eventTypeId, startTime)`

**Extensions to existing models:**
- `ScheduledEvent` gains:
  - `sheetSlotId String? @unique` — 1:1 link to a SheetSlot (when generated from a sheet)
  - `eventTypeId String?` — provenance link, `onDelete: SetNull`
  - `capacity Int?` — snapshotted from EventType at booking creation
- `ScheduledEventInvite` gains:
  - `uid String @unique` — per-invite URL for cancel/reschedule links
  - `inviteeLocale String?` — for confirmation emails

**Existing `scheduled_event_invites.uid` is backfilled from `id`** in the migration (existing ids are already unique cuids — safe).

The poll-finalize flow in `polls.ts` now generates a `uid` per invite (`nanoid()`).

## Why reuse ScheduledEvent instead of a new Booking model

Initial design introduced parallel `Booking` + `Attendee` models. Discussion landed on reusing `ScheduledEvent` + `ScheduledEventInvite` because:

- One "Upcoming/Past meetings" page queries a single table
- Reschedule history (`RescheduledEventDate`), `allDay`, iCal `uid`/`sequence`, and User linkage (`inviteeId`) all exist already
- No `UNION` queries across two parallel calendar models forever
- Cosmetic rename of tables to `bookings` / `attendees` can happen in a future cleanup

## Snapshot principle

EventType is a generator; the resulting `ScheduledEvent` is an immutable snapshot. `title`, `description`, `location`, `end` (= `start + duration`), and `capacity` are copied from EventType at booking-creation time. The `eventTypeId` reference is provenance only.

## Test plan

- [x] `pnpm type-check` passes across all 10 packages
- [x] Migration applies cleanly to the dev DB (existing 39 ScheduledEventInvite rows backfilled successfully)
- [ ] Verify `pnpm db:reset` re-seeds without errors
- [ ] Verify poll finalize flow still creates invites correctly (seeded poll in dev DB)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Sheet-based event scheduling system for organizing and managing events.

* **Improvements**
  * Event scheduling now supports capacity management and event type associations.
  * Enhanced invite tracking with unique identifiers.
  * Added support for tracking attendee locale preferences.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lukevella/rallly/pull/2391?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->