### PR TITLE
💄 Replace OTP inputs with shadcn input-otp component

### DIFF
--- a/apps/web/src/app/[locale]/(auth)/components/auth-page.tsx
+++ b/apps/web/src/app/[locale]/(auth)/components/auth-page.tsx
@@ -2,7 +2,7 @@ import { Logo } from "@/components/logo";
 
 export function AuthPageContainer({ children }: { children: React.ReactNode }) {
   return (
-    <div className="space-y-8 lg:space-y-10">
+    <div className="space-y-8">
       <div className="mb-12 flex justify-center">
         <Logo />
       </div>

--- a/apps/web/src/app/[locale]/(auth)/login/verify/components/otp-form.tsx
+++ b/apps/web/src/app/[locale]/(auth)/login/verify/components/otp-form.tsx
@@ -15,10 +15,10 @@ import { useSearchParams } from "next/navigation";
 import { useForm } from "react-hook-form";
 import * as z from "zod";
 
+import { InputOTP } from "@/components/input-otp";
 import { Trans, useTranslation } from "@/i18n/client";
 import { authClient } from "@/lib/auth-client";
 import { validateRedirectUrl } from "@/utils/redirect";
-import { InputOTP } from "../../../../../../components/input-otp";
 
 const otpFormSchema = z.object({
   otp: z.string().length(6),
@@ -83,7 +83,10 @@ export function OTPForm({ email }: { email: string }) {
 
   return (
     <Form {...form}>
-      <form className="space-y-6" onSubmit={handleSubmit}>
+      <form
+        className="flex flex-col items-center space-y-6 text-center"
+        onSubmit={handleSubmit}
+      >
         <FormField
           control={form.control}
           name="otp"
@@ -92,8 +95,6 @@ export function OTPForm({ email }: { email: string }) {
               <FormItem>
                 <FormControl>
                   <InputOTP
-                    large
-                    placeholder={t("verificationCodePlaceholder")}
                     disabled={
                       form.formState.isSubmitting ||
                       form.formState.isSubmitSuccessful
@@ -105,7 +106,7 @@ export function OTPForm({ email }: { email: string }) {
                     {...field}
                   />
                 </FormControl>
-                <FormDescription>
+                <FormDescription className="mt-4">
                   <Trans i18nKey="verificationCodeHelp" />
                 </FormDescription>
                 <FormMessage />

--- a/apps/web/src/app/[locale]/(space)/settings/profile/profile-email-address.tsx
+++ b/apps/web/src/app/[locale]/(space)/settings/profile/profile-email-address.tsx
@@ -120,7 +120,6 @@ function VerifyEmailChangeForm({
               <FormItem>
                 <FormControl>
                   <InputOTP
-                    placeholder={t("verificationCodePlaceholder")}
                     disabled={form.formState.isSubmitting}
                     autoFocus={true}
                     onValidCode={() => {

--- a/apps/web/src/app/[locale]/e/[id]/components/rsvp-verify-email.tsx
+++ b/apps/web/src/app/[locale]/e/[id]/components/rsvp-verify-email.tsx
@@ -144,7 +144,6 @@ export function RsvpVerifyEmail({
                     <FormControl>
                       <InputOTP
                         autoFocus
-                        placeholder={t("verificationCodePlaceholder")}
                         disabled={form.formState.isSubmitting}
                         onValidCode={() => handleSubmit()}
                         {...field}

--- a/apps/web/src/app/[locale]/setup/page.tsx
+++ b/apps/web/src/app/[locale]/setup/page.tsx
@@ -18,7 +18,7 @@ export default async function SetupPage() {
   return (
     <div className="flex min-h-dvh justify-center bg-background p-4 sm:items-center">
       <div className="w-full max-w-sm">
-        <article className="space-y-8 lg:space-y-10">
+        <article className="space-y-8">
           <div className="flex justify-center py-8">
             <Logo />
           </div>

--- a/apps/web/src/components/input-otp.tsx
+++ b/apps/web/src/components/input-otp.tsx
@@ -1,30 +1,38 @@
-import { Input } from "@rallly/ui/input";
-import React from "react";
+"use client";
 
-const InputOTP = React.forwardRef<
-  HTMLInputElement,
-  React.ComponentProps<typeof Input> & { onValidCode?: (code: string) => void }
->(({ onValidCode, onChange, ...rest }, ref) => {
+import {
+  InputOTP as InputOTPBase,
+  InputOTPGroup,
+  InputOTPSlot,
+} from "@rallly/ui/input-otp";
+import type * as React from "react";
+
+type InputOTPProps = Omit<
+  React.ComponentProps<typeof InputOTPBase>,
+  "maxLength" | "pattern" | "children" | "render" | "onComplete"
+> & {
+  onValidCode?: (code: string) => void;
+};
+
+function InputOTP({ onValidCode, ...props }: InputOTPProps) {
   return (
-    <Input
-      ref={ref}
-      {...rest}
-      onChange={(e) => {
-        onChange?.(e);
-
-        if (e.target.value.length === 6) {
-          onValidCode?.(e.target.value);
-        }
-      }}
+    <InputOTPBase
       maxLength={6}
-      data-1p-ignore
       inputMode="numeric"
-      autoComplete="one-time-code"
       pattern="\d{6}"
-    />
+      onComplete={onValidCode}
+      {...props}
+    >
+      <InputOTPGroup>
+        <InputOTPSlot index={0} />
+        <InputOTPSlot index={1} />
+        <InputOTPSlot index={2} />
+        <InputOTPSlot index={3} />
+        <InputOTPSlot index={4} />
+        <InputOTPSlot index={5} />
+      </InputOTPGroup>
+    </InputOTPBase>
   );
-});
-
-InputOTP.displayName = "InputOTP";
+}
 
 export { InputOTP };

--- a/apps/web/src/components/input-otp.tsx
+++ b/apps/web/src/components/input-otp.tsx
@@ -4,8 +4,10 @@ import {
   InputOTP as InputOTPBase,
   InputOTPGroup,
   InputOTPSlot,
+  REGEXP_ONLY_DIGITS,
 } from "@rallly/ui/input-otp";
 import type * as React from "react";
+import { useTranslation } from "@/i18n/client";
 
 type InputOTPProps = Omit<
   React.ComponentProps<typeof InputOTPBase>,
@@ -15,11 +17,13 @@ type InputOTPProps = Omit<
 };
 
 function InputOTP({ onValidCode, ...props }: InputOTPProps) {
+  const { t } = useTranslation();
   return (
     <InputOTPBase
       maxLength={6}
       inputMode="numeric"
-      pattern="\d{6}"
+      pattern={REGEXP_ONLY_DIGITS}
+      aria-label={t("verificationCodePlaceholder")}
       onComplete={onValidCode}
       {...props}
     >

--- a/apps/web/tests/authentication.spec.ts
+++ b/apps/web/tests/authentication.spec.ts
@@ -60,7 +60,7 @@ test.describe.serial(() => {
 
       // The existing user should have received a sign-in OTP
       const code = await getCode(testUserEmail);
-      await page.getByPlaceholder("Enter your 6-digit code").fill(code);
+      await page.getByLabel("Enter your 6-digit code").fill(code);
 
       // Existing user should be signed in
       await expect(page.getByText("Test User")).toBeVisible();
@@ -97,7 +97,7 @@ test.describe.serial(() => {
 
       await page.getByRole("button", { name: "Login with email" }).click();
 
-      await page.getByPlaceholder("Enter your 6-digit code").fill("000000");
+      await page.getByLabel("Enter your 6-digit code").fill("000000");
 
       await expect(
         page.getByText("Your verification code is incorrect"),
@@ -119,7 +119,7 @@ test.describe.serial(() => {
 
       const code = await getCode(testUserEmail);
 
-      await page.getByPlaceholder("Enter your 6-digit code").fill(code);
+      await page.getByLabel("Enter your 6-digit code").fill(code);
 
       await expect(page.getByText("Test User")).toBeVisible();
     });

--- a/apps/web/tests/login-page.ts
+++ b/apps/web/tests/login-page.ts
@@ -31,7 +31,7 @@ export class LoginPage {
       await this.page
         .getByRole("heading", { name: "Finish Logging In" })
         .waitFor();
-      await this.page.getByPlaceholder("Enter your 6-digit code").fill(code);
+      await this.page.getByLabel("Enter your 6-digit code").fill(code);
     }
 
     // Wait for page to load

--- a/apps/web/tests/register-page.ts
+++ b/apps/web/tests/register-page.ts
@@ -36,7 +36,7 @@ export class RegisterPage {
     await this.page
       .getByRole("heading", { name: "Finish Logging In" })
       .waitFor();
-    await this.page.getByPlaceholder("Enter your 6-digit code").fill(code);
+    await this.page.getByLabel("Enter your 6-digit code").fill(code);
 
     // Verify successful registration
     await expect(this.page.getByText(name)).toBeVisible();

--- a/packages/tailwind-config/shared-styles.css
+++ b/packages/tailwind-config/shared-styles.css
@@ -172,6 +172,20 @@
   --ease-in-expo: cubic-bezier(0.68, -0.6, 0.32, 1.6);
   --ease-out-expo: cubic-bezier(0.19, 1, 0.22, 1);
 
+  --animate-caret-blink: caret-blink 1.25s ease-out infinite;
+
+  @keyframes caret-blink {
+    0%,
+    70%,
+    100% {
+      opacity: 1;
+    }
+    20%,
+    50% {
+      opacity: 0;
+    }
+  }
+
   --font-sans:
     var(--font-inter), ui-sans-serif, system-ui, sans-serif,
     "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";

--- a/packages/test-helpers/src/login.ts
+++ b/packages/test-helpers/src/login.ts
@@ -18,7 +18,7 @@ export async function loginWithEmail(
   } else {
     const code = await getCode(email);
     await page.getByRole("heading", { name: "Finish Logging In" }).waitFor();
-    await page.getByPlaceholder("Enter your 6-digit code").fill(code);
+    await page.getByLabel("Enter your 6-digit code").fill(code);
   }
 
   await page.waitForLoadState("networkidle");

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -43,6 +43,7 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^1.2.1",
     "cmdk": "^1.1.1",
+    "input-otp": "^1.4.2",
     "lucide-react": "^0.479.0",
     "next-themes": "^0.4.6",
     "react": "19.2.6",

--- a/packages/ui/src/input-otp.tsx
+++ b/packages/ui/src/input-otp.tsx
@@ -1,0 +1,84 @@
+"use client";
+
+import { OTPInput, OTPInputContext, REGEXP_ONLY_DIGITS } from "input-otp";
+import { MinusIcon } from "lucide-react";
+import * as React from "react";
+import { cn } from "./lib/utils";
+
+function InputOTP({
+  className,
+  containerClassName,
+  ...props
+}: React.ComponentProps<typeof OTPInput> & {
+  containerClassName?: string;
+}) {
+  return (
+    <OTPInput
+      data-slot="input-otp"
+      containerClassName={cn(
+        "flex items-center gap-2 has-disabled:opacity-50",
+        containerClassName,
+      )}
+      className={cn("disabled:cursor-not-allowed", className)}
+      {...props}
+    />
+  );
+}
+
+function InputOTPGroup({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="input-otp-group"
+      className={cn("flex items-center gap-2", className)}
+      {...props}
+    />
+  );
+}
+
+function InputOTPSlot({
+  index,
+  className,
+  ...props
+}: React.ComponentProps<"div"> & {
+  index: number;
+}) {
+  const inputOTPContext = React.useContext(OTPInputContext);
+  const { char, hasFakeCaret, isActive } = inputOTPContext?.slots[index] ?? {};
+
+  return (
+    <div
+      data-slot="input-otp-slot"
+      data-active={isActive}
+      className={cn(
+        "relative flex h-12 w-10 items-center justify-center rounded-lg border border-input bg-background/80 text-base shadow-xs outline-none transition-[color,box-shadow] dark:bg-foreground/5",
+        "data-[active=true]:z-10 data-[active=true]:border-ring data-[active=true]:ring-[3px] data-[active=true]:ring-ring/50",
+        "aria-invalid:border-destructive aria-invalid:ring-destructive/20 data-[active=true]:aria-invalid:border-destructive dark:aria-invalid:ring-destructive/40",
+        className,
+      )}
+      {...props}
+    >
+      {char}
+      {hasFakeCaret && (
+        <div className="pointer-events-none absolute inset-0 flex items-center justify-center">
+          <div className="h-5 w-px animate-caret-blink bg-foreground duration-1000" />
+        </div>
+      )}
+    </div>
+  );
+}
+
+function InputOTPSeparator({ ...props }: React.ComponentProps<"div">) {
+  return (
+    <div data-slot="input-otp-separator" aria-hidden="true" {...props}>
+      <MinusIcon />
+    </div>
+  );
+}
+
+export {
+  InputOTP,
+  InputOTPGroup,
+  InputOTPSeparator,
+  InputOTPSlot,
+  REGEXP_ONLY_DIGITS,
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -843,6 +843,9 @@ importers:
       cmdk:
         specifier: ^1.1.1
         version: 1.1.1(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      input-otp:
+        specifier: ^1.4.2
+        version: 1.4.2(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       lucide-react:
         specifier: ^0.479.0
         version: 0.479.0(react@19.2.6)
@@ -8296,6 +8299,12 @@ packages:
 
   inline-style-prefixer@7.0.1:
     resolution: {integrity: sha512-lhYo5qNTQp3EvSSp3sRvXMbVQTLrvGV6DycRMJ5dm2BLMiJ30wpXKdDdgX+GmJZ5uQMucwRKHamXSst3Sj/Giw==}
+
+  input-otp@1.4.2:
+    resolution: {integrity: sha512-l3jWwYNvrEa6NTCt7BECfCm48GvwuZzkoeG3gBL2w4CHeOXW3eKFmf9UNYkNfYc3mxMrthMnxjIE07MT0zLBQA==}
+    peerDependencies:
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc
 
   inquirer@12.3.0:
     resolution: {integrity: sha512-3NixUXq+hM8ezj2wc7wC37b32/rHq1MwNZDYdvx+d6jokOD+r+i8Q4Pkylh9tISYP114A128LCX8RKhopC5RfQ==}
@@ -20668,6 +20677,11 @@ snapshots:
   inline-style-prefixer@7.0.1:
     dependencies:
       css-in-js-utils: 3.1.0
+
+  input-otp@1.4.2(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
+    dependencies:
+      react: 19.2.6
+      react-dom: 19.2.6(react@19.2.6)
 
   inquirer@12.3.0(@types/node@24.10.11):
     dependencies:


### PR DESCRIPTION
## Summary

Installs the [shadcn `input-otp`](https://ui.shadcn.com/docs/components/base/input-otp) component (built on the [`input-otp`](https://github.com/guilhermerodz/input-otp) library) and replaces our custom single-field OTP input with the slotted, styled version across all three verification flows.

## Changes

- **New component** [`packages/ui/src/input-otp.tsx`](packages/ui/src/input-otp.tsx) — standard shadcn primitives (`InputOTP`, `InputOTPGroup`, `InputOTPSlot`, `InputOTPSeparator`). Slot styling is adapted to match the existing `Input` component (rounded-lg, `border-input`, `bg-background/80 dark:bg-foreground/5`, active `ring-[3px]`) so it fits the design system rather than the raw shadcn defaults.
- **Dependency** — added `input-otp@^1.4.2` to `@rallly/ui`.
- **Animation** — added the `caret-blink` keyframe + `--animate-caret-blink` to the shared Tailwind theme (`tailwindcss-animate` doesn't ship it, so the fake caret would otherwise be static).
- **App wrapper** [`apps/web/src/components/input-otp.tsx`](apps/web/src/components/input-otp.tsx) — rewritten as a thin wrapper composing the new slotted primitives (6 digit-only slots), preserving the existing `onValidCode` API (mapped to the library's `onComplete`).
- **Consumers updated** — login verify, RSVP verify-email, and profile email-change forms now use the slotted input; dropped the now-meaningless `large`/`placeholder` props, plus minor spacing polish on the auth/setup pages.

## Notes

- `REGEXP_ONLY_DIGITS` is re-exported from `@rallly/ui/input-otp` and consumed from there, keeping the `input-otp` dependency encapsulated in the UI package (the app doesn't declare it directly).
- `InputOTPSeparator` uses `aria-hidden` instead of `role="separator"` — the shadcn default trips biome a11y rules and `aria-hidden` is more correct for a decorative divider.

## Verification

- `pnpm type-check` passes for `@rallly/ui` and `@rallly/web`
- Biome clean on all changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Redesigned OTP input to display as 6 individual character slots for improved code entry experience
  * Added blinking caret animation for better visual feedback on OTP inputs

* **Bug Fixes**
  * Adjusted spacing on authentication pages for better responsive design

* **Tests**
  * Updated verification code tests to use label-based selectors instead of placeholders
<!-- end of auto-generated comment: release notes by coderabbit.ai -->