### PR TITLE
♻️ Use namespace import for zod

### DIFF
--- a/apps/api/src/utils/timezone-schema.ts
+++ b/apps/api/src/utils/timezone-schema.ts
@@ -1,4 +1,4 @@
-import { z } from "zod";
+import * as z from "zod";
 
 // Override runtime canonicalization when ICU data lags behind IANA updates.
 const ianaOverrides: Record<string, string> = {

--- a/apps/web/src/features/event-types/components/event-type-form.tsx
+++ b/apps/web/src/features/event-types/components/event-type-form.tsx
@@ -14,7 +14,7 @@ import { Textarea } from "@rallly/ui/textarea";
 import { Link2Icon, MapPinIcon, PlusIcon } from "lucide-react";
 import React from "react";
 import type { UseFormReturn } from "react-hook-form";
-import { z } from "zod";
+import * as z from "zod";
 import type { EventTypeDTO } from "@/features/event-types/types";
 import { Trans, useTranslation } from "@/i18n/client";
 import type { Location } from "@/lib/location";

--- a/apps/web/src/features/event-types/schema.ts
+++ b/apps/web/src/features/event-types/schema.ts
@@ -1,4 +1,4 @@
-import { z } from "zod";
+import * as z from "zod";
 import { locationSchema } from "@/lib/location";
 
 export const eventTypeInputSchema = z.object({

--- a/apps/web/src/lib/location.ts
+++ b/apps/web/src/lib/location.ts
@@ -1,4 +1,4 @@
-import { z } from "zod";
+import * as z from "zod";
 
 const inPersonLocationSchema = z.object({
   type: z.literal("in_person"),

--- a/apps/web/src/trpc/routers/event-types.ts
+++ b/apps/web/src/trpc/routers/event-types.ts
@@ -1,6 +1,6 @@
 import { Prisma, prisma } from "@rallly/database";
 import { TRPCError } from "@trpc/server";
-import { z } from "zod";
+import * as z from "zod";
 import { isEventTypesEnabled } from "@/features/event-types/constants";
 import { createEventTypeDTO, getEventTypes } from "@/features/event-types/data";
 import {

--- a/apps/web/src/utils/timezone-schema.ts
+++ b/apps/web/src/utils/timezone-schema.ts
@@ -1,4 +1,4 @@
-import { z } from "zod";
+import * as z from "zod";
 
 // Override runtime canonicalization when ICU data lags behind IANA updates.
 const ianaOverrides: Record<string, string> = {


### PR DESCRIPTION
## Summary

Align all remaining `import { z } from "zod"` callsites with the Zod v4 docs pattern (`import * as z from "zod"`). Functionally equivalent; the namespace form is the current canonical style.

Files updated:

- apps/api/src/utils/timezone-schema.ts
- apps/web/src/features/event-types/components/event-type-form.tsx
- apps/web/src/features/event-types/schema.ts
- apps/web/src/lib/location.ts
- apps/web/src/trpc/routers/event-types.ts
- apps/web/src/utils/timezone-schema.ts

Polls router and other existing callsites already used the namespace form; this brings the rest into line.

## Test plan

- [x] `pnpm type-check` passes across all 10 packages

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated internal import patterns across codebase to improve code consistency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lukevella/rallly/pull/2393?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->