### PR TITLE
♻️ Centralize PostHog reset in signOut helper

### DIFF
--- a/apps/web/src/app/[locale]/accept-invite/[inviteId]/components/sign-out-button.tsx
+++ b/apps/web/src/app/[locale]/accept-invite/[inviteId]/components/sign-out-button.tsx
@@ -1,12 +1,13 @@
 "use client";
 
-import { posthog } from "@rallly/posthog/client";
 import { Button } from "@rallly/ui/button";
+import { useRouter } from "next/navigation";
 import React from "react";
 import { Trans } from "@/i18n/client";
 import { signOut } from "@/lib/auth-client";
 
 export function SignOutButton() {
+  const router = useRouter();
   const [isPending, setIsPending] = React.useState(false);
   return (
     <Button
@@ -15,7 +16,7 @@ export function SignOutButton() {
       onClick={async () => {
         setIsPending(true);
         await signOut();
-        posthog?.reset();
+        router.refresh();
       }}
     >
       <Trans

--- a/apps/web/src/app/[locale]/accept-invite/[inviteId]/components/sign-out-button.tsx
+++ b/apps/web/src/app/[locale]/accept-invite/[inviteId]/components/sign-out-button.tsx
@@ -15,8 +15,12 @@ export function SignOutButton() {
       loading={isPending}
       onClick={async () => {
         setIsPending(true);
-        await signOut();
-        router.refresh();
+        try {
+          await signOut();
+          router.refresh();
+        } finally {
+          setIsPending(false);
+        }
       }}
     >
       <Trans

--- a/apps/web/src/app/[locale]/e/[id]/components/user-dropdown.tsx
+++ b/apps/web/src/app/[locale]/e/[id]/components/user-dropdown.tsx
@@ -15,7 +15,7 @@ import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { OptimizedAvatarImage } from "@/components/optimized-avatar-image";
 import { Trans } from "@/i18n/client";
-import { authClient } from "@/lib/auth-client";
+import { signOut } from "@/lib/auth-client";
 
 export function UserDropdown({
   name,
@@ -69,7 +69,7 @@ export function UserDropdown({
         <DropdownMenuItem
           className="flex items-center gap-x-2"
           onClick={async () => {
-            await authClient.signOut();
+            await signOut();
             router.refresh();
           }}
         >

--- a/apps/web/src/app/[locale]/error.tsx
+++ b/apps/web/src/app/[locale]/error.tsx
@@ -10,7 +10,7 @@ import React from "react";
 import { ErrorPage, ErrorPageLinkItem } from "@/components/error-page";
 import { RouterLoadingIndicator } from "@/components/router-loading-indicator";
 import { Trans } from "@/i18n/client";
-import { authClient } from "@/lib/auth-client";
+import { signOut } from "@/lib/auth-client";
 import { INVALID_SESSION } from "@/lib/errors/invalid-session-error";
 
 export default function LocaleErrorBoundary({
@@ -25,12 +25,8 @@ export default function LocaleErrorBoundary({
 
   React.useEffect(() => {
     if (isInvalidSession) {
-      authClient.signOut({
-        fetchOptions: {
-          onSuccess: () => {
-            router.push("/login");
-          },
-        },
+      signOut().then(() => {
+        router.push("/login");
       });
       return;
     }

--- a/apps/web/src/app/[locale]/error.tsx
+++ b/apps/web/src/app/[locale]/error.tsx
@@ -25,7 +25,7 @@ export default function LocaleErrorBoundary({
 
   React.useEffect(() => {
     if (isInvalidSession) {
-      signOut().then(() => {
+      signOut().finally(() => {
         router.push("/login");
       });
       return;

--- a/apps/web/src/components/nav-user.tsx
+++ b/apps/web/src/components/nav-user.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { posthog } from "@rallly/posthog/client";
 import { Button } from "@rallly/ui/button";
 import {
   DropdownMenu,
@@ -28,6 +27,7 @@ import {
   UserIcon,
 } from "lucide-react";
 import Link from "next/link";
+import { useRouter } from "next/navigation";
 import React from "react";
 import { OptimizedAvatarImage } from "@/components/optimized-avatar-image";
 import { RouterLoadingIndicator } from "@/components/router-loading-indicator";
@@ -40,6 +40,7 @@ export function NavUser() {
   const { data: user } = trpc.user.getAuthed.useQuery();
   const [isPending, setIsPending] = React.useState(false);
   const { theme, setTheme } = useTheme();
+  const router = useRouter();
 
   if (!user) {
     return null;
@@ -125,7 +126,7 @@ export function NavUser() {
             onClick={async () => {
               setIsPending(true);
               await signOut();
-              posthog?.reset();
+              router.refresh();
             }}
           >
             <Icon>

--- a/apps/web/src/components/nav-user.tsx
+++ b/apps/web/src/components/nav-user.tsx
@@ -125,8 +125,12 @@ export function NavUser() {
           <DropdownMenuItem
             onClick={async () => {
               setIsPending(true);
-              await signOut();
-              router.refresh();
+              try {
+                await signOut();
+                router.refresh();
+              } finally {
+                setIsPending(false);
+              }
             }}
           >
             <Icon>

--- a/apps/web/src/components/user-dropdown.tsx
+++ b/apps/web/src/components/user-dropdown.tsx
@@ -1,5 +1,4 @@
 "use client";
-import { posthog } from "@rallly/posthog/client";
 import { buttonVariants, cn } from "@rallly/ui";
 import { Button } from "@rallly/ui/button";
 import {
@@ -30,6 +29,7 @@ import {
   UserIcon,
 } from "lucide-react";
 import Link from "next/link";
+import { useRouter } from "next/navigation";
 import { OptimizedAvatarImage } from "@/components/optimized-avatar-image";
 import { useUser } from "@/components/user-provider";
 import { useTheme } from "@/features/theme/client";
@@ -39,6 +39,7 @@ import { useFeatureFlag } from "@/lib/feature-flags/client";
 
 export const UserDropdown = ({ className }: { className?: string }) => {
   const { user } = useUser();
+  const router = useRouter();
   const { theme, setTheme } = useTheme();
 
   const isRegistrationEnabled = useFeatureFlag("registration");
@@ -162,7 +163,7 @@ export const UserDropdown = ({ className }: { className?: string }) => {
         <DropdownMenuItem
           onClick={async () => {
             await signOut();
-            posthog?.reset();
+            router.refresh();
           }}
           className="flex items-center gap-x-2"
         >

--- a/apps/web/src/lib/auth-client.ts
+++ b/apps/web/src/lib/auth-client.ts
@@ -1,3 +1,4 @@
+import { posthog } from "@rallly/posthog/client";
 import { absoluteUrl } from "@rallly/utils/absolute-url";
 import {
   anonymousClient,
@@ -22,5 +23,5 @@ export const authClient = createAuthClient({
 
 export async function signOut() {
   await authClient.signOut();
-  window.location.href = "/login";
+  posthog?.reset();
 }

--- a/apps/web/src/trpc/client/provider.tsx
+++ b/apps/web/src/trpc/client/provider.tsx
@@ -11,7 +11,7 @@ import { httpBatchLink, TRPCClientError } from "@trpc/client";
 import { useState } from "react";
 import superjson from "superjson";
 import { useTranslation } from "@/i18n/client";
-import { authClient } from "@/lib/auth-client";
+import { signOut } from "@/lib/auth-client";
 import { trpc } from "../client";
 import type { AppRouter } from "../routers";
 
@@ -29,7 +29,7 @@ export function TRPCProvider(props: { children: React.ReactNode }) {
 
       switch (error.data?.code) {
         case "UNAUTHORIZED":
-          authClient.signOut().finally(() => {
+          signOut().finally(() => {
             window.location.href = "/login";
           });
           break;


### PR DESCRIPTION
## Summary

Refactors sign-out handling so the shared `signOut()` helper is the single source of truth for sign-out side effects, and each caller decides how to navigate afterward.

- Move `posthog?.reset()` **into** the `signOut()` helper in `auth-client.ts` so call sites can't forget to reset analytics identity on sign out.
- Drop the hardcoded `window.location.href = "/login"` full-page redirect from the helper — navigation is now the caller's responsibility.
- Dropdown sign-out buttons (`nav-user`, `user-dropdown`, event-page `user-dropdown`, accept-invite `sign-out-button`) now use a soft `router.refresh()` instead of a full page reload.
- `error.tsx` invalid-session handler and the tRPC `UNAUTHORIZED` handler navigate explicitly after `signOut()`.
- Event-page `user-dropdown` switched from calling `authClient.signOut()` directly to the shared `signOut()` helper, so it now also resets PostHog.

## Test plan

- [x] `pnpm type-check` passes
- [x] `pnpm check` (Biome) passes
- [x] Manual: sign out from each entry point (nav user, user dropdown, event page, accept-invite, invalid-session error, expired session) and confirm redirect + analytics reset behave correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Streamlined sign-out across the app by routing all logout actions through a single sign-out helper.
  * Moved analytics/session reset into the centralized sign-out flow and removed analytics reset logic from UI components.
* **Bug Fixes**
  * Improved post-logout UI reliability by refreshing route state after sign-out completes.
  * Updated error and unauthorized handling to consistently sign out and then redirect to the login page.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->