### PR TITLE
🔥 Remove deprecated validEmail export

### DIFF
--- a/apps/web/src/utils/form-validation.ts
+++ b/apps/web/src/utils/form-validation.ts
@@ -5,11 +5,7 @@ import { useTranslation } from "@/i18n/client";
  */
 export const requiredString = (value: string) => !!value.trim();
 
-/**
- * @deprecated Use form validation hook instead
- */
-export const validEmail = (value: string) =>
-  /^[^@\s]+@[^@\s]+\.[^@\s]+$/.test(value);
+const emailRegex = /^[^@\s]+@[^@\s]+\.[^@\s]+$/;
 
 export const useFormValidation = () => {
   const { t } = useTranslation();
@@ -22,8 +18,7 @@ export const useFormValidation = () => {
     },
 
     validEmail: (value: string) => {
-      const isValidEmail = validEmail(value);
-      if (!isValidEmail) {
+      if (!emailRegex.test(value)) {
         return t("validEmail");
       }
     },


### PR DESCRIPTION
## Summary

`validEmail` in `apps/web/src/utils/form-validation.ts` was marked `@deprecated` but couldn't be deleted outright: its only remaining caller was the non-deprecated `useFormValidation` hook in the same file. This inlines the regex as a private `emailRegex` constant and removes the deprecated export, so the deprecation surface is gone and no one can import it again.

The deprecated `requiredString` export is intentionally left in place — it still has live call sites in `discussion.tsx` and migrating those is a separate change.

## Verification

- `tsc --noEmit` passes for `@rallly/web`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined internal email validation logic to improve code maintainability. No changes to form validation behavior for end-users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->