### PR TITLE
✨ Add Intl-based date/time formatting layer

### DIFF
--- a/apps/web/src/lib/localization/components.tsx
+++ b/apps/web/src/lib/localization/components.tsx
@@ -1,0 +1,129 @@
+"use client";
+
+import { cn } from "@rallly/ui";
+import { Skeleton } from "@rallly/ui/skeleton";
+import React from "react";
+import { useLocalization } from "@/lib/localization/context";
+import type { DateInput, DateTimePreset } from "@/lib/localization/format";
+import {
+  formatDateTime,
+  formatDateTimeRange,
+  formatRelativeTime,
+} from "@/lib/localization/format";
+import { getBrowserTimeZone } from "@/utils/date-time-utils";
+
+function useMounted() {
+  const [mounted, setMounted] = React.useState(false);
+  React.useEffect(() => {
+    setMounted(true);
+  }, []);
+  return mounted;
+}
+
+function toISO(value: DateInput) {
+  return (value instanceof Date ? value : new Date(value)).toISOString();
+}
+
+export function TimeSkeleton({ className }: { className?: string }) {
+  return (
+    <Skeleton
+      className={cn("inline-block h-[1em] w-12 align-middle", className)}
+    />
+  );
+}
+
+/**
+ * Resolves the timezone for display. `floating` values are wall-clock
+ * (all-day / tz-agnostic) and format in UTC. Otherwise we use the localization
+ * timezone when known (SSR-personalized), falling back to the browser zone
+ * after mount — `undefined` before that, so the caller renders a skeleton.
+ */
+function useDisplayTimeZone(floating?: boolean) {
+  const { timeZone } = useLocalization();
+  const mounted = useMounted();
+  if (floating) return "UTC";
+  return timeZone ?? (mounted ? getBrowserTimeZone() : undefined);
+}
+
+type TimeProps = {
+  value: DateInput;
+  preset?: DateTimePreset;
+  floating?: boolean;
+  className?: string;
+};
+
+export function Time({
+  value,
+  preset = "time",
+  floating,
+  className,
+}: TimeProps) {
+  const { locale, timeFormat } = useLocalization();
+  const timeZone = useDisplayTimeZone(floating);
+
+  if (!timeZone) {
+    return <TimeSkeleton className={className} />;
+  }
+
+  return (
+    <time dateTime={toISO(value)} className={className}>
+      {formatDateTime(value, preset, { locale, timeFormat, timeZone })}
+    </time>
+  );
+}
+
+type TimeRangeProps = {
+  start: DateInput;
+  end: DateInput;
+  preset?: DateTimePreset;
+  floating?: boolean;
+  className?: string;
+};
+
+export function TimeRange({
+  start,
+  end,
+  preset = "time",
+  floating,
+  className,
+}: TimeRangeProps) {
+  const { locale, timeFormat } = useLocalization();
+  const timeZone = useDisplayTimeZone(floating);
+
+  if (!timeZone) {
+    return <TimeSkeleton className={cn("w-24", className)} />;
+  }
+
+  return (
+    <span className={className}>
+      {formatDateTimeRange(start, end, preset, {
+        locale,
+        timeFormat,
+        timeZone,
+      })}
+    </span>
+  );
+}
+
+export function RelativeTime({
+  value,
+  className,
+}: {
+  value: DateInput;
+  className?: string;
+}) {
+  const { locale } = useLocalization();
+  const mounted = useMounted();
+
+  // Relative time depends on "now", which differs between server and client,
+  // so render it client-only to avoid a hydration mismatch.
+  if (!mounted) {
+    return <TimeSkeleton className={className} />;
+  }
+
+  return (
+    <time dateTime={toISO(value)} className={className}>
+      {formatRelativeTime(value, locale)}
+    </time>
+  );
+}

