### PR TITLE
🐛 Fix typos and grammar in English source locales

### DIFF
--- a/apps/landing/public/locales/en/blog.json
+++ b/apps/landing/public/locales/en/blog.json
@@ -1,5 +1,5 @@
 {
-  "blogDescription": "News, updates and announcement about Rallly.",
+  "blogDescription": "News, updates and announcements about Rallly.",
   "blogTitle": "Rallly - Blog",
   "recentPosts": "Recent Posts"
 }

--- a/apps/landing/public/locales/en/home.json
+++ b/apps/landing/public/locales/en/home.json
@@ -9,7 +9,7 @@
   "doodleAlternativeMetaTitle": "Best Free Doodle Alternative | Rallly",
   "ericJobTitle": "Executive Assistant at MIT",
   "ericQuote": "“If your scheduling workflow lives in emails, I strongly encourage you to try and let Rallly simplify your scheduling tasks for a more organized and less stressful workday.”",
-  "freeSchedulingPollDescription": "Rallly let's you create beautiful and easy to use scheduling polls so you can find the best time for your next event.",
+  "freeSchedulingPollDescription": "Rallly lets you create beautiful and easy to use scheduling polls so you can find the best time for your next event.",
   "freeSchedulingPollMetaDescription": "Create a free scheduling poll in seconds. Ideal for organizing meetings, events, conferences, sports teams and more.",
   "freeSchedulingPollMetaTitle": "Create a Free Scheduling Poll Instantly | No Account Required",
   "freeSchedulingPollTitle": "Find a date for your next event",

--- a/packages/emails/locales/en/emails.json
+++ b/packages/emails/locales/en/emails.json
@@ -45,7 +45,7 @@
   "license_key_subject": "Your Rallly Self-Hosted {tier} License",
   "license_key_support": "Reply to this email or contact us at <a>{supportEmail}</a> if you need help.",
   "license_key_yourKey": "License Details",
-  "login_content2": "You're receiving this email because a request was made to login to <domain />. If this wasn't you contact <a>{supportEmail}</a>.",
+  "login_content2": "You're receiving this email because a request was made to login to <domain />. If this wasn't you, contact <a>{supportEmail}</a>.",
   "newComment_content": "<b>{authorName}</b> has commented on <b>{title}</b>.",
   "newComment_heading": "New Comment",
   "newComment_preview": "Go to your poll to see what they said.",


### PR DESCRIPTION
Fixes objective typos/grammar in the English **source** locale files. Crowdin will pull these source changes and propagate to translations automatically.

## Changes
- **blog.json** — `blogDescription`: "announcement" → "announcement**s**"
- **home.json** — `freeSchedulingPollDescription`: "Rallly **let's**" → "Rallly **lets**" (verb, not contraction)
- **emails.json** — `login_content2`: added missing comma — "If this wasn't you**,** contact …" (matches the punctuation already used in `newParticipantConfirmation_footnote`)

## Audit scope
Audited every English locale file for spelling/grammar errors:
`apps/landing/.../{blog,common,home,pricing}.json`, `apps/web/.../app.json` (688 keys), `packages/emails/.../emails.json`.

The three above were the only objective issues. Notably **not** changed (out of scope):
- Key naming (e.g. snake_case keys, the misspelled key `schedulateDate`) — renaming keys requires updating call sites and risks breaking lookups.
- British vs American spelling, tone/style, capitalization.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Corrected pluralization in blog description text from "announcement" to "announcements"
  * Fixed grammar in home page description text from "let's" to "lets"
  * Improved email copy punctuation for better clarity

<!-- end of auto-generated comment: release notes by coderabbit.ai -->