### PR TITLE
✨ Add sheets/slots/bookings tRPC router + signupSheets flag (RAL-1190)

### DIFF
--- a/apps/web/src/features/sheets/constants.ts
+++ b/apps/web/src/features/sheets/constants.ts
@@ -1,0 +1,1 @@
+export const isSignupSheetsEnabled = process.env.NODE_ENV === "development";

--- a/apps/web/src/features/sheets/data.ts
+++ b/apps/web/src/features/sheets/data.ts
@@ -1,0 +1,139 @@
+import type { EventType, Sheet, SheetSlot } from "@rallly/database";
+import { prisma } from "@rallly/database";
+import { createLogger } from "@rallly/logger";
+import type {
+  SheetDetailDTO,
+  SheetDTO,
+  SheetSlotDTO,
+} from "@/features/sheets/types";
+import { locationSchema } from "@/lib/location";
+
+const logger = createLogger("sheets/data");
+
+type EventTypeForSlot = Pick<
+  EventType,
+  "id" | "name" | "duration" | "description" | "location" | "capacity"
+>;
+
+type SlotWithRelations = SheetSlot & {
+  eventType: EventTypeForSlot;
+  scheduledEvent: {
+    capacity: number | null;
+    _count: { invites: number };
+  } | null;
+};
+
+function parseLocation(
+  raw: EventTypeForSlot["location"],
+  context: { eventTypeId: string },
+) {
+  if (raw === null) {
+    return null;
+  }
+  const parsed = locationSchema.safeParse(raw);
+  if (!parsed.success) {
+    logger.warn(
+      { eventTypeId: context.eventTypeId, value: raw },
+      "Failed to parse event type location",
+    );
+    return null;
+  }
+  return parsed.data;
+}
+
+export function createSheetSlotDTO(slot: SlotWithRelations): SheetSlotDTO {
+  return {
+    id: slot.id,
+    startTime: slot.startTime,
+    eventType: {
+      id: slot.eventType.id,
+      name: slot.eventType.name,
+      duration: slot.eventType.duration,
+      description: slot.eventType.description,
+      location: parseLocation(slot.eventType.location, {
+        eventTypeId: slot.eventType.id,
+      }),
+      capacity: slot.eventType.capacity,
+    },
+    bookingCount: slot.scheduledEvent?._count.invites ?? 0,
+    capacity: slot.scheduledEvent?.capacity ?? slot.eventType.capacity,
+  };
+}
+
+export function createSheetDTO(sheet: Sheet): SheetDTO {
+  return {
+    id: sheet.id,
+    title: sheet.title,
+    description: sheet.description,
+    urlId: sheet.urlId,
+    createdAt: sheet.createdAt,
+    updatedAt: sheet.updatedAt,
+  };
+}
+
+export function createSheetDetailDTO(
+  sheet: Sheet & { slots: SlotWithRelations[] },
+): SheetDetailDTO {
+  return {
+    ...createSheetDTO(sheet),
+    slots: sheet.slots.map(createSheetSlotDTO),
+  };
+}
+
+const slotInclude = {
+  eventType: {
+    select: {
+      id: true,
+      name: true,
+      duration: true,
+      description: true,
+      location: true,
+      capacity: true,
+    },
+  },
+  scheduledEvent: {
+    select: {
+      capacity: true,
+      _count: { select: { invites: true } },
+    },
+  },
+} as const;
+
+export async function getSheets(spaceId: string): Promise<SheetDTO[]> {
+  const rows = await prisma.sheet.findMany({
+    where: { spaceId, deleted: false },
+    orderBy: { updatedAt: "desc" },
+  });
+  return rows.map(createSheetDTO);
+}
+
+export async function getSheetById(
+  id: string,
+  spaceId: string,
+): Promise<SheetDetailDTO | null> {
+  const sheet = await prisma.sheet.findFirst({
+    where: { id, spaceId, deleted: false },
+    include: {
+      slots: {
+        orderBy: { startTime: "asc" },
+        include: slotInclude,
+      },
+    },
+  });
+  return sheet ? createSheetDetailDTO(sheet) : null;
+}
+
+export async function getSheetByUrlId(
+  urlId: string,
+): Promise<SheetDetailDTO | null> {
+  const sheet = await prisma.sheet.findFirst({
+    where: { urlId, deleted: false },
+    include: {
+      slots: {
+        orderBy: { startTime: "asc" },
+        include: slotInclude,
+      },
+    },
+  });
+  return sheet ? createSheetDetailDTO(sheet) : null;
+}

