### PR TITLE
♿️ Add skip-to-content link and main landmarks (WCAG 2.4.1)

### DIFF
--- a/apps/web/public/locales/en/app.json
+++ b/apps/web/public/locales/en/app.json
@@ -602,6 +602,7 @@
   "signIn": "Sign in",
   "signOut": "Sign Out",
   "signUp": "Sign Up",
+  "skipToContent": "Skip to main content",
   "space": "Space",
   "spaceInviteMember": "Invite Member",
   "spaceName": "Space Name",

--- a/apps/web/src/app/[locale]/(auth)/layout.tsx
+++ b/apps/web/src/app/[locale]/(auth)/layout.tsx
@@ -14,7 +14,13 @@ export default async function Layout({
       <div className="z-10 flex w-full flex-1 lg:p-4">
         <div className="flex flex-1 flex-col gap-4 p-6">
           <div className="my-auto">
-            <div className="mx-auto w-full max-w-sm">{children}</div>
+            <main
+              id="main-content"
+              tabIndex={-1}
+              className="mx-auto w-full max-w-sm"
+            >
+              {children}
+            </main>
           </div>
           {isQuickCreateEnabled ? (
             <div className="flex justify-center lg:hidden">

--- a/apps/web/src/app/[locale]/(optional-space)/new/page.tsx
+++ b/apps/web/src/app/[locale]/(optional-space)/new/page.tsx
@@ -45,9 +45,13 @@ export default async function Page() {
           </div>
         </div>
       </div>
-      <div className="mx-auto max-w-4xl p-3 sm:px-6 sm:py-5">
+      <main
+        id="main-content"
+        tabIndex={-1}
+        className="mx-auto max-w-4xl p-3 sm:px-6 sm:py-5"
+      >
         <CreatePoll />
-      </div>
+      </main>
     </div>
   );
 }

--- a/apps/web/src/app/[locale]/(space)/(dashboard)/layout.tsx
+++ b/apps/web/src/app/[locale]/(space)/(dashboard)/layout.tsx
@@ -76,7 +76,7 @@ export default async function Layout({
             <NavUser />
           </SidebarFooter>
         </Sidebar>
-        <SidebarInset className="min-w-0">
+        <SidebarInset id="main-content" tabIndex={-1} className="min-w-0">
           <LicenseLimitWarning />
           <CustomBrandingPrompt />
           <div className="flex flex-1 flex-col">

--- a/apps/web/src/app/[locale]/(space)/settings/layout.tsx
+++ b/apps/web/src/app/[locale]/(space)/settings/layout.tsx
@@ -88,7 +88,7 @@ export default async function Layout({
             <NavUser />
           </SidebarFooter>
         </Sidebar>
-        <SidebarInset>
+        <SidebarInset id="main-content" tabIndex={-1}>
           <div className="flex flex-1 flex-col">
             <header className="sticky top-0 z-10 border-b bg-background/90 p-3 backdrop-blur-xs md:hidden">
               <div className="flex items-center gap-4">
@@ -103,7 +103,7 @@ export default async function Layout({
                 </div>
               </div>
             </header>
-            <main className="flex-1 p-4 lg:py-12">{children}</main>
+            <div className="flex-1 p-4 lg:py-12">{children}</div>
           </div>
         </SidebarInset>
       </SidebarProvider>

--- a/apps/web/src/app/[locale]/accept-invite/[inviteId]/page.tsx
+++ b/apps/web/src/app/[locale]/accept-invite/[inviteId]/page.tsx
@@ -50,59 +50,61 @@ export default async function JoinPage({
   return (
     <div className="flex h-dvh flex-col items-center gap-12 py-12">
       <Logo />
-      <Card className="flex w-full max-w-sm flex-col p-12 text-center">
-        <div className="mx-auto mb-4">
-          <SpaceIcon
-            src={invite.space.image ?? undefined}
-            name={invite.space.name}
-            size="xl"
-          />
-        </div>
-        <h1 className="font-bold text-base">
-          <Trans
-            i18nKey="joinSpace"
-            defaults="Join {spaceName}"
-            values={{
-              spaceName: invite.space.name,
-            }}
-          />
-        </h1>
-        <p className="mt-1 text-sm">
-          <Trans
-            i18nKey="acceptInviteTitle"
-            defaults="{inviterName} invited you to join {spaceName}"
-            values={{
-              spaceName: invite.space.name,
-              inviterName: invite.invitedBy.name,
-            }}
-          />
-        </p>
-        <div className="mt-6">
-          <div className="flex flex-col items-center gap-y-2">
-            <p className="text-muted-foreground text-sm">
-              <Trans
-                i18nKey="youAreSignedInAs"
-                defaults="You're signed in as"
-              />
-            </p>
-            <div className="flex items-center gap-x-2 rounded-full border p-1 pr-2">
-              <OptimizedAvatarImage
-                src={user.image}
-                name={user.name}
-                size="sm"
-              />
-              <p className="text-sm">{user.email}</p>
+      <main id="main-content" tabIndex={-1} className="w-full max-w-sm">
+        <Card className="flex w-full flex-col p-12 text-center">
+          <div className="mx-auto mb-4">
+            <SpaceIcon
+              src={invite.space.image ?? undefined}
+              name={invite.space.name}
+              size="xl"
+            />
+          </div>
+          <h1 className="font-bold text-base">
+            <Trans
+              i18nKey="joinSpace"
+              defaults="Join {spaceName}"
+              values={{
+                spaceName: invite.space.name,
+              }}
+            />
+          </h1>
+          <p className="mt-1 text-sm">
+            <Trans
+              i18nKey="acceptInviteTitle"
+              defaults="{inviterName} invited you to join {spaceName}"
+              values={{
+                spaceName: invite.space.name,
+                inviterName: invite.invitedBy.name,
+              }}
+            />
+          </p>
+          <div className="mt-6">
+            <div className="flex flex-col items-center gap-y-2">
+              <p className="text-muted-foreground text-sm">
+                <Trans
+                  i18nKey="youAreSignedInAs"
+                  defaults="You're signed in as"
+                />
+              </p>
+              <div className="flex items-center gap-x-2 rounded-full border p-1 pr-2">
+                <OptimizedAvatarImage
+                  src={user.image}
+                  name={user.name}
+                  size="sm"
+                />
+                <p className="text-sm">{user.email}</p>
+              </div>
             </div>
           </div>
-        </div>
-        <div className="mt-6">
-          {isWrongAccount ? (
-            <SignOutButton />
-          ) : (
-            <AcceptInviteButton spaceId={invite.spaceId} />
-          )}
-        </div>
-      </Card>
+          <div className="mt-6">
+            {isWrongAccount ? (
+              <SignOutButton />
+            ) : (
+              <AcceptInviteButton spaceId={invite.spaceId} />
+            )}
+          </div>
+        </Card>
+      </main>
     </div>
   );
 }

--- a/apps/web/src/app/[locale]/admin-setup/page.tsx
+++ b/apps/web/src/app/[locale]/admin-setup/page.tsx
@@ -29,7 +29,11 @@ export default async function AdminSetupPage() {
   }
 
   return (
-    <div className="flex h-dvh items-center justify-center">
+    <main
+      id="main-content"
+      tabIndex={-1}
+      className="flex h-dvh items-center justify-center"
+    >
       <EmptyState className="h-full">
         <EmptyStateIcon>
           <CrownIcon />
@@ -50,7 +54,7 @@ export default async function AdminSetupPage() {
           <MakeMeAdminButton />
         </EmptyStateFooter>
       </EmptyState>
-    </div>
+    </main>
   );
 }
 

--- a/apps/web/src/app/[locale]/control-panel/layout.tsx
+++ b/apps/web/src/app/[locale]/control-panel/layout.tsx
@@ -24,7 +24,7 @@ export default async function AdminLayout({
       <ControlPanelSidebarProvider>
         <CommandMenu />
         <ControlPanelSidebar />
-        <SidebarInset>
+        <SidebarInset id="main-content" tabIndex={-1}>
           <LicenseLimitWarning />
           <div className="flex flex-1 flex-col">
             <header className="sticky top-0 z-10 border-b bg-background/90 p-3 backdrop-blur-xs md:hidden">
@@ -40,7 +40,7 @@ export default async function AdminLayout({
                 </div>
               </div>
             </header>
-            <main className="flex-1 p-4 lg:py-12">{children}</main>
+            <div className="flex-1 p-4 lg:py-12">{children}</div>
           </div>
         </SidebarInset>
       </ControlPanelSidebarProvider>

--- a/apps/web/src/app/[locale]/e/[id]/page.tsx
+++ b/apps/web/src/app/[locale]/e/[id]/page.tsx
@@ -123,7 +123,7 @@ export default async function EventPage({
           )}
         </div>
       </header>
-      <div className="mx-auto max-w-lg pt-16">
+      <main id="main-content" tabIndex={-1} className="mx-auto max-w-lg pt-16">
         <div className="flex flex-col justify-between gap-6 p-4">
           <EventHeader>
             {isBranded && branding ? (
@@ -231,7 +231,7 @@ export default async function EventPage({
             </EventSection>
           ) : null}
         </div>
-      </div>
+      </main>
     </div>
   );
 }

--- a/apps/web/src/app/[locale]/globals.css
+++ b/apps/web/src/app/[locale]/globals.css
@@ -2,3 +2,12 @@
 @import "@rallly/tailwind-config";
 
 /* Any app specific overrides will go here */
+
+/*
+ * The skip-to-content link moves focus to the page's #main-content landmark.
+ * The link itself is the visible focus indicator, so suppress the outline on
+ * the landmark to avoid drawing a box around the entire content region.
+ */
+#main-content:focus {
+  outline: none;
+}

--- a/apps/web/src/app/[locale]/invite/[urlId]/invite-page.tsx
+++ b/apps/web/src/app/[locale]/invite/[urlId]/invite-page.tsx
@@ -48,7 +48,11 @@ const GoToApp = () => {
 export function InvitePage() {
   return (
     <div className="page-bg-gray-100 h-dvh overflow-auto p-3 lg:p-6 dark:bg-gray-900">
-      <div className="mx-auto w-full max-w-4xl space-y-3">
+      <main
+        id="main-content"
+        tabIndex={-1}
+        className="mx-auto w-full max-w-4xl space-y-3"
+      >
         <GoToApp />
         <EventCard />
         <VotingForm>
@@ -56,7 +60,7 @@ export function InvitePage() {
         </VotingForm>
         <Discussion />
         <PollFooter />
-      </div>
+      </main>
     </div>
   );
 }

--- a/apps/web/src/app/[locale]/layout.tsx
+++ b/apps/web/src/app/[locale]/layout.tsx
@@ -9,6 +9,7 @@ import { Inter } from "next/font/google";
 import { notFound } from "next/navigation";
 import type React from "react";
 import type { Params } from "@/app/[locale]/types";
+import { SkipNavLink } from "@/components/skip-nav-link";
 import { BrandingProvider } from "@/features/branding/client";
 import { getInstanceBrandingConfig } from "@/features/branding/queries";
 import { ThemeProvider } from "@/features/theme/client";
@@ -78,6 +79,7 @@ export default async function Root({
               <I18nProvider locale={locale} resources={resources}>
                 <TRPCProvider>
                   <LazyMotion features={domAnimation}>
+                    <SkipNavLink />
                     <PostHogPageView />
                     <TooltipProvider>{children}</TooltipProvider>
                   </LazyMotion>

--- a/apps/web/src/app/[locale]/quick-create/page.tsx
+++ b/apps/web/src/app/[locale]/quick-create/page.tsx
@@ -18,7 +18,7 @@ export default async function QuickCreatePage() {
 
   const { t } = await getTranslation();
   return (
-    <div className="flex h-dvh p-2">
+    <main id="main-content" tabIndex={-1} className="flex h-dvh p-2">
       <Card className="flex flex-1 flex-col gap-6 p-6">
         <div className="mx-auto w-full max-w-md flex-1">
           <div className="space-y-8">
@@ -39,7 +39,7 @@ export default async function QuickCreatePage() {
           </Link>
         </div>
       </Card>
-    </div>
+    </main>
   );
 }
 

--- a/apps/web/src/app/[locale]/setup/page.tsx
+++ b/apps/web/src/app/[locale]/setup/page.tsx
@@ -17,7 +17,7 @@ export default async function SetupPage() {
 
   return (
     <div className="flex min-h-dvh justify-center bg-background p-4 sm:items-center">
-      <div className="w-full max-w-sm">
+      <main id="main-content" tabIndex={-1} className="w-full max-w-sm">
         <article className="space-y-8">
           <div className="flex justify-center py-8">
             <Logo />
@@ -33,11 +33,11 @@ export default async function SetupPage() {
               />
             </p>
           </header>
-          <main>
+          <div>
             <CreateSpaceForm />
-          </main>
+          </div>
         </article>
-      </div>
+      </main>
     </div>
   );
 }

--- a/apps/web/src/components/error-page.tsx
+++ b/apps/web/src/components/error-page.tsx
@@ -19,7 +19,11 @@ export function ErrorPage({
 }) {
   return (
     <div className="page-bg-gray-100">
-      <main className="mx-auto w-full max-w-7xl px-6 pt-10 pb-16 sm:pb-24 lg:px-8">
+      <main
+        id="main-content"
+        tabIndex={-1}
+        className="mx-auto w-full max-w-7xl px-6 pt-10 pb-16 sm:pb-24 lg:px-8"
+      >
         <Image
           src="/static/logo.svg"
           alt="Rallly"

--- a/apps/web/src/components/layouts/poll-layout.tsx
+++ b/apps/web/src/components/layouts/poll-layout.tsx
@@ -71,9 +71,9 @@ const Layout = ({ children }: React.PropsWithChildren) => {
           </div>
         </div>
       </div>
-      <div className="p-3">
+      <main id="main-content" tabIndex={-1} className="p-3">
         <div className="mx-auto max-w-4xl space-y-3">{children}</div>
-      </div>
+      </main>
     </div>
   );
 };

--- a/apps/web/src/components/skip-nav-link.tsx
+++ b/apps/web/src/components/skip-nav-link.tsx
@@ -1,0 +1,14 @@
+"use client";
+
+import { Trans } from "@/i18n/client";
+
+export function SkipNavLink() {
+  return (
+    <a
+      href="#main-content"
+      className="sr-only rounded-md bg-background font-medium text-foreground text-sm shadow-md ring-2 ring-ring focus:not-sr-only focus:fixed focus:top-4 focus:left-4 focus:z-100 focus:px-4 focus:py-2"
+    >
+      <Trans i18nKey="skipToContent" defaults="Skip to main content" />
+    </a>
+  );
+}


### PR DESCRIPTION
## What

Implements **WCAG 2.4.1 Bypass Blocks** (RAL-1233, gap #6 in the VPAT draft):

- Adds a visually-hidden **"Skip to main content"** link (`SkipNavLink`) rendered once in the root layout. It is the first focusable element on every page and becomes visible on keyboard focus, jumping to `#main-content`.
- Ensures **every page exposes a single `<main id="main-content">` landmark** (focusable via `tabIndex={-1}` so focus actually lands there after activating the link).

## Why

The VPAT draft (`compliance/`) flagged: *"No 'skip to content' link; some pages (notably auth pages) do not render a `<main>` landmark."* Keyboard and screen-reader users had no mechanism to bypass the repeated navigation/sidebar blocks.

## Changes

**Skip link**
- `components/skip-nav-link.tsx` — new `sr-only` → `focus:not-sr-only` anchor targeting `#main-content`
- `[locale]/layout.tsx` — renders `<SkipNavLink />` ahead of page content

**Main landmarks (one per page)**
- Shells: `(auth)`, `(dashboard)`, `settings`, `control-panel`, `poll-layout`
  - `settings` and `control-panel` previously nested a second `<main>` inside `SidebarInset` (already `<main>`) — the duplicate landmark is removed; the inner element is now a `<div>`.
- Standalone pages: `invite`, `accept-invite`, `admin-setup`, `setup`, `quick-create`, `e/[id]`, `(optional-space)/new`, and the shared `error-page` (covers 404 + error boundary).

**Focus handling**
- The skip link itself carries the visible focus indicator (`ring-2 ring-ring`). The `#main-content` landmark receives focus programmatically only, so a single global rule in `globals.css` (`#main-content:focus { outline: none }`) suppresses the outline on the landmark — otherwise the app-wide `:focus-visible` rule would draw a box around the entire content region. This matches the established skip-link pattern (Vercel, PostHog, GOV.UK).

**i18n**
- `skipToContent` key added to `en/app.json` via `pnpm i18n:scan`.

## Testing

- `pnpm type-check` ✅
- `pnpm check` ✅
- Manual keyboard check: Tab from page load → skip link appears → Enter moves focus into `<main>` (page scrolls to content, no outline box).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a localized “Skip to main content” link to help keyboard and screen-reader users jump to the primary page area.

* **Bug Fixes**
  * Improved accessibility by standardizing the primary content landmark across auth, space, admin/control, and invite/poll/setup/error flows.
  * Updated focus behavior for the main content target and adjusted focus styling to better support skip-navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->