### PR TITLE
♿️ Re-enable mobile pinch-zoom (WCAG 1.4.4)

### DIFF
--- a/apps/web/src/app/[locale]/layout.tsx
+++ b/apps/web/src/app/[locale]/layout.tsx
@@ -27,7 +27,6 @@ const inter = Inter({
 export const viewport: Viewport = {
   width: "device-width",
   initialScale: 1,
-  maximumScale: 1,
 };
 
 async function loadData(locale: string) {


### PR DESCRIPTION
## What

Removes `maximumScale: 1` from the viewport config in `apps/web/src/app/[locale]/layout.tsx`.

```diff
 export const viewport: Viewport = {
   width: "device-width",
   initialScale: 1,
-  maximumScale: 1,
 };
```

## Why

`maximum-scale=1` disables pinch-to-zoom on mobile browsers, which fails **WCAG 2.1 SC 1.4.4 (Resize Text)** — flagged as the only "Does Not Support" finding in the draft ACR. This is the trivial-effort quick win from RAL-1233.

## Scope

One of three independent "quick win" PRs for RAL-1233 (accessibility / VPAT 2.5 remediation). No `userScalable: false` exists in the codebase; this single line was the only suppression.

Part of RAL-1233.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved mobile viewport behavior by allowing users to adjust zoom more freely on supported devices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->