### PR TITLE
🔧 Move local dev domains off rallly.co to avoid prod cookie conflicts

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -75,7 +75,7 @@ The following instructions are for running the project locally for development.
 
 6. Start the portless proxy
 
-   The dev scripts route the apps through [portless](https://portless.sh), which exposes them at stable HTTPS URLs (e.g. `https://web.local.rallly.co`) instead of `localhost:<port>`.
+   The dev scripts route the apps through [portless](https://portless.sh), which exposes them at stable HTTPS URLs (e.g. `https://web.rallly.test`) instead of `localhost:<port>`.
 
    Start the proxy:
 

--- a/apps/landing/.env.sample
+++ b/apps/landing/.env.sample
@@ -1,8 +1,8 @@
 # URL of the main web app
-NEXT_PUBLIC_APP_BASE_URL=http://web.local.rallly.co
+NEXT_PUBLIC_APP_BASE_URL=https://web.rallly.test
 
 # The base url where the landing page is accessible, including the scheme.
-NEXT_PUBLIC_BASE_URL=http://landing.local.rallly.co
+NEXT_PUBLIC_BASE_URL=https://landing.rallly.test
 
 # A connection string to your Postgres database
 DATABASE_URL=postgres://postgres:postgres@localhost:5450/rallly

--- a/apps/landing/next.config.ts
+++ b/apps/landing/next.config.ts
@@ -14,7 +14,7 @@ function createAppUrl(subpath: string) {
 
 const nextConfig: NextConfig = {
   cacheComponents: true,
-  allowedDevOrigins: ["landing.local.rallly.co"],
+  allowedDevOrigins: ["landing.rallly.test"],
   productionBrowserSourceMaps: true,
   transpilePackages: [
     "@rallly/ui",

--- a/apps/landing/package.json
+++ b/apps/landing/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "private": true,
   "scripts": {
-    "dev": "portless landing.local.rallly cross-env TAILWIND_MODE=watch next dev --turbopack",
+    "dev": "portless landing.rallly cross-env TAILWIND_MODE=watch next dev --turbopack",
     "build": "next build",
     "analyze": "cross-env ANALYZE=true next build",
     "start": "next start",

--- a/apps/web/.env.sample
+++ b/apps/web/.env.sample
@@ -4,7 +4,7 @@ SECRET_PASSWORD=
 
 # The base url where this instance is accessible, including the scheme.
 # Example: https://example.com
-NEXT_PUBLIC_BASE_URL=https://web.local.rallly.co
+NEXT_PUBLIC_BASE_URL=https://web.rallly.test
 
 # A connection string to your Postgres database
 DATABASE_URL=postgres://postgres:postgres@localhost:5450/rallly

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -12,7 +12,7 @@ const withBundleAnalyzer = createBundleAnalyzer({
 });
 
 const nextConfig: NextConfig = {
-  allowedDevOrigins: ["web.local.rallly.co"],
+  allowedDevOrigins: ["web.rallly.test"],
   experimental: {
     staleTimes: {
       dynamic: 60,

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "private": true,
   "scripts": {
-    "dev": "portless web.local.rallly next dev",
+    "dev": "portless web.rallly next dev",
     "build": "next build",
     "build:test": "NODE_ENV=test next build",
     "analyze": "cross-env ANALYZE=true next build",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "db:seed": "pnpm --filter @rallly/database exec prisma db seed",
     "db:push": "pnpm --filter @rallly/database exec prisma db push",
     "db:format": "pnpm --filter @rallly/database exec prisma format",
-    "proxy:start": "portless proxy start --tld co",
+    "proxy:start": "portless proxy start --tld test",
     "proxy:stop": "portless proxy stop",
     "docker:up": "docker compose -f docker-compose.dev.yml up -d --wait",
     "docker:pull": "docker compose -f docker-compose.dev.yml pull",


### PR DESCRIPTION
## Problem

Local dev ran at `web.local.rallly.co` / `landing.local.rallly.co` — subdomains of the production domain `rallly.co`. Production (`app.rallly.co`) sets cross-subdomain auth cookies scoped to `.rallly.co`. Because the local dev hosts are also under `.rallly.co`, the browser sends those prod cookies to the local dev server, colliding on identical cookie names and corrupting local sessions.

Separately, the portless proxy ran with `--tld co`, hijacking the real `.co` ccTLD locally.

## Fix

Move local dev off the `rallly.co` parent entirely, onto the IANA-reserved `.test` TLD:

| | Before | After |
|---|---|---|
| web app | `web.local.rallly.co` | `web.rallly.test` |
| landing | `landing.local.rallly.co` | `landing.rallly.test` |
| portless proxy | `--tld co` | `--tld test` |

`.test` is IANA-reserved (no collision risk, unlike `.co`) and is not a subdomain of `rallly.co`, so production's `.rallly.co` cookies are never sent to the local dev server.

Also bumped landing's sample env from `http://` to `https://` to match the portless TLS default and the web app's scheme.

## Applying locally

The portless proxy persists its TLD, so the running daemon must be restarted:

```bash
pnpm proxy:stop
portless hosts clean   # drop stale *.local.rallly.co /etc/hosts entries
pnpm proxy:start       # restarts with --tld test
pnpm dev
```

> If you later want to reproduce prod's cross-subdomain cookie behavior locally, set `NEXT_PUBLIC_COOKIE_DOMAIN=.rallly.test` — safe, since it can never match a real `.rallly.co` cookie.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated local development environment configuration to use `.rallly.test` domain instead of `.local.rallly.co` across all app configurations and scripts.
  * Updated proxy configuration to use `test` as the top-level domain.
  * Updated contributing documentation to reflect new development domain conventions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->