### PR TITLE
♻️ Convert space setActive to a server action

### DIFF
--- a/apps/web/src/features/space/actions.ts
+++ b/apps/web/src/features/space/actions.ts
@@ -1,0 +1,45 @@
+"use server";
+
+import { prisma } from "@rallly/database";
+import * as z from "zod";
+import { posthog } from "@/features/analytics/posthog";
+import { setActiveSpace } from "@/features/user/mutations";
+import { AppError } from "@/lib/errors";
+import { authActionClient } from "@/lib/safe-action/server";
+
+export const setActiveSpaceAction = authActionClient
+  .metadata({ actionName: "set_active_space" })
+  .inputSchema(z.object({ spaceId: z.string() }))
+  .action(async ({ ctx, parsedInput }) => {
+    const member = await prisma.spaceMember.findUnique({
+      where: {
+        spaceId_userId: {
+          spaceId: parsedInput.spaceId,
+          userId: ctx.user.id,
+        },
+      },
+    });
+
+    if (!member) {
+      throw new AppError({
+        code: "NOT_FOUND",
+        message: "Space not found",
+      });
+    }
+
+    await setActiveSpace({
+      userId: ctx.user.id,
+      spaceId: parsedInput.spaceId,
+    });
+
+    posthog()?.capture({
+      distinctId: ctx.user.id,
+      event: "space_set_active",
+      properties: {
+        space_id: parsedInput.spaceId,
+      },
+      groups: {
+        space: parsedInput.spaceId,
+      },
+    });
+  });

--- a/apps/web/src/features/space/components/space-dropdown.tsx
+++ b/apps/web/src/features/space/components/space-dropdown.tsx
@@ -21,8 +21,10 @@ import {
   UserPlusIcon,
 } from "lucide-react";
 import Link from "next/link";
+import { setActiveSpaceAction } from "@/features/space/actions";
 import { SpaceTierLabel } from "@/features/space/components/space-tier";
 import { Trans } from "@/i18n/client";
+import { useSafeAction } from "@/lib/safe-action/client";
 import { trpc } from "@/trpc/client";
 import { CreateSpaceDialog } from "./create-space-dialog";
 import { SpaceIcon } from "./space-icon";
@@ -31,7 +33,12 @@ export function SpaceDropdown() {
   const { data: spaces = [] } = trpc.spaces.list.useQuery();
   const { data: activeSpace } = trpc.spaces.getCurrent.useQuery();
 
-  const setActiveSpace = trpc.spaces.setActive.useMutation();
+  const utils = trpc.useUtils();
+  const setActiveSpace = useSafeAction(setActiveSpaceAction, {
+    onSuccess: () => {
+      utils.spaces.getCurrent.invalidate();
+    },
+  });
   const newSpaceDialog = useDialog();
 
   if (!activeSpace) {
@@ -47,7 +54,7 @@ export function SpaceDropdown() {
         <DropdownMenuTrigger asChild={true}>
           <Button
             className={cn("flex h-auto w-full gap-2.5 p-2", {
-              "pointer-events-none animate-pulse": setActiveSpace.isPending,
+              "pointer-events-none animate-pulse": setActiveSpace.isExecuting,
             })}
             variant="ghost"
           >
@@ -80,7 +87,7 @@ export function SpaceDropdown() {
             value={selectedSpaceId}
             onValueChange={(value) => {
               if (value === selectedSpaceId) return;
-              setActiveSpace.mutate({ spaceId: value });
+              setActiveSpace.execute({ spaceId: value });
             }}
           >
             {spaces.map((space) => (

--- a/apps/web/src/trpc/routers/spaces.ts
+++ b/apps/web/src/trpc/routers/spaces.ts
@@ -155,42 +155,6 @@ export const spaces = router({
   }),
 
   // ── Mutations ────────────────────────────────────────────────────────
-  setActive: privateProcedure
-    .input(z.object({ spaceId: z.string() }))
-    .mutation(async ({ ctx, input }) => {
-      const member = await prisma.spaceMember.findUnique({
-        where: {
-          spaceId_userId: {
-            spaceId: input.spaceId,
-            userId: ctx.user.id,
-          },
-        },
-      });
-
-      if (!member) {
-        throw new TRPCError({
-          code: "NOT_FOUND",
-          message: "Space not found",
-        });
-      }
-
-      await setActiveSpace({
-        userId: ctx.user.id,
-        spaceId: input.spaceId,
-      });
-
-      posthog()?.capture({
-        distinctId: ctx.user.id,
-        event: "space_set_active",
-        properties: {
-          space_id: input.spaceId,
-        },
-        groups: {
-          space: input.spaceId,
-        },
-      });
-    }),
-
   create: privateProcedure
     .use(createRateLimitMiddleware("space_create", 5, "1 m"))
     .input(z.object({ name: z.string().min(1).max(100) }))


### PR DESCRIPTION
## What

Migrates the space dropdown's active-space switch from the tRPC `spaces.setActive` mutation to a `setActiveSpaceAction` server action.

## Why

Aligns with the project direction of keeping tRPC queries-only and moving writes to server actions that call `features/*/mutations.ts`.

## Changes

- **New `features/space/actions.ts`** — `setActiveSpaceAction` (`authActionClient`), preserving the original logic: membership check (now `AppError` `NOT_FOUND`), `setActiveSpace()` call, and the `space_set_active` PostHog capture.
- **`space-dropdown.tsx`** — `useMutation()` → `useSafeAction(setActiveSpaceAction)`; `.mutate()`/`.isPending` → `.execute()`/`.isExecuting`. Added `onSuccess` to invalidate the `spaces.getCurrent` query. `useSafeAction` already calls `router.refresh()` (refreshing the server-rendered dashboard layout that reads the active space server-side); the added invalidation refreshes the client `getCurrent` query so the radio checkmark reflects the new selection — the old mutation did neither.
- **`spaces.ts`** — removed the now-unused `setActive` procedure. The `setActiveSpace` import stays (still used by `acceptInvite`).

The `spaces.list` / `spaces.getCurrent` queries remain on tRPC.

## Verification

- `tsc --noEmit` on `apps/web`: pass
- `biome check` on changed files: pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Switching spaces now uses a dedicated server action, improving the active-space update flow.

* **Bug Fixes**
  * Added a membership check before changing the active space, so users can only select spaces they belong to.
  * The current space view now refreshes automatically after a successful switch.

* **Chores**
  * Removed the older space-switching path in favor of the new implementation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->