### PR TITLE
⚡️ Statically prerender landing pages with Cache Components

### DIFF
--- a/apps/landing/src/app/[locale]/(main)/(seo)/best-doodle-alternative/page.tsx
+++ b/apps/landing/src/app/[locale]/(main)/(seo)/best-doodle-alternative/page.tsx
@@ -1,4 +1,7 @@
+"use cache";
+
 import type { Metadata } from "next";
+import { cacheLife } from "next/cache";
 import { Trans } from "react-i18next/TransWithoutContext";
 import Bonus from "@/components/home/bonus";
 import { MarketingHero } from "@/components/home/hero";
@@ -8,6 +11,7 @@ import { getTranslation } from "@/i18n/server";
 export default async function Page(props: {
   params: Promise<{ locale: string }>;
 }) {
+  cacheLife("max");
   const { locale } = await props.params;
   const { t } = await getTranslation(locale, ["home"]);
   return (
@@ -31,6 +35,7 @@ export default async function Page(props: {
 export async function generateMetadata(props: {
   params: Promise<{ locale: string }>;
 }): Promise<Metadata> {
+  cacheLife("max");
   const { locale } = await props.params;
   const { t } = await getTranslation(locale, "home");
   return {

--- a/apps/landing/src/app/[locale]/(main)/(seo)/free-scheduling-poll/page.tsx
+++ b/apps/landing/src/app/[locale]/(main)/(seo)/free-scheduling-poll/page.tsx
@@ -1,4 +1,7 @@
+"use cache";
+
 import type { Metadata } from "next";
+import { cacheLife } from "next/cache";
 import { Trans } from "react-i18next/TransWithoutContext";
 import Bonus from "@/components/home/bonus";
 import { MarketingHero } from "@/components/home/hero";
@@ -8,6 +11,7 @@ import { getTranslation } from "@/i18n/server";
 export default async function Page(props: {
   params: Promise<{ locale: string }>;
 }) {
+  cacheLife("max");
   const { locale } = await props.params;
   const { t } = await getTranslation(locale, ["home"]);
   return (
@@ -31,6 +35,7 @@ export default async function Page(props: {
 export async function generateMetadata(props: {
   params: Promise<{ locale: string }>;
 }): Promise<Metadata> {
+  cacheLife("max");
   const { locale } = await props.params;
   const { t } = await getTranslation(locale, "home");
   return {

--- a/apps/landing/src/app/[locale]/(main)/(seo)/when2meet-alternative/page.tsx
+++ b/apps/landing/src/app/[locale]/(main)/(seo)/when2meet-alternative/page.tsx
@@ -1,4 +1,7 @@
+"use cache";
+
 import type { Metadata } from "next";
+import { cacheLife } from "next/cache";
 import { Trans } from "react-i18next/TransWithoutContext";
 import Bonus from "@/components/home/bonus";
 import { MarketingHero } from "@/components/home/hero";
@@ -8,6 +11,7 @@ import { getTranslation } from "@/i18n/server";
 export default async function Page(props: {
   params: Promise<{ locale: string }>;
 }) {
+  cacheLife("max");
   const { locale } = await props.params;
   const { t } = await getTranslation(locale, ["home"]);
   return (
@@ -31,6 +35,7 @@ export default async function Page(props: {
 export async function generateMetadata(props: {
   params: Promise<{ locale: string }>;
 }): Promise<Metadata> {
+  cacheLife("max");
   const { locale } = await props.params;
   const { t } = await getTranslation(locale, "home");
   return {

--- a/apps/landing/src/app/[locale]/(main)/blog/[slug]/page.tsx
+++ b/apps/landing/src/app/[locale]/(main)/blog/[slug]/page.tsx
@@ -1,7 +1,10 @@
+"use cache";
+
 import { buttonVariants } from "@rallly/ui";
 import { absoluteUrl } from "@rallly/utils/absolute-url";
 import { ArrowLeftIcon } from "lucide-react";
 import type { Metadata } from "next";
+import { cacheLife } from "next/cache";
 import Image from "next/image";
 import Link from "next/link";
 import { notFound } from "next/navigation";
@@ -12,6 +15,7 @@ import { getAllPosts, getPostBySlug } from "@/lib/api";
 export default async function Page(props: {
   params: Promise<{ locale: string; slug: string }>;
 }) {
+  cacheLife("max");
   const params = await props.params;
   const post = getPostBySlug(params.slug, [
     "title",
@@ -75,6 +79,7 @@ export async function generateStaticParams() {
 export async function generateMetadata(props: {
   params: Promise<{ locale: string; slug: string }>;
 }): Promise<Metadata> {
+  cacheLife("max");
   const params = await props.params;
   const post = getPostBySlug(params.slug, [
     "title",

--- a/apps/landing/src/app/[locale]/(main)/blog/page.tsx
+++ b/apps/landing/src/app/[locale]/(main)/blog/page.tsx
@@ -1,4 +1,7 @@
+"use cache";
+
 import type { Metadata } from "next";
+import { cacheLife } from "next/cache";
 import { Trans } from "react-i18next/TransWithoutContext";
 import { getTranslation } from "@/i18n/server";
 import { getAllPosts } from "@/lib/api";
@@ -7,6 +10,7 @@ import { PostPreview } from "./post-preview";
 export default async function Page(props: {
   params: Promise<{ locale: string }>;
 }) {
+  cacheLife("max");
   const { locale } = await props.params;
   const { t } = await getTranslation(locale, "blog");
   const allPosts = getAllPosts([
@@ -48,6 +52,7 @@ export default async function Page(props: {
 export async function generateMetadata(props: {
   params: Promise<{ locale: string }>;
 }): Promise<Metadata> {
+  cacheLife("max");
   const { locale } = await props.params;
   const { t } = await getTranslation(locale, "blog");
   return {

--- a/apps/landing/src/app/[locale]/(main)/cookie-policy/page.tsx
+++ b/apps/landing/src/app/[locale]/(main)/cookie-policy/page.tsx
@@ -1,4 +1,9 @@
-export default function CookiePolicy() {
+"use cache";
+
+import { cacheLife } from "next/cache";
+
+export default async function CookiePolicy() {
+  cacheLife("max");
   return (
     <div className="prose mx-auto max-w-3xl">
       <h1>Cookie Policy</h1>
@@ -57,7 +62,8 @@ export default function CookiePolicy() {
   );
 }
 
-export function generateMetadata() {
+export async function generateMetadata() {
+  cacheLife("max");
   return {
     title: "Rallly: Cookie Policy",
     description: "The cookie policy for Rallly.",

--- a/apps/landing/src/app/[locale]/(main)/layout.tsx
+++ b/apps/landing/src/app/[locale]/(main)/layout.tsx
@@ -12,6 +12,7 @@ import {
 import { Icon } from "@rallly/ui/icon";
 import { MenuIcon } from "lucide-react";
 import type { Viewport } from "next";
+import { cacheLife } from "next/cache";
 import Image from "next/image";
 
 import { Trans } from "react-i18next/TransWithoutContext";
@@ -37,6 +38,8 @@ export default async function Root(props: {
   children: React.ReactNode;
   params: Promise<{ locale: string }>;
 }) {
+  "use cache";
+  cacheLife("max");
   const { children, params } = props;
   const { locale } = await params;
 

--- a/apps/landing/src/app/[locale]/(main)/page.tsx
+++ b/apps/landing/src/app/[locale]/(main)/page.tsx
@@ -1,4 +1,7 @@
+"use cache";
+
 import type { Metadata } from "next";
+import { cacheLife } from "next/cache";
 import Bonus from "@/components/home/bonus";
 import { MarketingHero } from "@/components/home/hero";
 import { BigTestimonial, Marketing, MentionedBy } from "@/components/marketing";
@@ -7,6 +10,7 @@ import { getTranslation } from "@/i18n/server";
 export default async function Page(props: {
   params: Promise<{ locale: string }>;
 }) {
+  cacheLife("max");
   const { locale } = await props.params;
   const { t } = await getTranslation(locale, ["home", "common"]);
   return (
@@ -35,6 +39,7 @@ export default async function Page(props: {
 export async function generateMetadata(props: {
   params: Promise<{ locale: string }>;
 }): Promise<Metadata> {
+  cacheLife("max");
   const { locale } = await props.params;
   const { t } = await getTranslation(locale, "home");
   return {

--- a/apps/landing/src/app/[locale]/(main)/pricing/page.tsx
+++ b/apps/landing/src/app/[locale]/(main)/pricing/page.tsx
@@ -1,4 +1,7 @@
+"use cache";
+
 import { BirdIcon } from "lucide-react";
+import { cacheLife } from "next/cache";
 import Link from "next/link";
 import { Trans } from "react-i18next/TransWithoutContext";
 
@@ -125,6 +128,7 @@ const FAQ = async (props: { locale: string }) => {
 export default async function Page(props: {
   params: Promise<{ locale: string }>;
 }) {
+  cacheLife("max");
   const { locale } = await props.params;
   const { t } = await getTranslation(locale, "pricing");
   return (
@@ -182,6 +186,7 @@ export default async function Page(props: {
 export async function generateMetadata(props: {
   params: Promise<{ locale: string }>;
 }) {
+  cacheLife("max");
   const { locale } = await props.params;
   const { t } = await getTranslation(locale, ["common", "pricing"]);
   return {

--- a/apps/landing/src/app/[locale]/(main)/privacy-policy/page.tsx
+++ b/apps/landing/src/app/[locale]/(main)/privacy-policy/page.tsx
@@ -1,4 +1,9 @@
-export default function PrivacyPolicy() {
+"use cache";
+
+import { cacheLife } from "next/cache";
+
+export default async function PrivacyPolicy() {
+  cacheLife("max");
   return (
     <div className="prose mx-auto max-w-3xl">
       <h1>Privacy Policy</h1>
@@ -120,7 +125,8 @@ export default function PrivacyPolicy() {
   );
 }
 
-export function generateMetadata() {
+export async function generateMetadata() {
+  cacheLife("max");
   return {
     title: "Rallly: Privacy Policy",
     description: "The privacy policy for Rallly.",

--- a/apps/landing/src/app/[locale]/(main)/terms-of-use/page.tsx
+++ b/apps/landing/src/app/[locale]/(main)/terms-of-use/page.tsx
@@ -1,6 +1,10 @@
-import type { Metadata } from "next";
+"use cache";
 
-export default function TermsOfUse() {
+import type { Metadata } from "next";
+import { cacheLife } from "next/cache";
+
+export default async function TermsOfUse() {
+  cacheLife("max");
   return (
     <div className="prose mx-auto max-w-3xl">
       <h1>Terms of Use</h1>
@@ -232,7 +236,8 @@ export default function TermsOfUse() {
   );
 }
 
-export function generateMetadata(): Metadata {
+export async function generateMetadata(): Promise<Metadata> {
+  cacheLife("max");
   return {
     title: "Rallly: Terms of Use",
     description: "The terms of use for Rallly.",

--- a/apps/landing/src/app/[locale]/layout.tsx
+++ b/apps/landing/src/app/[locale]/layout.tsx
@@ -4,6 +4,7 @@ import languages from "@rallly/languages";
 import { Analytics } from "@vercel/analytics/react";
 import { domAnimation, LazyMotion } from "motion/react";
 import type { Metadata, Viewport } from "next";
+import { cacheLife } from "next/cache";
 import { Suspense } from "react";
 import { PostHogPageView } from "@/components/posthog-page-view";
 import { sans } from "@/fonts/sans";
@@ -23,6 +24,8 @@ export default async function Root(props: {
   children: React.ReactNode;
   params: Promise<{ locale: string }>;
 }) {
+  "use cache";
+  cacheLife("max");
   const { children, params } = props;
   const { locale } = await params;
 

--- a/apps/landing/src/app/[locale]/licensing/thank-you/page.tsx
+++ b/apps/landing/src/app/[locale]/licensing/thank-you/page.tsx
@@ -1,3 +1,6 @@
+"use cache";
+
+import { cacheLife } from "next/cache";
 import Image from "next/image";
 import { Trans } from "react-i18next/TransWithoutContext";
 import { LinkBase } from "@/i18n/client/link";
@@ -6,6 +9,7 @@ import { getTranslation } from "@/i18n/server";
 export default async function LicensingThankYouPage(props: {
   params: Promise<{ locale: string }>;
 }) {
+  cacheLife("max");
   const { locale } = await props.params;
   const { t } = await getTranslation(locale);
   return (


### PR DESCRIPTION
## Summary

The landing app runs with `cacheComponents: true`, which flips rendering to dynamic-by-default. With no `"use cache"` boundaries, every page was server rendered on each request.

This adds `"use cache"` + `cacheLife("max")` so every route is prerendered into a cached static shell (revalidate 30d, expire 1y), regenerated on deploy (the build ID busts the cache) instead of per request.

## Changes

- **Pages** (home, 3 SEO, pricing, blog list, blog post, legal pages, licensing): file-level `"use cache"` at the top of each file. File-level placement also caches `generateMetadata`, so the localized `<head>` is baked into the shell rather than recomputed per request.
- **Layouts** (`[locale]`, `(main)`): inline `"use cache"` in the component body. They export a static `const metadata`/`viewport`, which file-level `"use cache"` would reject (non-async exports) and cannot serialize (the root layout's `metadataBase` is a `URL`).
- Pure-static legal pages (privacy, terms, cookie) were made `async` so the directive applies.

Left untouched: `[...notFound]` (dynamic 404), `not-found.tsx` (client component), `blog/layout.tsx` (static markup), and the `og-image` / `sitemap` routes (legitimately dynamic).

## Result

All routes now report `◐` (cached static shell, 30d / 1y) in the build output instead of rendering per request. The only dynamic hole is the existing PostHog page-view tracker (`useSearchParams` client bail), which is intended.

## Verification

- `pnpm build:landing` passes; build table shows every `[locale]` route as `◐` with `30d / 1y`.
- Biome and `tsc` clean.

## Note for deploy

The registered-users stat (`getUserCount`) stays DB-backed and cached, so it is **baked at build** and served from cache to every visitor (never a per-request DB hit), refreshing on each deploy. This means the landing build queries the DB a few times (once per build worker). `DATABASE_URL` must be reachable during the landing build on Vercel, which it already is for this monorepo. Flag it if the landing build is ever split out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved load times across several landing, blog, pricing, policy, and licensing pages by caching page content and metadata more aggressively.
  * Reduced repeated server work for shared layout and SEO pages, which should make browsing feel faster and more consistent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->