### PR TITLE
🐛 Keep env validation out of the client bundle (fixes #2474)

### DIFF
--- a/apps/web/src/env.ts
+++ b/apps/web/src/env.ts
@@ -1,3 +1,8 @@
+// Keep this module out of client bundles: its runtime validation requires
+// `NEXT_PUBLIC_BASE_URL`, which self-hosted deployments set at runtime and is
+// therefore absent on the client. A client import here crashes those builds
+// (see issue #2474). Client code must read `process.env.NEXT_PUBLIC_*` directly.
+import "server-only";
 import { createEnv } from "@t3-oss/env-nextjs";
 import * as z from "zod";
 

--- a/apps/web/src/lib/locale/client.tsx
+++ b/apps/web/src/lib/locale/client.tsx
@@ -3,7 +3,6 @@ import { toast } from "@rallly/ui/sonner";
 import Cookies from "js-cookie";
 import { useParams, useRouter } from "next/navigation";
 import React from "react";
-import { env } from "@/env";
 import { useTranslation } from "@/i18n/client";
 import { LOCALE_COOKIE_NAME } from "@/lib/locale/constants";
 
@@ -38,7 +37,7 @@ export function LocaleSync({ userLocale }: { userLocale?: string }) {
 export function setLocaleCookie(locale: string) {
   Cookies.set(LOCALE_COOKIE_NAME, locale, {
     path: "/",
-    domain: env.NEXT_PUBLIC_COOKIE_DOMAIN,
+    domain: process.env.NEXT_PUBLIC_COOKIE_DOMAIN,
   });
 }
 

--- a/apps/web/src/utils/storage.ts
+++ b/apps/web/src/utils/storage.ts
@@ -1,5 +1,4 @@
 import { absoluteUrl } from "@rallly/utils/absolute-url";
-import { env } from "@/env";
 
 /**
  * Resolves a storage key to an absolute URL.
@@ -7,6 +6,12 @@ import { env } from "@/env";
  * 1. If the key is already an absolute URL (e.g. OAuth avatars) or a data URI → returned as-is.
  * 2. If `NEXT_PUBLIC_CDN_BASE_URL` is set → served directly from the CDN/bucket.
  * 3. Otherwise → proxied through `/api/storage/`.
+ *
+ * Reads `process.env` directly rather than the validated `env` object so this
+ * stays safe to import from client components (same pattern as absolute-url.ts).
+ * Importing `@/env` here pulls its client-side validation into the browser
+ * bundle, which crashes self-hosted builds where `NEXT_PUBLIC_BASE_URL` is set
+ * at runtime and is therefore absent on the client.
  */
 export function resolveStorageUrl(key: string): string {
   if (
@@ -19,8 +24,9 @@ export function resolveStorageUrl(key: string): string {
 
   const normalizedKey = key.replace(/^\/+/, "");
 
-  if (env.NEXT_PUBLIC_CDN_BASE_URL) {
-    const base = env.NEXT_PUBLIC_CDN_BASE_URL.replace(/\/+$/, "");
+  const cdnBaseUrl = process.env.NEXT_PUBLIC_CDN_BASE_URL;
+  if (cdnBaseUrl) {
+    const base = cdnBaseUrl.replace(/\/+$/, "");
     return `${base}/${normalizedKey}`;
   }
 


### PR DESCRIPTION
## Problem

Self-hosted instances on `lukevella/rallly:latest` crash on every page with a client-side `❌ Invalid environment variables … path: ["NEXT_PUBLIC_BASE_URL"]` error boundary. Pinning to `4.10` works. Reported in #2474.

## Root cause

The self-hosted Docker image builds with a plain `next build` and **no** `NEXT_PUBLIC_BASE_URL` — it's a runtime `-e` var set per self-hoster. `NEXT_PUBLIC_*` vars are inlined at build time; one image / many domains means it genuinely cannot be inlined, so on the **client** it is `undefined` (Next does not inject runtime `NEXT_PUBLIC_*` into client chunks for a standalone `next build` — verified identical on 16.2.1 and 16.2.6).

The app's [`env.ts`](apps/web/src/env.ts) declares `NEXT_PUBLIC_BASE_URL: z.url()` (**required**) in the `client` schema. `@t3-oss/env-nextjs` `createEnv` validates the client schema in the browser too, so the moment `env.ts` is evaluated client-side it throws.

At **v4.10.0 every importer of `@/env` was server-only**, so `createEnv` only ran on the server (where the runtime value exists) — no crash. Two changes since then pulled `env` into the **client** bundle:

1. `lib/locale/client.tsx` — a `"use client"` module added with `NEXT_PUBLIC_COOKIE_DOMAIN` that `import { env }` (matches the reporter's `client.tsx:6` ← `preferences.tsx:9` stack trace).
2. `utils/storage.ts` (`resolveStorageUrl`) — had 2 server-only importers at v4.10; now imported by 28 client components (avatars, event lists, …), dragging `env` into the browser graph.

It only affects self-hosted because cloud/Vercel builds **do** have `NEXT_PUBLIC_BASE_URL` at build time, so it's inlined and validation passes.

## Fix

- Read `process.env.NEXT_PUBLIC_*` directly in the two client-reachable modules (same pattern [`absolute-url.ts`](packages/utils/src/absolute-url.ts) already uses, with a `window.location.origin` fallback). This removes `createEnv` from the client bundle entirely.
- Add `import "server-only"` to `env.ts` so any **future** client import fails at build time instead of silently shipping the crash.

## Verification

Reproduced the broken build locally (env var absent at build, standalone server with the value set at runtime → served client chunk unchanged → `undefined` → throw). After the fix, a self-hosted build (`NEXT_PUBLIC_SELF_HOSTED=true`, no `NEXT_PUBLIC_BASE_URL`):

- `createEnv` / `env.ts` is **completely gone** from `.next/static` (0 occurrences of the validation error string).
- The only remaining client `NEXT_PUBLIC_BASE_URL` reference is the safe `absolute-url.ts` read (`?? window.location.origin`), which never throws — the client now derives its base URL from the real browser origin.
- `pnpm --filter @rallly/web type-check` and `biome check` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced application configuration handling to optimize bundle size and improve performance across server and client contexts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->