### PR TITLE
🔥 Drop legacy verification_tokens table

### DIFF
--- a/packages/database/prisma/migrations/20260616094409_drop_verification_tokens_table/migration.sql
+++ b/packages/database/prisma/migrations/20260616094409_drop_verification_tokens_table/migration.sql
@@ -1,0 +1,8 @@
+/*
+  Warnings:
+
+  - You are about to drop the `verification_tokens` table. If the table is not empty, all the data it contains will be lost.
+
+*/
+-- DropTable
+DROP TABLE "verification_tokens";

--- a/packages/database/prisma/models/user.prisma
+++ b/packages/database/prisma/models/user.prisma
@@ -89,15 +89,6 @@ model User {
   @@map("users")
 }
 
-model VerificationToken {
-  identifier String   @db.Citext
-  token      String   @unique
-  expires    DateTime
-
-  @@unique([identifier, token])
-  @@map("verification_tokens")
-}
-
 model Session {
   id             String   @id
   expiresAt      DateTime @map("expires_at")


### PR DESCRIPTION
## Summary

Drops the legacy `verification_tokens` table, which was used by NextAuth (auth.js). NextAuth has since been replaced by Better Auth, which uses its own `verifications` table. Nothing in the codebase references `verification_tokens` anymore.

## Changes

- Remove the `VerificationToken` model from `packages/database/prisma/models/user.prisma`
- Add migration `drop_verification_tokens_table` (`DROP TABLE "verification_tokens"`)

## Notes

- The `Verification` → `verifications` table used by Better Auth is untouched.
- This migration is destructive (`DROP TABLE`). Any rows still present are dead NextAuth data, so this is expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Database Schema Updates**
  * Removed verification token functionality from the database schema.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->