### PR TITLE
🐛 Keep all-day poll options on the same date across timezones

### DIFF
--- a/apps/web/src/components/poll-context.test.ts
+++ b/apps/web/src/components/poll-context.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+
+import { createOptionsContextValue } from "./poll-context";
+
+// An all-day option is a floating date: "July 1" everywhere on Earth. It must
+// render as the same calendar date regardless of the poll timezone (source) or
+// the viewer timezone (target). Regression test for the bug where date options
+// were timezone-shifted, so a viewer in an earlier timezone saw the prior day.
+describe("createOptionsContextValue — all-day options are timezone-invariant", () => {
+  const allDayOption = {
+    id: "opt-1",
+    startTime: new Date("2026-07-01T00:00:00Z"),
+    duration: 0,
+  };
+
+  it.each([
+    ["America/Los_Angeles", "Europe/Berlin"], // viewer far behind source
+    ["Europe/Berlin", "America/Los_Angeles"], // viewer far ahead of source
+    ["Asia/Tokyo", "Europe/Berlin"],
+    ["UTC", "Europe/Berlin"],
+  ])("renders Jul 1 for target=%s, source=%s", (targetTimeZone, sourceTimeZone) => {
+    const result = createOptionsContextValue(
+      [allDayOption],
+      targetTimeZone,
+      sourceTimeZone,
+    );
+
+    expect(result.pollType).toBe("date");
+    expect(result.options[0]).toMatchObject({
+      type: "date",
+      day: "1",
+      month: "Jul",
+      year: "2026",
+    });
+  });
+
+  it("does not shift when the poll has no timezone", () => {
+    const result = createOptionsContextValue(
+      [allDayOption],
+      "America/Los_Angeles",
+      null,
+    );
+
+    expect(result.options[0]).toMatchObject({ day: "1", month: "Jul" });
+  });
+});

--- a/apps/web/src/components/poll-context.tsx
+++ b/apps/web/src/components/poll-context.tsx
@@ -130,7 +130,7 @@ export const useOptions = () => {
   return context;
 };
 
