### PR TITLE
✨ Add sheets list page + nav entry (RAL-1191)

### DIFF
--- a/apps/web/public/locales/en/app.json
+++ b/apps/web/public/locales/en/app.json
@@ -653,5 +653,17 @@
   "maxAttendeesInvalid": "Must be a positive integer",
   "requiredField": "Required",
   "urlInvalid": "Must be a valid URL",
-  "locationDisplayTextPlaceholder": "Meeting link"
+  "locationDisplayTextPlaceholder": "Meeting link",
+  "eventTypeActionsLabel": "Event type actions",
+  "edit": "Edit",
+  "sheets": "Sheets",
+  "sheetsEmptyTitle": "No sheets yet",
+  "sheetsEmptyDescription": "Create a sign-up sheet so people can book the time slots you offer.",
+  "newSheet": "New Sheet",
+  "sheetUpdatedRelative": "Updated {relativeTime}",
+  "deleteEventTypeTitle": "Delete event type?",
+  "deleteEventTypeDescription": "<b>{name}</b> will be hidden from creation pickers. This cannot be undone.",
+  "deleteEventTypeError": "Failed to delete event type",
+  "editEventTypeTitle": "Edit Event Type",
+  "updateEventTypeError": "Failed to update event type"
 }

--- a/apps/web/public/locales/en/app.json
+++ b/apps/web/public/locales/en/app.json
@@ -656,14 +656,14 @@
   "locationDisplayTextPlaceholder": "Meeting link",
   "eventTypeActionsLabel": "Event type actions",
   "edit": "Edit",
-  "sheets": "Sheets",
-  "sheetsEmptyTitle": "No sheets yet",
-  "sheetsEmptyDescription": "Create a sign-up sheet so people can book the time slots you offer.",
-  "newSheet": "New Sheet",
   "sheetUpdatedRelative": "Updated {relativeTime}",
   "deleteEventTypeTitle": "Delete event type?",
   "deleteEventTypeDescription": "<b>{name}</b> will be hidden from creation pickers. This cannot be undone.",
   "deleteEventTypeError": "Failed to delete event type",
   "editEventTypeTitle": "Edit Event Type",
-  "updateEventTypeError": "Failed to update event type"
+  "updateEventTypeError": "Failed to update event type",
+  "signupSheets": "Sign-up Sheets",
+  "signupSheetsEmptyTitle": "No sign-up sheets yet",
+  "signupSheetsEmptyDescription": "Create a sign-up sheet so people can book the time slots you offer.",
+  "newSignupSheet": "New Sign-up Sheet"
 }

