### PR TITLE
🐛 Allow changing the time zone on polls without votes

### DIFF
--- a/apps/web/public/locales/en/app.json
+++ b/apps/web/public/locales/en/app.json
@@ -64,7 +64,7 @@
   "authErrorsUserBanned": "This account has been banned. Please contact support if you believe this is an error.",
   "authErrorsUserNotFound": "No account found with this email address. Please check the email or register for a new account.",
   "autoTimeZone": "Automatic Time Zone Conversion",
-  "autoTimeZoneDisabledHelp": "Time zone cannot be changed after votes have been cast. To change the time zone, ask participants to clear their votes first.",
+  "autoTimeZoneDisabledHelp": "The time zone can't be changed after votes have been cast.",
   "autoTimeZoneHelp": "Enable this setting to automatically adjust event times to each participant's local time zone.",
   "back": "Back",
   "banned": "Banned",

--- a/apps/web/public/locales/en/app.json
+++ b/apps/web/public/locales/en/app.json
@@ -64,6 +64,7 @@
   "authErrorsUserBanned": "This account has been banned. Please contact support if you believe this is an error.",
   "authErrorsUserNotFound": "No account found with this email address. Please check the email or register for a new account.",
   "autoTimeZone": "Automatic Time Zone Conversion",
+  "autoTimeZoneDisabledHelp": "Time zone cannot be changed after votes have been cast. To change the time zone, ask participants to clear their votes first.",
   "autoTimeZoneHelp": "Enable this setting to automatically adjust event times to each participant's local time zone.",
   "back": "Back",
   "banned": "Banned",

--- a/apps/web/src/app/[locale]/(optional-space)/poll/[urlId]/edit-options/page.tsx
+++ b/apps/web/src/app/[locale]/(optional-space)/poll/[urlId]/edit-options/page.tsx
@@ -39,7 +39,7 @@ const Page = () => {
   const { poll } = usePoll();
   const { participants } = useParticipants();
   const hasVotes = participants.some(
-    (p: { votes: unknown[] }) => p.votes.length > 0,
+    (participant) => participant.votes.length > 0,
   );
   const { mutate: updatePollMutation, isPending: isUpdating } =
     useUpdatePollMutation();

--- a/apps/web/src/app/[locale]/(optional-space)/poll/[urlId]/edit-options/page.tsx
+++ b/apps/web/src/app/[locale]/(optional-space)/poll/[urlId]/edit-options/page.tsx
@@ -38,6 +38,9 @@ const convertOptionToString = (
 const Page = () => {
   const { poll } = usePoll();
   const { participants } = useParticipants();
+  const hasVotes = participants.some(
+    (p: { votes: unknown[] }) => p.votes.length > 0,
+  );
   const { mutate: updatePollMutation, isPending: isUpdating } =
     useUpdatePollMutation();
   const { t } = useTranslation();
@@ -150,7 +153,7 @@ const Page = () => {
           }
         })}
       >
-        <PollOptionsForm disableTimeZoneChange={true}>
+        <PollOptionsForm disableTimeZoneChange={hasVotes}>
           <CardFooter className="justify-between">
             <Link href={pollLink} className={buttonVariants()}>
               <Trans i18nKey="cancel" />

--- a/apps/web/src/features/poll/components/forms/poll-options-form/poll-options-form.tsx
+++ b/apps/web/src/features/poll/components/forms/poll-options-form/poll-options-form.tsx
@@ -221,7 +221,12 @@ const PollOptionsForm = ({
                     }
                   }}
                 />
-                <Label htmlFor="timeZone">
+                <Label
+                  htmlFor="timeZone"
+                  className={
+                    disableTimeZoneChange ? "text-muted-foreground" : undefined
+                  }
+                >
                   <Trans
                     i18nKey="autoTimeZone"
                     defaults="Automatic Time Zone Conversion"
