### PR TITLE
🔥 Drop redundant client-side group identify

### DIFF
--- a/apps/web/src/features/space/client.tsx
+++ b/apps/web/src/features/space/client.tsx
@@ -48,13 +48,9 @@ export function SpaceProvider({ children }: { children: React.ReactNode }) {
 
   React.useEffect(() => {
     if (space?.id) {
-      posthog?.group("space", space.id, {
-        name: space.name,
-        tier: space.tier,
-        custom_branding_enabled: space.showBranding,
-      });
+      posthog?.group("space", space.id);
     }
-  }, [posthog, space?.id, space?.name, space?.tier, space?.showBranding]);
+  }, [posthog, space?.id]);
 
   if (!space) {
     return <RouterLoadingIndicator />;


### PR DESCRIPTION
## What

`SpaceProvider` was passing group properties to `posthog.group()`:

```tsx
posthog?.group("space", space.id, {
  name: space.name,
  tier: space.tier,
  custom_branding_enabled: space.showBranding,
});
```

Passing a properties argument to `group()` fires a `$groupidentify` event. This effect runs on every provider mount (i.e. nearly every in-space navigation) and on any property change, so it generated a redundant `$groupidentify` per page load.

## Why it's safe to drop

Every property was already set authoritatively server-side:

| Property | Server source |
|---|---|
| `name`, `tier`, `memberCount`, `seatCount` | space create (`spaces.ts`) + Stripe subscription webhooks (created/updated/deleted) |
| `custom_branding_enabled` | `updateShowBranding` mutation (`spaces.ts`) |

The client added no new information — only event volume — and could **clobber fresh server state with a stale tRPC cache** (e.g. a Stripe webhook upgrades `tier`, then the next navigation overwrites it with the old cached value).

## What's kept

The `group()` call stays — without properties — so client-captured events (paywall triggers, button clicks) are still attributed to the `space` group and feature-flag group context is intact. Only the redundant `$groupidentify` is removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Streamlined analytics tracking for the active space association so monitoring receives only essential grouping details.
  * Reduced how often analytics are updated when non-identifier space attributes change, improving stability of tracking behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->