### PR TITLE
⚡️ Refresh session at most once a day

### DIFF
--- a/apps/web/src/components/session-refresher.tsx
+++ b/apps/web/src/components/session-refresher.tsx
@@ -1,14 +1,26 @@
 import { getSession } from "@/lib/auth";
 import { SessionKeepAlive } from "./session-keep-alive";
 
+const ONE_DAY_MS = 24 * 60 * 60 * 1000;
+
 // Keeps an existing session (guest OR authenticated) alive while the user is
 // active. Gated on getSession — which reads the cookie cache — so truly
 // anonymous viewers with no session never mount the client keep-alive and
 // never trigger a /get-session request. Safe to mount on public layouts.
+//
+// SessionKeepAlive only mounts once the session is at least a day old, matching
+// better-auth's `updateAge` of one day: refreshing more often would just fire
+// /get-session requests that can't advance the sliding expiry anyway.
 export async function SessionRefresher() {
   const session = await getSession();
 
   if (!session) {
+    return null;
+  }
+
+  const age = Date.now() - new Date(session.updatedAt).getTime();
+
+  if (age < ONE_DAY_MS) {
     return null;
   }
 

--- a/apps/web/src/lib/auth.ts
+++ b/apps/web/src/lib/auth.ts
@@ -509,6 +509,7 @@ export const getSession = cache(async () => {
           timeZone: session.user.timeZone ?? undefined,
         },
         expires: session.session.expiresAt.toISOString(),
+        updatedAt: session.session.updatedAt.toISOString(),
       };
     }
   } catch (e) {


### PR DESCRIPTION
## Summary

`SessionKeepAlive` fires `/get-session` on mount and on every tab focus. But better-auth only advances a session's sliding expiry once the session is older than `updateAge` — which we set to **1 day** ([`auth.ts`](apps/web/src/lib/auth.ts)). Every keep-alive request inside that window can't move the expiry forward; it just costs a request, plus a DB lookup once the 5-minute cookie cache lapses.

This gates `SessionKeepAlive` on session age: it only mounts once `updatedAt` is more than a day old, so an active user refreshes their session at most once per day.

## Changes

- **`session-refresher.tsx`** — compute session age from `updatedAt` and return early (no client keep-alive) when it's under a day old.
- **`auth.ts`** — expose `updatedAt` (ISO string, alongside the existing `expires`) from `getSession` so the server component can decide before rendering the client component.

## Notes

- The threshold is fixed-millisecond arithmetic (`24 * 60 * 60 * 1000`), intentionally mirroring better-auth's `updateAge: 60 * 60 * 24` (a fixed 86,400 s, not a calendar day). Using calendar-aware date math would drift 23/25 h across DST and no longer match the config it tracks.
- `updatedAt` is preserved through better-auth's cookie cache, so the gate works on cache hits without a DB read.
- The freshness check runs at request render time (`getSession` is wrapped in React `cache()`), which is the intended behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved session handling so background keep-alive logic only starts after a session is at least one day old, helping avoid unnecessary refresh activity on newly created sessions.
  * Session timing is now tracked more accurately, which supports more consistent behavior over time.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->