### PR TITLE
💄 Bump icon button sizes

### DIFF
--- a/packages/ui/src/button-variants.ts
+++ b/packages/ui/src/button-variants.ts
@@ -28,12 +28,12 @@ export const buttonVariants = cva(
         sm: "h-7 gap-1.5 in-data-[slot=button-group]:rounded-lg rounded-lg px-2.5 text-[0.8rem] text-sm has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1 [&_svg:not([class*='size-'])]:size-3.5",
         lg: "h-10 gap-1.5 rounded-lg px-3 text-sm has-data-[icon=inline-end]:pr-2.5 has-data-[icon=inline-start]:pl-2.5",
         xl: "h-12 gap-2 rounded-xl px-4 text-base has-data-[icon=inline-end]:pr-3.5 has-data-[icon=inline-start]:pl-3.5",
-        icon: "size-8 rounded-lg",
+        icon: "size-9 rounded-lg",
         "icon-xs":
           "size-6 in-data-[slot=button-group]:rounded-lg rounded-[min(var(--radius-md),10px)] [&_svg:not([class*='size-'])]:size-3",
         "icon-sm":
           "size-7 in-data-[slot=button-group]:rounded-lg rounded-[min(var(--radius-md),12px)]",
-        "icon-lg": "size-9",
+        "icon-lg": "size-10 rounded-lg",
       },
     },
     defaultVariants: {


### PR DESCRIPTION
## Summary

Bumps the icon button sizes in the shared `buttonVariants`:

- `icon`: `size-8` → `size-9` (32px → 36px)
- `icon-lg`: `size-9` → `size-10` (36px → 40px), and adds `rounded-lg` to match the other icon sizes

## Notes

Extracted from the `luke/ral-1246-datetime-formatting` branch where these tweaks were made incidentally; isolating them here so they can land independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Increased the default size of icon buttons for better touch and visual consistency.
  * Adjusted the larger icon button size to remain proportionate while preserving rounded styling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->