### PR TITLE
♿️ Darken muted text for AA contrast (WCAG 1.4.3)

### DIFF
--- a/packages/tailwind-config/shared-styles.css
+++ b/packages/tailwind-config/shared-styles.css
@@ -39,7 +39,7 @@
   --action-bar-foreground: var(--color-gray-100);
 
   --muted: var(--color-gray-100);
-  --muted-foreground: var(--color-gray-500);
+  --muted-foreground: var(--color-gray-600);
   --muted-border: var(--color-gray-200);
 
   --popover: var(--color-white);


### PR DESCRIPTION
## What

Bumps the light-mode `--muted-foreground` token one step, zinc-500 → zinc-600, in `packages/tailwind-config/shared-styles.css`.

```diff
 --muted: var(--color-gray-100);
-  --muted-foreground: var(--color-gray-500);
+  --muted-foreground: var(--color-gray-600);
```

## Why

Muted secondary text (zinc-500 `#71717a`) on muted backgrounds (zinc-100 `#f4f4f5`) measured **≈4.49:1**, marginally below the 4.5:1 minimum for **WCAG 2.1 SC 1.4.3 (Contrast Minimum)**. axe flagged 7 such nodes on the voting page (e.g. avatar initials). zinc-600 on zinc-100 measures ≈7:1.

Dark mode (`--muted-foreground: zinc-400`) is unchanged.

## Follow-up

ACR calls for re-running axe to confirm; the temporary Playwright/axe scaffolding was removed from the tree, so that re-run is tracked under the RAL-1233 verification step rather than blocking this token change.

## Scope

One of three independent "quick win" PRs for RAL-1233 (accessibility / VPAT 2.5 remediation).

Part of RAL-1233.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted the default muted text color to a slightly darker gray for better readability across the app.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->