### PR TITLE
✨ Auto-close polls with all dates in the past

### DIFF
--- a/apps/web/src/app/api/house-keeping/[...method]/route.ts
+++ b/apps/web/src/app/api/house-keeping/[...method]/route.ts
@@ -76,6 +76,41 @@ app.get("/delete-inactive-polls", async (c) => {
 });
 
 /**
+ * Closes polls whose options have all ended — i.e. no option ends in the
+ * future, where an option ends at start_time + duration (all-day options, with
+ * duration 0, are treated as ending 24h after their start). Closing is
+ * non-destructive: the poll becomes read-only but is preserved.
+ *
+ * Raw SQL because the option-end comparison (start_time + duration) can't be
+ * expressed in a Prisma `where`. It also deliberately does not touch
+ * `updated_at`, so closing a poll doesn't reset the inactivity clock that
+ * delete-inactive-polls keys off.
+ */
+app.get("/auto-close-polls", async (c) => {
+  const closed = await prisma.$executeRaw`
+    UPDATE polls p
+    SET status = 'closed'
+    WHERE p.status = 'open'
+      AND p.deleted = false
+      AND EXISTS (SELECT 1 FROM options o WHERE o.poll_id = p.id)
+      AND NOT EXISTS (
+        SELECT 1 FROM options o
+        WHERE o.poll_id = p.id
+          AND o.start_time + (CASE WHEN o.duration_minutes = 0
+                THEN interval '24 hours'
+                ELSE make_interval(mins => o.duration_minutes) END) > (now() AT TIME ZONE 'UTC')
+      )
+  `;
+
+  return c.json({
+    success: true,
+    summary: {
+      closed,
+    },
+  });
+});
+
+/**
  * Remove polls and corresponding data that have been marked deleted for more than 7 days.
  */
 app.get("/remove-deleted-polls", async (c) => {

--- a/apps/web/vercel.json
+++ b/apps/web/vercel.json
@@ -3,6 +3,10 @@
   "buildCommand": "cd ../.. && pnpm build:web && pnpm db:deploy",
   "crons": [
     {
+      "path": "/api/house-keeping/auto-close-polls",
+      "schedule": "30 5 * * *"
+    },
+    {
       "path": "/api/house-keeping/delete-inactive-polls",
       "schedule": "0 6 * * *"
     },


### PR DESCRIPTION
Closes [RAL-1234](https://linear.app/rallly/issue/RAL-1234/auto-close-polls-with-all-dates-in-the-past).

## What

Adds a house-keeping cron, `GET /api/house-keeping/auto-close-polls`, that closes a poll once **every option has ended** — no option ends in the future, where an option ends at `start_time + duration` (all-day options, `duration = 0`, are treated as ending 24h after their start).

Registered in `apps/web/vercel.json` to run **daily at 05:30**, just before `delete-inactive-polls` (06:00), so the lifecycle reads cleanly: close → eventually delete.

## How / why these choices

- **Non-destructive.** Sets `status = closed` (reusing the existing `PollStatus.closed` — no schema change). The poll stays viewable read-only; it is not deleted or hidden. `closed` is already a first-class, host-facing state (manual close), so nothing new to render.
- **Raw SQL (`$executeRaw`).** The option-end comparison (`start_time + duration < now`) can't be expressed in a Prisma `where`. The `NOT EXISTS` form gates on whichever option ends *last*, so a poll with an early-but-long option isn't closed prematurely.
- **Leaves `updated_at` untouched.** `delete-inactive-polls` keys off `updatedAt < 30 days ago`; raw SQL doesn't bump it, so closing a poll doesn't reset its inactivity clock. (A Prisma `updateMany` would auto-bump `@updatedAt` — another reason for raw SQL.)
- **All tiers.** Unlike `delete-inactive-polls` (which spares Pro), this is only a lifecycle state change, so it applies to everyone.
- **`now() AT TIME ZONE 'UTC'`** because `start_time` is stored as a UTC-naive timestamp.

## Backlog

The one-time backfill of the existing ~14k+ stale polls was handled separately (RAL-1236) and has already been run. This cron only needs to keep up with the small forward trickle, so a single `UPDATE` per run is sufficient.

## Notes / not included

- No automated test — the existing house-keeping routes have none, and this is a raw-SQL DB op. Verified the predicate against prod data (a poll matched by the predicate that still has a future option returns 0).
- Follow-ups tracked on RAL-1234, intentionally out of scope: pre-expiry nudge email, an "add new dates"/reopen path so a closed poll isn't a dead end, and optionally distinguishing auto- from manually-closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic closing for polls that have expired and are still open.
  * Scheduled the system to run this cleanup daily, helping keep poll status up to date.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->