--- a/apps/web/src/lib/localization/components.tsx
+++ b/apps/web/src/lib/localization/components.tsx
@@ -33,41 +33,47 @@ export function TimeSkeleton({ className }: { className?: string }) {
 }
 
 /**
- * Resolves the timezone for display. `floating` values are wall-clock
- * (all-day / tz-agnostic) and format in UTC. Otherwise we use the localization
- * timezone when known (SSR-personalized), falling back to the browser zone
- * after mount — `undefined` before that, so the caller renders a skeleton.
+ * Resolves the timezone to display in. A fixed `timeZone` (the event's own zone,
+ * or "UTC" for all-day) is known regardless of the viewer, so it renders
+ * directly — SSR-safe even for anonymous viewers, no skeleton. Omitting it means
+ * "automatic": display in the viewer's zone, falling back to the browser zone
+ * after mount (`undefined` before that, so the caller renders a skeleton).
  */
-function useDisplayTimeZone(floating?: boolean) {
-  const { timeZone } = useLocalization();
+function useDisplayTimeZone(fixedTimeZone?: string) {
+  const { timeZone: viewerTimeZone } = useLocalization();
   const mounted = useMounted();
-  if (floating) return "UTC";
-  return timeZone ?? (mounted ? getBrowserTimeZone() : undefined);
+  if (fixedTimeZone) return fixedTimeZone;
+  return viewerTimeZone ?? (mounted ? getBrowserTimeZone() : undefined);
 }
 
 type TimeProps = {
   value: DateInput;
   preset?: DateTimePreset;
-  floating?: boolean;
+  /** Fixed display zone (the event's zone, or "UTC" for all-day). Omit for the viewer's zone. */
+  timeZone?: string;
   className?: string;
 };
 
 export function Time({
   value,
   preset = "time",
-  floating,
+  timeZone,
   className,
 }: TimeProps) {
   const { locale, timeFormat } = useLocalization();
-  const timeZone = useDisplayTimeZone(floating);
+  const displayTimeZone = useDisplayTimeZone(timeZone);
 
-  if (!timeZone) {
+  if (!displayTimeZone) {
     return <TimeSkeleton className={className} />;
   }
 
   return (
     <time dateTime={toISO(value)} className={className}>
-      {formatDateTime(value, preset, { locale, timeFormat, timeZone })}
+      {formatDateTime(value, preset, {
+        locale,
+        timeFormat,
+        timeZone: displayTimeZone,
+      })}
     </time>
   );
 }
@@ -76,7 +82,8 @@ type TimeRangeProps = {
   start: DateInput;
   end: DateInput;
   preset?: DateTimePreset;
-  floating?: boolean;
+  /** Fixed display zone (the event's zone, or "UTC" for all-day). Omit for the viewer's zone. */
+  timeZone?: string;
   className?: string;
 };
 
@@ -84,13 +91,13 @@ export function TimeRange({
   start,
   end,
   preset = "time",
-  floating,
+  timeZone,
   className,
 }: TimeRangeProps) {
   const { locale, timeFormat } = useLocalization();
-  const timeZone = useDisplayTimeZone(floating);
+  const displayTimeZone = useDisplayTimeZone(timeZone);
 
-  if (!timeZone) {
+  if (!displayTimeZone) {
     return <TimeSkeleton className={cn("w-24", className)} />;
   }
 
@@ -99,7 +106,7 @@ export function TimeRange({
       {formatDateTimeRange(start, end, preset, {
         locale,
         timeFormat,
-        timeZone,
+        timeZone: displayTimeZone,
       })}
     </span>
   );

--- a/apps/web/src/lib/localization/format.test.ts
+++ b/apps/web/src/lib/localization/format.test.ts
@@ -1,0 +1,142 @@
+import { describe, expect, it } from "vitest";
+import {
+  formatDateTime,
+  formatDateTimeRange,
+  formatRelativeTime,
+} from "@/lib/localization/format";
+
+// Fri 26 Jun 2026, in UTC.
+const at = (hour: number, minute = 0) =>
+  new Date(Date.UTC(2026, 5, 26, hour, minute));
+
+describe("formatDateTime", () => {
+  it("formats 24-hour time", () => {
+    expect(
+      formatDateTime(at(13), "time", {
+        locale: "en",
+        timeFormat: "hours24",
+        timeZone: "UTC",
+      }),
+    ).toBe("13:00");
+  });
+
+  it("formats 12-hour time", () => {
+    const out = formatDateTime(at(13), "time", {
+      locale: "en",
+      timeFormat: "hours12",
+      timeZone: "UTC",
+    });
+    expect(out).toMatch(/\bPM\b/i);
+    expect(out).not.toContain("13");
+  });
+
+  it("applies the 12-hour override on a 24-hour-default locale (de)", () => {
+    const out = formatDateTime(at(13), "time", {
+      locale: "de",
+      timeFormat: "hours12",
+      timeZone: "UTC",
+    });
+    // Override applied → hour rendered as 1, not 13.
+    expect(out).not.toContain("13");
+  });
+
+  it("preserves the locale separator under override (Finnish period)", () => {
+    expect(
+      formatDateTime(at(15, 30), "time", {
+        locale: "fi",
+        timeFormat: "hours24",
+        timeZone: "UTC",
+      }),
+    ).toBe("15.30");
+  });
+
+  it("produces different output for hours12 vs hours24 (override applied)", () => {
+    const base = { locale: "en", timeZone: "UTC" } as const;
+    expect(
+      formatDateTime(at(13), "time", { ...base, timeFormat: "hours12" }),
+    ).not.toBe(
+      formatDateTime(at(13), "time", { ...base, timeFormat: "hours24" }),
+    );
+  });
+
+  it("converts to the given timezone", () => {
+    // 13:00 UTC = 09:00 America/New_York (EDT) in June.
+    expect(
+      formatDateTime(at(13), "time", {
+        locale: "en",
+        timeFormat: "hours24",
+        timeZone: "America/New_York",
+      }),
+    ).toBe("09:00");
+  });
+
+  it("formats a weekday", () => {
+    expect(
+      formatDateTime(at(13), "weekday", {
+        locale: "en",
+        timeFormat: "hours24",
+        timeZone: "UTC",
+      }),
+    ).toBe("Friday");
+  });
+
+  it("formats a datetime with both date and time parts", () => {
+    const out = formatDateTime(at(13), "datetime", {
+      locale: "en",
+      timeFormat: "hours24",
+      timeZone: "UTC",
+    });
+    expect(out).toContain("2026");
+    expect(out).toContain("13:00");
+  });
+
+  it("date preset omits the time", () => {
+    const out = formatDateTime(at(13), "date", {
+      locale: "en",
+      timeFormat: "hours24",
+      timeZone: "UTC",
+    });
+    expect(out).toContain("2026");
+    expect(out).not.toContain("13:00");
+  });
+
+  it("accepts ISO strings and timestamps", () => {
+    const ctx = {
+      locale: "en",
+      timeFormat: "hours24",
+      timeZone: "UTC",
+    } as const;
+    expect(formatDateTime(at(13).toISOString(), "time", ctx)).toBe("13:00");
+    expect(formatDateTime(at(13).getTime(), "time", ctx)).toBe("13:00");
+  });
+});
+
+describe("formatDateTimeRange", () => {
+  it("formats a time range", () => {
+    const out = formatDateTimeRange(at(13), at(14), "time", {
+      locale: "en",
+      timeFormat: "hours24",
+      timeZone: "UTC",
+    });
+    expect(out).toContain("13:00");
+    expect(out).toContain("14:00");
+  });
+});
+
+describe("formatRelativeTime", () => {
+  const now = at(12);
+
+  it("formats future hours", () => {
+    expect(formatRelativeTime(at(14), "en", now)).toBe("in 2 hours");
+  });
+
+  it("formats past hours", () => {
+    expect(formatRelativeTime(at(10), "en", now)).toBe("2 hours ago");
+  });
+
+  it("uses numeric auto for adjacent days (tomorrow)", () => {
+    expect(
+      formatRelativeTime(new Date(Date.UTC(2026, 5, 27, 12)), "en", now),
+    ).toBe("tomorrow");
+  });
+});

--- a/apps/web/src/lib/localization/format.ts
+++ b/apps/web/src/lib/localization/format.ts
@@ -1,0 +1,117 @@
+import type { Localization } from "@/lib/localization/schema";
+
+export type DateInput = Date | string | number;
+
+export type DateTimePreset =
+  | "time"
+  | "date"
+  | "dateLong"
+  | "weekday"
+  | "datetime";
+
+type FormatContext = Pick<Localization, "locale" | "timeFormat"> & {
+  timeZone?: string;
+};
+
+function toDate(value: DateInput): Date {
+  return value instanceof Date ? value : new Date(value);
+}
+
+// Intl.DateTimeFormat construction is comparatively expensive; memoize by
+// (locale, options). Formatters are pure and request-agnostic, so sharing the
+// cache across requests on the server is safe.
+const formatterCache = new Map<string, Intl.DateTimeFormat>();
+
+function getFormatter(locale: string, options: Intl.DateTimeFormatOptions) {
+  const key = `${locale}|${JSON.stringify(options)}`;
+  let formatter = formatterCache.get(key);
+  if (!formatter) {
+    formatter = new Intl.DateTimeFormat(locale, options);
+    formatterCache.set(key, formatter);
+  }
+  return formatter;
+}
+
+const PRESET_OPTIONS: Record<DateTimePreset, Intl.DateTimeFormatOptions> = {
+  time: { timeStyle: "short" },
+  date: { dateStyle: "medium" },
+  dateLong: { dateStyle: "long" },
+  weekday: { weekday: "long" },
+  datetime: { dateStyle: "medium", timeStyle: "short" },
+};
+
+const PRESET_SHOWS_TIME: Record<DateTimePreset, boolean> = {
+  time: true,
+  date: false,
+  dateLong: false,
+  weekday: false,
+  datetime: true,
+};
+
+// The hour cycle (12/24h) is applied to the *locale*, not the options, so it is
+// honored alongside `timeStyle` and keeps every CLDR per-locale nuance intact:
+// separators (Finnish "15.30"), leading-zero rules, and meridiem placement.
+function resolveLocale(preset: DateTimePreset, ctx: FormatContext): string {
+  if (!PRESET_SHOWS_TIME[preset]) return ctx.locale;
+  const hourCycle = ctx.timeFormat === "hours12" ? "h12" : "h23";
+  return new Intl.Locale(ctx.locale, { hourCycle }).toString();
+}
+
+function formatterFor(preset: DateTimePreset, ctx: FormatContext) {
+  return getFormatter(resolveLocale(preset, ctx), {
+    ...PRESET_OPTIONS[preset],
+    timeZone: ctx.timeZone,
+  });
+}
+
+export function formatDateTime(
+  value: DateInput,
+  preset: DateTimePreset,
+  ctx: FormatContext,
+): string {
+  return formatterFor(preset, ctx).format(toDate(value));
+}
+
+export function formatDateTimeRange(
+  start: DateInput,
+  end: DateInput,
+  preset: DateTimePreset,
+  ctx: FormatContext,
+): string {
+  return formatterFor(preset, ctx).formatRange(toDate(start), toDate(end));
+}
+
+const RELATIVE_UNITS: [Intl.RelativeTimeFormatUnit, number][] = [
+  ["year", 31_536_000_000],
+  ["month", 2_592_000_000],
+  ["day", 86_400_000],
+  ["hour", 3_600_000],
+  ["minute", 60_000],
+  ["second", 1_000],
+];
+
+const relativeCache = new Map<string, Intl.RelativeTimeFormat>();
+
+function getRelativeFormatter(locale: string) {
+  let formatter = relativeCache.get(locale);
+  if (!formatter) {
+    formatter = new Intl.RelativeTimeFormat(locale, { numeric: "auto" });
+    relativeCache.set(locale, formatter);
+  }
+  return formatter;
+}
+
+export function formatRelativeTime(
+  value: DateInput,
+  locale: string,
+  now: DateInput = new Date(),
+): string {
+  const diff = toDate(value).getTime() - toDate(now).getTime();
+  const formatter = getRelativeFormatter(locale);
+  for (const [unit, ms] of RELATIVE_UNITS) {
+    if (Math.abs(diff) >= ms || unit === "second") {
+      return formatter.format(Math.round(diff / ms), unit);
+    }
+  }
+  return formatter.format(0, "second");
+}

--- a/apps/web/src/lib/localization/use-date-time-format.ts
+++ b/apps/web/src/lib/localization/use-date-time-format.ts
@@ -17,29 +17,31 @@ import { getBrowserTimeZone } from "@/utils/date-time-utils";
  * SSR/skeleton fallback.
  */
 export function useDateTimeFormat() {
-  const { locale, timeZone, timeFormat } = useLocalization();
-  const resolvedTimeZone = timeZone ?? getBrowserTimeZone();
+  const { locale, timeZone: viewerTimeZone, timeFormat } = useLocalization();
+  const automaticTimeZone = viewerTimeZone ?? getBrowserTimeZone();
 
   return React.useMemo(() => {
-    const ctx = (floating?: boolean) => ({
+    // `timeZone` is the fixed display zone (the event's zone, or "UTC" for
+    // all-day); omit it to use the viewer's zone.
+    const ctx = (timeZone?: string) => ({
       locale,
       timeFormat,
-      timeZone: floating ? "UTC" : resolvedTimeZone,
+      timeZone: timeZone ?? automaticTimeZone,
     });
     return {
       format: (
         value: DateInput,
         preset: DateTimePreset,
-        opts?: { floating?: boolean },
-      ) => formatDateTime(value, preset, ctx(opts?.floating)),
+        opts?: { timeZone?: string },
+      ) => formatDateTime(value, preset, ctx(opts?.timeZone)),
       formatRange: (
         start: DateInput,
         end: DateInput,
         preset: DateTimePreset,
-        opts?: { floating?: boolean },
-      ) => formatDateTimeRange(start, end, preset, ctx(opts?.floating)),
+        opts?: { timeZone?: string },
+      ) => formatDateTimeRange(start, end, preset, ctx(opts?.timeZone)),
       formatRelative: (value: DateInput, now?: DateInput) =>
         formatRelativeTime(value, locale, now),
     };
-  }, [locale, timeFormat, resolvedTimeZone]);
+  }, [locale, timeFormat, automaticTimeZone]);
 }

--- a/apps/web/src/lib/localization/use-date-time-format.ts
+++ b/apps/web/src/lib/localization/use-date-time-format.ts
@@ -1,0 +1,45 @@
+"use client";
+
+import React from "react";
+import { useLocalization } from "@/lib/localization/context";
+import type { DateInput, DateTimePreset } from "@/lib/localization/format";
+import {
+  formatDateTime,
+  formatDateTimeRange,
+  formatRelativeTime,
+} from "@/lib/localization/format";
+import { getBrowserTimeZone } from "@/utils/date-time-utils";
+
+/**
+ * Imperative date/time formatting for non-children contexts (aria-labels,
+ * `title` attributes, third-party localizers). For rendering into JSX prefer
+ * the `<Time>` / `<TimeRange>` / `<RelativeTime>` components, which handle the
+ * SSR/skeleton fallback.
+ */
+export function useDateTimeFormat() {
+  const { locale, timeZone, timeFormat } = useLocalization();
+  const resolvedTimeZone = timeZone ?? getBrowserTimeZone();
+
+  return React.useMemo(() => {
+    const ctx = (floating?: boolean) => ({
+      locale,
+      timeFormat,
+      timeZone: floating ? "UTC" : resolvedTimeZone,
+    });
+    return {
+      format: (
+        value: DateInput,
+        preset: DateTimePreset,
+        opts?: { floating?: boolean },
+      ) => formatDateTime(value, preset, ctx(opts?.floating)),
+      formatRange: (
+        start: DateInput,
+        end: DateInput,
+        preset: DateTimePreset,
+        opts?: { floating?: boolean },
+      ) => formatDateTimeRange(start, end, preset, ctx(opts?.floating)),
+      formatRelative: (value: DateInput, now?: DateInput) =>
+        formatRelativeTime(value, locale, now),
+    };
+  }, [locale, timeFormat, resolvedTimeZone]);
+}


### PR DESCRIPTION
Phase 2 of the **Localization** epic ([RAL-1244](https://linear.app/rallly/issue/RAL-1244)) — the work tracked in [RAL-1246](https://linear.app/rallly/issue/RAL-1246). Builds on the infrastructure merged in #2506.

Adds the date/time **rendering layer** on top of the Localization context: a pure `Intl`-based formatting core, the `<Time>` family of components, and an imperative hook. It **replaces** the dayjs custom-locale-variant design we'd originally planned — `Intl.DateTimeFormat` is CLDR-backed, so it handles per-locale nuances natively.

## What this adds — `apps/web/src/lib/localization/`

- **`format.ts`** — pure, isomorphic core: `formatDateTime` / `formatDateTimeRange` / `formatRelativeTime`, built on memoized `Intl.DateTimeFormat` + `Intl.RelativeTimeFormat`. Semantic presets: `time` · `date` · `dateLong` · `weekday` · `datetime`.
- **`components.tsx`** — `<Time>` · `<TimeRange>` · `<RelativeTime>` · `<TimeSkeleton>`. SSR-personalized when the timezone is known; skeleton → client-resolve when it isn't. `<RelativeTime>` is client-only (depends on "now").
- **`use-date-time-format.ts`** — `useDateTimeFormat()` for imperative strings (aria-labels, `title` attributes, the react-big-calendar localizer).
- **`format.test.ts`** — 14 tests.

## How the 12/24h override works

The hour cycle is applied to the **locale** (`new Intl.Locale(locale, { hourCycle })`), not the format options — so it's honored alongside `timeStyle` and keeps every CLDR nuance:

- `13:00` ↔ `1:00 PM`, and the override works even on 24h-default locales (German → 12h).
- Locale separators preserved: Finnish renders **`15.30`** (period), not `15:30`.
- Timezone conversion handled by Intl: `13:00 UTC → 09:00` in `America/New_York`.

No dayjs custom-locale variants, no `LT`-token surgery — `Intl` does it because it *is* CLDR.

## Not in this PR

Still **not wired into the UI** — no behavior change. The cutover (wiring `<LocalizationBoundary>`, migrating consumers off `useDayjs` / `PreferencesProvider` / `.format("LT")`, deleting the legacy stack) is [RAL-1247](https://linear.app/rallly/issue/RAL-1247).

## Testing

- 14 unit tests covering presets, the 12/24h override, the locale-separator nuance (fi), timezone conversion, ranges, and relative time — green.
- `tsc --noEmit` and Biome clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added client-localized time components for single times, ranges, and “relative to now”, including skeleton placeholders while time zone is resolved.
  * Introduced reusable date/time formatting utilities with presets (time, date, weekday, date-long, datetime).
  * Added a hook to generate localized date/time strings for non-visible contexts (labels/tooltips).
* **Bug Fixes**
  * Improved server/client consistency for time rendering to prevent hydration mismatches.
* **Tests**
  * Added coverage for datetime, range, and relative-time formatting (including locale and timezone behavior).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->