### PR TITLE
✨ Add structured location and conferencing to ScheduledEvent (RAL-1201)

### DIFF
--- a/apps/web/src/app/[locale]/e/[id]/event-date-time.tsx
+++ b/apps/web/src/app/[locale]/e/[id]/event-date-time.tsx
@@ -13,10 +13,10 @@ export function EventDateTime({
   start: Date;
   end: Date;
   allDay: boolean;
-  timezone: string;
+  timezone: string | null;
 }) {
-  const startD = dayjs(start).tz(timezone);
-  const endD = dayjs(end).tz(timezone);
+  const startD = timezone ? dayjs(start).tz(timezone) : dayjs(start);
+  const endD = timezone ? dayjs(end).tz(timezone) : dayjs(end);
   const date = startD.format("dddd, LL");
 
   return (

--- a/apps/web/src/app/[locale]/e/[id]/page.tsx
+++ b/apps/web/src/app/[locale]/e/[id]/page.tsx
@@ -19,7 +19,10 @@ import {
 import { PollFooter } from "@/components/poll/poll-footer";
 import { RandomGradientBar } from "@/components/random-gradient-bar";
 import { BrandingStyle } from "@/features/branding/branding-style";
+import { ConferencingLink } from "@/features/conferencing/components/conferencing-link";
+import { formatLocationText } from "@/features/location/utils";
 import { isScheduledEventEnabled } from "@/features/scheduled-event/constants";
+import { createScheduledEventDTO } from "@/features/scheduled-event/data";
 import { SpaceIcon } from "@/features/space/components/space-icon";
 import { Trans } from "@/i18n/client";
 import { EventDateTime } from "./event-date-time";
@@ -32,6 +35,7 @@ const getScheduledEvent = cache(async (id: string) => {
       title: true,
       description: true,
       location: true,
+      conferencing: true,
       start: true,
       end: true,
       allDay: true,
@@ -58,7 +62,10 @@ const getScheduledEvent = cache(async (id: string) => {
     notFound();
   }
 
-  return event;
+  return {
+    ...event,
+    ...createScheduledEventDTO(event),
+  };
 });
 
 async function EventsBackLink() {
@@ -173,12 +180,17 @@ export default async function EventPage({
                   start={event.start}
                   end={event.end}
                   allDay={event.allDay}
-                  timezone={event.timeZone || "UTC"}
+                  timezone={event.displayTimeZone}
                 />
                 {event.location ? (
                   <EventMetaItem>
                     <MapPinIcon />
-                    {event.location}
+                    {formatLocationText(event.location)}
+                  </EventMetaItem>
+                ) : null}
+                {event.conferencing ? (
+                  <EventMetaItem>
+                    <ConferencingLink conferencing={event.conferencing} />
                   </EventMetaItem>
                 ) : null}
               </EventMetaList>

--- a/apps/web/src/app/api/event/[...route]/route.ts
+++ b/apps/web/src/app/api/event/[...route]/route.ts
@@ -4,6 +4,10 @@ import { google, office365, outlook, yahoo } from "calendar-link";
 import { Hono } from "hono";
 import { handle } from "hono/vercel";
 
+import { parseConferencing } from "@/features/conferencing/data";
+import { getConferencingUri } from "@/features/conferencing/utils";
+import { parseLocation } from "@/features/location/data";
+import { formatLocationText } from "@/features/location/utils";
 import { createIcsEvent } from "@/utils/ics";
 
 const app = new Hono().basePath("/api/event");
@@ -12,10 +16,12 @@ async function getScheduledEvent(eventId: string) {
   return prisma.scheduledEvent.findUnique({
     where: { id: eventId },
     select: {
+      id: true,
       uid: true,
       title: true,
       description: true,
       location: true,
+      conferencing: true,
       start: true,
       end: true,
       allDay: true,
@@ -30,16 +36,50 @@ async function getScheduledEvent(eventId: string) {
   });
 }
 
-function toCalendarEvent(
-  event: NonNullable<Awaited<ReturnType<typeof getScheduledEvent>>>,
-): CalendarEvent {
+type ScheduledEventRow = NonNullable<
+  Awaited<ReturnType<typeof getScheduledEvent>>
+>;
+
+// Flattens structured location/conferencing into the single-string fields the
+// calendar-link / ICS libraries accept.
+function buildCalendarFields(event: ScheduledEventRow) {
+  const location = parseLocation(event.location, {
+    scheduledEventId: event.id,
+  });
+  const conferencing = parseConferencing(event.conferencing, {
+    scheduledEventId: event.id,
+  });
+
+  const locationText = location ? formatLocationText(location) : undefined;
+  const conferencingUri = conferencing
+    ? getConferencingUri(conferencing)
+    : undefined;
+
+  const descriptionParts: string[] = [];
+  if (event.description) {
+    descriptionParts.push(event.description);
+  }
+  if (conferencingUri) {
+    descriptionParts.push(conferencingUri);
+  }
+  const description =
+    descriptionParts.length > 0 ? descriptionParts.join("\n\n") : undefined;
+
+  return {
+    location: locationText ?? conferencingUri,
+    description,
+  };
+}
+
+function toCalendarEvent(event: ScheduledEventRow): CalendarEvent {
+  const { location, description } = buildCalendarFields(event);
   return {
     title: event.title,
-    description: event.description ?? undefined,
+    description,
     start: event.start,
     end: event.end,
     allDay: event.allDay,
-    location: event.location ?? undefined,
+    location,
     organizer: { name: event.user.name, email: event.user.email },
     busy: true,
   };
@@ -83,11 +123,13 @@ app.get("/:eventId/ics", async (c) => {
     return c.json({ error: "Event not found" }, 404);
   }
 
+  const { location, description } = buildCalendarFields(event);
+
   const { error, value } = createIcsEvent({
     uid: event.uid,
     title: event.title,
-    description: event.description ?? undefined,
-    location: event.location ?? undefined,
+    description,
+    location,
     start: event.start,
     end: event.end,
     allDay: event.allDay,

--- a/apps/web/src/features/conferencing/components/conferencing-link.tsx
+++ b/apps/web/src/features/conferencing/components/conferencing-link.tsx
@@ -16,7 +16,6 @@ export function ConferencingLink({
               ? `tel:${conferencing.number},,${conferencing.extension}`
               : `tel:${conferencing.number}`
           }
-          target="_blank"
           rel="noreferrer"
           className={buttonVariants({ variant: "ghost" })}
         >

--- a/apps/web/src/features/conferencing/components/conferencing-link.tsx
+++ b/apps/web/src/features/conferencing/components/conferencing-link.tsx
@@ -1,0 +1,76 @@
+import { buttonVariants } from "@rallly/ui";
+import { LinkIcon, PhoneIcon, VideoIcon } from "lucide-react";
+import type { Conferencing } from "../schema";
+
+export function ConferencingLink({
+  conferencing,
+}: {
+  conferencing: Conferencing;
+}) {
+  switch (conferencing.provider) {
+    case "phone":
+      return (
+        <a
+          href={
+            conferencing.extension
+              ? `tel:${conferencing.number},,${conferencing.extension}`
+              : `tel:${conferencing.number}`
+          }
+          target="_blank"
+          rel="noreferrer"
+          className={buttonVariants({ variant: "ghost" })}
+        >
+          <PhoneIcon />
+          {conferencing.number}
+        </a>
+      );
+    case "zoom":
+      return (
+        <a
+          href={conferencing.uri}
+          target="_blank"
+          rel="noreferrer"
+          className={buttonVariants({ variant: "ghost" })}
+        >
+          <VideoIcon />
+          Zoom
+        </a>
+      );
+    case "meet":
+      return (
+        <a
+          href={conferencing.uri}
+          target="_blank"
+          rel="noreferrer"
+          className={buttonVariants({ variant: "ghost" })}
+        >
+          <VideoIcon />
+          Google Meet
+        </a>
+      );
+    case "teams":
+      return (
+        <a
+          href={conferencing.uri}
+          target="_blank"
+          rel="noreferrer"
+          className={buttonVariants({ variant: "ghost" })}
+        >
+          <VideoIcon />
+          Microsoft Teams
+        </a>
+      );
+    case "custom":
+      return (
+        <a
+          href={conferencing.uri}
+          target="_blank"
+          rel="noreferrer"
+          className={buttonVariants({ variant: "ghost" })}
+        >
+          <LinkIcon />
+          {conferencing.label}
+        </a>
+      );
+  }
+}

--- a/apps/web/src/features/conferencing/data.ts
+++ b/apps/web/src/features/conferencing/data.ts
@@ -1,0 +1,24 @@
+import type { Prisma } from "@rallly/database";
+import { createLogger } from "@rallly/logger";
+import type { Conferencing } from "./schema";
+import { conferencingSchema } from "./schema";
+
+const logger = createLogger("conferencing/data");
+
+export function parseConferencing(
+  raw: Prisma.JsonValue | null,
+  context?: { scheduledEventId?: string },
+): Conferencing | null {
+  if (raw === null) {
+    return null;
+  }
+  const parsed = conferencingSchema.safeParse(raw);
+  if (!parsed.success) {
+    logger.warn(
+      { scheduledEventId: context?.scheduledEventId, value: raw },
+      "Failed to parse conferencing",
+    );
+    return null;
+  }
+  return parsed.data;
+}

--- a/apps/web/src/features/conferencing/schema.ts
+++ b/apps/web/src/features/conferencing/schema.ts
@@ -1,0 +1,28 @@
+import * as z from "zod";
+
+const webConferencingSchema = z.object({
+  provider: z.enum(["zoom", "meet", "teams"]),
+  uri: z.url(),
+  meetingId: z.string().optional(),
+  password: z.string().optional(),
+});
+
+const phoneConferencingSchema = z.object({
+  provider: z.literal("phone"),
+  number: z.string().min(1),
+  extension: z.string().optional(),
+});
+
+const customConferencingSchema = z.object({
+  provider: z.literal("custom"),
+  uri: z.url(),
+  label: z.string().min(1),
+});
+
+export const conferencingSchema = z.discriminatedUnion("provider", [
+  webConferencingSchema,
+  phoneConferencingSchema,
+  customConferencingSchema,
+]);
+
+export type Conferencing = z.infer<typeof conferencingSchema>;

--- a/apps/web/src/features/conferencing/utils.ts
+++ b/apps/web/src/features/conferencing/utils.ts
@@ -1,0 +1,12 @@
+import type { Conferencing } from "./schema";
+
+// Returns the URI suitable for an href / ICS CONFERENCE value.
+// Phone numbers are formatted as `tel:` with DTMF pause + extension if present.
+export function getConferencingUri(conferencing: Conferencing): string {
+  if (conferencing.provider === "phone") {
+    return conferencing.extension
+      ? `tel:${conferencing.number},,${conferencing.extension}`
+      : `tel:${conferencing.number}`;
+  }
+  return conferencing.uri;
+}

--- a/apps/web/src/features/location/data.ts
+++ b/apps/web/src/features/location/data.ts
@@ -1,0 +1,24 @@
+import type { Prisma } from "@rallly/database";
+import { createLogger } from "@rallly/logger";
+import type { Location } from "./schema";
+import { locationSchema } from "./schema";
+
+const logger = createLogger("location/data");
+
+export function parseLocation(
+  raw: Prisma.JsonValue | null,
+  context?: { scheduledEventId?: string },
+): Location | null {
+  if (raw === null) {
+    return null;
+  }
+  const parsed = locationSchema.safeParse(raw);
+  if (!parsed.success) {
+    logger.warn(
+      { scheduledEventId: context?.scheduledEventId, value: raw },
+      "Failed to parse location",
+    );
+    return null;
+  }
+  return parsed.data;
+}

--- a/apps/web/src/features/location/schema.ts
+++ b/apps/web/src/features/location/schema.ts
@@ -1,0 +1,15 @@
+import * as z from "zod";
+
+const customLocationSchema = z.object({
+  provider: z.literal("custom"),
+  address: z.string().min(1),
+});
+
+// `provider` is the forward-compatible discriminator. Future providers
+// (e.g. google_places, what3words) can be added without a schema change
+// — parsers and pickers branch on `provider`.
+export const locationSchema = z.discriminatedUnion("provider", [
+  customLocationSchema,
+]);
+
+export type Location = z.infer<typeof locationSchema>;

--- a/apps/web/src/features/location/utils.ts
+++ b/apps/web/src/features/location/utils.ts
@@ -1,0 +1,5 @@
+import type { Location } from "./schema";
+
+export function formatLocationText(location: Location): string {
+  return location.address;
+}

--- a/apps/web/src/features/scheduled-event/data.ts
+++ b/apps/web/src/features/scheduled-event/data.ts
@@ -1,7 +1,91 @@
 import type { Prisma, ScheduledEventStatus } from "@rallly/database";
 import { prisma } from "@rallly/database";
+import { parseConferencing } from "@/features/conferencing/data";
+import type { Conferencing } from "@/features/conferencing/schema";
+import { parseLocation } from "@/features/location/data";
+import type { Location } from "@/features/location/schema";
 import { dayjs } from "@/lib/dayjs";
 import type { Status } from "./schema";
+
+// Legacy fallback used when neither location nor conferencing is populated.
+// Inverts the stored timeZone: stored null = "everyone sees UTC"; stored set = "viewer's TZ".
+function legacyDisplayTimeZone(timeZone: string | null): string | null {
+  return timeZone === null ? "UTC" : null;
+}
+
+// Derives the timezone the public page should render the event in, per the population table:
+//   in-person  (location set,  conferencing null) -> timeZone (venue TZ)
+//   remote     (location null, conferencing set)  -> null     (viewer's TZ)
+//   hybrid     (both set)                          -> timeZone (venue TZ; viewer toggle in UI)
+//   unspecified (neither set)                     -> legacy rule
+export function deriveDisplayTimeZone({
+  timeZone,
+  hasLocation,
+  hasConferencing,
+}: {
+  timeZone: string | null;
+  hasLocation: boolean;
+  hasConferencing: boolean;
+}): string | null {
+  if (hasLocation) {
+    return timeZone;
+  }
+  if (hasConferencing) {
+    return null;
+  }
+  return legacyDisplayTimeZone(timeZone);
+}
+
+export type ScheduledEventDTO = {
+  id: string;
+  title: string;
+  description: string | null;
+  location: Location | null;
+  conferencing: Conferencing | null;
+  start: Date;
+  end: Date;
+  allDay: boolean;
+  timeZone: string | null;
+  displayTimeZone: string | null;
+  status: ScheduledEventStatus;
+};
+
+export function createScheduledEventDTO(event: {
+  id: string;
+  title: string;
+  description: string | null;
+  location: Prisma.JsonValue | null;
+  conferencing: Prisma.JsonValue | null;
+  start: Date;
+  end: Date;
+  allDay: boolean;
+  timeZone: string | null;
+  status: ScheduledEventStatus;
+}): ScheduledEventDTO {
+  const location = parseLocation(event.location, {
+    scheduledEventId: event.id,
+  });
+  const conferencing = parseConferencing(event.conferencing, {
+    scheduledEventId: event.id,
+  });
+  return {
+    id: event.id,
+    title: event.title,
+    description: event.description,
+    location,
+    conferencing,
+    start: event.start,
+    end: event.end,
+    allDay: event.allDay,
+    timeZone: event.timeZone,
+    status: event.status,
+    displayTimeZone: deriveDisplayTimeZone({
+      timeZone: event.timeZone,
+      hasLocation: location !== null,
+      hasConferencing: conferencing !== null,
+    }),
+  };
+}
 
 // Common event selection fields
 const eventSelectFields = {
@@ -9,6 +93,7 @@ const eventSelectFields = {
   title: true,
   description: true,
   location: true,
+  conferencing: true,
   start: true,
   end: true,
   allDay: true,
@@ -42,7 +127,8 @@ type RawEventData = {
   id: string;
   title: string;
   description: string | null;
-  location: string | null;
+  location: Prisma.JsonValue | null;
+  conferencing: Prisma.JsonValue | null;
   start: Date;
   end: Date;
   allDay: boolean;
@@ -65,16 +151,9 @@ type RawEventData = {
 
 // Common event transformation function
 function transformEvent(event: RawEventData) {
+  const dto = createScheduledEventDTO(event);
   return {
-    id: event.id,
-    title: event.title,
-    description: event.description,
-    location: event.location,
-    start: event.start,
-    end: event.end,
-    allDay: event.allDay,
-    timeZone: event.timeZone,
-    status: event.status,
+    ...dto,
     createdBy: {
       name: event.user.name,
       image: event.user.image ?? undefined,

--- a/apps/web/src/trpc/routers/events.ts
+++ b/apps/web/src/trpc/routers/events.ts
@@ -3,6 +3,10 @@ import { prisma } from "@rallly/database";
 import { TRPCError } from "@trpc/server";
 import { after } from "next/server";
 import * as z from "zod";
+import { parseConferencing } from "@/features/conferencing/data";
+import { getConferencingUri } from "@/features/conferencing/utils";
+import { parseLocation } from "@/features/location/data";
+import { formatLocationText } from "@/features/location/utils";
 import { getEventsChronological } from "@/features/scheduled-event/data";
 import { formatEventDateTime } from "@/features/scheduled-event/utils";
 import { defineAbilityForMember } from "@/features/space/member/ability";
@@ -96,12 +100,36 @@ export const events = router({
         include: { invites: true },
       });
 
+      const cancelLocation = parseLocation(updatedEvent.location, {
+        scheduledEventId: updatedEvent.id,
+      });
+      const cancelConferencing = parseConferencing(updatedEvent.conferencing, {
+        scheduledEventId: updatedEvent.id,
+      });
+      const cancelLocationText = cancelLocation
+        ? formatLocationText(cancelLocation)
+        : undefined;
+      const cancelConferencingUri = cancelConferencing
+        ? getConferencingUri(cancelConferencing)
+        : undefined;
+      const cancelDescriptionParts: string[] = [];
+      if (updatedEvent.description) {
+        cancelDescriptionParts.push(updatedEvent.description);
+      }
+      if (cancelConferencingUri) {
+        cancelDescriptionParts.push(cancelConferencingUri);
+      }
+      const cancelDescription =
+        cancelDescriptionParts.length > 0
+          ? cancelDescriptionParts.join("\n\n")
+          : undefined;
+
       const cancelEvent = createIcsEvent({
         uid: updatedEvent.uid,
         sequence: updatedEvent.sequence,
         title: updatedEvent.title,
-        description: updatedEvent.description ?? undefined,
-        location: updatedEvent.location ?? undefined,
+        description: cancelDescription,
+        location: cancelLocationText ?? cancelConferencingUri,
         start: updatedEvent.start,
         end: updatedEvent.end,
         allDay: updatedEvent.allDay,

--- a/apps/web/src/trpc/routers/polls.ts
+++ b/apps/web/src/trpc/routers/polls.ts
@@ -841,7 +841,9 @@ export const polls = router({
                 : eventStart.add(1, "day").toDate(),
             title: poll.title,
             description: poll.description,
-            location: poll.location,
+            location: poll.location
+              ? { provider: "custom", address: poll.location }
+              : undefined,
             timeZone: poll.timeZone,
             userId: ctx.user.id,
             spaceId,

--- a/apps/web/src/trpc/routers/sheets.ts
+++ b/apps/web/src/trpc/routers/sheets.ts
@@ -2,6 +2,8 @@ import { prisma } from "@rallly/database";
 import { nanoid } from "@rallly/utils/nanoid";
 import { TRPCError } from "@trpc/server";
 import * as z from "zod";
+import type { Conferencing } from "@/features/conferencing/schema";
+import type { Location as ScheduledEventLocation } from "@/features/location/schema";
 import { isSignupSheetsEnabled } from "@/features/sheets/constants";
 import {
   createSheetDTO,
@@ -38,19 +40,39 @@ const requireSignupSheetsEnabled = middleware(async ({ next }) => {
 const sheetSpaceProcedure = spaceProcedure.use(requireSignupSheetsEnabled);
 const sheetPublicProcedure = publicProcedure.use(requireSignupSheetsEnabled);
 
-function locationSnapshot(value: unknown): string | null {
+// Convert an EventType.location (in_person or custom_link) into the new
+// scheduled-event structured `location` / `conferencing` columns. An
+// in-person source becomes a custom location; a custom link becomes
+// conferencing metadata.
+function locationSnapshot(value: unknown): {
+  location: ScheduledEventLocation | null;
+  conferencing: Conferencing | null;
+} {
   if (value === null || value === undefined) {
-    return null;
+    return { location: null, conferencing: null };
   }
   const parsed = locationSchema.safeParse(value);
   if (!parsed.success) {
-    return null;
+    return { location: null, conferencing: null };
   }
-  const location: Location = parsed.data;
-  if (location.type === "in_person") {
-    return location.address;
+  const source: Location = parsed.data;
+  if (source.type === "in_person") {
+    return {
+      location: {
+        provider: "custom",
+        address: source.address,
+      },
+      conferencing: null,
+    };
   }
-  return location.text ?? location.url;
+  return {
+    location: null,
+    conferencing: {
+      provider: "custom",
+      uri: source.url,
+      label: source.text ?? source.url,
+    },
+  };
 }
 
 const sheetsRoot = router({
@@ -310,6 +332,9 @@ const bookings = router({
         });
 
         const eventId = nanoid();
+        const { location, conferencing } = locationSnapshot(
+          slot.eventType.location,
+        );
         const created = await tx.scheduledEvent.create({
           data: {
             id: eventId,
@@ -320,7 +345,8 @@ const bookings = router({
             spaceId: slot.sheet.spaceId,
             title: slot.eventType.name,
             description: slot.eventType.description,
-            location: locationSnapshot(slot.eventType.location),
+            location: location ?? undefined,
+            conferencing: conferencing ?? undefined,
             capacity: slot.eventType.capacity,
             start: slot.startTime,
             end: endTime,

--- a/packages/database/prisma/migrations/20260525130443_structured_location_and_conferencing/migration.sql
+++ b/packages/database/prisma/migrations/20260525130443_structured_location_and_conferencing/migration.sql
@@ -1,0 +1,16 @@
+-- Add new structured location column (Json) and conferencing column (Json) on scheduled_events.
+-- The existing free-text "location" String column is migrated into the new Json shape:
+--   non-empty existing value -> { "provider": "custom", "address": <existing> }
+-- Then the old String column is dropped and the new Json column takes its name.
+
+ALTER TABLE "scheduled_events" ADD COLUMN "location_json" JSONB;
+ALTER TABLE "scheduled_events" ADD COLUMN "conferencing" JSONB;
+
+-- Backfill location_json from any existing non-empty free-text location.
+UPDATE "scheduled_events"
+SET "location_json" = jsonb_build_object('provider', 'custom', 'address', "location")
+WHERE "location" IS NOT NULL AND "location" <> '';
+
+-- Drop the legacy text column and promote the new Json column into its place.
+ALTER TABLE "scheduled_events" DROP COLUMN "location";
+ALTER TABLE "scheduled_events" RENAME COLUMN "location_json" TO "location";

--- a/packages/database/prisma/models/event.prisma
+++ b/packages/database/prisma/models/event.prisma
@@ -23,11 +23,13 @@ model ScheduledEvent {
   sheetSlotId   String?              @unique @map("sheet_slot_id")
   title         String
   description   String?
-  location      String?
+  location      Json?
+  conferencing  Json?
   capacity      Int?
   createdAt     DateTime             @default(now()) @map("created_at")
   updatedAt     DateTime             @updatedAt @map("updated_at")
   status        ScheduledEventStatus @default(confirmed)
+  /// Venue / anchor timezone for in-person or hybrid events. Null means no fixed venue (e.g. remote-only).
   timeZone      String?              @map("time_zone")
   start         DateTime
   end           DateTime


### PR DESCRIPTION
## Summary

- Replace free-text `location` column on `ScheduledEvent` with a structured Json column, and add a new `conferencing` Json column. Single Postgres migration: add Json cols, backfill existing strings as `{provider:"custom", address}`, drop the old text column, rename.
- Add Zod schemas for both shapes (`features/scheduled-event/schema.ts`). Conferencing is a discriminated union: `web` (zoom/meet/teams with optional meetingId/password), `phone` (number + optional extension), `custom` (uri + label).
- New `createScheduledEventDTO` derives `displayTimeZone` from population: in-person → venue TZ, remote (conferencing only) → null (viewer's TZ), hybrid → venue TZ, unspecified → legacy fallback. Public event page now reads `displayTimeZone` and renders structured location + conferencing.
- Update all consumers: ICS route, `events.cancel`, sheets booking (EventType in_person → location.custom; custom_link → conferencing.custom), `polls.book` (string → location.custom).

## Test plan

- [ ] Run `pnpm db:migrate` against dev DB, verify existing rows backfill as `{provider:"custom", address:<original>}` and old `location` column is gone
- [ ] Create a poll with a location, book a date, confirm `ScheduledEvent.location` is structured
- [ ] Visit `/e/[id]` for in-person, remote (conferencing only), and hybrid events; verify time renders in the right TZ for each
- [ ] Download ICS — location and conferencing URL appear correctly; calendar-link redirects (google/outlook/yahoo) work
- [ ] Cancel an event with both location + conferencing, confirm cancellation email/ICS includes both

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Structured conferencing support (Zoom, Meet, Teams, phone, custom) with clickable links on event pages
  * Structured location support and improved location display formatting
  * Calendar/ICS exports and cancellations now include conferencing info and formatted location
  * Event time display tolerates null timezones and derives a display timezone when needed

* **Chores**
  * Database migrated to store structured location and conferencing data

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lukevella/rallly/pull/2404?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->