### PR TITLE
♻️ Generate gravatar URL on the server as participant image fallback

### DIFF
--- a/apps/web/src/components/optimized-avatar-image.tsx
+++ b/apps/web/src/components/optimized-avatar-image.tsx
@@ -1,52 +1,20 @@
-"use client";
 import { cn } from "@rallly/ui";
 import { Avatar, AvatarFallback, AvatarImage } from "@rallly/ui/avatar";
 import { Icon } from "@rallly/ui/icon";
 import { UserIcon } from "lucide-react";
-import React from "react";
 import { resolveStorageUrl } from "@/utils/storage";
-
-async function getGravatarUrl(email: string): Promise<string | null> {
-  if (typeof crypto === "undefined" || !crypto.subtle) {
-    return null;
-  }
-
-  const normalizedEmail = email.trim().toLowerCase();
-  const encoder = new TextEncoder();
-  const data = encoder.encode(normalizedEmail);
-  const hashBuffer = await crypto.subtle.digest("SHA-256", data);
-  const hashArray = Array.from(new Uint8Array(hashBuffer));
-  const hashHex = hashArray
-    .map((b) => b.toString(16).padStart(2, "0"))
-    .join("");
-  return `https://0.gravatar.com/avatar/${hashHex}?d=404&s=128&r=g`;
-}
 
 export function OptimizedAvatarImage({
   size = "md",
   className,
   src,
   name,
-  email,
 }: {
   size: "sm" | "md" | "lg" | "xl";
   src?: string;
   name: string;
   className?: string;
-  email?: string;
 }) {
-  const [gravatarUrl, setGravatarUrl] = React.useState<string | null>(null);
-
-  React.useEffect(() => {
-    if (!src && email) {
-      getGravatarUrl(email)
-        .then(setGravatarUrl)
-        .catch(() => {
-          setGravatarUrl(null);
-        });
-    }
-  }, [src, email]);
-
   const initials = name
     .trim()
     .split(" ")
@@ -56,13 +24,9 @@ export function OptimizedAvatarImage({
     .replace(/[^\p{L}]/gu, "")
     .toUpperCase();
 
-  const imageSrc = src || gravatarUrl;
-
   return (
     <Avatar className={className} size={size === "md" ? "default" : size}>
-      {imageSrc ? (
-        <AvatarImage src={resolveStorageUrl(imageSrc)} alt={name} />
-      ) : null}
+      <AvatarImage src={src ? resolveStorageUrl(src) : undefined} alt={name} />
       <AvatarFallback className={cn("shrink-0")}>
         {/^\p{L}+$/u.test(initials) ? (
           initials

--- a/apps/web/src/components/poll/desktop-poll/participant-row-form.tsx
+++ b/apps/web/src/components/poll/desktop-poll/participant-row-form.tsx
@@ -22,7 +22,6 @@ import { toggleVote, VoteSelector } from "../vote-selector";
 export interface ParticipantRowFormProps {
   name?: string;
   className?: string;
-  email?: string;
   image?: string;
   isYou?: boolean;
   isNew?: boolean;
@@ -32,7 +31,6 @@ export interface ParticipantRowFormProps {
 const ParticipantRowForm = ({
   name,
   image,
-  email,
   isNew,
   className,
 }: ParticipantRowFormProps) => {
@@ -67,7 +65,6 @@ const ParticipantRowForm = ({
               <OptimizedAvatarImage
                 name={participantName}
                 size="sm"
-                email={email}
                 src={image ?? undefined}
               />
             ) : (

--- a/apps/web/src/components/poll/desktop-poll/participant-row.tsx
+++ b/apps/web/src/components/poll/desktop-poll/participant-row.tsx
@@ -35,23 +35,13 @@ export interface ParticipantRowProps {
 
 export const ParticipantRowView: React.FunctionComponent<{
   name: string;
-  email?: string;
   image?: string | null;
   action?: React.ReactNode;
   votes: Array<VoteType | undefined>;
   className?: string;
   isYou?: boolean;
   participantId: string;
-}> = ({
-  name,
-  email,
-  image,
-  action,
-  votes,
-  className,
-  isYou,
-  participantId,
-}) => {
+}> = ({ name, image, action, votes, className, isYou, participantId }) => {
   return (
     <tr
       data-testid="participant-row"
@@ -67,7 +57,6 @@ export const ParticipantRowView: React.FunctionComponent<{
             <OptimizedAvatarImage
               size="sm"
               name={name}
-              email={email}
               src={image ?? undefined}
             />
             <ParticipantName>{name}</ParticipantName>
@@ -120,7 +109,6 @@ const ParticipantRow: React.FunctionComponent<ParticipantRowProps> = ({
       <ParticipantRowForm
         className={className}
         name={participant.name}
-        email={participant.email}
         image={participant.image ?? undefined}
         isYou={isYou}
         onCancel={() => onChangeEditMode?.(false)}
@@ -132,7 +120,6 @@ const ParticipantRow: React.FunctionComponent<ParticipantRowProps> = ({
     <ParticipantRowView
       className={className}
       name={participant.name}
-      email={participant.email}
       image={participant.image}
       votes={optionIds.map((optionId) => {
         return getVote(participant.id, optionId);

--- a/apps/web/src/components/poll/mobile-poll.tsx
+++ b/apps/web/src/components/poll/mobile-poll.tsx
@@ -96,7 +96,6 @@ const MobilePoll: React.FunctionComponent = () => {
                     <Participant>
                       <OptimizedAvatarImage
                         name={participant.name}
-                        email={participant.email ?? undefined}
                         src={participant.image ?? undefined}
                         size="sm"
                       />

--- a/apps/web/src/components/poll/mobile-poll/poll-option.tsx
+++ b/apps/web/src/components/poll/mobile-poll/poll-option.tsx
@@ -63,14 +63,13 @@ const PollOptionVoteSummary: React.FunctionComponent<{ optionId: string }> = ({
       ) : (
         <div className="grid grid-cols-2 gap-2">
           <div className="col-span-1 space-y-2.5">
-            {participantsWhoVotedYes.map(({ name, email, image }, i) => (
+            {participantsWhoVotedYes.map(({ name, image }, i) => (
               // biome-ignore lint/suspicious/noArrayIndexKey: Fix this later
               <div key={i} className="flex">
                 <div className="relative mr-2.5 flex size-4 items-center justify-center">
                   <OptimizedAvatarImage
                     size="sm"
                     name={name}
-                    email={email ?? undefined}
                     src={image ?? undefined}
                   />
                   <VoteIcon
@@ -82,14 +81,13 @@ const PollOptionVoteSummary: React.FunctionComponent<{ optionId: string }> = ({
                 <div className="truncate text-sm">{name}</div>
               </div>
             ))}
-            {participantsWhoVotedIfNeedBe.map(({ name, email, image }, i) => (
+            {participantsWhoVotedIfNeedBe.map(({ name, image }, i) => (
               // biome-ignore lint/suspicious/noArrayIndexKey: Fix this later
               <div key={i} className="flex">
                 <div className="relative mr-2.5 flex size-4 items-center justify-center">
                   <OptimizedAvatarImage
                     size="sm"
                     name={name}
-                    email={email ?? undefined}
                     src={image ?? undefined}
                   />
                   <VoteIcon
@@ -103,14 +101,13 @@ const PollOptionVoteSummary: React.FunctionComponent<{ optionId: string }> = ({
             ))}
           </div>
           <div className="col-span-1 space-y-2.5">
-            {participantsWhoVotedNo.map(({ name, email, image }, i) => (
+            {participantsWhoVotedNo.map(({ name, image }, i) => (
               // biome-ignore lint/suspicious/noArrayIndexKey: Fix this later
               <div key={i} className="flex">
                 <div className="relative mr-2.5 flex size-4 items-center justify-center">
                   <OptimizedAvatarImage
                     size="sm"
                     name={name}
-                    email={email ?? undefined}
                     src={image ?? undefined}
                   />
                   <VoteIcon

--- a/apps/web/src/features/space/components/space-icon.tsx
+++ b/apps/web/src/features/space/components/space-icon.tsx
@@ -18,7 +18,7 @@ export function SpaceIcon({
 }: SpaceIconProps) {
   return (
     <Avatar className={className} size={size} shape="square" bordered={!src}>
-      {src ? <AvatarImage src={resolveStorageUrl(src)} alt={name} /> : null}
+      <AvatarImage src={src ? resolveStorageUrl(src) : undefined} alt={name} />
       <AvatarFallback>{name.slice(0, 2).toUpperCase()}</AvatarFallback>
     </Avatar>
   );

--- a/apps/web/src/trpc/routers/polls/participants.ts
+++ b/apps/web/src/trpc/routers/polls/participants.ts
@@ -11,6 +11,7 @@ import { getInstanceBranding, getSpaceBranding } from "@/emails/branding";
 import { posthog } from "@/features/analytics/posthog";
 import { getNotificationRecipient } from "@/features/notifications/queries";
 import { hasPollAdminAccess } from "@/features/poll/query";
+import { getGravatarUrl } from "@/utils/gravatar";
 import {
   createRateLimitMiddleware,
   publicProcedure,
@@ -35,7 +36,7 @@ function createParticipantFullDTO(
   const { votes, user, ...rest } = participant;
   return {
     ...rest,
-    image: user?.image ?? null,
+    image: user?.image ?? getGravatarUrl(rest.email),
     votes,
     hidden: false,
   };

--- a/apps/web/src/utils/gravatar.ts
+++ b/apps/web/src/utils/gravatar.ts
@@ -1,0 +1,18 @@
+import { createHash } from "node:crypto";
+
+/**
+ * Builds a Gravatar URL for an email address. Returns `null` when no email is
+ * provided. `d=404` makes Gravatar respond with a 404 when no avatar exists so
+ * the client falls back to initials.
+ */
+export function getGravatarUrl(email?: string | null) {
+  if (!email) {
+    return null;
+  }
+
+  const hash = createHash("sha256")
+    .update(email.trim().toLowerCase())
+    .digest("hex");
+
+  return `https://0.gravatar.com/avatar/${hash}?d=404&s=128&r=g`;
+}

--- a/packages/ui/src/avatar.tsx
+++ b/packages/ui/src/avatar.tsx
@@ -7,35 +7,38 @@ import type * as React from "react";
 
 import { cn } from "./lib/utils";
 
-const avatarVariants = cva("group/avatar relative flex shrink-0 select-none", {
-  variants: {
-    size: {
-      sm: "size-6",
-      default: "size-8",
-      lg: "size-10",
-      xl: "size-12",
+const avatarVariants = cva(
+  "group/avatar relative flex shrink-0 select-none overflow-hidden bg-muted",
+  {
+    variants: {
+      size: {
+        sm: "size-6",
+        default: "size-8",
+        lg: "size-10",
+        xl: "size-12",
+      },
+      shape: {
+        circle: "rounded-full",
+        square: "",
+      },
+      bordered: {
+        true: "after:absolute after:inset-0 after:rounded-[inherit] after:border after:border-border after:mix-blend-darken dark:after:mix-blend-lighten",
+        false: "",
+      },
     },
-    shape: {
-      circle: "rounded-full",
-      square: "",
-    },
-    bordered: {
-      true: "after:absolute after:inset-0 after:rounded-[inherit] after:border after:border-border after:mix-blend-darken dark:after:mix-blend-lighten",
-      false: "",
+    compoundVariants: [
+      { shape: "square", size: "sm", className: "rounded-md" },
+      { shape: "square", size: "default", className: "rounded-md" },
+      { shape: "square", size: "lg", className: "rounded-lg" },
+      { shape: "square", size: "xl", className: "rounded-lg" },
+    ],
+    defaultVariants: {
+      size: "default",
+      shape: "circle",
+      bordered: true,
     },
   },
-  compoundVariants: [
-    { shape: "square", size: "sm", className: "rounded-md" },
-    { shape: "square", size: "default", className: "rounded-md" },
-    { shape: "square", size: "lg", className: "rounded-lg" },
-    { shape: "square", size: "xl", className: "rounded-lg" },
-  ],
-  defaultVariants: {
-    size: "default",
-    shape: "circle",
-    bordered: true,
-  },
-});
+);
 
 function Avatar({
   className,
@@ -60,7 +63,7 @@ function AvatarImage({ className, ...props }: AvatarPrimitive.Image.Props) {
     <AvatarPrimitive.Image
       data-slot="avatar-image"
       className={cn(
-        "aspect-square size-full rounded-[inherit] object-cover",
+        "absolute inset-0 size-full rounded-[inherit] object-cover opacity-100 data-[ending-style]:opacity-0 data-[starting-style]:opacity-0",
         className,
       )}
       {...props}


### PR DESCRIPTION
## Summary

Two related changes, squashed into one commit.

### 1. Server-side gravatar fallback

Moves Gravatar URL generation off the client. Previously `OptimizedAvatarImage` hashed the participant's email with `crypto.subtle` inside a `useEffect`, which required shipping the raw email to the client just to compute a hash and caused a flash of initials before the async hash resolved.

The Gravatar URL is now computed server-side in the participant DTO as a fallback when a participant has no image, so the component simply renders `src`.

- **New util** `apps/web/src/utils/gravatar.ts` — `getGravatarUrl(email)` using `node:crypto`. Same SHA-256 / `d=404&s=128&r=g` format as before (404 → falls through to initials).
- **DTO computes the fallback** in `participants.ts` — `image: user?.image ?? getGravatarUrl(rest.email)`, preserving the old `src || gravatar` precedence across `list`, `add`, and `update`. The `hideParticipants` branch still nulls `image`, so no hash leaks for hidden participants.
- **Simplified `OptimizedAvatarImage`** — dropped the client-side hashing, the `useState`/`useEffect`, and the `email` prop.
- **Updated callers** that passed `email` (`participant-row`, `participant-row-form`, `poll-option`, `mobile-poll`).

### 2. Avatar rendering fixes

Feeding avatars a `src` that can 404 surfaced a difference between base-ui (which we migrated to in #2429) and Radix: base-ui mounts the `<img>` **while it is still loading**, so it coexists with the fallback, whereas Radix only mounts it once loaded. In our shadcn-derived layout the loading `<img>` (a `size-full` flex sibling) filled the box and pushed the fallback out, and a 404 briefly painted the browser's broken-image state.

Fixes in `packages/ui/src/avatar.tsx`:
- Overlay the image (`absolute inset-0`) so it never displaces the fallback.
- Keep it hidden (`opacity-0` while `data-starting-style` / `data-ending-style`) until it actually loads — fallback shows first, image appears on top only once it exists, and a 404 never paints a broken image.
- `overflow-hidden` on the root.

Net result matches Radix's "fallback until loaded" behavior, for every avatar in the app.

## Testing

- `pnpm type-check` passes
- `pnpm check` (Biome) passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)