### PR TITLE
🚚 Move Event Types out of primary sidebar into Settings (RAL-1197)

### DIFF
--- a/apps/web/public/locales/en/app.json
+++ b/apps/web/public/locales/en/app.json
@@ -666,5 +666,5 @@
   "signupSheetsEmptyTitle": "No sign-up sheets yet",
   "signupSheetsEmptyDescription": "Create a sign-up sheet so people can book the time slots you offer.",
   "newSignupSheet": "New Sign-up Sheet",
-  "eventTypesDescription": "Reusable event configurations that power sign-up sheets."
+  "eventTypesDescription": "Reusable event configurations."
 }

--- a/apps/web/public/locales/en/app.json
+++ b/apps/web/public/locales/en/app.json
@@ -665,5 +665,6 @@
   "signupSheets": "Sign-up Sheets",
   "signupSheetsEmptyTitle": "No sign-up sheets yet",
   "signupSheetsEmptyDescription": "Create a sign-up sheet so people can book the time slots you offer.",
-  "newSignupSheet": "New Sign-up Sheet"
+  "newSignupSheet": "New Sign-up Sheet",
+  "eventTypesDescription": "Reusable event configurations that power sign-up sheets."
 }

--- a/apps/web/src/app/[locale]/(space)/settings/components/sidebar.tsx
+++ b/apps/web/src/app/[locale]/(space)/settings/components/sidebar.tsx
@@ -19,6 +19,7 @@ import {
   LockIcon,
   PanelsTopLeftIcon,
   Settings2Icon,
+  ShapesIcon,
   UserIcon,
   UsersIcon,
 } from "lucide-react";
