### PR TITLE
♻️ Add a useSignOut hook that resets PostHog on sign out

### DIFF
--- a/apps/web/src/app/[locale]/accept-invite/[inviteId]/components/sign-out-button.tsx
+++ b/apps/web/src/app/[locale]/accept-invite/[inviteId]/components/sign-out-button.tsx
@@ -1,14 +1,13 @@
 "use client";
 
-import { usePostHog } from "@rallly/posthog/client";
 import { Button } from "@rallly/ui/button";
 import React from "react";
+import { useSignOut } from "@/features/user/use-sign-out";
 import { Trans } from "@/i18n/client";
-import { signOut } from "@/lib/auth-client";
 
 export function SignOutButton() {
   const [isPending, setIsPending] = React.useState(false);
-  const posthog = usePostHog();
+  const signOut = useSignOut();
   return (
     <Button
       variant="link"
@@ -16,7 +15,7 @@ export function SignOutButton() {
       onClick={async () => {
         setIsPending(true);
         await signOut();
-        posthog?.reset();
+        window.location.href = "/login";
       }}
     >
       <Trans

--- a/apps/web/src/app/[locale]/e/[id]/components/user-dropdown.tsx
+++ b/apps/web/src/app/[locale]/e/[id]/components/user-dropdown.tsx
@@ -14,8 +14,8 @@ import { LogOutIcon, Settings2Icon, UserIcon } from "lucide-react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { OptimizedAvatarImage } from "@/components/optimized-avatar-image";
+import { useSignOut } from "@/features/user/use-sign-out";
 import { Trans } from "@/i18n/client";
-import { authClient } from "@/lib/auth-client";
 
 export function UserDropdown({
   name,
@@ -29,6 +29,7 @@ export function UserDropdown({
   className?: string;
 }) {
   const router = useRouter();
+  const signOut = useSignOut();
 
   return (
     <DropdownMenu modal={false}>
@@ -69,7 +70,7 @@ export function UserDropdown({
         <DropdownMenuItem
           className="flex items-center gap-x-2"
           onClick={async () => {
-            await authClient.signOut();
+            await signOut();
             router.refresh();
           }}
         >

--- a/apps/web/src/app/[locale]/error.tsx
+++ b/apps/web/src/app/[locale]/error.tsx
@@ -5,12 +5,11 @@ import { Button } from "@rallly/ui/button";
 import * as Sentry from "@sentry/nextjs";
 import { GithubIcon, HomeIcon, LifeBuoyIcon, PlusIcon } from "lucide-react";
 import Link from "next/link";
-import { useRouter } from "next/navigation";
 import React from "react";
 import { ErrorPage, ErrorPageLinkItem } from "@/components/error-page";
 import { RouterLoadingIndicator } from "@/components/router-loading-indicator";
+import { useSignOut } from "@/features/user/use-sign-out";
 import { Trans } from "@/i18n/client";
-import { authClient } from "@/lib/auth-client";
 import { INVALID_SESSION } from "@/lib/errors/invalid-session-error";
 
 export default function LocaleErrorBoundary({
@@ -20,23 +19,19 @@ export default function LocaleErrorBoundary({
   error: Error & { digest?: string };
   reset: () => void;
 }) {
-  const router = useRouter();
   const isInvalidSession = error.digest === INVALID_SESSION;
+  const signOut = useSignOut();
 
   React.useEffect(() => {
     if (isInvalidSession) {
-      authClient.signOut({
-        fetchOptions: {
-          onSuccess: () => {
-            router.push("/login");
-          },
-        },
+      signOut().then(() => {
+        window.location.href = "/login";
       });
       return;
     }
 
     Sentry.captureException(error);
-  }, [error, router, isInvalidSession]);
+  }, [error, isInvalidSession, signOut]);
 
   if (isInvalidSession) {
     return <RouterLoadingIndicator />;

--- a/apps/web/src/components/nav-user.tsx
+++ b/apps/web/src/components/nav-user.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { usePostHog } from "@rallly/posthog/client";
 import { Button } from "@rallly/ui/button";
 import {
   DropdownMenu,
@@ -32,14 +31,14 @@ import React from "react";
 import { OptimizedAvatarImage } from "@/components/optimized-avatar-image";
 import { RouterLoadingIndicator } from "@/components/router-loading-indicator";
 import { useTheme } from "@/features/theme/client";
+import { useSignOut } from "@/features/user/use-sign-out";
 import { Trans } from "@/i18n/client";
-import { signOut } from "@/lib/auth-client";
 import { trpc } from "@/trpc/client";
 
 export function NavUser() {
   const { data: user } = trpc.user.getAuthed.useQuery();
   const [isPending, setIsPending] = React.useState(false);
-  const posthog = usePostHog();
+  const signOut = useSignOut();
   const { theme, setTheme } = useTheme();
 
   if (!user) {
@@ -126,7 +125,7 @@ export function NavUser() {
             onClick={async () => {
               setIsPending(true);
               await signOut();
-              posthog?.reset();
+              window.location.href = "/login";
             }}
           >
             <Icon>

--- a/apps/web/src/components/user-dropdown.tsx
+++ b/apps/web/src/components/user-dropdown.tsx
@@ -1,5 +1,4 @@
 "use client";
-import { usePostHog } from "@rallly/posthog/client";
 import { buttonVariants, cn } from "@rallly/ui";
 import { Button } from "@rallly/ui/button";
 import {
@@ -33,13 +32,13 @@ import Link from "next/link";
 import { OptimizedAvatarImage } from "@/components/optimized-avatar-image";
 import { useUser } from "@/components/user-provider";
 import { useTheme } from "@/features/theme/client";
+import { useSignOut } from "@/features/user/use-sign-out";
 import { Trans } from "@/i18n/client";
-import { signOut } from "@/lib/auth-client";
 import { useFeatureFlag } from "@/lib/feature-flags/client";
 
 export const UserDropdown = ({ className }: { className?: string }) => {
   const { user } = useUser();
-  const posthog = usePostHog();
+  const signOut = useSignOut();
   const { theme, setTheme } = useTheme();
 
   const isRegistrationEnabled = useFeatureFlag("registration");
@@ -163,7 +162,7 @@ export const UserDropdown = ({ className }: { className?: string }) => {
         <DropdownMenuItem
           onClick={async () => {
             await signOut();
-            posthog?.reset();
+            window.location.href = "/login";
           }}
           className="flex items-center gap-x-2"
         >

--- a/apps/web/src/features/user/use-sign-out.ts
+++ b/apps/web/src/features/user/use-sign-out.ts
@@ -1,0 +1,16 @@
+"use client";
+
+import { usePostHog } from "@rallly/posthog/client";
+import React from "react";
+import { authClient } from "@/lib/auth-client";
+
+// Tears down the session and analytics identity. Navigation is the caller's
+// concern — handle it after awaiting.
+export function useSignOut() {
+  const posthog = usePostHog();
+
+  return React.useCallback(async () => {
+    await authClient.signOut();
+    posthog?.reset();
+  }, [posthog]);
+}

--- a/apps/web/src/lib/auth-client.ts
+++ b/apps/web/src/lib/auth-client.ts
@@ -19,8 +19,3 @@ export const authClient = createAuthClient({
     anonymousClient(),
   ],
 });
-
-export async function signOut() {
-  await authClient.signOut();
-  window.location.href = "/login";
-}

--- a/apps/web/src/trpc/client/provider.tsx
+++ b/apps/web/src/trpc/client/provider.tsx
@@ -10,8 +10,8 @@ import {
 import { httpBatchLink, TRPCClientError } from "@trpc/client";
 import { useState } from "react";
 import superjson from "superjson";
+import { useSignOut } from "@/features/user/use-sign-out";
 import { useTranslation } from "@/i18n/client";
-import { authClient } from "@/lib/auth-client";
 import { trpc } from "../client";
 import type { AppRouter } from "../routers";
 
@@ -21,6 +21,7 @@ function isTRPCClientError(error: Error): error is TRPCClientError<AppRouter> {
 
 export function TRPCProvider(props: { children: React.ReactNode }) {
   const { t } = useTranslation();
+  const signOut = useSignOut();
   const [queryClient] = useState(() => {
     function handleError(error: Error) {
       if (!isTRPCClientError(error)) {
@@ -29,7 +30,7 @@ export function TRPCProvider(props: { children: React.ReactNode }) {
 
       switch (error.data?.code) {
         case "UNAUTHORIZED":
-          authClient.signOut().finally(() => {
+          signOut().finally(() => {
             window.location.href = "/login";
           });
           break;


### PR DESCRIPTION
Fixes RAL-1227

## Problem

Sign-out was implemented inconsistently. Some call sites manually called `posthog.reset()` after signing out; others didn't reset at all. The paths without a reset left the previous user's `distinct_id` / `$user_state` in the cookie, so the next session on that browser stayed attributed to the logged-out user — the exact conflation `posthog.identify` (called centrally in `useUser`) is meant to prevent.

## Approach

Rather than couple the analytics SDK to the low-level Better-Auth client, the teardown moves into a shared **`useSignOut()`** hook. `auth-client.ts` goes back to just exporting `authClient`.

```ts
// hook = teardown only; navigation is the caller's concern
export function useSignOut() {
  const posthog = usePostHog();
  return React.useCallback(async () => {
    await authClient.signOut();
    posthog?.reset();
  }, [posthog]);
}
```

Each call site awaits the teardown and then does its own redirect:

| Call site | Redirect |
|---|---|
| `components/user-dropdown.tsx`, `nav-user.tsx`, `accept-invite/.../sign-out-button.tsx` | `window.location.href = "/login"` |
| `e/[id]/.../user-dropdown.tsx` (public) | `router.refresh()` (stay on page) |
| `error.tsx` (invalid session) | `window.location.href = "/login"` |
| `trpc/client/provider.tsx` (auto-logout) | `window.location.href = "/login"` |

The `/login` cases use a full reload deliberately: a client `router.push` keeps the React Query cache and any mounted authenticated views alive, which then refetch unauthenticated and 401-loop through the tRPC error handler. The public page stays put with `router.refresh()`.

Notes:
- `useSignOut` (not `useUser.signOut`) because `useUser` suspends on `user.getMe` — the error boundary and public/guest pages shouldn't depend on that query.
- The tRPC provider can use the hook even though it renders above `PostHogProvider`: `usePostHog()` falls back to the global singleton via the context's default `client` getter.
- Removed now-unused `usePostHog` / `authClient` imports from the call sites.

## Audit notes (not addressed here)

While auditing sign-out usage I also found, left for follow-up:
- **Dead code:** the server `signOut` in `lib/auth.ts` has zero callers anywhere in the repo.
- **Vestigial:** `delete-account-dialog.tsx` has `action="/auth/logout"` (no such route; react-hook-form `preventDefault`s the native submit), and account deletion doesn't reset PostHog — same bug class as this issue.

## Verification

Biome passes on all changed files. Type-check deferred to CI (worktree had no installed deps).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a centralized `useSignOut` hook for performing sign-out and resetting analytics when available.
* **Improvements**
  * Standardized logout/sign-out flows across the app to use the shared hook.
  * Updated error and logout handling to consistently sign out and return to the login screen.
  * Removed repeated analytics reset logic from individual UI components.
* **Refactor**
  * Removed the standalone exported sign-out helper and migrated callers to the hook-based approach.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->