--- a/apps/web/src/features/sheets/schema.ts
+++ b/apps/web/src/features/sheets/schema.ts
@@ -1,0 +1,31 @@
+import * as z from "zod";
+
+export const createSheetInputSchema = z.object({
+  title: z.string().min(1).max(255),
+});
+
+export type CreateSheetInput = z.infer<typeof createSheetInputSchema>;
+
+export const updateSheetInputSchema = z.object({
+  id: z.string(),
+  title: z.string().min(1).max(255),
+});
+
+export type UpdateSheetInput = z.infer<typeof updateSheetInputSchema>;
+
+export const createSlotInputSchema = z.object({
+  sheetId: z.string(),
+  eventTypeId: z.string(),
+  startTime: z.date(),
+});
+
+export type CreateSlotInput = z.infer<typeof createSlotInputSchema>;
+
+export const createBookingInputSchema = z.object({
+  slotId: z.string(),
+  name: z.string().min(1).max(100),
+  email: z.email(),
+  timeZone: z.string().min(1).max(64),
+});
+
+export type CreateBookingInput = z.infer<typeof createBookingInputSchema>;

--- a/apps/web/src/features/sheets/types.ts
+++ b/apps/web/src/features/sheets/types.ts
@@ -1,0 +1,29 @@
+import type { Location } from "@/lib/location";
+
+export interface SheetDTO {
+  id: string;
+  title: string;
+  description: string | null;
+  urlId: string;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+export interface SheetSlotDTO {
+  id: string;
+  startTime: Date;
+  eventType: {
+    id: string;
+    name: string;
+    duration: number;
+    description: string | null;
+    location: Location | null;
+    capacity: number | null;
+  };
+  bookingCount: number;
+  capacity: number | null;
+}
+
+export interface SheetDetailDTO extends SheetDTO {
+  slots: SheetSlotDTO[];
+}

--- a/apps/web/src/lib/feature-flags/config.ts
+++ b/apps/web/src/lib/feature-flags/config.ts
@@ -4,6 +4,7 @@ import { isBillingEnabled } from "@/features/billing/constants";
 import { isCalendarsEnabled } from "@/features/calendars/constants";
 import { isEventTypesEnabled } from "@/features/event-types/constants";
 import { isFeedbackEnabled } from "@/features/feedback/constants";
+import { isSignupSheetsEnabled } from "@/features/sheets/constants";
 import type { FeatureFlagConfig } from "@/lib/feature-flags/types";
 import { isStorageEnabled } from "@/lib/storage";
 
@@ -18,4 +19,5 @@ export const featureFlagConfig: FeatureFlagConfig = {
   registration: isEmailLoginEnabled && isRegistrationEnabled,
   calendars: isCalendarsEnabled,
   eventTypes: isEventTypesEnabled,
+  signupSheets: isSignupSheetsEnabled,
 };

--- a/apps/web/src/lib/feature-flags/types.ts
+++ b/apps/web/src/lib/feature-flags/types.ts
@@ -6,6 +6,7 @@ export interface FeatureFlagConfig {
   registration: boolean;
   calendars: boolean;
   eventTypes: boolean;
+  signupSheets: boolean;
 }
 
 export type Feature = keyof FeatureFlagConfig;

--- a/apps/web/src/trpc/routers/index.ts
+++ b/apps/web/src/trpc/routers/index.ts
@@ -9,6 +9,7 @@ import { dashboard } from "./dashboard";
 import { eventTypes } from "./event-types";
 import { events } from "./events";
 import { polls } from "./polls";
+import { sheets } from "./sheets";
 import { spaces } from "./spaces";
 import { system } from "./system";
 import { user } from "./user";
@@ -22,6 +23,7 @@ export const appRouter = mergeRouters(
     eventTypes,
     events,
     polls,
+    sheets,
     spaces,
     system,
     user,

--- a/apps/web/src/trpc/routers/sheets.ts
+++ b/apps/web/src/trpc/routers/sheets.ts
@@ -1,0 +1,355 @@
+import { prisma } from "@rallly/database";
+import { nanoid } from "@rallly/utils/nanoid";
+import { TRPCError } from "@trpc/server";
+import * as z from "zod";
+import { isSignupSheetsEnabled } from "@/features/sheets/constants";
+import {
+  createSheetDTO,
+  getSheetById,
+  getSheetByUrlId,
+  getSheets,
+} from "@/features/sheets/data";
+import {
+  createBookingInputSchema,
+  createSheetInputSchema,
+  createSlotInputSchema,
+  updateSheetInputSchema,
+} from "@/features/sheets/schema";
+import type { Location } from "@/lib/location";
+import { locationSchema } from "@/lib/location";
+import {
+  mergeRouters,
+  middleware,
+  publicProcedure,
+  router,
+  spaceProcedure,
+} from "../trpc";
+
+const requireSignupSheetsEnabled = middleware(async ({ next }) => {
+  if (!isSignupSheetsEnabled) {
+    throw new TRPCError({
+      code: "NOT_FOUND",
+      message: "Sign-up sheets are not enabled",
+    });
+  }
+  return next();
+});
+
+const sheetSpaceProcedure = spaceProcedure.use(requireSignupSheetsEnabled);
+const sheetPublicProcedure = publicProcedure.use(requireSignupSheetsEnabled);
+
+function locationSnapshot(value: unknown): string | null {
+  if (value === null || value === undefined) {
+    return null;
+  }
+  const parsed = locationSchema.safeParse(value);
+  if (!parsed.success) {
+    return null;
+  }
+  const location: Location = parsed.data;
+  if (location.type === "in_person") {
+    return location.address;
+  }
+  return location.text ?? location.url;
+}
+
+const sheetsRoot = router({
+  list: sheetSpaceProcedure.query(async ({ ctx }) => {
+    const sheets = await getSheets(ctx.space.id);
+    return { sheets };
+  }),
+
+  get: sheetSpaceProcedure
+    .input(z.object({ id: z.string() }))
+    .query(async ({ ctx, input }) => {
+      const sheet = await getSheetById(input.id, ctx.space.id);
+      if (!sheet) {
+        throw new TRPCError({ code: "NOT_FOUND", message: "Sheet not found" });
+      }
+      return { sheet };
+    }),
+
+  getByUrlId: sheetPublicProcedure
+    .input(z.object({ urlId: z.string() }))
+    .query(async ({ input }) => {
+      const sheet = await getSheetByUrlId(input.urlId);
+      if (!sheet) {
+        throw new TRPCError({ code: "NOT_FOUND", message: "Sheet not found" });
+      }
+      return { sheet };
+    }),
+
+  create: sheetSpaceProcedure
+    .input(createSheetInputSchema)
+    .mutation(async ({ ctx, input }) => {
+      const created = await prisma.sheet.create({
+        data: {
+          spaceId: ctx.space.id,
+          hostId: ctx.user.id,
+          title: input.title,
+          urlId: nanoid(),
+        },
+      });
+      return { sheet: createSheetDTO(created) };
+    }),
+
+  update: sheetSpaceProcedure
+    .input(updateSheetInputSchema)
+    .mutation(async ({ ctx, input }) => {
+      const updated = await prisma.sheet.updateMany({
+        where: {
+          id: input.id,
+          spaceId: ctx.space.id,
+          deleted: false,
+        },
+        data: {
+          title: input.title,
+        },
+      });
+      if (updated.count === 0) {
+        throw new TRPCError({ code: "NOT_FOUND", message: "Sheet not found" });
+      }
+      return { success: true };
+    }),
+
+  softDelete: sheetSpaceProcedure
+    .input(z.object({ id: z.string() }))
+    .mutation(async ({ ctx, input }) => {
+      const deleted = await prisma.sheet.updateMany({
+        where: {
+          id: input.id,
+          spaceId: ctx.space.id,
+          deleted: false,
+        },
+        data: {
+          deleted: true,
+          deletedAt: new Date(),
+        },
+      });
+      if (deleted.count === 0) {
+        throw new TRPCError({ code: "NOT_FOUND", message: "Sheet not found" });
+      }
+      return { success: true };
+    }),
+});
+
+const slots = router({
+  create: sheetSpaceProcedure
+    .input(createSlotInputSchema)
+    .mutation(async ({ ctx, input }) => {
+      const sheet = await prisma.sheet.findFirst({
+        where: {
+          id: input.sheetId,
+          spaceId: ctx.space.id,
+          deleted: false,
+        },
+        select: { id: true },
+      });
+      if (!sheet) {
+        throw new TRPCError({ code: "NOT_FOUND", message: "Sheet not found" });
+      }
+
+      const eventType = await prisma.eventType.findFirst({
+        where: {
+          id: input.eventTypeId,
+          spaceId: ctx.space.id,
+          deleted: false,
+        },
+        select: { id: true },
+      });
+      if (!eventType) {
+        throw new TRPCError({
+          code: "NOT_FOUND",
+          message: "Event type not found in this space",
+        });
+      }
+
+      const slot = await prisma.sheetSlot.create({
+        data: {
+          sheetId: input.sheetId,
+          eventTypeId: input.eventTypeId,
+          startTime: input.startTime,
+        },
+      });
+
+      return {
+        slot: {
+          id: slot.id,
+          sheetId: slot.sheetId,
+          eventTypeId: slot.eventTypeId,
+          startTime: slot.startTime,
+          createdAt: slot.createdAt,
+          updatedAt: slot.updatedAt,
+        },
+      };
+    }),
+
+  delete: sheetSpaceProcedure
+    .input(z.object({ id: z.string() }))
+    .mutation(async ({ ctx, input }) => {
+      const slot = await prisma.sheetSlot.findFirst({
+        where: {
+          id: input.id,
+          sheet: { spaceId: ctx.space.id, deleted: false },
+        },
+        select: {
+          id: true,
+          scheduledEvent: { select: { id: true } },
+        },
+      });
+      if (!slot) {
+        throw new TRPCError({ code: "NOT_FOUND", message: "Slot not found" });
+      }
+      if (slot.scheduledEvent) {
+        throw new TRPCError({
+          code: "CONFLICT",
+          message:
+            "Cannot delete a slot with bookings. Cancel the booking first.",
+        });
+      }
+      await prisma.sheetSlot.delete({ where: { id: input.id } });
+      return { success: true };
+    }),
+});
+
+const bookings = router({
+  create: sheetPublicProcedure
+    .input(createBookingInputSchema)
+    .mutation(async ({ input }) => {
+      return await prisma.$transaction(async (tx) => {
+        // Lock the slot row to serialize concurrent bookings on the same slot
+        await tx.$queryRaw`SELECT id FROM "sheet_slots" WHERE id = ${input.slotId} FOR UPDATE`;
+
+        const slot = await tx.sheetSlot.findFirst({
+          where: {
+            id: input.slotId,
+            sheet: { deleted: false },
+          },
+          include: {
+            sheet: { select: { spaceId: true } },
+            eventType: {
+              select: {
+                id: true,
+                name: true,
+                description: true,
+                location: true,
+                duration: true,
+                capacity: true,
+                hostId: true,
+              },
+            },
+            scheduledEvent: {
+              select: {
+                id: true,
+                capacity: true,
+                _count: { select: { invites: true } },
+              },
+            },
+          },
+        });
+
+        if (!slot) {
+          throw new TRPCError({
+            code: "NOT_FOUND",
+            message: "Slot not found",
+          });
+        }
+
+        const capacity =
+          slot.scheduledEvent?.capacity ?? slot.eventType.capacity;
+        const currentCount = slot.scheduledEvent?._count.invites ?? 0;
+
+        if (capacity !== null && currentCount >= capacity) {
+          throw new TRPCError({
+            code: "CONFLICT",
+            message: "This slot is full",
+          });
+        }
+
+        if (slot.scheduledEvent) {
+          const existing = await tx.scheduledEventInvite.findFirst({
+            where: {
+              scheduledEventId: slot.scheduledEvent.id,
+              inviteeEmail: input.email,
+            },
+            select: { id: true },
+          });
+          if (existing) {
+            throw new TRPCError({
+              code: "CONFLICT",
+              message: "You've already booked this slot",
+            });
+          }
+        }
+
+        const inviteUid = nanoid();
+        const endTime = new Date(
+          slot.startTime.getTime() + slot.eventType.duration * 60_000,
+        );
+
+        if (slot.scheduledEvent) {
+          await tx.scheduledEventInvite.create({
+            data: {
+              uid: inviteUid,
+              scheduledEventId: slot.scheduledEvent.id,
+              inviteeName: input.name,
+              inviteeEmail: input.email,
+              inviteeTimeZone: input.timeZone,
+              status: "accepted",
+            },
+          });
+          return {
+            scheduledEventId: slot.scheduledEvent.id,
+            attendeeUid: inviteUid,
+          };
+        }
+
+        const host = await tx.user.findUnique({
+          where: { id: slot.eventType.hostId },
+          select: { timeZone: true },
+        });
+
+        const eventId = nanoid();
+        const created = await tx.scheduledEvent.create({
+          data: {
+            id: eventId,
+            uid: `${eventId}@rallly.co`,
+            sheetSlotId: slot.id,
+            eventTypeId: slot.eventType.id,
+            userId: slot.eventType.hostId,
+            spaceId: slot.sheet.spaceId,
+            title: slot.eventType.name,
+            description: slot.eventType.description,
+            location: locationSnapshot(slot.eventType.location),
+            capacity: slot.eventType.capacity,
+            start: slot.startTime,
+            end: endTime,
+            timeZone: host?.timeZone ?? null,
+            status: "confirmed",
+            invites: {
+              create: {
+                uid: inviteUid,
+                inviteeName: input.name,
+                inviteeEmail: input.email,
+                inviteeTimeZone: input.timeZone,
+                status: "accepted",
+              },
+            },
+          },
+        });
+
+        return {
+          scheduledEventId: created.id,
+          attendeeUid: inviteUid,
+        };
+      });
+    }),
+});
+
+export const sheets = mergeRouters(
+  sheetsRoot,
+  router({
+    slots,
+    bookings,
+  }),
+);

--- a/packages/database/prisma/migrations/20260519111112_invitee_email_citext/migration.sql
+++ b/packages/database/prisma/migrations/20260519111112_invitee_email_citext/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "scheduled_event_invites" ALTER COLUMN "invitee_email" SET DATA TYPE CITEXT;

--- a/packages/database/prisma/models/event.prisma
+++ b/packages/database/prisma/models/event.prisma
@@ -69,7 +69,7 @@ model ScheduledEventInvite {
   uid              String                     @unique
   scheduledEventId String                     @map("scheduled_event_id")
   inviteeName      String                     @map("invitee_name")
-  inviteeEmail     String                     @map("invitee_email")
+  inviteeEmail     String                     @map("invitee_email") @db.Citext
   inviteeId        String?                    @map("invitee_id")
   inviteeTimeZone  String?                    @map("invitee_time_zone")
   inviteeLocale    String?                    @map("invitee_locale")


### PR DESCRIPTION
## Summary

Adds the tRPC router for sign-up sheets and gates the entire surface behind a `signupSheets` feature flag (dev-only by default).

## Routes

All routes are nested under `sheets`. Every procedure passes through `requireSignupSheetsEnabled` middleware — throws `NOT_FOUND` when the flag is off.

**Host (authenticated, `spaceProcedure`):**

- `sheets.list` — non-deleted sheets in the current space, ordered by `updatedAt DESC`
- `sheets.get` — by id, returns sheet + slots + per-slot booking counts
- `sheets.create` — input `{ title }`; generates `urlId` via `nanoid()`
- `sheets.update` — input `{ id, title }`
- `sheets.softDelete` — sets `deleted = true`, `deletedAt = now()`
- `sheets.slots.create` — validates the EventType belongs to the same space before creating the slot
- `sheets.slots.delete` — refuses deletion if the slot has a `ScheduledEvent`; host must cancel the booking first

**Public (no auth):**

- `sheets.getByUrlId` — for the booker view
- `sheets.bookings.create` — input `{ slotId, name, email, timeZone }`

## Booking flow

`sheets.bookings.create` wraps the work in a transaction with `SELECT … FOR UPDATE` on the `sheet_slots` row to serialize concurrent first-bookers on the same slot. Within the transaction:

1. Load slot + sheet + eventType + scheduledEvent (with invite count)
2. Compute active capacity: snapshot from `ScheduledEvent.capacity` if it exists, otherwise live from `EventType.capacity`
3. Reject with `CONFLICT` if the slot is full
4. Reject with `CONFLICT` if the same email already booked (app-level check; no DB constraint yet)
5. First booker creates the `ScheduledEvent` (snapshotting title / description / location / capacity from EventType) plus the invite; subsequent bookers just add an invite

Per-invite `uid` generated via `nanoid()` for future cancel/reschedule links. Host TZ on the new ScheduledEvent comes from `User.timeZone` with null fallback.

## Notes / deferred

- Duplicate-email check is app-side; the DB constraint waits on the poll-finalize dedupe (separate ticket)
- Location snapshot flattens JSON → string (`address` for in-person, `text || url` for custom link). When `ScheduledEvent.location` becomes JSON in a future migration, this collapses to a direct copy.
- `slots.delete` cascade behaviour differs from the ticket spec (which assumed Cascade on the FK); we refuse-if-booked instead so attendees aren't silently dropped

## Test plan

- [x] `pnpm type-check` passes across all 10 packages
- [ ] Verify the feature flag returns `NOT_FOUND` when off (manual)
- [ ] Create a sheet, add slots, book against a slot end-to-end via tRPC client (manual)
- [ ] Concurrent booking race holds capacity (manual; load test deferred)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Signup sheets: create and manage sign-up sheets with configurable titles and slots.
  * Slots: add and remove time slots; deletion blocked if existing bookings/scheduled events exist.
  * Booking: attendees can book slots (public via URL), receive an attendee UID/confirmation, with capacity limits and duplicate-booking prevention.
  * Sheets: list, view, create, update, and soft-delete sheets (deleted sheets are hidden).
* **Feature Flags**
  * New feature flag to enable/disable signup sheets.
* **Bug Fixes**
  * Booking duplicate detection improved to treat email casing consistently.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lukevella/rallly/pull/2392?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->