### PR TITLE
🔒️ Disable Gravatar for self-hosted instances

### DIFF
--- a/apps/web/src/utils/gravatar.ts
+++ b/apps/web/src/utils/gravatar.ts
@@ -1,12 +1,15 @@
 import { createHash } from "node:crypto";
+import { isSelfHosted } from "@/utils/constants";
 
 /**
  * Builds a Gravatar URL for an email address. Returns `null` when no email is
- * provided. `d=404` makes Gravatar respond with a 404 when no avatar exists so
- * the client falls back to initials.
+ * provided, or for self-hosted instances — which often must keep personal data
+ * (email hashes, client IPs) within the EU, so we don't send anything to a
+ * third party there. `d=404` makes Gravatar respond with a 404 when no avatar
+ * exists so the client falls back to initials.
  */
 export function getGravatarUrl(email?: string | null) {
-  if (!email) {
+  if (!email || isSelfHosted) {
     return null;
   }
 


### PR DESCRIPTION
## Summary

Gravatar fetches happen in the visitor's browser and leak a **SHA-256 of the participant's email** plus the **client IP** to Automattic (US) on every avatar render. A hashed email is pseudonymous, not anonymous (re-identifiable via dictionary attacks / Gravatar's own email↔hash mapping), so it's personal data under GDPR — a problem for self-hosted instances that must keep data in the EU.

This skips Gravatar entirely when self-hosted (`isSelfHosted`). Those instances send nothing to a third party; avatars fall back to initials. No new config — it's tied to the existing self-hosted flag.

## Changes

- `apps/web/src/utils/gravatar.ts` — `getGravatarUrl` returns `null` when `isSelfHosted`.

## Notes

For context: Gravatar's avatar image endpoint is exempt from rate limits and serves `Cache-Control: max-age=300` on hits and 404s, so request volume was never the real concern — privacy / EU data residency is.

## Testing

- `tsc --noEmit` passes
- `biome check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Profile pictures from Gravatar are now disabled on self-hosted instances. Users on self-hosted deployments will no longer see Gravatar avatars.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->