@@ -232,19 +237,40 @@ const PollOptionsForm = ({
                     <InfoIcon className="size-4 text-muted-foreground" />
                   </TooltipTrigger>
                   <TooltipContent className="w-72">
-                    <Trans
-                      i18nKey="autoTimeZoneHelp"
-                      defaults="Enable this setting to automatically adjust event times to each participant's local time zone."
-                    />
+                    {disableTimeZoneChange ? (
+                      <Trans
+                        i18nKey="autoTimeZoneDisabledHelp"
+                        defaults="Time zone cannot be changed after votes have been cast. To change the time zone, ask participants to clear their votes first."
+                      />
+                    ) : (
+                      <Trans
+                        i18nKey="autoTimeZoneHelp"
+                        defaults="Enable this setting to automatically adjust event times to each participant's local time zone."
+                      />
+                    )}
                   </TooltipContent>
                 </Tooltip>
               </div>
               {field.value ? (
-                <TimeZoneSelect
-                  disabled={disableTimeZoneChange}
-                  value={field.value}
-                  onValueChange={field.onChange}
-                />
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <span>
+                      <TimeZoneSelect
+                        disabled={disableTimeZoneChange}
+                        value={field.value}
+                        onValueChange={field.onChange}
+                      />
+                    </span>
+                  </TooltipTrigger>
+                  {disableTimeZoneChange ? (
+                    <TooltipContent className="w-72">
+                      <Trans
+                        i18nKey="autoTimeZoneDisabledHelp"
+                        defaults="Time zone cannot be changed after votes have been cast. To change the time zone, ask participants to clear their votes first."
+                      />
+                    </TooltipContent>
+                  ) : null}
+                </Tooltip>
               ) : null}
             </div>
           )}

--- a/apps/web/src/features/poll/components/forms/poll-options-form/poll-options-form.tsx
+++ b/apps/web/src/features/poll/components/forms/poll-options-form/poll-options-form.tsx
@@ -240,7 +240,7 @@ const PollOptionsForm = ({
                     {disableTimeZoneChange ? (
                       <Trans
                         i18nKey="autoTimeZoneDisabledHelp"
-                        defaults="Time zone cannot be changed after votes have been cast. To change the time zone, ask participants to clear their votes first."
+                        defaults="The time zone can't be changed after votes have been cast."
                       />
                     ) : (
                       <Trans
@@ -252,25 +252,11 @@ const PollOptionsForm = ({
                 </Tooltip>
               </div>
               {field.value ? (
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <span>
-                      <TimeZoneSelect
-                        disabled={disableTimeZoneChange}
-                        value={field.value}
-                        onValueChange={field.onChange}
-                      />
-                    </span>
-                  </TooltipTrigger>
-                  {disableTimeZoneChange ? (
-                    <TooltipContent className="w-72">
-                      <Trans
-                        i18nKey="autoTimeZoneDisabledHelp"
-                        defaults="Time zone cannot be changed after votes have been cast. To change the time zone, ask participants to clear their votes first."
-                      />
-                    </TooltipContent>
-                  ) : null}
-                </Tooltip>
+                <TimeZoneSelect
+                  disabled={disableTimeZoneChange}
+                  value={field.value}
+                  onValueChange={field.onChange}
+                />
               ) : null}
             </div>
           )}


### PR DESCRIPTION
Fixes #1085.

**Problem:** the timezone selector and auto-detect toggle are locked once a poll is created — you can't change the timezone after creation.

**Why it was locked:** in #1037 the controls were disabled unconditionally to prevent a data-safety issue — changing the timezone re-runs `convertOptionToString` with the new TZ, making every existing option look "changed", so options get deleted/recreated and all votes are wiped.

**Fix:** make the guard *conditional* — `disableTimeZoneChange = hasVotes` (computed from the already-fetched participants). Polls with **zero votes** have nothing to corrupt, so the controls are fully editable again. When votes exist, the controls stay locked and the tooltip now explains why ("Time zone cannot be changed after votes have been cast. To change it, ask participants to clear their votes first."), which also addresses the UX confusion in the report.

**Verified:** `tsc --noEmit` clean on the changed files; `timezone-change-detector` (5/5) and `time-zone-select` (8/8) tests pass.

---

Came across rallly and noticed #1085 had been open a while, so I fixed it — scoped to the zero-votes case so it doesn't reintroduce the vote-reset issue from #1037. No strings. I do this kind of work (Choreless — we fix and ship code for small teams), so if you ever want a hand, I'm around. — Charles


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Event time zone changes are now available only before any votes are submitted.
  * After voting begins, time zone changes are disabled to prevent inconsistent scheduling.
* **Documentation**
  * Updated the event time zone help/tooltip text to explain why the time zone can’t be changed once votes are cast.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->