### PR TITLE
♻️ Bind email <Trans> to the emails namespace via ctx.i18nProps (RAL-1219)

### DIFF
--- a/packages/emails/src/components/email-context.tsx
+++ b/packages/emails/src/components/email-context.tsx
@@ -16,4 +16,9 @@ export const previewEmailContext: EmailContext = {
   appName: "Rallly",
   primaryColor: "#4f46e5",
   hideAttribution: false,
+  i18nProps: {
+    i18n: i18nInstance,
+    t: i18nInstance.getFixedT("en"),
+    ns: "emails",
+  },
 };

--- a/packages/emails/src/components/email-layout.tsx
+++ b/packages/emails/src/components/email-layout.tsx
@@ -55,10 +55,8 @@ export const EmailLayout = ({
             <Section>
               <Text light={true}>
                 <Trans
-                  i18n={ctx.i18n}
-                  t={ctx.t}
+                  {...ctx.i18nProps}
                   i18nKey="common_poweredBy"
-                  ns="emails"
                   defaults="Powered by <a>{domain}</a>"
                   values={{ domain: "rallly.co" }}
                   components={{

--- a/packages/emails/src/components/notification-email.tsx
+++ b/packages/emails/src/components/notification-email.tsx
@@ -38,10 +38,8 @@ export const NotificationEmail = ({
       </Section>
       <Text light={true}>
         <Trans
-          i18n={ctx.i18n}
-          t={ctx.t}
+          {...ctx.i18nProps}
           i18nKey="common_disableNotifications"
-          ns="emails"
           defaults="You can <a>manage your notification settings</a> to stop receiving these emails."
           components={{
             a: (

--- a/packages/emails/src/create-email-template.tsx
+++ b/packages/emails/src/create-email-template.tsx
@@ -43,6 +43,7 @@ export function createEmailTemplate<
       supportEmail: process.env.SUPPORT_EMAIL ?? "",
       i18n,
       t,
+      i18nProps: { i18n, t, ns: "emails" },
     };
 
     return sendEmail({

--- a/packages/emails/src/templates/abandoned-checkout.tsx
+++ b/packages/emails/src/templates/abandoned-checkout.tsx
@@ -34,32 +34,26 @@ export const AbandonedCheckoutEmail = ({
       {name ? (
         <Text>
           <Trans
-            t={ctx.t}
-            i18n={ctx.i18n}
+            {...ctx.i18nProps}
             i18nKey="abandoned_checkout_name"
             defaults="Hey {name},"
             values={{ name }}
-            ns="emails"
           />
         </Text>
       ) : (
         <Text>
           <Trans
-            t={ctx.t}
-            i18n={ctx.i18n}
+            {...ctx.i18nProps}
             i18nKey="abandoned_checkout_noname"
             defaults="Hey there,"
-            ns="emails"
           />
         </Text>
       )}
       <Text>
         <Trans
-          t={ctx.t}
-          i18n={ctx.i18n}
+          {...ctx.i18nProps}
           i18nKey="abandoned_checkout_content"
           defaults="I noticed you were exploring <b>Rallly Pro</b> and wanted to personally reach out. I'd love to hear what features caught your interest and answer any questions you might have."
-          ns="emails"
           components={{
             b: <b />,
           }}
@@ -67,11 +61,9 @@ export const AbandonedCheckoutEmail = ({
       </Text>
       <Text>
         <Trans
-          t={ctx.t}
-          i18n={ctx.i18n}
+          {...ctx.i18nProps}
           i18nKey="abandoned_checkout_offer"
           defaults="To help you get started, I'd like to offer you <b>{discount}% off your first year</b> with Rallly Pro. Simply use this code during checkout:"
-          ns="emails"
           values={{
             discount,
           }}
@@ -94,33 +86,27 @@ export const AbandonedCheckoutEmail = ({
         </Card>
         <Button href={recoveryUrl} id="recoveryUrl" color={ctx.primaryColor}>
           <Trans
-            i18n={ctx.i18n}
-            t={ctx.t}
+            {...ctx.i18nProps}
             i18nKey="abandoned_checkout_button"
             defaults="Upgrade to Rallly Pro"
-            ns="emails"
           />
         </Button>
       </Section>
       <Section>
         <Text>
           <Trans
-            i18n={ctx.i18n}
-            t={ctx.t}
+            {...ctx.i18nProps}
             i18nKey="abandoned_checkout_support"
             defaults="Have questions or need assistance? Just reply to this email."
-            ns="emails"
           />
         </Text>
       </Section>
       <Section>
         <Text>
           <Trans
-            i18n={ctx.i18n}
-            t={ctx.t}
+            {...ctx.i18nProps}
             i18nKey="abandoned_checkout_signoff"
             defaults="Best regards,"
-            ns="emails"
           />
         </Text>
       </Section>

--- a/packages/emails/src/templates/change-email-request.tsx
+++ b/packages/emails/src/templates/change-email-request.tsx
@@ -35,10 +35,8 @@ export const ChangeEmailRequest = ({
       </Heading>
       <Text>
         <Trans
-          i18n={ctx.i18n}
-          t={ctx.t}
+          {...ctx.i18nProps}
           i18nKey="changeEmailRequest_text1"
-          ns="emails"
           defaults="We've received a request to change the email address for your account from <b>{fromEmail}</b> to <b>{toEmail}</b>."
           values={{ fromEmail, toEmail }}
           components={{ b: <b /> }}

--- a/packages/emails/src/templates/event-canceled.tsx
+++ b/packages/emails/src/templates/event-canceled.tsx
@@ -41,10 +41,8 @@ const EventCanceledEmail = ({
       </Heading>
       <Text>
         <Trans
-          i18n={ctx.i18n}
-          t={ctx.t}
+          {...ctx.i18nProps}
           i18nKey="eventCanceledContent"
-          ns="emails"
           defaults="<b>{hostName}</b> has canceled <b>{title}</b> that was scheduled for:"
           values={{ hostName, title }}
           components={{

--- a/packages/emails/src/templates/finalized-host.tsx
+++ b/packages/emails/src/templates/finalized-host.tsx
@@ -51,10 +51,8 @@ const FinalizeHostEmail = ({
       </Heading>
       <Text>
         <Trans
-          i18n={ctx.i18n}
-          t={ctx.t}
+          {...ctx.i18nProps}
           i18nKey="finalizeHost_content"
-          ns="emails"
           values={{ title }}
           components={{
             b: <strong />,

--- a/packages/emails/src/templates/finalized-participant.tsx
+++ b/packages/emails/src/templates/finalized-participant.tsx
@@ -48,10 +48,8 @@ const FinalizeParticipantEmail = ({
       </Heading>
       <Text>
         <Trans
-          i18n={ctx.i18n}
-          t={ctx.t}
+          {...ctx.i18nProps}
           i18nKey="finalizeParticipant_content"
-          ns="emails"
           defaults="<b>{hostName}</b> has booked <b>{title}</b> for the following date:"
           values={{ hostName, title }}
           components={{
@@ -106,8 +104,7 @@ const FinalizeParticipantEmail = ({
       <Section style={{ marginTop: 32 }}>
         <Button href={pollUrl} color={ctx.primaryColor}>
           <Trans
-            t={ctx.t}
-            ns="emails"
+            {...ctx.i18nProps}
             i18nKey="finalizeHost_button"
             defaults="View Event"
           />

--- a/packages/emails/src/templates/license-key.tsx
+++ b/packages/emails/src/templates/license-key.tsx
@@ -29,18 +29,14 @@ export const LicenseKeyEmail = ({
     >
       <Text>
         <Trans
-          t={ctx.t}
-          i18n={ctx.i18n}
-          ns="emails"
+          {...ctx.i18nProps}
           i18nKey="license_key_content"
           defaults="Your purchase has been confirmed and your license key has been generated."
         />
       </Text>
       <Heading as="h2">
         <Trans
-          t={ctx.t}
-          i18n={ctx.i18n}
-          ns="emails"
+          {...ctx.i18nProps}
           i18nKey="license_key_yourKey"
           defaults="License Details"
         />
@@ -49,9 +45,7 @@ export const LicenseKeyEmail = ({
         <tr>
           <td style={{ paddingRight: "16px" }}>
             <Trans
-              t={ctx.t}
-              i18n={ctx.i18n}
-              ns="emails"
+              {...ctx.i18nProps}
               i18nKey="license_key_plan"
               defaults="Plan"
             />
@@ -61,9 +55,7 @@ export const LicenseKeyEmail = ({
         <tr>
           <td style={{ paddingRight: "16px" }}>
             <Trans
-              t={ctx.t}
-              i18n={ctx.i18n}
-              ns="emails"
+              {...ctx.i18nProps}
               i18nKey="license_key_seats"
               defaults="Seats"
             />
@@ -73,9 +65,7 @@ export const LicenseKeyEmail = ({
         <tr>
           <td style={{ paddingRight: "16px" }}>
             <Trans
-              t={ctx.t}
-              i18n={ctx.i18n}
-              ns="emails"
+              {...ctx.i18nProps}
               i18nKey="license_key_licenseKey"
               defaults="License Key"
             />
@@ -93,16 +83,14 @@ export const LicenseKeyEmail = ({
       </table>
       <Heading as="h2">
         <Trans
-          t={ctx.t}
-          ns="emails"
+          {...ctx.i18nProps}
           i18nKey="license_key_nextStepsHeading"
           defaults="Next Steps"
         />
       </Heading>
       <Text>
         <Trans
-          t={ctx.t}
-          ns="emails"
+          {...ctx.i18nProps}
           i18nKey="license_key_activationSteps"
           defaults={
             "Follow these <a>instructions</a> to activate your license on your Rallly Self-Hosted instance."
@@ -120,16 +108,14 @@ export const LicenseKeyEmail = ({
       </Text>
       <Heading as="h2">
         <Trans
-          t={ctx.t}
-          ns="emails"
+          {...ctx.i18nProps}
           i18nKey="license_key_questionsHeading"
           defaults="Questions?"
         />
       </Heading>
       <Text>
         <Trans
-          t={ctx.t}
-          ns="emails"
+          {...ctx.i18nProps}
           i18nKey="license_key_support"
           defaults={
             "Reply to this email or contact us at <a>{supportEmail}</a> if you need help."
@@ -148,8 +134,7 @@ export const LicenseKeyEmail = ({
       </Text>
       <Text>
         <Trans
-          t={ctx.t}
-          ns="emails"
+          {...ctx.i18nProps}
           i18nKey="license_key_signoff"
           defaults="Thank you for choosing Rallly!"
         />

--- a/packages/emails/src/templates/new-comment.tsx
+++ b/packages/emails/src/templates/new-comment.tsx
@@ -29,16 +29,14 @@ const NewCommentEmail = ({
     >
       <Heading>
         <Trans
-          i18n={ctx.i18n}
-          ns="emails"
+          {...ctx.i18nProps}
           i18nKey="newComment_heading"
           defaults="New Comment"
         />
       </Heading>
       <Text>
         <Trans
-          i18n={ctx.i18n}
-          ns="emails"
+          {...ctx.i18nProps}
           i18nKey="newComment_content"
           defaults="<b>{authorName}</b> has commented on <b>{title}</b>."
           components={{

--- a/packages/emails/src/templates/new-participant-confirmation.tsx
+++ b/packages/emails/src/templates/new-participant-confirmation.tsx
@@ -39,24 +39,20 @@ const NewParticipantConfirmationEmail = ({
       </Heading>
       <Text>
         <Trans
-          i18n={ctx.i18n}
-          t={ctx.t}
+          {...ctx.i18nProps}
           i18nKey="newParticipantConfirmation_content"
           defaults="Your response to <b>{title}</b> has been submitted."
           components={{
             b: <strong />,
           }}
           values={{ title }}
-          ns="emails"
         />
       </Text>
       <Text>
         <Trans
-          i18n={ctx.i18n}
-          t={ctx.t}
+          {...ctx.i18nProps}
           i18nKey="newParticipantConfirmation_content2"
           defaults="While the poll is still open you can change your response using the link below."
-          ns="emails"
         />
       </Text>
       <Section style={{ marginTop: 32 }}>
@@ -66,25 +62,21 @@ const NewParticipantConfirmationEmail = ({
           color={ctx.primaryColor}
         >
           <Trans
-            i18n={ctx.i18n}
-            t={ctx.t}
+            {...ctx.i18nProps}
             i18nKey="newParticipantConfirmation_button"
             defaults="Review response on {domain}"
             values={{ domain }}
-            ns="emails"
           />
         </Button>
       </Section>
       <Text light>
         <Trans
-          i18n={ctx.i18n}
-          t={ctx.t}
+          {...ctx.i18nProps}
           i18nKey="newParticipantConfirmation_footnote"
           defaults="You are receiving this email because a response was submitted on <domain />. If this wasn't you, please ignore this email."
           components={{
             domain: <Domain ctx={ctx} />,
           }}
-          ns="emails"
         />
       </Text>
     </EmailLayout>

--- a/packages/emails/src/templates/new-participant.tsx
+++ b/packages/emails/src/templates/new-participant.tsx
@@ -35,10 +35,8 @@ const NewParticipantEmail = ({
       </Heading>
       <Text>
         <Trans
-          i18n={ctx.i18n}
-          t={ctx.t}
+          {...ctx.i18nProps}
           i18nKey="newParticipant_content"
-          ns="emails"
           defaults="<b>{name}</b> has responded to <b>{title}</b>."
           components={{
             b: <strong />,
@@ -48,11 +46,9 @@ const NewParticipantEmail = ({
       </Text>
       <Text>
         <Trans
-          i18n={ctx.i18n}
-          t={ctx.t}
+          {...ctx.i18nProps}
           i18nKey="newParticipant_content2"
           defaults="Go to your poll to see the new response."
-          ns="emails"
         />
       </Text>
     </NotificationEmail>

--- a/packages/emails/src/templates/new-poll.tsx
+++ b/packages/emails/src/templates/new-poll.tsx
@@ -42,10 +42,8 @@ export const NewPollEmail = ({
       </Heading>
       <Text>
         <Trans
-          i18n={ctx.i18n}
-          t={ctx.t}
+          {...ctx.i18nProps}
           i18nKey="newPoll_content"
-          ns="emails"
           values={{ title }}
           components={{
             b: <strong />,

--- a/packages/emails/src/templates/register.tsx
+++ b/packages/emails/src/templates/register.tsx
@@ -63,8 +63,7 @@ export const RegisterEmail = ({ code, ctx }: RegisterEmailProps) => {
       <Section>
         <Text light={true}>
           <Trans
-            i18n={ctx.i18n}
-            t={ctx.t}
+            {...ctx.i18nProps}
             i18nKey="login_content2"
             defaults="You're receiving this email because a request was made to login to <domain />. If this wasn't you contact <a>{supportEmail}</a>."
             values={{ supportEmail: ctx.supportEmail }}
@@ -77,7 +76,6 @@ export const RegisterEmail = ({ code, ctx }: RegisterEmailProps) => {
                 />
               ),
             }}
-            ns="emails"
           />
         </Text>
       </Section>

--- a/packages/emails/src/templates/reset-password.tsx
+++ b/packages/emails/src/templates/reset-password.tsx
@@ -39,18 +39,15 @@ export const ResetPasswordEmail = ({
       <Section style={{ marginBottom: 32 }}>
         <Button href={resetLink} id="resetLink" color={ctx.primaryColor}>
           <Trans
-            i18n={ctx.i18n}
-            t={ctx.t}
+            {...ctx.i18nProps}
             i18nKey="resetPassword_button"
             defaults="Reset password"
-            ns="emails"
           />
         </Button>
       </Section>
       <Text light>
         <Trans
-          i18n={ctx.i18n}
-          t={ctx.t}
+          {...ctx.i18nProps}
           i18nKey="resetPassword_content2"
           defaults="If you didn't request a password reset, you can ignore this email. Your password will not change unless you create a new one. If this request is suspicious, contact <a>{supportEmail}</a>."
           values={{ supportEmail: ctx.supportEmail }}
@@ -62,7 +59,6 @@ export const ResetPasswordEmail = ({
               />
             ),
           }}
-          ns="emails"
         />
       </Text>
     </EmailLayout>

--- a/packages/emails/src/templates/space-invite.tsx
+++ b/packages/emails/src/templates/space-invite.tsx
@@ -37,12 +37,10 @@ export const SpaceInviteEmail = ({
     </Heading>
     <Text>
       <Trans
-        i18n={ctx.i18n}
-        t={ctx.t}
+        {...ctx.i18nProps}
         i18nKey="spaceInvite_content"
         defaults="{inviterName} has invited you to join the {spaceName} space as a {role}."
         values={{ inviterName, spaceName, role }}
-        ns="emails"
       />
     </Text>
     <Section style={{ marginBottom: 16 }}>

--- a/packages/emails/src/types.ts
+++ b/packages/emails/src/types.ts
@@ -25,4 +25,10 @@ export type EmailContext = EmailBranding & {
   supportEmail: string;
   i18n: I18nInstance;
   t: TFunction;
+  /**
+   * Spread into every `<Trans {...ctx.i18nProps} />` to bind it to the email
+   * instance, locale-pinned `t`, and the `emails` namespace — so a template
+   * can't accidentally resolve a key against the wrong namespace.
+   */
+  i18nProps: { i18n: I18nInstance; t: TFunction; ns: "emails" };
 };


### PR DESCRIPTION
Email templates repeated `i18n={ctx.i18n} t={ctx.t} ns="emails"` on every `<Trans>`. Omitting the `ns` silently resolved the key against the **app** namespace — the `finalized-participant` near-miss from the i18next upgrade.

> Follow-up to #2416 (RAL-1218, merged).

## Approach
`EmailContext` carries an `i18nProps` bundle that templates spread into the real `<Trans>`:
```tsx
// before
<Trans i18n={ctx.i18n} t={ctx.t} ns="emails" i18nKey="…" defaults="…" />
// after
<Trans {...ctx.i18nProps} i18nKey="…" defaults="…" />
```
`i18nProps` is `{ i18n, t, ns: "emails" }`, built once in `createEmailTemplate`.

## Why this is safe (no wrapper, no lint rule)
The `ns: "emails"` **literal** flows through the spread, so i18next still types `i18nKey` against the emails namespace. Forgetting `{...ctx.i18nProps}` leaves the key resolving against `"app"` — a **compile error**. The binding is self-enforcing through the type system, so there's no custom `<Trans>` wrapper and no lint guardrail; the stock react-i18next `<Trans>` is used unchanged.

## Scope
- `EmailContext.i18nProps` + built in `createEmailTemplate` (and the preview context).
- All 13 templates + `EmailLayout`/`NotificationEmail` migrated.
- `ctx.t("…", { ns: "emails" })` direct calls are unchanged (explicit, type-safe).

## Verification
- `pnpm type-check` (emails + web), incl. a planted bad-key check that correctly errors against the emails key union
- `pnpm test:unit`, `pnpm build` (web)
- A render smoke test confirming `<Trans>` renders its text + interpolated `<strong>` components through the spread

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Standardized internationalization handling across email templates for improved code maintainability and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->