### PR TITLE
📝 Log results of each house-keeping task

### DIFF
--- a/apps/web/src/app/api/house-keeping/[...method]/route.ts
+++ b/apps/web/src/app/api/house-keeping/[...method]/route.ts
@@ -1,9 +1,12 @@
 import { prisma } from "@rallly/database";
+import { createLogger } from "@rallly/logger";
 import { Hono } from "hono";
 import { bearerAuth } from "hono/bearer-auth";
 import { handle } from "hono/vercel";
 
 const BATCH_SIZE = 100;
+
+const logger = createLogger("api/house-keeping");
 
 const app = new Hono().basePath("/api/house-keeping");
 
@@ -11,6 +14,8 @@ app.use("*", async (c, next) => {
   if (process.env.CRON_SECRET) {
     return bearerAuth({ token: process.env.CRON_SECRET })(c, next);
   }
+
+  logger.error("CRON_SECRET is not set in environment variables");
 
   return c.json(
     {
@@ -67,6 +72,11 @@ app.get("/delete-inactive-polls", async (c) => {
     },
   });
 
+  logger.info(
+    { task: "delete-inactive-polls", markedDeleted },
+    "Marked inactive polls as deleted",
+  );
+
   return c.json({
     success: true,
     summary: {
@@ -101,6 +111,11 @@ app.get("/auto-close-polls", async (c) => {
                 ELSE make_interval(mins => o.duration_minutes) END) > (now() AT TIME ZONE 'UTC')
       )
   `;
+
+  logger.info(
+    { task: "auto-close-polls", closed },
+    "Closed polls with all options ended",
+  );
 
   return c.json({
     success: true,
@@ -145,6 +160,11 @@ app.get("/remove-deleted-polls", async (c) => {
 
     totalDeletedPolls += deleted.count;
   }
+
+  logger.info(
+    { task: "remove-deleted-polls", deletedPolls: totalDeletedPolls },
+    "Removed polls marked deleted over 7 days ago",
+  );
 
   return c.json({
     success: true,


### PR DESCRIPTION
## Summary

Adds structured logging to the house-keeping cron endpoints so each run is observable in the logs.

- Emits a single wide event per handler — `delete-inactive-polls`, `auto-close-polls`, `remove-deleted-polls` — tagged with the `task` name and its result count.
- Logs an error when `CRON_SECRET` is unset (previously this only returned a 500 with no log trail).

Follows the project's Pino wide-event convention (`logger.info({ ...fields }, "message")` — one structured event per request, counts as queryable fields rather than interpolated into the message string).

## Test plan

- [ ] Trigger each house-keeping endpoint and confirm a single info event is emitted with the expected `task` and count fields.
- [ ] Unset `CRON_SECRET` and confirm the error is logged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved logging for housekeeping tasks, making failures and task outcomes easier to trace.
  * Added clearer error logging when required scheduled-task configuration is missing, while keeping the same user-facing API responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->