### PR TITLE
🔥 Slim poll response analytics

### DIFF
--- a/apps/web/src/trpc/routers/polls.ts
+++ b/apps/web/src/trpc/routers/polls.ts
@@ -245,7 +245,6 @@ export const polls = router({
           status: poll.status,
           is_guest: ctx.user.isGuest,
           created_at: poll.createdAt,
-          participant_count: 0,
           comment_count: 0,
           option_count: poll.options.length,
           has_location: !!location,

--- a/apps/web/src/trpc/routers/polls/participants.ts
+++ b/apps/web/src/trpc/routers/polls/participants.ts
@@ -345,21 +345,11 @@ export const participants = router({
           }),
         );
 
-        posthog()?.groupIdentify({
-          groupType: "poll",
-          groupKey: pollId,
-          properties: {
-            participant_count: totalResponses,
-          },
-        });
-
-        // Track participant addition analytics
         posthog()?.capture({
           distinctId: ctx.user.id,
           event: "poll_response_submit",
           properties: {
             participant_id: participant.id,
-            participant_name: participant.name,
             has_email: !!email,
             total_responses: totalResponses,
           },


### PR DESCRIPTION
## Summary

Trims redundant PostHog volume on the poll response path — the hottest write in the app.

- **Remove the per-response `groupIdentify`** that updated the poll group's `participant_count`. PostHog bills `$groupidentify` as an event, so this **halves billed events** on the response path. The count is already recoverable from `poll_response_submit` events (`total_responses` property, group-associated), and the group property was **never decremented on participant removal** — so it was already drift-prone and misleading.
- **Remove the now-permanently-stale `participant_count: 0`** init from the poll-creation `groupIdentify`.
- **Drop `participant_name`** from the `poll_response_submit` event (PII, low analytical value).

Net: one fewer billed event per response, and no inaccurate group property.

## What's preserved

`poll_response_submit` still carries `total_responses` and is group-associated, so "responses over time per poll" and "current/peak count" remain answerable from events. The `poll_schedule` event's `participant_count` is an accurate event property (computed at schedule time) and is left untouched.

## Note for reviewer

⚠️ Verify no PostHog insight/dashboard filters on the **`participant_count` group property**. If one does, it's already getting bad data (never decremented), but it should be repointed at the `total_responses` event property before this ships.

## Stacking

Based on `refactor/posthog-module-import` (#2456), not `main` — rebase onto main once that merges.

## Test plan

- [x] `pnpm type-check` passes
- [x] `pnpm biome check` passes on changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Refined internal analytics tracking for poll operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->