### PR TITLE
🐛 Reuse OTP codes on resend instead of rotating

### DIFF
--- a/apps/web/src/lib/auth.ts
+++ b/apps/web/src/lib/auth.ts
@@ -152,6 +152,7 @@ export const authLib = betterAuth({
     emailOTP({
       disableSignUp: true,
       expiresIn: 15 * 60,
+      resendStrategy: "reuse",
       overrideDefaultEmailVerification: true,
       changeEmail: {
         enabled: true,


### PR DESCRIPTION
## Problem

We regularly get reports from users that their email OTP is "expired" by the time they receive it, even though sending isn't measurably delayed.

The real cause is Better Auth's `emailOTP` default `resendStrategy: "rotate"`: every code request generates a **new** code and silently invalidates the previous one. `findVerificationValue` only ever returns the latest code. So the common pattern —

1. User requests a code, email is slow to arrive
2. User retries (re-submits the login form), generating a second code that kills the first
3. The first email finally lands; user enters that code
4. → `INVALID_OTP`

— presents to the user as an "expired"/"invalid" code even though delivery was fine.

Note: because verification state lives in KV (`secondaryStorage`) with a TTL equal to the expiry, the `OTP_EXPIRED` branch is effectively unreachable — expired codes return `INVALID_OTP` too. So this class of failure is invisible to analytics by error code alone.

## Change

Set `resendStrategy: "reuse"`. Re-requesting now resends the **same** code and extends its expiry instead of rotating, so codes from earlier emails keep working.

Safe here because `storeOTP` is the default `"plain"` — reuse requires a recoverable code and falls back to `rotate` automatically if the code were hashed. Re-send is still bounded by the existing rate limit (`max: 100/hour` on `/email-otp/send-verification-otp`), so there's no indefinite-validity hole. The 15-minute `expiresIn` is unchanged.

## Verification

This is a behavioral config change; the failure mode it fixes can't be cleanly isolated by error code (see note above). Plan to watch support volume for "expired OTP" reports after this ships.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved email OTP resend behavior to enhance authentication experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->