### PR TITLE
✨ Add "Responded on" column to poll CSV export

### DIFF
--- a/apps/web/public/locales/en/app.json
+++ b/apps/web/public/locales/en/app.json
@@ -540,6 +540,7 @@
   "resetPasswordFooter": "Don't need to reset? <a>Back to login</a>",
   "resetPasswordInvalidTokenMessage": "The password reset link is invalid or has expired. Please request a new one.",
   "resetPasswordTitle": "Reset Password",
+  "respondedOn": "Responded on",
   "response": "Response",
   "responseOptions": "Response Options",
   "revoke": "Revoke",

--- a/apps/web/src/components/poll/manage-poll/use-csv-exporter.ts
+++ b/apps/web/src/components/poll/manage-poll/use-csv-exporter.ts
@@ -13,14 +13,14 @@ export const useCsvExporter = () => {
   return {
     exportToCsv: () => {
       // Excel only recognises a naive "YYYY-MM-DD HH:mm:ss" value (no "T", no
-      // offset) as a date, so the zone lives in the header instead of the cell.
-      const respondedOnHeader = `${t("respondedOn", {
-        defaultValue: "Responded on",
-      })} (UTC${dayjs().format("Z")})`;
+      // offset) as a date, so the timezone lives in the header, not the cell.
+      // Use the IANA zone name rather than a fixed offset so the label stays
+      // correct for rows on either side of a DST change.
+      const timeZone = Intl.DateTimeFormat().resolvedOptions().timeZone;
       const header = [
         t("name"),
         t("email"),
-        respondedOnHeader,
+        `${t("respondedOn", { defaultValue: "Responded on" })} (${timeZone})`,
         ...options.map((decodedOption) => {
           const day = `${decodedOption.dow} ${decodedOption.day} ${decodedOption.month} ${decodedOption.year}`;
           return decodedOption.type === "date"

--- a/apps/web/src/components/poll/manage-poll/use-csv-exporter.ts
+++ b/apps/web/src/components/poll/manage-poll/use-csv-exporter.ts
@@ -12,9 +12,15 @@ export const useCsvExporter = () => {
 
   return {
     exportToCsv: () => {
+      // Excel only recognises a naive "YYYY-MM-DD HH:mm:ss" value (no "T", no
+      // offset) as a date, so the zone lives in the header instead of the cell.
+      const respondedOnHeader = `${t("respondedOn", {
+        defaultValue: "Responded on",
+      })} (UTC${dayjs().format("Z")})`;
       const header = [
         t("name"),
         t("email"),
+        respondedOnHeader,
         ...options.map((decodedOption) => {
           const day = `${decodedOption.dow} ${decodedOption.day} ${decodedOption.month} ${decodedOption.year}`;
           return decodedOption.type === "date"
@@ -26,6 +32,7 @@ export const useCsvExporter = () => {
         return [
           participant.name,
           participant.email,
+          dayjs(participant.createdAt).format("YYYY-MM-DD HH:mm:ss"),
           ...poll.options.map((option) => {
             const vote = participant.votes.find((vote) => {
               return vote.optionId === option.id;


### PR DESCRIPTION
## What

Adds a **Responded on** column to the poll participant CSV export, capturing when each participant first submitted their response (`participant.createdAt`). The column sits between the existing **Email** and option columns.

## Excel-friendly date format

The timestamp is written as a naive `YYYY-MM-DD HH:mm:ss` value — no `T` separator, no offset — because that is the form Excel reliably auto-recognises as a date cell. The ISO-8601-with-offset form (`2026-06-30T15:45:00+01:00`) lands in Excel as plain text.

Since Excel has no timezone-aware datetime concept, the zone can't live in the cell, so the exporter's UTC offset is carried in the **column header** instead:

```
Responded on (UTC+01:00)
2026-06-30 15:45:00
```

Times are rendered in the exporter's local timezone (via dayjs, consistent with the rest of this file — the new localization layer isn't wired into the poll routes yet).

## Notes

- `createdAt` reflects the participant's **first** response; it does not change when they later edit their votes (that's `updatedAt`).
- `respondedOn` i18n key added via `pnpm i18n:scan`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Poll CSV exports now add a **“Responded on”** column for each participant.
  * The CSV header includes an Excel-compatible **“Responded on”** label with the current time zone, and dates are formatted for readability in spreadsheet tools.
* **Localization**
  * Added an English translation for the **“Responded on”** label.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->