### PR TITLE
🧹 Add script to deactivate stale seat-update portal configs

### DIFF
--- a/packages/billing/package.json
+++ b/packages/billing/package.json
@@ -8,6 +8,7 @@
   },
   "scripts": {
     "checkout-expiry": "dotenv -e .env -- pnpx tsx ./src/scripts/checkout-expiry.ts",
+    "cleanup-portal-configurations": "dotenv -e .env -- pnpx tsx ./src/scripts/cleanup-portal-configurations.ts",
     "invoice-pending-prorations": "dotenv -e .env -- pnpx tsx ./src/scripts/invoice-pending-prorations.ts",
     "subscription-data-sync": "dotenv -e .env -- pnpx tsx ./src/scripts/subscription-data-sync.ts",
     "sync-payment-methods": "dotenv -e .env -- pnpx tsx ./src/scripts/sync-payment-methods.ts",

--- a/packages/billing/src/scripts/cleanup-portal-configurations.ts
+++ b/packages/billing/src/scripts/cleanup-portal-configurations.ts
@@ -1,0 +1,92 @@
+import { stripe } from "../lib/stripe";
+
+/**
+ * `createQuantityUpdatePortalConfiguration()` (apps/web/src/features/billing/utils.ts)
+ * creates a brand-new billing portal configuration on every seat-update session
+ * and never reuses it, so the Stripe account accumulates throwaway config objects.
+ *
+ * Stripe has no API to DELETE a portal configuration — the only cleanup available
+ * is to deactivate it (`active: false`). This script does that for the stale
+ * seat-update configs, identified by the headline they were created with so it
+ * never touches a manually-configured or default portal.
+ *
+ * Note: this only stops the bleeding for what already exists. The real fix is to
+ * cache/reuse a single configuration instead of creating one per session.
+ *
+ * DRY RUN by default — lists what would be deactivated and changes nothing.
+ * Pass --apply to deactivate.
+ *
+ * Usage:
+ *   pnpm --filter @rallly/billing cleanup-portal-configurations
+ *   pnpm --filter @rallly/billing cleanup-portal-configurations -- --apply
+ */
+
+// Must match the headline set in createQuantityUpdatePortalConfiguration().
+const SEAT_UPDATE_HEADLINE = "Update your seat allocation";
+
+(async function cleanupPortalConfigurations() {
+  const apply = process.argv.slice(2).includes("--apply");
+
+  console.info(
+    apply
+      ? "⚠️  APPLY mode — matching configurations will be deactivated."
+      : "🔍 DRY RUN — nothing will change. Pass --apply to deactivate.",
+  );
+
+  const stale: { id: string; created: Date }[] = [];
+  let scanned = 0;
+
+  for await (const config of stripe.billingPortal.configurations.list({
+    limit: 100,
+  })) {
+    scanned++;
+
+    if (config.business_profile?.headline !== SEAT_UPDATE_HEADLINE) continue;
+    if (config.is_default) continue; // can't deactivate the default, and never should
+    if (!config.active) continue; // already inactive
+
+    stale.push({ id: config.id, created: new Date(config.created * 1000) });
+  }
+
+  console.info(
+    `\nScanned ${scanned} configuration(s); ${stale.length} active seat-update config(s) to deactivate.\n`,
+  );
+
+  if (stale.length === 0) {
+    console.info("✅ Nothing to clean up.");
+    return;
+  }
+
+  for (const config of stale) {
+    console.info(
+      `• ${config.id} (created ${config.created.toISOString().slice(0, 10)})`,
+    );
+  }
+
+  if (!apply) {
+    console.info(
+      "\n🔍 Dry run complete. Re-run with --apply to deactivate these configurations.",
+    );
+    return;
+  }
+
+  console.info("\n⚠️  Deactivating...\n");
+  let deactivated = 0;
+  let failed = 0;
+
+  for (const config of stale) {
+    try {
+      await stripe.billingPortal.configurations.update(config.id, {
+        active: false,
+      });
+      deactivated++;
+    } catch (error) {
+      console.error(
+        `❌ ${config.id}: ${error instanceof Error ? error.message : error}`,
+      );
+      failed++;
+    }
+  }
+
+  console.info(`\n📊 Done: ${deactivated} deactivated, ${failed} failed.`);
+})();


### PR DESCRIPTION
## Context

Follow-up to #2481. `createQuantityUpdatePortalConfiguration()` ([apps/web/src/features/billing/utils.ts](apps/web/src/features/billing/utils.ts)) creates a **new** Stripe billing portal configuration on every seat-update session and never reuses it, so the account slowly accumulates throwaway config objects.

## What this adds

A dry-run-by-default script [`packages/billing/src/scripts/cleanup-portal-configurations.ts`](packages/billing/src/scripts/cleanup-portal-configurations.ts) that finds the stale seat-update configs and deactivates them.

```bash
# Dry run — lists what would be deactivated; changes nothing
pnpm --filter @rallly/billing cleanup-portal-configurations

# Deactivate them
pnpm --filter @rallly/billing cleanup-portal-configurations -- --apply
```

## Important caveats

- **Deactivate, not delete.** Stripe has **no delete endpoint** for billing portal configurations. The only cleanup possible is `active: false` — the objects remain in the account, just inactive. The script and its naming reflect this.
- **Targeted matching.** Only configs whose `business_profile.headline` equals `"Update your seat allocation"` are touched, and the default config is always skipped — so a manually-configured or default portal can't be affected. The headline constant must stay in sync with the one in `utils.ts`.
- **This is hygiene, not a fix.** Leaving the configs causes no billing or functional harm. The actual root-cause fix is to cache/reuse a single configuration instead of creating one per session — a separate change, not done here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added a new `cleanup-portal-configurations` script for managing Stripe Billing Portal configurations, which runs in dry-run mode by default and supports an `--apply` flag to execute permanent changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->