### PR TITLE
🐛 Derive space tier from active subscriptions in Stripe webhooks

### DIFF
--- a/apps/web/src/app/api/stripe/webhook/handlers/customer-subscription/created.ts
+++ b/apps/web/src/app/api/stripe/webhook/handlers/customer-subscription/created.ts
@@ -9,6 +9,7 @@ import {
   getExpandedSubscription,
   getSubscriptionDetails,
   isSubscriptionActive,
+  syncSpaceTier,
   toDate,
 } from "../utils";
 
@@ -18,7 +19,6 @@ export async function onCustomerSubscriptionCreated(event: Stripe.Event) {
   );
 
   const isActive = isSubscriptionActive(subscription);
-  const tier = isActive ? "pro" : "hobby";
   const { priceId, currency, interval, amount } =
     getSubscriptionDetails(subscription);
 
@@ -41,7 +41,7 @@ export async function onCustomerSubscriptionCreated(event: Stripe.Event) {
   const subscriptionItemId = subscriptionItem.id;
   const quantity = subscriptionItem.quantity ?? 1;
 
-  await prisma.$transaction(async (tx) => {
+  const tier = await prisma.$transaction(async (tx) => {
     await tx.subscription.upsert({
       where: { id: subscription.id },
       create: {
@@ -83,14 +83,7 @@ export async function onCustomerSubscriptionCreated(event: Stripe.Event) {
       },
     });
 
-    await tx.space.update({
-      where: {
-        id: spaceId,
-      },
-      data: {
-        tier,
-      },
-    });
+    return syncSpaceTier(tx, spaceId);
   });
 
   posthog()?.groupIdentify({

--- a/apps/web/src/app/api/stripe/webhook/handlers/customer-subscription/deleted.ts
+++ b/apps/web/src/app/api/stripe/webhook/handlers/customer-subscription/deleted.ts
@@ -3,6 +3,7 @@ import { stripe } from "@rallly/billing";
 import { prisma } from "@rallly/database";
 import { posthog } from "@/features/analytics/posthog";
 import { subscriptionMetadataSchema } from "@/features/subscription/schema";
+import { syncSpaceTier } from "../utils";
 
 export async function onCustomerSubscriptionDeleted(event: Stripe.Event) {
   const subscription = await stripe.subscriptions.retrieve(
@@ -27,7 +28,7 @@ export async function onCustomerSubscriptionDeleted(event: Stripe.Event) {
 
   const { userId, spaceId } = res.data;
 
-  await prisma.$transaction(async (tx) => {
+  const tier = await prisma.$transaction(async (tx) => {
     await tx.subscription.update({
       where: {
         id: subscription.id,
@@ -38,22 +39,14 @@ export async function onCustomerSubscriptionDeleted(event: Stripe.Event) {
       },
     });
 
-    await tx.space.update({
-      where: {
-        id: spaceId,
-      },
-      data: {
-        tier: "hobby",
-        showBranding: false,
-      },
-    });
+    return syncSpaceTier(tx, spaceId);
   });
 
   posthog()?.groupIdentify({
     groupType: "space",
     groupKey: spaceId,
     properties: {
-      tier: "hobby",
+      tier,
     },
   });
 
@@ -62,7 +55,7 @@ export async function onCustomerSubscriptionDeleted(event: Stripe.Event) {
     event: "subscription_cancel",
     properties: {
       $set: {
-        tier: "hobby",
+        tier,
       },
     },
     groups: {

--- a/apps/web/src/app/api/stripe/webhook/handlers/customer-subscription/updated.ts
+++ b/apps/web/src/app/api/stripe/webhook/handlers/customer-subscription/updated.ts
@@ -6,6 +6,7 @@ import {
   getExpandedSubscription,
   getSubscriptionDetails,
   isSubscriptionActive,
+  syncSpaceTier,
   toDate,
 } from "../utils";
 
@@ -30,8 +31,6 @@ export async function onCustomerSubscriptionUpdated(event: Stripe.Event) {
 
   const { userId, spaceId } = res.data;
 
-  const tier = isActive ? "pro" : "hobby";
-
   const subscriptionItem = subscription.items.data[0];
 
   if (!subscriptionItem) {
@@ -42,7 +41,7 @@ export async function onCustomerSubscriptionUpdated(event: Stripe.Event) {
   const quantity = subscriptionItem.quantity ?? 1;
 
   // Update the subscription in the database
-  await prisma.$transaction(async (tx) => {
+  const tier = await prisma.$transaction(async (tx) => {
     await tx.subscription.upsert({
       where: {
         id: subscription.id,
@@ -78,15 +77,7 @@ export async function onCustomerSubscriptionUpdated(event: Stripe.Event) {
       },
     });
 
-    await tx.space.update({
-      where: {
-        id: spaceId,
-      },
-      data: {
-        tier,
-        ...(tier === "hobby" ? { showBranding: false } : {}),
-      },
-    });
+    return syncSpaceTier(tx, spaceId);
   });
 
   posthog()?.groupIdentify({

--- a/apps/web/src/app/api/stripe/webhook/handlers/utils.ts
+++ b/apps/web/src/app/api/stripe/webhook/handlers/utils.ts
@@ -22,6 +22,34 @@ export function isSubscriptionActive(subscription: Stripe.Subscription) {
   );
 }
 
+/**
+ * Recomputes a space's tier from its subscriptions so the tier reflects whether
+ * *any* subscription is active, rather than the state of a single webhook event.
+ * Must run after the triggering subscription's `active` flag has been written in
+ * the same transaction. Returns the resolved tier.
+ */
+export async function syncSpaceTier(
+  tx: Prisma.TransactionClient,
+  spaceId: string,
+) {
+  const activeSubscription = await tx.subscription.findFirst({
+    where: { spaceId, active: true },
+    select: { id: true },
+  });
+
+  const tier = activeSubscription ? "pro" : "hobby";
+
+  await tx.space.update({
+    where: { id: spaceId },
+    data: {
+      tier,
+      ...(tier === "hobby" ? { showBranding: false } : {}),
+    },
+  });
+
+  return tier;
+}
+
 export function getSubscriptionDetails(subscription: Stripe.Subscription) {
   const subscriptionItem = subscription.items.data[0];
   const interval = subscriptionItem.price.recurring?.interval;

--- a/apps/web/src/app/api/stripe/webhook/handlers/utils.ts
+++ b/apps/web/src/app/api/stripe/webhook/handlers/utils.ts
@@ -15,11 +15,7 @@ export async function getExpandedSubscription(subscriptionId: string) {
 }
 
 export function isSubscriptionActive(subscription: Stripe.Subscription) {
-  return (
-    subscription.status === "active" ||
-    subscription.status === "trialing" ||
-    subscription.status === "past_due"
-  );
+  return subscription.status === "active" || subscription.status === "trialing";
 }
 
 /**

--- a/apps/web/src/app/api/stripe/webhook/handlers/utils.ts
+++ b/apps/web/src/app/api/stripe/webhook/handlers/utils.ts
@@ -15,7 +15,11 @@ export async function getExpandedSubscription(subscriptionId: string) {
 }
 
 export function isSubscriptionActive(subscription: Stripe.Subscription) {
-  return subscription.status === "active" || subscription.status === "trialing";
+  return (
+    subscription.status === "active" ||
+    subscription.status === "trialing" ||
+    subscription.status === "past_due"
+  );
 }
 
 /**


### PR DESCRIPTION
Fixes [RAL-1225](https://linear.app/rallly/issue/RAL-1225).

## Problem

A space with a valid **active** Pro subscription was being silently downgraded to Hobby when a *different*, earlier **incomplete** subscription for the same space expired.

1. Customer starts a checkout that results in an `incomplete` subscription (sub **A**) — e.g. the card requires action or the initial payment fails.
2. Customer retries and creates a working subscription (sub **B**) → `active`. The space is correctly set to `pro`.
3. ~23h later Stripe expires sub **A** (`incomplete` → `incomplete_expired`) and fires `customer.subscription.deleted` for it.
4. `onCustomerSubscriptionDeleted` **unconditionally** set `space.tier = "hobby"` — downgrading the space even though sub B is still active.

`space.tier` is the entitlement source of truth (read by CASL in `features/space/ability.ts`), so the paying customer lost Pro features.

The `created` and `updated` handlers shared the same flaw: they wrote `space.tier` from the single subscription in the event, ignoring any other active subscription on the space.

## Fix

Add `syncSpaceTier(tx, spaceId)` which recomputes the tier from whether the space has **any** active subscription, and call it from all three subscription handlers (`created` / `updated` / `deleted`) instead of writing the tier per-event. It runs inside the same transaction, after the triggering subscription's `active` flag has been written, so it sees the up-to-date set of subscriptions.

This makes `space.tier` a derived value with a single source of truth, eliminating the whole class of "one subscription's lifecycle event clobbers the space tier" bugs. PostHog tier properties now also reflect the recomputed tier.

## Testing

This path depends on live Stripe webhook delivery and isn't covered by the existing test suite. Verified by code review and type-check. Manual verification would require replaying the incomplete→active→expire sequence against Stripe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved subscription tier determination by synchronizing the workspace tier from the latest subscription status during subscription create, update, and cancellation.
  * Ensures related workspace tier settings (including branding visibility for basic tier) stay consistent across all subscription lifecycle events.
  * Updated analytics tracking so both workspace tier attribution and subscription cancellation events reflect the computed tier.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->