### PR TITLE
⚡️ Cache the manifest and static icons in the browser

### DIFF
--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -120,6 +120,28 @@ const nextConfig: NextConfig = {
           },
         ],
       },
+      // Browser-cache the manifest and root icons; without this they default to
+      // `max-age=0, must-revalidate` and are revalidated on every page load.
+      {
+        source: "/manifest.json",
+        headers: [
+          {
+            key: "Cache-Control",
+            value: "public, max-age=86400, stale-while-revalidate=604800",
+          },
+        ],
+      },
+      {
+        // Single-segment root files only, so content-hashed `/_next/static/*`
+        // assets keep their immutable headers.
+        source: "/:file([^/]+\\.(?:ico|png|svg|webp))",
+        headers: [
+          {
+            key: "Cache-Control",
+            value: "public, max-age=604800, stale-while-revalidate=86400",
+          },
+        ],
+      },
     ];
   },
   devIndicators:


### PR DESCRIPTION
## Problem

The PWA manifest and the favicon/app icons are among the top routes by **Vercel edge request** volume (`/manifest.json` ~9.8K, `/favicon.ico` ~8.2K, `/android-chrome-192x192.png` ~7.1K in the observed window), despite being static files that change rarely.

The cause is the default `Cache-Control` Next applies to assets served at stable, non content-hashed URLs:

```
cache-control: public, max-age=0, must-revalidate
```

`max-age=0, must-revalidate` means the browser must revalidate the file with the edge **on every page load**. Each revalidation is a billed edge request even when it returns `304` / `x-vercel-cache: HIT` (the edge already caches it for hours — `age` was ~6h — so there's no function cost, only the per-request charge).

Next only hands out long-lived `immutable` caching to **content-hashed** URLs (`/_next/static/*`), because the hash is its cache-bust mechanism. It can't safely do that for stable URLs like `/manifest.json`, so it falls back to revalidate-always. This change supplies the knowledge Next lacks: these files change rarely, so the browser may cache them.

## Change

Add two `Cache-Control` rules to `headers()` in `next.config.ts`:

- `/manifest.json` → `public, max-age=86400, stale-while-revalidate=604800` (1 day fresh)
- root-level icons `/:file([^/]+\.(?:ico|png|svg|webp))` → `public, max-age=604800, stale-while-revalidate=86400` (1 week fresh)

The icon matcher only matches **single-segment root files**, so content-hashed `/_next/static/*` assets keep their `immutable` headers (verified against the compiled path-to-regexp matcher).

## Why this is the right lever

Edge requests are counted when the **browser** hits the edge. `max-age > 0` lets the browser serve from its own local cache with no network request during the freshness window, which is the only thing that removes the request from the count. (`revalidate` / ISR was considered and rejected — it controls the *edge/CDN* `s-maxage`, which is already a HIT; it doesn't change the browser-facing `max-age`.)

This won't drop to zero — you still pay one request per browser per freshness window — but it moves the manifest/icons from "once per page view" to "once per user per day/week."

## Verification needed on the preview deploy

`headers()` overriding the `Cache-Control` of an **App Router metadata route** (`app/manifest.json`) is not guaranteed — Next sometimes sets these at a level the config doesn't override. The icons live in `public/`, where `headers()` is reliably applied.

After this deploys to a preview, confirm:

```bash
curl -sI https://<preview-url>/manifest.json | grep -i cache-control
curl -sI https://<preview-url>/favicon.ico  | grep -i cache-control
```

Both should show the new `max-age`. **If `/manifest.json` still shows `max-age=0, must-revalidate`**, the fallback is to move the file to `public/manifest.webmanifest` (plain static files are always covered by `headers()`) and point the root `metadata.manifest` at it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved browser caching for static assets by updating caching headers. The manifest and root-level icon files now use tailored `Cache-Control` policies to enhance performance, reduce repeat downloads, and speed up subsequent page loads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->