### PR TITLE
🐛 Honor edit token in participants.list when participants are hidden

### DIFF
--- a/apps/web/src/app/[locale]/invite/[urlId]/page.tsx
+++ b/apps/web/src/app/[locale]/invite/[urlId]/page.tsx
@@ -43,14 +43,14 @@ export default async function Page(props: {
 
   const trpc = await createPublicSSRHelper();
 
+  const token = (await props.searchParams).token;
+
   await Promise.all([
     trpc.user.getMe.prefetch(),
     trpc.polls.get.prefetch({ urlId: params.urlId }),
-    trpc.polls.participants.list.prefetch({ pollId: params.urlId }),
+    trpc.polls.participants.list.prefetch({ pollId: params.urlId, token }),
     trpc.polls.comments.list.prefetch({ pollId: params.urlId }),
   ]);
-
-  const token = (await props.searchParams).token;
 
   let impersonatedUserId: string | null = null;
   if (token) {

--- a/apps/web/src/components/participants-provider.tsx
+++ b/apps/web/src/components/participants-provider.tsx
@@ -1,5 +1,5 @@
 import type { VoteType } from "@rallly/database";
-import { useParams } from "next/navigation";
+import { useParams, useSearchParams } from "next/navigation";
 import * as React from "react";
 import { useVisibility } from "@/components/visibility";
 import { usePermissions } from "@/contexts/permissions";
@@ -17,8 +17,10 @@ export function filterParticipantsByVote<
 
 export const useParticipants = () => {
   const urlId = useParams<{ urlId: string }>().urlId;
+  const token = useSearchParams().get("token") ?? undefined;
   const [participants] = trpc.polls.participants.list.useSuspenseQuery({
     pollId: urlId,
+    token,
   });
 
   return { participants };

--- a/apps/web/src/components/poll/mutations.ts
+++ b/apps/web/src/components/poll/mutations.ts
@@ -26,10 +26,11 @@ export const useAddParticipantMutation = () => {
 
 export const useUpdateParticipantMutation = () => {
   const queryClient = trpc.useUtils();
+  const token = useEditToken();
   return trpc.polls.participants.update.useMutation({
     onSuccess: (participant) => {
       queryClient.polls.participants.list.setData(
-        { pollId: participant.pollId },
+        { pollId: participant.pollId, token },
         (existingParticipants = []) => {
           const newParticipants = [...existingParticipants];
 
@@ -51,10 +52,11 @@ export const useUpdateParticipantMutation = () => {
 export const useDeleteParticipantMutation = () => {
   const queryClient = trpc.useUtils();
   const { poll } = usePoll();
+  const token = useEditToken();
   return trpc.polls.participants.delete.useMutation({
     onMutate: ({ participantId }) => {
       queryClient.polls.participants.list.setData(
-        { pollId: poll.id },
+        { pollId: poll.id, token },
         (existingParticipants = []) => {
           return existingParticipants.filter(({ id }) => id !== participantId);
         },

--- a/apps/web/src/trpc/routers/polls/participants.ts
+++ b/apps/web/src/trpc/routers/polls/participants.ts
@@ -16,7 +16,11 @@ import {
   requireUserMiddleware,
   router,
 } from "../../trpc";
-import { createParticipantEditToken, resolveUserId } from "./utils";
+import {
+  createParticipantEditToken,
+  resolveUserId,
+  tryResolveUserId,
+} from "./utils";
 
 const logger = createLogger("participants");
 
@@ -107,9 +111,10 @@ export const participants = router({
     .input(
       z.object({
         pollId: z.string(),
+        token: z.string().optional(),
       }),
     )
-    .query(async ({ ctx, input: { pollId } }) => {
+    .query(async ({ ctx, input: { pollId, token } }) => {
       const poll = await prisma.poll.findUnique({
         where: { id: pollId },
         select: {
@@ -152,12 +157,16 @@ export const participants = router({
       // Hide participants if the poll has hideParticipants enabled
       // and the current user is not an admin
       if (poll.hideParticipants) {
+        // Admin check is intentionally bound to ctx.user only — an edit
+        // token must never unlock the admin view of other participants.
         const isAdmin =
           ctx.user && (await hasPollAdminAccess(pollId, ctx.user.id));
         if (!isAdmin) {
+          // Fall back to the edit token so a guest can still see their own
+          // response when opening the email link in a fresh browser.
+          const viewerId = await tryResolveUserId(token, ctx.user);
           return participants.map((participant) => {
-            // If the current user is the participant, return the participant
-            if (ctx.user && participant.userId === ctx.user.id) {
+            if (viewerId && participant.userId === viewerId) {
               return participant;
             }
 

--- a/apps/web/src/trpc/routers/polls/utils.ts
+++ b/apps/web/src/trpc/routers/polls/utils.ts
@@ -27,8 +27,7 @@ export async function resolveUserId(
   token: string | undefined,
   ctxUser: { id: string } | undefined,
 ): Promise<string> {
-  const userIdFromToken = await getUserIdFromToken(token);
-  const userId = userIdFromToken ?? ctxUser?.id;
+  const userId = await tryResolveUserId(token, ctxUser);
   if (!userId) {
     throw new TRPCError({
       code: "UNAUTHORIZED",
@@ -36,4 +35,12 @@ export async function resolveUserId(
     });
   }
   return userId;
+}
+
+export async function tryResolveUserId(
+  token: string | undefined,
+  ctxUser: { id: string } | undefined,
+): Promise<string | null> {
+  const userIdFromToken = await getUserIdFromToken(token);
+  return userIdFromToken ?? ctxUser?.id ?? null;
 }


### PR DESCRIPTION
Fixes #2398.

## Summary

- `participants.list` now accepts an optional `token` and uses it (via a new `tryResolveUserId` helper) to identify the caller when there is no session cookie. Without this, a guest opening their edit link in a fresh browser sees every participant — including their own — as "Anonymous", and `canEditParticipant` cannot match them to their record.
- The admin branch is intentionally left bound to `ctx.user` only, so an edit token cannot unlock the admin view of other participants.
- The `?token=` is threaded through the SSR prefetch in `/invite/[urlId]/page.tsx` and through the client `useParticipants` hook so the cache keys match.
- The optimistic `setData` writers for update/delete now include the token in the cache key for the same reason.

## Test plan

- [x] Create a poll with **Hide participant list** enabled.
- [x] Submit a response as a logged-out guest with an email address.
- [x] Open the edit link from the confirmation email in a fresh browser / incognito window (no session cookie).
- [x] Confirm the previous response is visible, identified as the guest's own, and editable.
- [x] Confirm other participants still appear as "Anonymous".
- [x] Confirm an arbitrary/invalid `?token=` value does **not** reveal any other participant.
- [x] Confirm the poll admin still sees real names in the same scenario.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Invite links now provide token-based participant visibility. Guests accessing polls via invite links can view participant information according to their authorization level. When poll participants are hidden, only the invited user's own details are displayed while others remain anonymized for privacy protection.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lukevella/rallly/pull/2399?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->