### PR TITLE
✨ Keep guest sessions alive while actively using the app

### DIFF
--- a/apps/web/src/app/[locale]/(optional-space)/layout.tsx
+++ b/apps/web/src/app/[locale]/(optional-space)/layout.tsx
@@ -1,4 +1,5 @@
 import { dehydrate, HydrationBoundary } from "@tanstack/react-query";
+import { SessionRefresher } from "@/components/session-refresher";
 import { PreferencesProvider } from "@/contexts/preferences";
 import { PayWall } from "@/features/billing/components/pay-wall";
 import { isQuickCreateEnabled } from "@/features/quick-create";
@@ -23,6 +24,7 @@ export default async function Layout({
 
   return (
     <HydrationBoundary state={dehydrate(helpers.queryClient)}>
+      <SessionRefresher />
       <PreferencesProvider>
         {children}
         <PayWall />

--- a/apps/web/src/app/[locale]/e/[id]/page.tsx
+++ b/apps/web/src/app/[locale]/e/[id]/page.tsx
@@ -11,6 +11,7 @@ import { UserDropdown } from "@/app/[locale]/e/[id]/components/user-dropdown";
 import LogoMarkGray from "@/assets/logo-mark-gray.svg";
 import { OptimizedAvatarImage } from "@/components/optimized-avatar-image";
 import TruncatedLinkify from "@/components/poll/truncated-linkify";
+import { SessionRefresher } from "@/components/session-refresher";
 import { BrandingStyle } from "@/features/branding/branding-style";
 import { formatLocationText } from "@/features/location/utils";
 import { isScheduledEventEnabled } from "@/features/scheduled-event/constants";
@@ -101,6 +102,7 @@ export default async function EventPage({
 
   return (
     <div className="page-bg-gray-50 absolute inset-0 h-dvh overflow-auto md:h-dvh md:items-center md:justify-center md:p-5 dark:bg-gray-900">
+      <SessionRefresher />
       {brandingColor ? <BrandingStyle primaryColor={brandingColor} /> : null}
       <header className="fixed top-0 right-0 left-0 z-10 flex justify-between p-4">
         <Link href="/">

--- a/apps/web/src/app/[locale]/invite/[urlId]/page.tsx
+++ b/apps/web/src/app/[locale]/invite/[urlId]/page.tsx
@@ -4,6 +4,7 @@ import { dehydrate, HydrationBoundary } from "@tanstack/react-query";
 import type { Metadata } from "next";
 import { notFound } from "next/navigation";
 import { cache } from "react";
+import { SessionRefresher } from "@/components/session-refresher";
 import { PermissionProvider } from "@/contexts/permissions";
 import { PreferencesProvider } from "@/contexts/preferences";
 import { createPublicSSRHelper } from "@/trpc/server/create-ssr-helper";
@@ -62,6 +63,7 @@ export default async function Page(props: {
 
   return (
     <HydrationBoundary state={dehydrate(trpc.queryClient)}>
+      <SessionRefresher />
       <PreferencesProvider>
         <Providers>
           <PermissionProvider impersonatedUserId={impersonatedUserId}>

--- a/apps/web/src/components/session-keep-alive.tsx
+++ b/apps/web/src/components/session-keep-alive.tsx
@@ -1,0 +1,12 @@
+"use client";
+
+import { authClient } from "@/lib/auth-client";
+
+// Fires /get-session on mount (and on tab focus, via better-auth defaults) so
+// the cookieCache Set-Cookie reaches the browser and the session's sliding
+// expiry keeps advancing while the user is active. Mounted by SessionRefresher
+// only once a session is known to exist.
+export function SessionKeepAlive() {
+  authClient.useSession();
+  return null;
+}

--- a/apps/web/src/components/session-refresher.tsx
+++ b/apps/web/src/components/session-refresher.tsx
@@ -1,15 +1,16 @@
-"use client";
+import { getSession } from "@/lib/auth";
+import { SessionKeepAlive } from "./session-keep-alive";
 
-import { authClient } from "@/lib/auth-client";
+// Keeps an existing session (guest OR authenticated) alive while the user is
+// active. Gated on getSession — which reads the cookie cache — so truly
+// anonymous viewers with no session never mount the client keep-alive and
+// never trigger a /get-session request. Safe to mount on public layouts.
+export async function SessionRefresher() {
+  const session = await getSession();
 
-// Fires /get-session on mount (and on tab focus, via better-auth defaults)
-// so the cookieCache Set-Cookie reaches the browser. Without this, the
-// session_data cookie only ever propagates at sign-in and every request
-// past its 5-min lifetime falls back to a DB lookup.
-//
-// Only mount inside authenticated layouts — using this on public layouts
-// would trigger a /get-session call for every anonymous poll viewer.
-export function SessionRefresher() {
-  authClient.useSession();
-  return null;
+  if (!session) {
+    return null;
+  }
+
+  return <SessionKeepAlive />;
 }


### PR DESCRIPTION
## Problem

The session is a sliding window (`expiresIn: 60d`, `updateAge: 1d`). Its expiry only advances when something triggers a fresh server-side session read past the 5-min cookie cache — which is exactly what `SessionRefresher`'s `useSession()` does on mount + tab focus.

But `SessionRefresher` was only mounted in the authenticated `(space)` layout. Guests live entirely in public surfaces — poll voting (`/invite/[urlId]`), guest poll management (`/poll/[urlId]`), and event RSVP (`/e/[id]`) — none of which mounted it. So an active guest's session expiry was never extended and could silently lapse, dropping them from a poll they created or voted on.

We couldn't simply mount the old component on those layouts: they're also hit by truly **anonymous** viewers with no session, and an unconditional `useSession()` fires a `/get-session` request (a function invocation) for every one of them.

## Change

- **`session-refresher.tsx`** is now an async **server component**. It calls `getSession()` (a cookie-cache read, `cache()`-deduped per request) and renders the client keep-alive only when a session already exists. No tRPC, no client-side gate request.
- **`session-keep-alive.tsx`** (new client component) holds the `authClient.useSession()` ping.
- Mounted on the guest surfaces: `(optional-space)` layout, `invite/[urlId]` page, and `e/[id]` page. The `(space)` layout keeps its existing mount.

## Why it's cheap

- The server gate means **anonymous viewers (no session) trigger zero `/get-session` calls** — the high-volume cohort costs nothing.
- `cookieCache` (5 min) means most pings return from the signed cookie with no Redis/Postgres read.
- The `lastSeenAt` write + posthog `login` side effects are gated by `updateAge` (1 day), so they are **not** amplified by the refresher.
- better-auth defaults: no interval polling (`refetchInterval: 0`), focus refetch rate-limited to 1 call / 5s, and a shared atom dedupes multiple mounts.

`refetchOnWindowFocus` is left at its default (on) — it's cheap and keeps long-idle tabs alive on refocus.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved session handling so signed-in users stay connected more reliably.
  * Reduced unnecessary session checks for anonymous visitors, helping avoid extra background requests.
  * Session refresh behavior now runs consistently across key pages after hydration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->