### PR TITLE
♿️ Increase light-mode focus ring contrast (WCAG 2.4.7)

### DIFF
--- a/packages/tailwind-config/shared-styles.css
+++ b/packages/tailwind-config/shared-styles.css
@@ -22,7 +22,7 @@
   --input: var(--color-gray-200);
   --input-foreground: var(--color-gray-800);
 
-  --ring: #d1d5db;
+  --ring: var(--color-gray-500);
 
   --destructive: var(--color-rose-600);
   --destructive-foreground: var(--color-rose-100);


### PR DESCRIPTION
## What

Replaces the hard-coded light-mode `--ring` value with the zinc-500 token in `packages/tailwind-config/shared-styles.css`.

```diff
-  --ring: #d1d5db;
+  --ring: var(--color-gray-500);
```

## Why

The previous ring color (`#d1d5db`, ≈1.3:1 on white) gave a low-contrast focus indicator, failing **WCAG 2.1 SC 2.4.7 (Focus Visible)** and **1.4.11 (Non-text Contrast)**. zinc-500 (`#71717a`) is ≈4.6:1 on white.

`--ring` drives the full-opacity `border-ring` applied to inputs/textarea/combobox on focus (the qualifying 3:1 indicator), plus the `ring-ring/50` glow. Dark mode (`--ring: zinc-600`) is unchanged.

## Scope

One of three independent "quick win" PRs for RAL-1233 (accessibility / VPAT 2.5 remediation).

Part of RAL-1233.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the app’s ring/focus color to align with the shared gray theme, improving visual consistency across the interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->