### PR TITLE
♻️ Replace BillingProvider with zustand paywall store

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -105,6 +105,7 @@
     "tailwindcss": "^4.1.18",
     "timezone-soft": "^1.5.2",
     "zod": "^4.3.6",
+    "zustand": "^5.0.14",
     "zxcvbn": "^4.4.2"
   },
   "devDependencies": {

--- a/apps/web/src/app/[locale]/(optional-space)/layout.tsx
+++ b/apps/web/src/app/[locale]/(optional-space)/layout.tsx
@@ -1,6 +1,6 @@
 import { dehydrate, HydrationBoundary } from "@tanstack/react-query";
 import { PreferencesProvider } from "@/contexts/preferences";
-import { BillingProvider } from "@/features/billing/client";
+import { PayWall } from "@/features/billing/components/pay-wall";
 import { isQuickCreateEnabled } from "@/features/quick-create";
 import {
   createPrivateSSRHelper,
@@ -24,7 +24,8 @@ export default async function Layout({
   return (
     <HydrationBoundary state={dehydrate(helpers.queryClient)}>
       <PreferencesProvider>
-        <BillingProvider>{children}</BillingProvider>
+        {children}
+        <PayWall />
       </PreferencesProvider>
     </HydrationBoundary>
   );

--- a/apps/web/src/app/[locale]/(space)/(dashboard)/components/upgrade-menu-item.tsx
+++ b/apps/web/src/app/[locale]/(space)/(dashboard)/components/upgrade-menu-item.tsx
@@ -3,11 +3,12 @@
 import { usePostHog } from "@rallly/posthog/client";
 import { SidebarMenuButton, SidebarMenuItem } from "@rallly/ui/sidebar";
 import { SparklesIcon } from "lucide-react";
-import { useBilling } from "@/features/billing/client";
+import { useIsFree } from "@/features/billing/client";
+import { showPayWall } from "@/features/billing/paywall-store";
 import { Trans } from "@/i18n/client";
 
 export function UpgradeMenuItem() {
-  const { showPayWall, isFree } = useBilling();
+  const isFree = useIsFree();
   const posthog = usePostHog();
 
   if (!isFree) {

--- a/apps/web/src/app/[locale]/(space)/layout.tsx
+++ b/apps/web/src/app/[locale]/(space)/layout.tsx
@@ -2,7 +2,7 @@ import { dehydrate, HydrationBoundary } from "@tanstack/react-query";
 import { redirect } from "next/navigation";
 import { SessionRefresher } from "@/components/session-refresher";
 import { PreferencesProvider } from "@/contexts/preferences";
-import { BillingProvider } from "@/features/billing/client";
+import { PayWall } from "@/features/billing/components/pay-wall";
 import { SpaceProvider } from "@/features/space/client";
 import { getPathname } from "@/lib/pathname";
 import { createPrivateSSRHelper } from "@/trpc/server/create-ssr-helper";
@@ -31,7 +31,8 @@ export default async function Layout({
       <SessionRefresher />
       <PreferencesProvider>
         <SpaceProvider>
-          <BillingProvider>{children}</BillingProvider>
+          {children}
+          <PayWall />
         </SpaceProvider>
       </PreferencesProvider>
     </HydrationBoundary>

--- a/apps/web/src/app/[locale]/(space)/settings/billing/page-client.tsx
+++ b/apps/web/src/app/[locale]/(space)/settings/billing/page-client.tsx
@@ -36,8 +36,8 @@ import {
   EmptyStateIcon,
   EmptyStateTitle,
 } from "@/components/empty-state";
-import { useBilling } from "@/features/billing/client";
 import { SubscriptionStatusLabel } from "@/features/billing/components/subscription-status-label";
+import { showPayWall } from "@/features/billing/paywall-store";
 import { useSpace } from "@/features/space/client";
 import type { SpaceTier } from "@/features/space/schema";
 import { Trans } from "@/i18n/client";
@@ -75,7 +75,6 @@ export function BillingPageClient() {
 function BillingPageContent({ tier }: { tier: SpaceTier }) {
   const posthog = usePostHog();
   const searchParams = useSearchParams();
-  const { showPayWall } = useBilling();
 
   const [subscription] = trpc.billing.getSubscription.useSuspenseQuery();
   const [seats] = trpc.spaces.getSeats.useSuspenseQuery();

--- a/apps/web/src/app/[locale]/(space)/settings/general/components/custom-branding-section.tsx
+++ b/apps/web/src/app/[locale]/(space)/settings/general/components/custom-branding-section.tsx
@@ -14,7 +14,8 @@ import {
   PageSectionTitle,
 } from "@/app/components/page-layout";
 import { ProBadge } from "@/components/pro-badge";
-import { useBilling } from "@/features/billing/client";
+import { useIsFree } from "@/features/billing/client";
+import { showPayWall } from "@/features/billing/paywall-store";
 import { DEFAULT_PRIMARY_COLOR } from "@/features/branding/constants";
 import { useSpace } from "@/features/space/client";
 import { Trans } from "@/i18n/client";
@@ -27,7 +28,7 @@ export function CustomBrandingSection({
   disabled?: boolean;
 }) {
   const { data: space } = useSpace();
-  const { isFree, showPayWall } = useBilling();
+  const isFree = useIsFree();
   const toastProgress = useToastProgress();
   const utils = trpc.useUtils();
   const posthog = usePostHog();

--- a/apps/web/src/app/[locale]/(space)/settings/layout.tsx
+++ b/apps/web/src/app/[locale]/(space)/settings/layout.tsx
@@ -20,7 +20,6 @@ import { ArrowLeftIcon, SettingsIcon } from "lucide-react";
 import Link from "next/link";
 import type React from "react";
 import { NavUser } from "@/components/nav-user";
-import { BillingProvider } from "@/features/billing/client";
 import { Trans } from "@/i18n/client";
 import { createPrivateSSRHelper } from "@/trpc/server/create-ssr-helper";
 import {
@@ -39,77 +38,75 @@ export default async function Layout({
 
   return (
     <HydrationBoundary state={dehydrate(helpers.queryClient)}>
-      <BillingProvider>
-        <SidebarProvider>
-          <Sidebar>
-            <SidebarHeader>
-              <SidebarGroup>
-                <SidebarGroupContent>
-                  <SidebarMenu>
-                    <SidebarMenuItem className="flex items-center gap-3">
-                      <Link
-                        href="/"
-                        className={buttonVariants({
-                          variant: "ghost",
-                          size: "icon",
-                        })}
-                      >
-                        <Icon>
-                          <ArrowLeftIcon />
-                        </Icon>
-                      </Link>
-                      <span className="font-medium text-sm">
-                        <Trans i18nKey="settings" defaults="Settings" />
-                      </span>
-                    </SidebarMenuItem>
-                  </SidebarMenu>
-                </SidebarGroupContent>
-              </SidebarGroup>
-            </SidebarHeader>
-            <SidebarSeparator />
-            <SidebarContent>
-              <SidebarGroup>
-                <SidebarGroupLabel>
-                  <Trans i18nKey="account" defaults="Account" />
-                </SidebarGroupLabel>
-                <SidebarGroupContent>
-                  <AccountSidebarMenu />
-                </SidebarGroupContent>
-              </SidebarGroup>
-              <SidebarGroup>
-                <SidebarGroupLabel>
-                  <Trans i18nKey="space" defaults="Space" />
-                </SidebarGroupLabel>
-                <SidebarGroupContent>
-                  <SpaceSidebarMenu />
-                </SidebarGroupContent>
-              </SidebarGroup>
-              <DeveloperSidebarMenu />
-            </SidebarContent>
-            <SidebarFooter>
-              <NavUser />
-            </SidebarFooter>
-          </Sidebar>
-          <SidebarInset>
-            <div className="flex flex-1 flex-col">
-              <header className="sticky top-0 z-10 border-b bg-background/90 p-3 backdrop-blur-xs md:hidden">
-                <div className="flex items-center gap-4">
-                  <SidebarTrigger />
-                  <div className="flex items-center gap-2">
-                    <Icon>
-                      <SettingsIcon />
-                    </Icon>
+      <SidebarProvider>
+        <Sidebar>
+          <SidebarHeader>
+            <SidebarGroup>
+              <SidebarGroupContent>
+                <SidebarMenu>
+                  <SidebarMenuItem className="flex items-center gap-3">
+                    <Link
+                      href="/"
+                      className={buttonVariants({
+                        variant: "ghost",
+                        size: "icon",
+                      })}
+                    >
+                      <Icon>
+                        <ArrowLeftIcon />
+                      </Icon>
+                    </Link>
                     <span className="font-medium text-sm">
                       <Trans i18nKey="settings" defaults="Settings" />
                     </span>
-                  </div>
+                  </SidebarMenuItem>
+                </SidebarMenu>
+              </SidebarGroupContent>
+            </SidebarGroup>
+          </SidebarHeader>
+          <SidebarSeparator />
+          <SidebarContent>
+            <SidebarGroup>
+              <SidebarGroupLabel>
+                <Trans i18nKey="account" defaults="Account" />
+              </SidebarGroupLabel>
+              <SidebarGroupContent>
+                <AccountSidebarMenu />
+              </SidebarGroupContent>
+            </SidebarGroup>
+            <SidebarGroup>
+              <SidebarGroupLabel>
+                <Trans i18nKey="space" defaults="Space" />
+              </SidebarGroupLabel>
+              <SidebarGroupContent>
+                <SpaceSidebarMenu />
+              </SidebarGroupContent>
+            </SidebarGroup>
+            <DeveloperSidebarMenu />
+          </SidebarContent>
+          <SidebarFooter>
+            <NavUser />
+          </SidebarFooter>
+        </Sidebar>
+        <SidebarInset>
+          <div className="flex flex-1 flex-col">
+            <header className="sticky top-0 z-10 border-b bg-background/90 p-3 backdrop-blur-xs md:hidden">
+              <div className="flex items-center gap-4">
+                <SidebarTrigger />
+                <div className="flex items-center gap-2">
+                  <Icon>
+                    <SettingsIcon />
+                  </Icon>
+                  <span className="font-medium text-sm">
+                    <Trans i18nKey="settings" defaults="Settings" />
+                  </span>
                 </div>
-              </header>
-              <main className="flex-1 p-4 lg:py-12">{children}</main>
-            </div>
-          </SidebarInset>
-        </SidebarProvider>
-      </BillingProvider>
+              </div>
+            </header>
+            <main className="flex-1 p-4 lg:py-12">{children}</main>
+          </div>
+        </SidebarInset>
+      </SidebarProvider>
     </HydrationBoundary>
   );
 }

--- a/apps/web/src/app/[locale]/(space)/settings/members/components/invite-member-button.tsx
+++ b/apps/web/src/app/[locale]/(space)/settings/members/components/invite-member-button.tsx
@@ -5,7 +5,7 @@ import { useDialog } from "@rallly/ui/dialog";
 import { Icon } from "@rallly/ui/icon";
 import { toast } from "@rallly/ui/sonner";
 import { UserPlusIcon } from "lucide-react";
-import { useBilling } from "@/features/billing/client";
+import { showPayWall } from "@/features/billing/paywall-store";
 import { useSpace } from "@/features/space/client";
 import { Trans, useTranslation } from "@/i18n/client";
 import { InviteMemberDialog } from "./invite-member-dialog";
@@ -20,7 +20,6 @@ export function InviteMemberButton({
   const { t } = useTranslation();
   const inviteMemberDialog = useDialog();
   const space = useSpace();
-  const { showPayWall } = useBilling();
   const availableSeats = Math.max(totalSeats - usedSeats, 0);
   return (
     <>

--- a/apps/web/src/components/forms/poll-settings.tsx
+++ b/apps/web/src/components/forms/poll-settings.tsx
@@ -12,7 +12,8 @@ import { AtSignIcon, EyeIcon, MessageCircleIcon, VoteIcon } from "lucide-react";
 import type React from "react";
 import { useFormContext } from "react-hook-form";
 import { ProBadge } from "@/components/pro-badge";
-import { useBilling } from "@/features/billing/client";
+import { useIsFree } from "@/features/billing/client";
+import { showPayWall } from "@/features/billing/paywall-store";
 import { Trans } from "@/i18n/client";
 
 export type PollSettingsFormData = {
@@ -37,7 +38,7 @@ const PollSetting = ({
 }) => {
   const form = useFormContext<PollSettingsFormData>();
   const posthog = usePostHog();
-  const { showPayWall, isFree } = useBilling();
+  const isFree = useIsFree();
 
   return (
     <FormField

--- a/apps/web/src/components/poll/manage-poll.tsx
+++ b/apps/web/src/components/poll/manage-poll.tsx
@@ -28,7 +28,8 @@ import { DuplicateDialog } from "@/app/[locale]/(optional-space)/poll/[urlId]/du
 import { SchedulePollDialog } from "@/components/poll/manage-poll/schedule-poll-dialog";
 import { ProBadge } from "@/components/pro-badge";
 import { usePoll } from "@/contexts/poll";
-import { useBilling } from "@/features/billing/client";
+import { useIsFree } from "@/features/billing/client";
+import { showPayWall } from "@/features/billing/paywall-store";
 import { Trans } from "@/i18n/client";
 import { trpc } from "@/trpc/client";
 import { DeletePollDialog } from "./manage-poll/delete-poll-dialog";
@@ -123,7 +124,7 @@ const ManagePoll: React.FunctionComponent<{
   const [showDeletePollDialog, setShowDeletePollDialog] = React.useState(false);
   const duplicateDialog = useDialog();
   const scheduleDialog = useDialog();
-  const { showPayWall, isFree } = useBilling();
+  const isFree = useIsFree();
   const posthog = usePostHog();
   const { exportToCsv } = useCsvExporter();
 

--- a/apps/web/src/features/billing/client.tsx
+++ b/apps/web/src/features/billing/client.tsx
@@ -1,53 +1,14 @@
 "use client";
 
-import React from "react";
 import type { SpaceTier } from "@/features/space/schema";
 import { trpc } from "@/trpc/client";
-import { PayWallDialog } from "./components/pay-wall-dialog";
 
-interface BillingContextType {
-  tier: SpaceTier;
-  isFree: boolean;
-  showPayWall: () => void;
-}
-
-const BillingContext = React.createContext<BillingContextType | null>(null);
-
-function useCurrentTier(): SpaceTier {
+export function useTier(): SpaceTier {
   const { data: tier } = trpc.billing.getTier.useQuery();
 
   return tier ?? "hobby";
 }
 
-export function BillingProvider({ children }: { children: React.ReactNode }) {
-  const [isPayWallOpen, setIsPayWallOpen] = React.useState(false);
-  const tier = useCurrentTier();
-
-  const showPayWall = React.useCallback(() => {
-    setIsPayWallOpen(true);
-  }, []);
-
-  const contextValue = React.useMemo(
-    () => ({
-      tier,
-      isFree: tier === "hobby",
-      showPayWall,
-    }),
-    [tier, showPayWall],
-  );
-
-  return (
-    <BillingContext.Provider value={contextValue}>
-      {children}
-      <PayWallDialog isOpen={isPayWallOpen} onOpenChange={setIsPayWallOpen} />
-    </BillingContext.Provider>
-  );
-}
-
-export function useBilling() {
-  const context = React.useContext(BillingContext);
-  if (!context) {
-    throw new Error("useBilling must be used within a BillingProvider");
-  }
-  return context;
+export function useIsFree() {
+  return useTier() === "hobby";
 }

--- a/apps/web/src/features/billing/components/pay-wall.tsx
+++ b/apps/web/src/features/billing/components/pay-wall.tsx
@@ -1,0 +1,24 @@
+"use client";
+
+import { usePayWallStore } from "../paywall-store";
+import { PayWallDialog } from "./pay-wall-dialog";
+
+/**
+ * Single, app-wide paywall instance.
+ * Open it from anywhere with `showPayWall()`.
+ */
+export function PayWall() {
+  const isOpen = usePayWallStore((state) => state.isOpen);
+  const hide = usePayWallStore((state) => state.hide);
+
+  return (
+    <PayWallDialog
+      isOpen={isOpen}
+      onOpenChange={(open) => {
+        if (!open) {
+          hide();
+        }
+      }}
+    />
+  );
+}

--- a/apps/web/src/features/billing/paywall-store.ts
+++ b/apps/web/src/features/billing/paywall-store.ts
@@ -1,0 +1,15 @@
+import { create } from "zustand";
+
+type PayWallStore = {
+  isOpen: boolean;
+  show: () => void;
+  hide: () => void;
+};
+
+export const usePayWallStore = create<PayWallStore>((set) => ({
+  isOpen: false,
+  show: () => set({ isOpen: true }),
+  hide: () => set({ isOpen: false }),
+}));
+
+export const showPayWall = () => usePayWallStore.getState().show();

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -445,6 +445,9 @@ importers:
       zod:
         specifier: ^4.3.6
         version: 4.3.6
+      zustand:
+        specifier: ^5.0.14
+        version: 5.0.14(@types/react@19.2.13)(immer@9.0.21)(react@19.2.6)(use-sync-external-store@1.6.0(react@19.2.6))
       zxcvbn:
         specifier: ^4.4.2
         version: 4.4.2
@@ -11546,6 +11549,24 @@ packages:
 
   zod@4.3.6:
     resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}
+
+  zustand@5.0.14:
+    resolution: {integrity: sha512-/8tAspM5LMPr28b3fwLYrtdj77ECpfZviaP75CMTnwO8ISyaE4GDIG/9rDDYq/cH9D2Xw2A2RXglLInmVBQB/g==}
+    engines: {node: '>=12.20.0'}
+    peerDependencies:
+      '@types/react': '>=18.0.0'
+      immer: '>=9.0.6'
+      react: '>=18.0.0'
+      use-sync-external-store: '>=1.2.0'
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      immer:
+        optional: true
+      react:
+        optional: true
+      use-sync-external-store:
+        optional: true
 
   zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
@@ -24699,6 +24720,13 @@ snapshots:
   zod@3.24.0: {}
 
   zod@4.3.6: {}
+
+  zustand@5.0.14(@types/react@19.2.13)(immer@9.0.21)(react@19.2.6)(use-sync-external-store@1.6.0(react@19.2.6)):
+    optionalDependencies:
+      '@types/react': 19.2.13
+      immer: 9.0.21
+      react: 19.2.6
+      use-sync-external-store: 1.6.0(react@19.2.6)
 
   zwitch@2.0.4: {}
 


### PR DESCRIPTION
## Summary

Replaces the `BillingProvider` React context with a small [zustand](https://github.com/pmndrs/zustand) store for paywall open/close state.

- Deletes `BillingProvider` + `BillingContext` + `useBilling` from `features/billing/client.tsx`.
- Adds `paywall-store.ts` (zustand) and a `<PayWall />` component wrapping the existing `PayWallDialog`.
- Mounts `<PayWall />` in the `(space)` and `(optional-space)` layouts — the two route groups that contain every paywall trigger site. This keeps the dialog out of the bundle for routes that can never open it (`(auth)`, public invite/event pages, control-panel) and mirrors where `BillingProvider` was previously mounted.
- The paywall is now opened from anywhere via `showPayWall()` instead of `useBilling().showPayWall`.
- Migrates all six trigger sites (manage-poll, poll-settings, upgrade-menu-item, billing settings, invite-member-button, custom-branding-section).
- `useTier` / `useIsFree` are unchanged and still read from tRPC, so tier behavior is identical.

The large `settings/layout.tsx` diff is almost entirely re-indentation from unwrapping `<BillingProvider>`.

## Why

The provider forced every paywall trigger to live inside its subtree and coupled paywall UI state to the React tree. A store decouples the trigger from the mount point and lets the paywall be invoked imperatively.

## Testing

- `pnpm type-check` ✅
- `pnpm check` (Biome) ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured the billing and paywall system architecture for improved state management
  * Updated paywall display logic across layouts and feature components
  * Improved how free tier restrictions are enforced throughout the application

* **Chores**
  * Added new state management dependency

<!-- end of auto-generated comment: release notes by coderabbit.ai -->