### PR TITLE
✨ Track lastSeenAt on users via session activity

### DIFF
--- a/apps/web/src/lib/auth.ts
+++ b/apps/web/src/lib/auth.ts
@@ -452,7 +452,13 @@ export const authLib = betterAuth({
                 where: { id: session.userId },
                 data: { lastSeenAt: new Date() },
               })
-              .catch(() => null),
+              .catch((error) => {
+                logger.error(
+                  { error, userId: session.userId },
+                  "Failed to update lastSeenAt",
+                );
+                return null;
+              }),
           );
         },
       },

--- a/apps/web/src/lib/auth.ts
+++ b/apps/web/src/lib/auth.ts
@@ -424,20 +424,36 @@ export const authLib = betterAuth({
     session: {
       create: {
         after: async (session) => {
-          const user = await prisma.user.findUnique({
-            where: { id: session.userId },
-            select: { isAnonymous: true, lastLoginMethod: true },
-          });
+          after(async () => {
+            const user = await prisma.user
+              .update({
+                where: { id: session.userId },
+                data: { lastSeenAt: new Date() },
+                select: { isAnonymous: true, lastLoginMethod: true },
+              })
+              .catch(() => null);
 
-          // Only track login events for non-anonymous users
-          // Anonymous users shouldn't trigger login events or create person profiles
-          if (user && !user.isAnonymous) {
-            posthog()?.capture({
-              distinctId: session.userId,
-              event: "login",
-              properties: { method: user.lastLoginMethod },
-            });
-          }
+            // Anonymous users shouldn't trigger login events or create person profiles.
+            if (user && !user.isAnonymous) {
+              posthog()?.capture({
+                distinctId: session.userId,
+                event: "login",
+                properties: { method: user.lastLoginMethod },
+              });
+            }
+          });
+        },
+      },
+      update: {
+        after: async (session) => {
+          after(() =>
+            prisma.user
+              .updateMany({
+                where: { id: session.userId },
+                data: { lastSeenAt: new Date() },
+              })
+              .catch(() => null),
+          );
         },
       },
     },

--- a/apps/web/src/lib/auth.ts
+++ b/apps/web/src/lib/auth.ts
@@ -448,7 +448,7 @@ export const authLib = betterAuth({
         after: async (session) => {
           after(() =>
             prisma.user
-              .updateMany({
+              .update({
                 where: { id: session.userId },
                 data: { lastSeenAt: new Date() },
               })

--- a/packages/database/prisma/migrations/20260615095634_add_user_last_seen_at/migration.sql
+++ b/packages/database/prisma/migrations/20260615095634_add_user_last_seen_at/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "users" ADD COLUMN     "last_seen_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP;

--- a/packages/database/prisma/models/user.prisma
+++ b/packages/database/prisma/models/user.prisma
@@ -56,6 +56,7 @@ model User {
   role            UserRole    @default(user)
   lastLoginMethod String?     @map("last_login_method")
   isAnonymous     Boolean     @default(false) @map("anonymous")
+  lastSeenAt      DateTime    @default(now()) @map("last_seen_at")
 
   comments                Comment[]
   polls                   Poll[]


### PR DESCRIPTION
Part of RAL-1220. Step 1 of safely deleting orphaned anonymous guest users: add the `last_seen_at` signal the cleanup will key on. The house-keeping endpoint itself is a follow-up PR.

## Changes
- Add `last_seen_at` to `users`, maintained by Better-Auth's `session.create.after` (login) and `session.update.after` (refresh — ~once/day per active user via `updateAge`) hooks.
- Both writes are deferred with `after()` so they don't add latency to auth responses (Better-Auth awaits these hooks).
- The login analytics event now gates off the row returned by the `last_seen_at` write instead of issuing a separate read.

## Migration
`ADD COLUMN last_seen_at TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP` — metadata-only (stable default, no table rewrite). Existing rows are backfilled to deploy time, so the eventual 60-day staleness clock starts at deploy.

## Why last_seen_at
In production, sessions live in Redis (`secondaryStorage`), not Postgres, so a cleanup job can't query session liveness directly. `last_seen_at` projects session activity into Postgres: a value older than the 60-day session TTL provably means no live session — a session can't survive 60 days without a refresh, and every refresh bumps `last_seen_at`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatically records the latest account access time, updating it during both initial session creation and subsequent session activity.
* **Database**
  * Added a new `last_seen_at` timestamp on user records to persist the most recent access.
* **Bug Fixes**
  * Ensures last-access tracking runs consistently and, on failures, logs errors without disrupting normal session handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->