### PR TITLE
🔧 Disable caching for i18n:scan task

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -54,8 +54,7 @@
       "persistent": true
     },
     "i18n:scan": {
-      "inputs": ["src/**", "i18next-scanner.config.js"],
-      "outputs": ["public/locales/**", "locales/**"]
+      "cache": false
     },
     "//#check": {},
     "//#check:fix": {


### PR DESCRIPTION
## Summary
- Disable Turbo caching for the `i18n:scan` task so the scan always runs fresh instead of restoring a cached result.

## Why
The scan should always execute against the current source. With caching on, Turbo could restore stale locale output and mask newly added translation keys. Dropped the now-moot `inputs`/`outputs` entries since they only feed cache key computation and output restoration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build configuration for improved caching behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->