--- a/apps/web/src/app/[locale]/(space)/(dashboard)/sheets/page.tsx
+++ b/apps/web/src/app/[locale]/(space)/(dashboard)/sheets/page.tsx
@@ -24,8 +24,8 @@ export default async function Page() {
 export async function generateMetadata(): Promise<Metadata> {
   const { t } = await getTranslation();
   return {
-    title: t("sheets", {
-      defaultValue: "Sheets",
+    title: t("signupSheets", {
+      defaultValue: "Sign-up Sheets",
     }),
   };
 }

--- a/apps/web/src/app/[locale]/(space)/(dashboard)/sheets/page.tsx
+++ b/apps/web/src/app/[locale]/(space)/(dashboard)/sheets/page.tsx
@@ -1,0 +1,31 @@
+import { dehydrate, HydrationBoundary } from "@tanstack/react-query";
+import type { Metadata } from "next";
+import { notFound } from "next/navigation";
+import { getTranslation } from "@/i18n/server";
+import { isFeatureEnabled } from "@/lib/feature-flags/server";
+import { createPrivateSSRHelper } from "@/trpc/server/create-ssr-helper";
+import { SheetsPage } from "./sheets-page";
+
+export default async function Page() {
+  if (!isFeatureEnabled("signupSheets")) {
+    notFound();
+  }
+
+  const helpers = await createPrivateSSRHelper();
+  await helpers.sheets.list.prefetch();
+
+  return (
+    <HydrationBoundary state={dehydrate(helpers.queryClient)}>
+      <SheetsPage />
+    </HydrationBoundary>
+  );
+}
+
+export async function generateMetadata(): Promise<Metadata> {
+  const { t } = await getTranslation();
+  return {
+    title: t("sheets", {
+      defaultValue: "Sheets",
+    }),
+  };
+}

--- a/apps/web/src/app/[locale]/(space)/(dashboard)/sheets/sheets-page.tsx
+++ b/apps/web/src/app/[locale]/(space)/(dashboard)/sheets/sheets-page.tsx
@@ -33,11 +33,14 @@ function SheetsEmptyState() {
         <ClipboardListIcon />
       </EmptyStateIcon>
       <EmptyStateTitle>
-        <Trans i18nKey="sheetsEmptyTitle" defaults="No sheets yet" />
+        <Trans
+          i18nKey="signupSheetsEmptyTitle"
+          defaults="No sign-up sheets yet"
+        />
       </EmptyStateTitle>
       <EmptyStateDescription>
         <Trans
-          i18nKey="sheetsEmptyDescription"
+          i18nKey="signupSheetsEmptyDescription"
           defaults="Create a sign-up sheet so people can book the time slots you offer."
         />
       </EmptyStateDescription>
@@ -47,7 +50,7 @@ function SheetsEmptyState() {
           className={buttonVariants({ variant: "primary" })}
         >
           <PlusIcon data-icon="inline-start" />
-          <Trans i18nKey="newSheet" defaults="New Sheet" />
+          <Trans i18nKey="newSignupSheet" defaults="New Sign-up Sheet" />
         </Link>
       </EmptyStateFooter>
     </EmptyState>
@@ -98,7 +101,7 @@ export function SheetsPage() {
       <PageHeader>
         <PageHeaderContent>
           <PageTitle>
-            <Trans i18nKey="sheets" defaults="Sheets" />
+            <Trans i18nKey="signupSheets" defaults="Sign-up Sheets" />
           </PageTitle>
         </PageHeaderContent>
         <PageHeaderActions>
@@ -107,7 +110,7 @@ export function SheetsPage() {
             className={buttonVariants({ variant: "primary" })}
           >
             <PlusIcon data-icon="inline-start" />
-            <Trans i18nKey="newSheet" defaults="New Sheet" />
+            <Trans i18nKey="newSignupSheet" defaults="New Sign-up Sheet" />
           </Link>
         </PageHeaderActions>
       </PageHeader>

--- a/apps/web/src/app/[locale]/(space)/(dashboard)/sheets/sheets-page.tsx
+++ b/apps/web/src/app/[locale]/(space)/(dashboard)/sheets/sheets-page.tsx
@@ -1,0 +1,133 @@
+"use client";
+
+import { buttonVariants } from "@rallly/ui";
+import { shortUrl } from "@rallly/utils/absolute-url";
+import { ClipboardListIcon, PlusIcon } from "lucide-react";
+import Link from "next/link";
+import {
+  PageContainer,
+  PageContent,
+  PageHeader,
+  PageHeaderActions,
+  PageHeaderContent,
+  PageTitle,
+} from "@/app/components/page-layout";
+import { CopyLinkButton } from "@/components/copy-link-button";
+import {
+  EmptyState,
+  EmptyStateDescription,
+  EmptyStateFooter,
+  EmptyStateIcon,
+  EmptyStateTitle,
+} from "@/components/empty-state";
+import { HoverPrefetchLink } from "@/components/hover-prefetch-link";
+import { StackedList, StackedListItem } from "@/components/stacked-list";
+import { Trans } from "@/i18n/client";
+import { dayjs } from "@/lib/dayjs";
+import { trpc } from "@/trpc/client";
+
+function SheetsEmptyState() {
+  return (
+    <EmptyState className="h-96">
+      <EmptyStateIcon>
+        <ClipboardListIcon />
+      </EmptyStateIcon>
+      <EmptyStateTitle>
+        <Trans i18nKey="sheetsEmptyTitle" defaults="No sheets yet" />
+      </EmptyStateTitle>
+      <EmptyStateDescription>
+        <Trans
+          i18nKey="sheetsEmptyDescription"
+          defaults="Create a sign-up sheet so people can book the time slots you offer."
+        />
+      </EmptyStateDescription>
+      <EmptyStateFooter>
+        <Link
+          href="/sheets/new"
+          className={buttonVariants({ variant: "primary" })}
+        >
+          <PlusIcon data-icon="inline-start" />
+          <Trans i18nKey="newSheet" defaults="New Sheet" />
+        </Link>
+      </EmptyStateFooter>
+    </EmptyState>
+  );
+}
+
+function SheetListItem({
+  id,
+  title,
+  urlId,
+  updatedAt,
+}: {
+  id: string;
+  title: string;
+  urlId: string;
+  updatedAt: Date;
+}) {
+  return (
+    <StackedListItem>
+      <div className="relative -m-4 flex min-w-0 flex-1 items-center gap-2 p-4">
+        <HoverPrefetchLink
+          className="min-w-0 text-sm hover:underline focus:ring-ring focus-visible:ring-2"
+          href={`/sheets/${id}`}
+        >
+          <span className="absolute inset-0" />
+          <span className="block truncate font-medium">{title}</span>
+        </HoverPrefetchLink>
+      </div>
+      <div className="flex items-center gap-4">
+        <span className="hidden text-muted-foreground text-sm sm:inline">
+          <Trans
+            i18nKey="sheetUpdatedRelative"
+            defaults="Updated {relativeTime}"
+            values={{ relativeTime: dayjs(updatedAt).fromNow() }}
+          />
+        </span>
+        <CopyLinkButton href={shortUrl(`/sheet/${urlId}`)} />
+      </div>
+    </StackedListItem>
+  );
+}
+
+export function SheetsPage() {
+  const [{ sheets }] = trpc.sheets.list.useSuspenseQuery();
+
+  return (
+    <PageContainer>
+      <PageHeader>
+        <PageHeaderContent>
+          <PageTitle>
+            <Trans i18nKey="sheets" defaults="Sheets" />
+          </PageTitle>
+        </PageHeaderContent>
+        <PageHeaderActions>
+          <Link
+            href="/sheets/new"
+            className={buttonVariants({ variant: "primary" })}
+          >
+            <PlusIcon data-icon="inline-start" />
+            <Trans i18nKey="newSheet" defaults="New Sheet" />
+          </Link>
+        </PageHeaderActions>
+      </PageHeader>
+      <PageContent>
+        {sheets.length === 0 ? (
+          <SheetsEmptyState />
+        ) : (
+          <StackedList>
+            {sheets.map((sheet) => (
+              <SheetListItem
+                key={sheet.id}
+                id={sheet.id}
+                title={sheet.title}
+                urlId={sheet.urlId}
+                updatedAt={sheet.updatedAt}
+              />
+            ))}
+          </StackedList>
+        )}
+      </PageContent>
+    </PageContainer>
+  );
+}

--- a/apps/web/src/features/navigation/config.tsx
+++ b/apps/web/src/features/navigation/config.tsx
@@ -5,6 +5,7 @@ import {
   BarChart2Icon,
   CalendarDaysIcon,
   CalendarIcon,
+  ClipboardListIcon,
   HomeIcon,
   ShapesIcon,
 } from "lucide-react";
@@ -39,6 +40,7 @@ export const useSpaceMenu = () => {
   const pathname = usePathname();
   const isCalendarsEnabled = useFeatureFlag("calendars");
   const isEventTypesEnabled = useFeatureFlag("eventTypes");
+  const isSignupSheetsEnabled = useFeatureFlag("signupSheets");
   const config = React.useMemo<NavigationConfig>(
     () => ({
       sections: [
@@ -96,11 +98,29 @@ export const useSpaceMenu = () => {
                   },
                 ]
               : []),
+            ...(isSignupSheetsEnabled
+              ? [
+                  {
+                    id: "sheets",
+                    label: t("sheets", { defaultValue: "Sheets" }),
+                    href: "/sheets",
+                    icon: ClipboardListIcon,
+                    isActive:
+                      pathname === "/sheets" || pathname.startsWith("/sheets/"),
+                  },
+                ]
+              : []),
           ],
         },
       ],
     }),
-    [pathname, t, isCalendarsEnabled, isEventTypesEnabled],
+    [
+      pathname,
+      t,
+      isCalendarsEnabled,
+      isEventTypesEnabled,
+      isSignupSheetsEnabled,
+    ],
   );
 
   return React.useMemo(

--- a/apps/web/src/features/navigation/config.tsx
+++ b/apps/web/src/features/navigation/config.tsx
@@ -102,7 +102,9 @@ export const useSpaceMenu = () => {
               ? [
                   {
                     id: "sheets",
-                    label: t("sheets", { defaultValue: "Sheets" }),
+                    label: t("signupSheets", {
+                      defaultValue: "Sign-up Sheets",
+                    }),
                     href: "/sheets",
                     icon: ClipboardListIcon,
                     isActive:

--- a/packages/database/prisma/seed.ts
+++ b/packages/database/prisma/seed.ts
@@ -4,6 +4,7 @@ import {
   eventTypes,
   polls,
   scheduledEvents,
+  sheets,
   spaceMembers,
   spaces,
   users,
@@ -190,6 +191,20 @@ async function main() {
     })),
   });
   console.info(`✓ ${eventTypes.length} event types`);
+
+  // 7. Sheets
+  await prisma.sheet.createMany({
+    data: sheets.map((sheet, i) => ({
+      id: sheet.id,
+      spaceId: sheet.spaceId,
+      hostId: sheet.hostId,
+      title: sheet.title,
+      description: sheet.description,
+      urlId: sheet.urlId,
+      updatedAt: new Date(now - i * 60_000),
+    })),
+  });
+  console.info(`✓ ${sheets.length} sheets`);
 }
 
 main()

--- a/packages/database/prisma/seed/data.ts
+++ b/packages/database/prisma/seed/data.ts
@@ -1020,6 +1020,61 @@ export type EventTypeDef = {
   location: EventTypeLocation | null;
 };
 
+export type SheetDef = {
+  id: string;
+  spaceId: string;
+  hostId: string;
+  title: string;
+  description: string | null;
+  urlId: string;
+};
+
+export const sheets: SheetDef[] = [
+  // ── Personal space (space-1) ─────────────────────────────────────────────
+  {
+    id: "sheet-1",
+    spaceId: "space-1",
+    hostId: "user-1",
+    title: "Coffee chat sign-ups",
+    description: "Pick a slot for a 30 minute coffee chat next week.",
+    urlId: "personal-coffee-chats",
+  },
+  {
+    id: "sheet-2",
+    spaceId: "space-1",
+    hostId: "user-1",
+    title: "Mentorship office hours",
+    description: null,
+    urlId: "personal-mentorship",
+  },
+
+  // ── Acme Inc (space-2) ───────────────────────────────────────────────────
+  {
+    id: "sheet-3",
+    spaceId: "space-2",
+    hostId: "user-3",
+    title: "Engineering office hours",
+    description: "Drop in for help with code reviews or architecture.",
+    urlId: "acme-eng-office-hours",
+  },
+  {
+    id: "sheet-4",
+    spaceId: "space-2",
+    hostId: "user-2",
+    title: "Design critique slots",
+    description: "30 minute critiques of in-progress designs.",
+    urlId: "acme-design-critiques",
+  },
+  {
+    id: "sheet-5",
+    spaceId: "space-2",
+    hostId: "user-1",
+    title: "New hire intro chats",
+    description: "Welcome chat with our newest team members.",
+    urlId: "acme-new-hire-intros",
+  },
+];
+
 export const eventTypes: EventTypeDef[] = [
   // ── Personal space (space-1) ─────────────────────────────────────────────
   {


### PR DESCRIPTION
## Summary

- Adds the `/sheets` route (server page prefetches `sheets.list` and hydrates the client list)
- Adds a `Sheets` sidebar entry under "Content", gated by `useFeatureFlag("signupSheets")`
- Adds 5 seed sheets across the Personal and Acme spaces

Both the route and the nav entry 404/hide when `signupSheets` is off, mirroring the Event Types pattern.

Notes:

- "New Sheet" CTA links to `/sheets/new` (creation route is a future ticket)
- Card row links to `/sheets/[id]` editor (also future)
- Public link uses `shortUrl(\`/sheet/{urlId}\`)` for now; URL customization (space slug + sheet slug) is intentionally deferred — see discussion on the issue

Linear: [RAL-1191](https://linear.app/rallly/issue/RAL-1191/sheets-list-page-nav-entry)

## Test plan

- [x] With `signupSheets` enabled, `/sheets` lists seeded sheets in updated-desc order
- [x] Empty state shows when a space has no sheets
- [x] "Copy link" copies the public sheet URL
- [x] Sidebar shows the Sheets entry when flag is on, hides when off
- [x] `/sheets` 404s when flag is off

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced the Sheets dashboard to create and manage sign-up sheets with edit, delete, copy-link, and relative update timestamps.
  * Added a navigation entry for Sheets (visible when the feature is enabled).
  * Added full English localization for event types and sign-up sheets UI and messages.

* **Chores**
  * Added sample seed data for sheets to the project database seeds.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lukevella/rallly/pull/2394?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->