@@ -99,6 +100,7 @@ export function SpaceSidebarMenu() {
   const { t } = useTranslation();
   const pathname = usePathname();
   const isBillingEnabled = useFeatureFlag("billing");
+  const isEventTypesEnabled = useFeatureFlag("eventTypes");
   const menuItems = [
     {
       id: "general",
@@ -112,6 +114,16 @@ export function SpaceSidebarMenu() {
       icon: <UsersIcon />,
       href: "/settings/members",
     },
+    ...(isEventTypesEnabled
+      ? [
+          {
+            id: "event-types",
+            label: t("eventTypes", { defaultValue: "Event Types" }),
+            icon: <ShapesIcon />,
+            href: "/settings/event-types",
+          },
+        ]
+      : []),
     ...(isBillingEnabled
       ? [
           {

--- a/apps/web/src/app/[locale]/(space)/settings/event-types/event-types-settings-page.tsx
+++ b/apps/web/src/app/[locale]/(space)/settings/event-types/event-types-settings-page.tsx
@@ -179,7 +179,7 @@ export function EventTypesSettingsPage() {
           <SettingsPageDescription>
             <Trans
               i18nKey="eventTypesDescription"
-              defaults="Reusable event configurations that power sign-up sheets."
+              defaults="Reusable event configurations."
             />
           </SettingsPageDescription>
         </SettingsPageHeader>

--- a/apps/web/src/app/[locale]/(space)/settings/event-types/event-types-settings-page.tsx
+++ b/apps/web/src/app/[locale]/(space)/settings/event-types/event-types-settings-page.tsx
@@ -24,13 +24,12 @@ import {
 } from "lucide-react";
 import React from "react";
 import {
-  PageContainer,
-  PageContent,
-  PageHeader,
-  PageHeaderActions,
-  PageHeaderContent,
-  PageTitle,
-} from "@/app/components/page-layout";
+  SettingsPage,
+  SettingsPageContent,
+  SettingsPageDescription,
+  SettingsPageHeader,
+  SettingsPageTitle,
+} from "@/app/components/settings-layout";
 import {
   EmptyState,
   EmptyStateDescription,
@@ -162,7 +161,7 @@ function EventTypeCard({
   );
 }
 
-export function EventTypesPage() {
+export function EventTypesSettingsPage() {
   const [{ eventTypes }] = trpc.eventTypes.list.useSuspenseQuery();
   const createDialog = useDialog();
   const editDialog = useDialog();
@@ -171,26 +170,32 @@ export function EventTypesPage() {
     React.useState<EventTypeDTO | null>(null);
 
   return (
-    <PageContainer>
-      <PageHeader>
-        <PageHeaderContent>
-          <PageTitle>
+    <SettingsPage>
+      <div className="flex justify-between gap-4">
+        <SettingsPageHeader>
+          <SettingsPageTitle>
             <Trans i18nKey="eventTypes" defaults="Event Types" />
-          </PageTitle>
-        </PageHeaderContent>
-        <PageHeaderActions>
+          </SettingsPageTitle>
+          <SettingsPageDescription>
+            <Trans
+              i18nKey="eventTypesDescription"
+              defaults="Reusable event configurations that power sign-up sheets."
+            />
+          </SettingsPageDescription>
+        </SettingsPageHeader>
+        <div>
           <Button variant="primary" onClick={() => createDialog.trigger()}>
             <PlusIcon data-icon="inline-start" />
             <Trans i18nKey="newEventType" defaults="New Event Type" />
           </Button>
-        </PageHeaderActions>
-      </PageHeader>
-      <PageContent>
+        </div>
+      </div>
+      <SettingsPageContent>
         {eventTypes.length === 0 ? (
           <EventTypesEmptyState onCreate={() => createDialog.trigger()} />
         ) : (
           <div className="@container">
-            <div className="grid @4xl:grid-cols-3 @md:grid-cols-2 grid-cols-1 gap-4">
+            <div className="grid @md:grid-cols-2 grid-cols-1 gap-4">
               {eventTypes.map((eventType) => (
                 <EventTypeCard
                   key={eventType.id}
@@ -220,7 +225,7 @@ export function EventTypesPage() {
             </div>
           </div>
         )}
-      </PageContent>
+      </SettingsPageContent>
       <CreateEventTypeDialog {...createDialog.dialogProps} />
       {selectedEventType ? (
         <>
@@ -235,6 +240,6 @@ export function EventTypesPage() {
           />
         </>
       ) : null}
-    </PageContainer>
+    </SettingsPage>
   );
 }

--- a/apps/web/src/app/[locale]/(space)/settings/event-types/page.tsx
+++ b/apps/web/src/app/[locale]/(space)/settings/event-types/page.tsx
@@ -4,7 +4,7 @@ import { notFound } from "next/navigation";
 import { getTranslation } from "@/i18n/server";
 import { isFeatureEnabled } from "@/lib/feature-flags/server";
 import { createPrivateSSRHelper } from "@/trpc/server/create-ssr-helper";
-import { EventTypesPage } from "./event-types-page";
+import { EventTypesSettingsPage } from "./event-types-settings-page";
 
 export default async function Page() {
   if (!isFeatureEnabled("eventTypes")) {
@@ -16,7 +16,7 @@ export default async function Page() {
 
   return (
     <HydrationBoundary state={dehydrate(helpers.queryClient)}>
-      <EventTypesPage />
+      <EventTypesSettingsPage />
     </HydrationBoundary>
   );
 }

--- a/apps/web/src/features/navigation/config.tsx
+++ b/apps/web/src/features/navigation/config.tsx
@@ -7,7 +7,6 @@ import {
   CalendarIcon,
   ClipboardListIcon,
   HomeIcon,
-  ShapesIcon,
 } from "lucide-react";
 import { usePathname } from "next/navigation";
 import React from "react";
@@ -39,7 +38,6 @@ export const useSpaceMenu = () => {
   const { t } = useTranslation();
   const pathname = usePathname();
   const isCalendarsEnabled = useFeatureFlag("calendars");
-  const isEventTypesEnabled = useFeatureFlag("eventTypes");
   const isSignupSheetsEnabled = useFeatureFlag("signupSheets");
   const config = React.useMemo<NavigationConfig>(
     () => ({
@@ -85,19 +83,6 @@ export const useSpaceMenu = () => {
                   },
                 ]
               : []),
-            ...(isEventTypesEnabled
-              ? [
-                  {
-                    id: "event-types",
-                    label: t("eventTypes", { defaultValue: "Event Types" }),
-                    href: "/event-types",
-                    icon: ShapesIcon,
-                    isActive:
-                      pathname === "/event-types" ||
-                      pathname.startsWith("/event-types/"),
-                  },
-                ]
-              : []),
             ...(isSignupSheetsEnabled
               ? [
                   {
@@ -116,13 +101,7 @@ export const useSpaceMenu = () => {
         },
       ],
     }),
-    [
-      pathname,
-      t,
-      isCalendarsEnabled,
-      isEventTypesEnabled,
-      isSignupSheetsEnabled,
-    ],
+    [pathname, t, isCalendarsEnabled, isSignupSheetsEnabled],
   );
 
   return React.useMemo(


### PR DESCRIPTION
## Summary

- Removes the `Event Types` entry from the primary space sidebar
- Moves the management UI to `/settings/event-types` (under the Space group, gated by the existing `eventTypes` flag) and refactors it onto the shared `SettingsPage*` layout
- Deletes the old `/event-types` route so it returns 404 — the new Settings route is canonical

Event Types are configuration that powers Sheets, not a destination users return to. With Sheets in the sidebar, having Event Types there too muddled the IA — Sheets are the content, Event Types are the materials.

Linear: https://linear.app/rallly/issue/RAL-1197

## Test plan

- [x] With `eventTypes` flag on, sidebar no longer shows Event Types under Content
- [x] Settings → Space sidebar shows Event Types (only when flag is on); navigates to `/settings/event-types`
- [x] Create / edit / delete event type works from the new Settings page
- [x] Visiting `/event-types` returns 404
- [x] With `eventTypes` flag off, `/settings/event-types` returns 404 and no settings entry is rendered
- [x] Sheet editor's event-type picker still works (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Event Types management is now accessible from the settings sidebar, allowing users to configure and manage reusable event configurations.

* **UI/UX Improvements**
  * Updated the Event Types settings page layout for a more consistent settings experience.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lukevella/rallly/pull/2395?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->