### PR TITLE
🐛 Enforce minimum one option on poll create/edit server-side

### DIFF
--- a/apps/web/src/trpc/routers/polls.ts
+++ b/apps/web/src/trpc/routers/polls.ts
@@ -110,7 +110,8 @@ export const polls = router({
             startDate: z.string(),
             endDate: z.string().optional(),
           })
-          .array(),
+          .array()
+          .min(1),
       }),
     )
     .use(requireUserMiddleware)
@@ -376,6 +377,14 @@ export const polls = router({
                 };
               }
             }),
+          });
+        }
+
+        const remainingOptions = await tx.option.count({ where: { pollId } });
+        if (remainingOptions === 0) {
+          throw new TRPCError({
+            code: "BAD_REQUEST",
+            message: "A poll must have at least one option",
           });
         }
 


### PR DESCRIPTION
## Problem

We have polls in production with zero options. `PollOptionsForm` enforces `options.length > 0`, but that validation is **client-side only** — the server mutations never re-checked it, so the database (the real source of truth) had no guard.

Any request that bypasses the React form is accepted today:
- a stale/cached client running old JS
- a programmatic/scripted tRPC call or integration
- browser tooling

`polls.modify` does delete-then-add in a transaction with two optional, no-minimum arrays (`optionsToDelete`, `optionsToAdd`). If all options are deleted and none added, it commits a zero-option poll. `polls.make` similarly accepted an empty `options` array.

## Fix

- **`polls.make`**: require at least one option via `.min(1)` on the options schema.
- **`polls.modify`**: count options inside the transaction after the delete/add and throw `BAD_REQUEST` if none remain. The throw rolls back the transaction, so the delete is undone.

The client-side rule stays as UX; this just makes the server authoritative.

## Out of scope

Remediating **existing** zero-option polls (delete or flag) — tracked separately.

Closes RAL-1235

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Poll creation now requires at least one option.
  * Poll updates now prevent saving a poll with no remaining options after edits.
  * Improved validation to reject invalid poll states before they are saved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->