### PR TITLE
✨ Add hideAttendees field to ScheduledEvent (RAL-1200)

### DIFF
--- a/apps/web/src/trpc/routers/polls.ts
+++ b/apps/web/src/trpc/routers/polls.ts
@@ -713,6 +713,7 @@ export const polls = router({
           location: true,
           description: true,
           spaceId: true,
+          hideParticipants: true,
           space: {
             select: {
               showBranding: true,
@@ -846,6 +847,7 @@ export const polls = router({
             spaceId,
             allDay: option.duration === 0,
             status: "confirmed",
+            hideAttendees: poll.hideParticipants,
             invites: {
               createMany: {
                 data: poll.participants

--- a/packages/database/prisma/migrations/20260519160226_add_hide_attendees_to_scheduled_event/migration.sql
+++ b/packages/database/prisma/migrations/20260519160226_add_hide_attendees_to_scheduled_event/migration.sql
@@ -1,0 +1,13 @@
+-- AlterTable
+ALTER TABLE "scheduled_events" ADD COLUMN     "hide_attendees" BOOLEAN NOT NULL DEFAULT false;
+
+-- Backfill: inherit hideAttendees from the source poll's hideParticipants
+-- (events created from a poll that had hideParticipants = true)
+UPDATE "scheduled_events" se
+SET "hide_attendees" = true
+WHERE EXISTS (
+  SELECT 1
+  FROM "polls" p
+  WHERE p."scheduled_event_id" = se."id"
+    AND p."hide_participants" = true
+);

--- a/packages/database/prisma/models/event.prisma
+++ b/packages/database/prisma/models/event.prisma
@@ -16,25 +16,26 @@ enum ScheduledEventInviteStatus {
 }
 
 model ScheduledEvent {
-  id          String               @id @default(cuid())
-  userId      String               @map("user_id")
-  spaceId     String               @map("space_id")
-  eventTypeId String?              @map("event_type_id")
-  sheetSlotId String?              @unique @map("sheet_slot_id")
-  title       String
-  description String?
-  location    String?
-  capacity    Int?
-  createdAt   DateTime             @default(now()) @map("created_at")
-  updatedAt   DateTime             @updatedAt @map("updated_at")
-  status      ScheduledEventStatus @default(confirmed)
-  timeZone    String?              @map("time_zone")
-  start       DateTime
-  end         DateTime
-  allDay      Boolean              @default(false) @map("all_day")
-  deletedAt   DateTime?            @map("deleted_at")
-  sequence    Int                  @default(0)
-  uid         String               @unique
+  id            String               @id @default(cuid())
+  userId        String               @map("user_id")
+  spaceId       String               @map("space_id")
+  eventTypeId   String?              @map("event_type_id")
+  sheetSlotId   String?              @unique @map("sheet_slot_id")
+  title         String
+  description   String?
+  location      String?
+  capacity      Int?
+  createdAt     DateTime             @default(now()) @map("created_at")
+  updatedAt     DateTime             @updatedAt @map("updated_at")
+  status        ScheduledEventStatus @default(confirmed)
+  timeZone      String?              @map("time_zone")
+  start         DateTime
+  end           DateTime
+  allDay        Boolean              @default(false) @map("all_day")
+  deletedAt     DateTime?            @map("deleted_at")
+  sequence      Int                  @default(0)
+  uid           String               @unique
+  hideAttendees Boolean              @default(false) @map("hide_attendees")
 
   user             User                   @relation(fields: [userId], references: [id], onDelete: Cascade)
   space            Space                  @relation(fields: [spaceId], references: [id], onDelete: Cascade)


### PR DESCRIPTION
## Summary
- Adds `hideAttendees Boolean @default(false)` to `ScheduledEvent`, mirroring `Poll.hideParticipants`
- Migration backfills `true` for events whose source poll had `hideParticipants = true` (uses `EXISTS` so the one-to-many `polls` relation is handled correctly)
- The `book` tRPC procedure copies `poll.hideParticipants` into the new `ScheduledEvent.hideAttendees` when a poll is finalized

Unblocks the public event page work in [RAL-1199](https://linear.app/rallly/issue/RAL-1199), which needs this field to render the count-only attendee view.

## Test plan
- [x] Migration applies cleanly to local DB (`pnpm db:migrate`)
- [x] `pnpm db:generate` produces a client with `hideAttendees` on `ScheduledEvent`
- [x] `pnpm type-check` passes
- [x] `pnpm check` passes for touched files
- [x] Spot-check on a non-prod copy: pre-existing event linked to a `hideParticipants = true` poll has `hide_attendees = true` after migration
- [x] Finalize a new poll with `hideParticipants = true` → resulting `ScheduledEvent` has `hideAttendees = true`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added ability to hide event attendees from other participants
  * Event privacy settings from polls now automatically sync to associated scheduled events

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lukevella/rallly/pull/2397?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->