### PR TITLE
♻️ Use posthog module directly instead of provider/hook

### DIFF
--- a/apps/landing/instrumentation-client.ts
+++ b/apps/landing/instrumentation-client.ts
@@ -1,0 +1,2 @@
+// Initializes the PostHog browser client (side-effect import).
+import "@rallly/posthog/client";

--- a/apps/landing/next.config.ts
+++ b/apps/landing/next.config.ts
@@ -20,6 +20,7 @@ const nextConfig: NextConfig = {
     "@rallly/ui",
     "@rallly/tailwind-config",
     "@rallly/utils",
+    "@rallly/posthog",
     "next-mdx-remote",
   ],
   webpack(config) {

--- a/apps/landing/src/app/[locale]/layout.tsx
+++ b/apps/landing/src/app/[locale]/layout.tsx
@@ -1,7 +1,6 @@
 import "./globals.css";
 
 import languages from "@rallly/languages";
-import { PostHogProvider } from "@rallly/posthog/client";
 import { Analytics } from "@vercel/analytics/react";
 import { domAnimation, LazyMotion } from "motion/react";
 import type { Metadata, Viewport } from "next";
@@ -34,17 +33,12 @@ export default async function Root(props: {
     <html lang={i18n.resolvedLanguage} className={sans.className}>
       <body>
         <LazyMotion features={domAnimation}>
-          <PostHogProvider>
-            <Suspense fallback={null}>
-              <PostHogPageView />
-            </Suspense>
-            <I18nProvider
-              locale={i18n.resolvedLanguage}
-              resources={translations}
-            >
-              {children}
-            </I18nProvider>
-          </PostHogProvider>
+          <Suspense fallback={null}>
+            <PostHogPageView />
+          </Suspense>
+          <I18nProvider locale={i18n.resolvedLanguage} resources={translations}>
+            {children}
+          </I18nProvider>
         </LazyMotion>
         <Analytics />
       </body>

--- a/apps/landing/src/components/posthog-page-view.tsx
+++ b/apps/landing/src/components/posthog-page-view.tsx
@@ -1,15 +1,14 @@
 "use client";
-import { usePostHog } from "@rallly/posthog/client";
+import { posthog } from "@rallly/posthog/client";
 import { usePathname, useSearchParams } from "next/navigation";
 import { useEffect } from "react";
 
 export function PostHogPageView() {
   const pathname = usePathname();
   const searchParams = useSearchParams();
-  const posthog = usePostHog();
   useEffect(() => {
     // Track pageviews
-    if (pathname && posthog) {
+    if (pathname) {
       let url = window.origin + pathname;
       if (searchParams?.toString()) {
         url = `${url}?${searchParams.toString()}`;
@@ -18,7 +17,7 @@ export function PostHogPageView() {
         $current_url: url,
       });
     }
-  }, [pathname, searchParams, posthog]);
+  }, [pathname, searchParams]);
 
   return null;
 }

--- a/apps/landing/src/components/sign-up-button.tsx
+++ b/apps/landing/src/components/sign-up-button.tsx
@@ -1,13 +1,12 @@
 "use client";
 
-import { usePostHog } from "@rallly/posthog/client";
+import { posthog } from "@rallly/posthog/client";
 import { buttonVariants } from "@rallly/ui";
 import Link from "next/link";
 import { Trans } from "@/i18n/client/trans";
 import { linkToApp } from "@/lib/linkToApp";
 
 export function SignUpButton() {
-  const posthog = usePostHog();
   return (
     <Link
       href={linkToApp("/register")}

--- a/apps/web/instrumentation-client.ts
+++ b/apps/web/instrumentation-client.ts
@@ -2,6 +2,8 @@
 // The config you add here will be used whenever a users loads a page in their browser.
 // https://docs.sentry.io/platforms/javascript/guides/nextjs/
 
+// Initializes the PostHog browser client (side-effect import).
+import "@rallly/posthog/client";
 import * as Sentry from "@sentry/nextjs";
 
 const SENTRY_DSN = process.env.SENTRY_DSN || process.env.NEXT_PUBLIC_SENTRY_DSN;

--- a/apps/web/src/app/[locale]/(auth)/login/verify/components/otp-form.tsx
+++ b/apps/web/src/app/[locale]/(auth)/login/verify/components/otp-form.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { zodResolver } from "@hookform/resolvers/zod";
-import { usePostHog } from "@rallly/posthog/client";
+import { posthog } from "@rallly/posthog/client";
 import { Button } from "@rallly/ui/button";
 import {
   Form,
@@ -26,7 +26,6 @@ const otpFormSchema = z.object({
 
 export function OTPForm({ email }: { email: string }) {
   const { t } = useTranslation();
-  const posthog = usePostHog();
   const form = useForm({
     defaultValues: {
       otp: "",

--- a/apps/web/src/app/[locale]/(space)/(dashboard)/components/upgrade-menu-item.tsx
+++ b/apps/web/src/app/[locale]/(space)/(dashboard)/components/upgrade-menu-item.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { usePostHog } from "@rallly/posthog/client";
+import { posthog } from "@rallly/posthog/client";
 import { SidebarMenuButton, SidebarMenuItem } from "@rallly/ui/sidebar";
 import { SparklesIcon } from "lucide-react";
 import { useIsFree } from "@/features/billing/client";
@@ -9,7 +9,6 @@ import { Trans } from "@/i18n/client";
 
 export function UpgradeMenuItem() {
   const isFree = useIsFree();
-  const posthog = usePostHog();
 
   if (!isFree) {
     return null;

--- a/apps/web/src/app/[locale]/(space)/settings/billing/page-client.tsx
+++ b/apps/web/src/app/[locale]/(space)/settings/billing/page-client.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { usePostHog } from "@rallly/posthog/client";
+import { posthog } from "@rallly/posthog/client";
 import { buttonVariants } from "@rallly/ui";
 import { Alert, AlertDescription, AlertTitle } from "@rallly/ui/alert";
 import { Button } from "@rallly/ui/button";
@@ -73,7 +73,6 @@ export function BillingPageClient() {
 }
 
 function BillingPageContent({ tier }: { tier: SpaceTier }) {
-  const posthog = usePostHog();
   const searchParams = useSearchParams();
 
   const [subscription] = trpc.billing.getSubscription.useSuspenseQuery();

--- a/apps/web/src/app/[locale]/(space)/settings/general/components/custom-branding-section.tsx
+++ b/apps/web/src/app/[locale]/(space)/settings/general/components/custom-branding-section.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { usePostHog } from "@rallly/posthog/client";
+import { posthog } from "@rallly/posthog/client";
 import { Button } from "@rallly/ui/button";
 import { ColorPicker, parseColor } from "@rallly/ui/color-picker";
 import { Field, FieldGroup, FieldLabel } from "@rallly/ui/field";
@@ -31,7 +31,6 @@ export function CustomBrandingSection({
   const isFree = useIsFree();
   const toastProgress = useToastProgress();
   const utils = trpc.useUtils();
-  const posthog = usePostHog();
 
   const currentColor = space.primaryColor ?? DEFAULT_PRIMARY_COLOR;
   const [color, setColor] = React.useState(() => parseColor(currentColor));

--- a/apps/web/src/app/[locale]/accept-invite/[inviteId]/components/sign-out-button.tsx
+++ b/apps/web/src/app/[locale]/accept-invite/[inviteId]/components/sign-out-button.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { usePostHog } from "@rallly/posthog/client";
+import { posthog } from "@rallly/posthog/client";
 import { Button } from "@rallly/ui/button";
 import React from "react";
 import { Trans } from "@/i18n/client";
@@ -8,7 +8,6 @@ import { signOut } from "@/lib/auth-client";
 
 export function SignOutButton() {
   const [isPending, setIsPending] = React.useState(false);
-  const posthog = usePostHog();
   return (
     <Button
       variant="link"

--- a/apps/web/src/app/[locale]/layout.tsx
+++ b/apps/web/src/app/[locale]/layout.tsx
@@ -1,7 +1,6 @@
 import "./globals.css";
 
 import { supportedLngs } from "@rallly/languages";
-import { PostHogProvider } from "@rallly/posthog/client";
 import { Toaster } from "@rallly/ui/sonner";
 import { TooltipProvider } from "@rallly/ui/tooltip";
 import { domAnimation, LazyMotion } from "motion/react";
@@ -80,10 +79,8 @@ export default async function Root({
               <I18nProvider locale={locale} resources={resources}>
                 <TRPCProvider>
                   <LazyMotion features={domAnimation}>
-                    <PostHogProvider>
-                      <PostHogPageView />
-                      <TooltipProvider>{children}</TooltipProvider>
-                    </PostHogProvider>
+                    <PostHogPageView />
+                    <TooltipProvider>{children}</TooltipProvider>
                   </LazyMotion>
                 </TRPCProvider>
               </I18nProvider>

--- a/apps/web/src/app/[locale]/timezone-change-detector.test.tsx
+++ b/apps/web/src/app/[locale]/timezone-change-detector.test.tsx
@@ -9,10 +9,6 @@ vi.mock("@/utils/date-time-utils", () => ({
   getBrowserTimeZone: () => mockTimeZone,
 }));
 
-vi.mock("@rallly/posthog/client", () => ({
-  usePostHog: () => ({ capture: vi.fn() }),
-}));
-
 describe("TimeZoneChangeDetector", () => {
   beforeEach(() => {
     localStorage.clear();

--- a/apps/web/src/app/posthog-page-view.tsx
+++ b/apps/web/src/app/posthog-page-view.tsx
@@ -1,15 +1,14 @@
 "use client";
-import { usePostHog } from "@rallly/posthog/client";
+import { posthog } from "@rallly/posthog/client";
 import { usePathname, useSearchParams } from "next/navigation";
 import { useEffect } from "react";
 
 export function PostHogPageView() {
   const pathname = usePathname();
   const searchParams = useSearchParams();
-  const posthog = usePostHog();
   useEffect(() => {
     // Track pageviews
-    if (pathname && posthog) {
+    if (pathname) {
       let url = window.origin + pathname;
       if (searchParams?.toString()) {
         url = `${url}?${searchParams.toString()}`;
@@ -18,7 +17,7 @@ export function PostHogPageView() {
         $current_url: url,
       });
     }
-  }, [pathname, searchParams, posthog]);
+  }, [pathname, searchParams]);
 
   return null;
 }

--- a/apps/web/src/components/create-poll.tsx
+++ b/apps/web/src/components/create-poll.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { usePostHog } from "@rallly/posthog/client";
+import { posthog } from "@rallly/posthog/client";
 import { buttonVariants } from "@rallly/ui";
 import { Button } from "@rallly/ui/button";
 import {
@@ -56,7 +56,6 @@ export interface CreatePollPageProps {
 
 export const CreatePoll: React.FunctionComponent = () => {
   const { t } = useTranslation();
-  const posthog = usePostHog();
   const { createGuestIfNeeded } = useUser();
   const [createdPollId, setCreatedPollId] = React.useState<string | null>(null);
   const [, copy] = useCopyToClipboard();

--- a/apps/web/src/components/forms/poll-settings.tsx
+++ b/apps/web/src/components/forms/poll-settings.tsx
@@ -1,4 +1,4 @@
-import { usePostHog } from "@rallly/posthog/client";
+import { posthog } from "@rallly/posthog/client";
 import {
   Card,
   CardContent,
@@ -37,7 +37,6 @@ const PollSetting = ({
   description: React.ReactNode;
 }) => {
   const form = useFormContext<PollSettingsFormData>();
-  const posthog = usePostHog();
   const isFree = useIsFree();
 
   return (

--- a/apps/web/src/components/nav-user.tsx
+++ b/apps/web/src/components/nav-user.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { usePostHog } from "@rallly/posthog/client";
+import { posthog } from "@rallly/posthog/client";
 import { Button } from "@rallly/ui/button";
 import {
   DropdownMenu,
@@ -39,7 +39,6 @@ import { trpc } from "@/trpc/client";
 export function NavUser() {
   const { data: user } = trpc.user.getAuthed.useQuery();
   const [isPending, setIsPending] = React.useState(false);
-  const posthog = usePostHog();
   const { theme, setTheme } = useTheme();
 
   if (!user) {

--- a/apps/web/src/components/poll/manage-poll.tsx
+++ b/apps/web/src/components/poll/manage-poll.tsx
@@ -1,4 +1,4 @@
-import { usePostHog } from "@rallly/posthog/client";
+import { posthog } from "@rallly/posthog/client";
 import { Button } from "@rallly/ui/button";
 import { useDialog } from "@rallly/ui/dialog";
 import {
@@ -125,7 +125,6 @@ const ManagePoll: React.FunctionComponent<{
   const duplicateDialog = useDialog();
   const scheduleDialog = useDialog();
   const isFree = useIsFree();
-  const posthog = usePostHog();
   const { exportToCsv } = useCsvExporter();
 
   return (

--- a/apps/web/src/components/user-dropdown.tsx
+++ b/apps/web/src/components/user-dropdown.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { usePostHog } from "@rallly/posthog/client";
+import { posthog } from "@rallly/posthog/client";
 import { buttonVariants, cn } from "@rallly/ui";
 import { Button } from "@rallly/ui/button";
 import {
@@ -39,7 +39,6 @@ import { useFeatureFlag } from "@/lib/feature-flags/client";
 
 export const UserDropdown = ({ className }: { className?: string }) => {
   const { user } = useUser();
-  const posthog = usePostHog();
   const { theme, setTheme } = useTheme();
 
   const isRegistrationEnabled = useFeatureFlag("registration");

--- a/apps/web/src/components/user-provider.tsx
+++ b/apps/web/src/components/user-provider.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { usePostHog } from "@rallly/posthog/client";
+import { posthog } from "@rallly/posthog/client";
 import { useRouter } from "next/navigation";
 import React from "react";
 import type { UserAbility } from "@/features/user/ability";
@@ -10,7 +10,6 @@ import { isOwner } from "@/utils/permissions";
 
 export function useUser() {
   const [user] = trpc.user.getMe.useSuspenseQuery();
-  const posthog = usePostHog();
   const router = useRouter();
 
   const userId = user?.id;
@@ -20,7 +19,7 @@ export function useUser() {
     if (userId && !isGuest) {
       posthog.identify(userId);
     }
-  }, [userId, isGuest, posthog]);
+  }, [userId, isGuest]);
 
   return React.useMemo(() => {
     return {

--- a/apps/web/src/features/branding/components/custom-branding-prompt.tsx
+++ b/apps/web/src/features/branding/components/custom-branding-prompt.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { usePostHog } from "@rallly/posthog/client";
+import { posthog } from "@rallly/posthog/client";
 import { Badge } from "@rallly/ui/badge";
 import { Button } from "@rallly/ui/button";
 import Image from "next/image";
@@ -16,7 +16,6 @@ export function CustomBrandingPrompt() {
   const { t } = useTranslation();
   const { data: space } = useSpace();
   const { user } = useUser();
-  const posthog = usePostHog();
 
   const [isDismissed, setIsDismissed] = useLocalStorage(
     "custom-branding-prompt-dismissed",

--- a/apps/web/src/features/event-types/components/create-event-type-dialog.tsx
+++ b/apps/web/src/features/event-types/components/create-event-type-dialog.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { zodResolver } from "@hookform/resolvers/zod";
-import { usePostHog } from "@rallly/posthog/client";
+import { posthog } from "@rallly/posthog/client";
 import { Button } from "@rallly/ui/button";
 import type { DialogProps } from "@rallly/ui/dialog";
 import {
@@ -28,7 +28,6 @@ import { trpc } from "@/trpc/client";
 
 export function CreateEventTypeDialog({ open, onOpenChange }: DialogProps) {
   const { t } = useTranslation();
-  const posthog = usePostHog();
   const createEventType = trpc.eventTypes.create.useMutation();
   const [showMaxAttendees, setShowMaxAttendees] = React.useState(false);
   const [showDescription, setShowDescription] = React.useState(false);

--- a/apps/web/src/features/event-types/components/delete-event-type-dialog.tsx
+++ b/apps/web/src/features/event-types/components/delete-event-type-dialog.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { usePostHog } from "@rallly/posthog/client";
+import { posthog } from "@rallly/posthog/client";
 import { Button } from "@rallly/ui/button";
 import type { DialogProps } from "@rallly/ui/dialog";
 import {
@@ -26,7 +26,6 @@ export function DeleteEventTypeDialog({
   eventTypeName: string;
 }) {
   const { t } = useTranslation();
-  const posthog = usePostHog();
   const softDelete = trpc.eventTypes.softDelete.useMutation();
 
   const handleDelete = async () => {

--- a/apps/web/src/features/event-types/components/edit-event-type-dialog.tsx
+++ b/apps/web/src/features/event-types/components/edit-event-type-dialog.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { zodResolver } from "@hookform/resolvers/zod";
-import { usePostHog } from "@rallly/posthog/client";
+import { posthog } from "@rallly/posthog/client";
 import { Button } from "@rallly/ui/button";
 import type { DialogProps } from "@rallly/ui/dialog";
 import {
@@ -34,7 +34,6 @@ export function EditEventTypeDialog({
   eventType: EventTypeDTO;
 }) {
   const { t } = useTranslation();
-  const posthog = usePostHog();
   const updateEventType = trpc.eventTypes.update.useMutation();
 
   const initialValues = React.useMemo(

--- a/apps/web/src/features/space/client.tsx
+++ b/apps/web/src/features/space/client.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { usePostHog } from "@rallly/posthog/client";
+import { posthog } from "@rallly/posthog/client";
 import { useRouter } from "next/navigation";
 import React from "react";
 import { RouterLoadingIndicator } from "@/components/router-loading-indicator";
@@ -38,7 +38,6 @@ export const useSpace = () => {
 export function SpaceProvider({ children }: { children: React.ReactNode }) {
   const router = useRouter();
   const { data: space, isLoading } = trpc.spaces.getCurrent.useQuery();
-  const posthog = usePostHog();
 
   React.useEffect(() => {
     if (!isLoading && !space) {
@@ -50,7 +49,7 @@ export function SpaceProvider({ children }: { children: React.ReactNode }) {
     if (space?.id) {
       posthog?.group("space", space.id);
     }
-  }, [posthog, space?.id]);
+  }, [space?.id]);
 
   if (!space) {
     return <RouterLoadingIndicator />;

--- a/packages/posthog/package.json
+++ b/packages/posthog/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "exports": {
     "./server": "./src/server.ts",
-    "./client": "./src/client.tsx",
+    "./client": "./src/client.ts",
     "./utils": "./src/utils.ts"
   },
   "scripts": {

--- a/packages/posthog/src/client.ts
+++ b/packages/posthog/src/client.ts
@@ -1,10 +1,8 @@
 "use client";
 import posthog from "posthog-js";
-import type React from "react";
 
-export { useFeatureFlagEnabled, usePostHog } from "posthog-js/react";
+export { useFeatureFlagEnabled } from "posthog-js/react";
 
-import { PostHogProvider as BasePostHogProvider } from "posthog-js/react";
 import { isGlobalPrivacyControlEnabled } from "./utils";
 
 if (typeof window !== "undefined" && process.env.NEXT_PUBLIC_POSTHOG_API_KEY) {
@@ -25,10 +23,6 @@ if (typeof window !== "undefined" && process.env.NEXT_PUBLIC_POSTHOG_API_KEY) {
       web_vitals: false,
     },
   });
-}
-
-export function PostHogProvider({ children }: { children: React.ReactNode }) {
-  return <BasePostHogProvider client={posthog}>{children}</BasePostHogProvider>;
 }
 
 export { posthog };


### PR DESCRIPTION
## Summary

`PostHogProvider` and `usePostHog` were unnecessary. `posthog-js/react` registers the global `posthog-js` singleton as the default context client at module load, so the hooks (e.g. `useFeatureFlagEnabled`) work **without** a provider, and `usePostHog()` just returned that same singleton you can import directly. This follows the [PostHog Next.js docs](https://posthog.com/docs/libraries/next-js).

## Changes

- **`@rallly/posthog/client`**: drop `PostHogProvider` and the `usePostHog` re-export; rename `client.tsx` → `client.ts` (no JSX left). Keep `posthog`, the `posthog.init()` side-effect, and the `useFeatureFlagEnabled` re-export.
- **Init trigger**: now fires from each app's `instrumentation-client` entry (web's existing one + a new one for landing), since the layouts no longer import the provider.
- **Call sites**: 19 components swap `const posthog = usePostHog()` for a direct `import { posthog }`. Both layouts unwrap the provider. Page-view components drop the now-redundant `&& posthog` guard; `posthog` removed from `useEffect` deps where it's now a module-level import. Deleted a dead `vi.mock` in `timezone-change-detector.test.tsx` (that component doesn't import posthog).
- Add `@rallly/posthog` to landing's `transpilePackages`.

## Verification

- `pnpm type-check` clean on `@rallly/posthog`, `@rallly/web`, `@rallly/landing`
- `pnpm biome check` clean
- Unit tests: 133 passed

Behavior is unchanged: `posthog.capture()` on the uninitialized singleton (self-hosted, no API key) is a safe no-op, same as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Refactored PostHog analytics integration across the application to use direct client imports instead of React hooks, improving code consistency and maintainability
  * Removed provider wrapper component from application layouts
  * Streamlined analytics initialization across multiple components
* **Tests**
  * Removed unnecessary analytics mocks from test files

<!-- end of auto-generated comment: release notes by coderabbit.ai -->