### PR TITLE
🗑️ Drop deprecated guest_id columns from polls, participants, comments

### DIFF
--- a/packages/database/prisma/migrations/20260620115022_drop_guest_id_columns/migration.sql
+++ b/packages/database/prisma/migrations/20260620115022_drop_guest_id_columns/migration.sql
@@ -1,0 +1,16 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `guest_id` on the `comments` table. All the data in the column will be lost.
+  - You are about to drop the column `guest_id` on the `participants` table. All the data in the column will be lost.
+  - You are about to drop the column `guest_id` on the `polls` table. All the data in the column will be lost.
+
+*/
+-- AlterTable
+ALTER TABLE "comments" DROP COLUMN "guest_id";
+
+-- AlterTable
+ALTER TABLE "participants" DROP COLUMN "guest_id";
+
+-- AlterTable
+ALTER TABLE "polls" DROP COLUMN "guest_id";

--- a/packages/database/prisma/models/poll.prisma
+++ b/packages/database/prisma/models/poll.prisma
@@ -31,7 +31,6 @@ model Poll {
   description             String?
   location                String?
   userId                  String?    @map("user_id")
-  guestId                 String?    @map("guest_id") // @deprecated - legacy NextAuth field, no longer used
   timeZone                String?    @map("time_zone")
   status                  PollStatus @default(open)
   kind                    PollKind   @default(date)
@@ -66,7 +65,6 @@ model Participant {
   name      String
   email     String?
   userId    String?   @map("user_id")
-  guestId   String?   @map("guest_id") // @deprecated - legacy NextAuth field, no longer used
   pollId    String    @map("poll_id")
   locale    String?
   timeZone  String?   @map("time_zone")
@@ -132,7 +130,6 @@ model Comment {
   pollId     String    @map("poll_id")
   authorName String    @map("author_name")
   userId     String?   @map("user_id")
-  guestId    String?   @map("guest_id") // @deprecated - legacy NextAuth field, no longer used
   createdAt  DateTime  @default(now()) @map("created_at")
   updatedAt  DateTime? @updatedAt @map("updated_at")
 


### PR DESCRIPTION
## Summary

Drops the deprecated `guest_id` column from the `Poll`, `Participant`, and `Comment` models. These are legacy NextAuth fields that have been dead data since next-auth was removed (#2230).

## Why it's safe

- **Zero code references** — grep for `guestId`/`guest_id` across all `.ts`/`.tsx` in `apps/` and `packages/` returns only the schema field definitions (now removed).
- **No indexes remain** — all three `guest_id` indexes were already dropped in prior migrations.
- **Functionally orphaned** — Better Auth tracks guests separately; nothing can match a current guest to an old NextAuth `guest_id`.

## Changes

- Removed `guestId` from `Poll`, `Participant`, `Comment` in `poll.prisma`
- Migration `20260620115022_drop_guest_id_columns`:

```sql
ALTER TABLE "comments" DROP COLUMN "guest_id";
ALTER TABLE "participants" DROP COLUMN "guest_id";
ALTER TABLE "polls" DROP COLUMN "guest_id";
```

## ⚠️ Irreversible

Dropping these columns permanently discards the legacy guest-ownership linkage. That linkage is already non-functional, so there's no behavioral loss — but confirm there's no plan to retroactively reclaim/migrate legacy guest polls before merging.

Closes RAL-1223

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed deprecated legacy authentication fields from the database schema to streamline data storage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->