### PR TITLE
♿️ Raise poll color contrast ratio to 5:1 (WCAG 1.4.11)

### DIFF
--- a/apps/web/src/utils/color.ts
+++ b/apps/web/src/utils/color.ts
@@ -78,7 +78,7 @@ export function getForegroundColor(backgroundColor: string): string {
 export function adjustColorForContrast(
   color: string,
   backgroundColor: string,
-  minContrastRatio = 3.5,
+  minContrastRatio = 5,
 ): string {
   const colorRgb = hexToRgb(color);
   const bgRgb = hexToRgb(backgroundColor);


### PR DESCRIPTION
## Summary

Bump the default `minContrastRatio` in `adjustColorForContrast` from `3.5` to `5` so participant/option colors are darkened enough to meet WCAG AA non-text contrast (1.4.11) against their background.

## Changes

- `apps/web/src/utils/color.ts` — default `minContrastRatio` `3.5` → `5`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved default color contrast adjustments, so text and UI elements now aim for stronger readability when no custom contrast setting is provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->