-function createOptionsContextValue(
+export function createOptionsContextValue(
   pollOptions: { id: string; startTime: Date; duration: number }[],
   targetTimeZone: string,
   sourceTimeZone: string | null,
@@ -175,9 +175,9 @@ function createOptionsContextValue(
     return {
       pollType: "date",
       options: pollOptions.map((option) => {
-        const localTime = sourceTimeZone
-          ? dayjs(option.startTime).tz(targetTimeZone)
-          : dayjs(option.startTime).utc();
+        // All-day options are floating dates: always read them in UTC so the
+        // calendar date is identical for every viewer, regardless of timezone.
+        const localTime = dayjs(option.startTime).utc();
 
         return {
           optionId: option.id,

--- a/apps/web/src/trpc/routers/polls.ts
+++ b/apps/web/src/trpc/routers/polls.ts
@@ -166,18 +166,23 @@ export const polls = router({
       const pollId = nanoid();
       const spaceId = activeSpace?.id;
 
+      // Date-only (all-day) polls are floating: they carry no timezone, so a
+      // falsy poll.timeZone is the single source of truth for "floating". Drop
+      // any timezone the client sent for a date-only poll so options are stored
+      // at UTC midnight and never shift across timezones.
+      const isTimePoll = input.options.some((option) => option.endDate);
+      const timeZone = isTimePoll ? input.timeZone : null;
+
       const optionsData = input.options.map((option) => ({
-        startTime: input.timeZone
-          ? dayjs(option.startDate).tz(input.timeZone, true).toDate()
+        startTime: timeZone
+          ? dayjs(option.startDate).tz(timeZone, true).toDate()
           : dayjs(option.startDate).utc(true).toDate(),
         duration: option.endDate
           ? dayjs(option.endDate).diff(dayjs(option.startDate), "minute")
           : 0,
       }));
 
-      const kind = optionsData.some((option) => option.duration > 0)
-        ? "time"
-        : "date";
+      const kind = isTimePoll ? "time" : "date";
 
       const poll = await prisma.poll.create({
         include: {
@@ -190,7 +195,7 @@ export const polls = router({
         data: {
           id: pollId,
           title,
-          timeZone: input.timeZone,
+          timeZone,
           location,
           description,
           adminUrlId: adminToken,
@@ -389,7 +394,9 @@ export const polls = router({
             title: input.title,
             location: input.location,
             description: input.description,
-            timeZone: input.timeZone,
+            // Date-only polls are floating: keep timeZone null so it stays the
+            // single source of truth for whether options are timezone-bound.
+            timeZone: kind === "time" ? input.timeZone : null,
             hideScores: input.hideScores,
             hideParticipants: input.hideParticipants,
             disableComments: input.disableComments,

--- a/packages/database/prisma/migrations/20260619150228_fix_all_day_option_timezone_shift/migration.sql
+++ b/packages/database/prisma/migrations/20260619150228_fix_all_day_option_timezone_shift/migration.sql
@@ -1,0 +1,76 @@
+-- Fix all-day (date-only) polls so they are timezone-invariant. The intended
+-- model is: a date-only poll carries NO timezone, so a falsy poll.time_zone is
+-- the single source of truth for "this is a floating date". Two things went
+-- wrong historically and both are repaired here:
+--
+--   1. Date-only polls ended up with a timezone, which made the UI convert
+--      their dates to each viewer's zone (a date picked as "Jul 1" rendered as
+--      "Jun 30" for an earlier-timezone viewer).
+--   2. Their option timestamps were stored with the creator's offset baked in
+--      (e.g. "Jul 1" in UTC+1 stored as 2026-06-30 23:00Z) instead of UTC
+--      midnight.
+--
+-- We must fix the timestamps BEFORE clearing the timezone: the offset is baked
+-- into start_time, so simply nulling the timezone would leave the stored value
+-- a day off (and regress the creator's own view). Recovery reinterprets the
+-- stored instant in the poll timezone to get the creator's intended local date,
+-- then snaps it to UTC midnight.
+--
+-- Guards: `::time <> '00:00:00'` targets only offset-baked rows and leaves
+-- already-correct (UTC-midnight) rows alone, keeping this idempotent. The
+-- pg_timezone_names check skips rows with a non-IANA timezone string so the
+-- migration cannot fail on bad data.
+--
+-- Preview (run before applying to size the blast radius):
+--   SELECT COUNT(*) FROM options o JOIN polls p ON p.id = o.poll_id
+--   WHERE o.duration_minutes = 0 AND p.time_zone IS NOT NULL
+--     AND o.start_time::time <> '00:00:00';
+--   SELECT COUNT(*) FROM polls p
+--   WHERE p.time_zone IS NOT NULL
+--     AND EXISTS (SELECT 1 FROM options o WHERE o.poll_id = p.id AND o.duration_minutes = 0)
+--     AND NOT EXISTS (SELECT 1 FROM options o WHERE o.poll_id = p.id AND o.duration_minutes > 0);
+
+-- 1. Snap offset-baked all-day OPTION timestamps to UTC midnight of the
+--    creator's intended date. Uses poll.time_zone, so it must run before step 3.
+UPDATE "options" o
+SET "start_time" = date_trunc(
+  'day',
+  (o."start_time" AT TIME ZONE 'UTC') AT TIME ZONE p."time_zone"
+)
+FROM "polls" p
+WHERE o."poll_id" = p."id"
+  AND o."duration_minutes" = 0
+  AND p."time_zone" IS NOT NULL
+  AND o."start_time"::time <> '00:00:00'
+  AND p."time_zone" IN (SELECT name FROM pg_timezone_names);
+
+-- 2. Same for all-day SCHEDULED EVENTS produced by finalizing those polls, so
+--    the scheduled banner and re-exported calendar invites land on the right
+--    date. Scoped to poll-linked events to stay within this bug's domain.
+UPDATE "scheduled_events" e
+SET
+  "start" = date_trunc(
+    'day',
+    (e."start" AT TIME ZONE 'UTC') AT TIME ZONE e."time_zone"
+  ),
+  "end" = date_trunc(
+    'day',
+    (e."end" AT TIME ZONE 'UTC') AT TIME ZONE e."time_zone"
+  )
+WHERE e."all_day" = true
+  AND e."time_zone" IS NOT NULL
+  AND e."start"::time <> '00:00:00'
+  AND e."time_zone" IN (SELECT name FROM pg_timezone_names)
+  AND EXISTS (SELECT 1 FROM "polls" p WHERE p."scheduled_event_id" = e."id");
+
+-- 3. Enforce the invariant: a date-only poll (has all-day options, no timed
+--    options) carries no timezone. Runs last so steps 1-2 can still read it.
+UPDATE "polls" p
+SET "time_zone" = NULL
+WHERE p."time_zone" IS NOT NULL
+  AND EXISTS (
+    SELECT 1 FROM "options" o WHERE o."poll_id" = p."id" AND o."duration_minutes" = 0
+  )
+  AND NOT EXISTS (
+    SELECT 1 FROM "options" o WHERE o."poll_id" = p."id" AND o."duration_minutes" > 0
+  );


### PR DESCRIPTION
Fixes #2467

## Problem

All-day (date-only) poll options were stored against the creator's timezone and then converted into each viewer's timezone on display. A date picked as **Jul 1** rendered as **Jun 30** for participants in an earlier timezone — the day-of-week shifted too. Reported on rallly.co with screenshots showing the same poll on two browsers a day apart.

An all-day option is a *floating date*: "July 1" everywhere on Earth. It must never be timezone-converted.

## Root cause

A date-only poll should carry **no timezone** — a falsy `poll.timeZone` is meant to be the single source of truth for "this option is floating". But the create flow attached the browser timezone to date polls anyway (~6.3k polls in prod), so every display site dutifully converted their dates to the viewer's zone. The option timestamps were also stored with the offset baked in (`Jul 1` in UTC+1 → `2026-06-30 23:00Z`) instead of UTC midnight.

## Fix

Enforce the invariant at the data layer instead of special-casing every display site:

- **`make` / `edit` mutations** drop the timezone for date-only polls (`isTimePoll ? input.timeZone : null`). Date options are then stored at UTC midnight and can never shift. Time polls are unchanged.
- **Poll grid** reads date options in UTC directly — defense in depth in the one function that already classifies date vs time options.
- The finalize dialog, scheduled-event banner, and finalize storage are **unchanged** — they already trust `poll.timeZone`, which is now reliably null for date polls.

## Data migration

`20260619150228_fix_all_day_option_timezone_shift` repairs existing data, in order:

1. Snap offset-baked all-day **option** timestamps to UTC midnight of the creator's intended date (using the old timezone — must run before step 3).
2. Same for poll-linked all-day **scheduled events** (`start`/`end`).
3. Null `time_zone` on date-only polls (has all-day options, no timed options).

Guards make it idempotent (`::time <> '00:00:00'` skips already-correct rows) and abort-proof (`pg_timezone_names` filter skips unparseable timezones without erroring). Verified against Postgres 18 across DST, fractional (+5:30, +5:45), negative, and far-positive offsets, plus a poison invalid-tz row.

### ⚠️ Pre-deploy steps (migration is irreversible)

1. **Snapshot the database first.** The migration overwrites `start_time` and nulls `time_zone` with no record of the originals.
2. **Run this diagnostic on prod** to confirm every affected poll uses a standard IANA zone:
   ```sql
   SELECT p.time_zone, count(DISTINCT p.id) AS polls
   FROM polls p
   JOIN options o ON o.poll_id = p.id
   WHERE o.duration_minutes = 0
     AND p.time_zone IS NOT NULL
     AND p.time_zone NOT LIKE '%/%'
   GROUP BY p.time_zone ORDER BY polls DESC;
   ```
   Empty (or only `UTC`/`GMT`) → clean, proceed. Anything else (`EST`, junk) → review first; abbreviation zones snap with a fixed offset and non-IANA junk is skipped.

**Out of scope:** mixed polls (both all-day and timed options) are forbidden by the form; the migration conservatively keeps their timezone and neither fixes nor worsens their pre-existing display behavior.

## Testing

- New regression test `poll-context.test.ts` — all-day options stay on the same date across source/target timezones (fails without the fix).
- `pnpm type-check`, `pnpm check`, and existing `ics.test.ts` pass.
- Migration SQL validated against the live Postgres 18 schema in a rolled-back transaction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed all-day polls to display consistently across different timezones. All-day options now render as their intended calendar date regardless of the viewer's timezone or poll creator's timezone settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->