### PR TITLE
♻️ Migrate remaining (space) dayjs formatting to Intl

### DIFF
--- a/apps/web/src/app/[locale]/(space)/settings/api-keys/components/api-keys-list.tsx
+++ b/apps/web/src/app/[locale]/(space)/settings/api-keys/components/api-keys-list.tsx
@@ -12,14 +12,13 @@ import {
 import { Spinner } from "@/components/spinner";
 import { StackedList, StackedListItem } from "@/components/stacked-list";
 import { Trans } from "@/i18n/client";
-import { useDateTimeConfig } from "@/lib/datetime/client";
-import { formatRelativeTime } from "@/lib/datetime/format";
+import { useDateTime } from "@/lib/datetime/client";
 import { trpc } from "@/trpc/client";
 import { RevokeApiKeyButton } from "./revoke-api-key-button";
 
 export function ApiKeysList() {
   const { data: apiKeys } = trpc.apiKeys.list.useQuery();
-  const { locale } = useDateTimeConfig();
+  const { toRelativeTime } = useDateTime();
 
   if (apiKeys === undefined) {
     return <Spinner />;
@@ -79,7 +78,7 @@ export function ApiKeysList() {
                 i18nKey="lastUsedAt"
                 defaults="Last used {date}"
                 values={{
-                  date: formatRelativeTime(apiKey.lastUsedAt, locale),
+                  date: toRelativeTime(apiKey.lastUsedAt),
                 }}
               />
             ) : (

--- a/apps/web/src/app/[locale]/(space)/settings/api-keys/components/api-keys-list.tsx
+++ b/apps/web/src/app/[locale]/(space)/settings/api-keys/components/api-keys-list.tsx
@@ -12,12 +12,14 @@ import {
 import { Spinner } from "@/components/spinner";
 import { StackedList, StackedListItem } from "@/components/stacked-list";
 import { Trans } from "@/i18n/client";
-import { dayjs } from "@/lib/dayjs";
+import { useDateTimeConfig } from "@/lib/datetime/client";
+import { formatRelativeTime } from "@/lib/datetime/format";
 import { trpc } from "@/trpc/client";
 import { RevokeApiKeyButton } from "./revoke-api-key-button";
 
 export function ApiKeysList() {
   const { data: apiKeys } = trpc.apiKeys.list.useQuery();
+  const { locale } = useDateTimeConfig();
 
   if (apiKeys === undefined) {
     return <Spinner />;
@@ -77,7 +79,7 @@ export function ApiKeysList() {
                 i18nKey="lastUsedAt"
                 defaults="Last used {date}"
                 values={{
-                  date: dayjs(apiKey.lastUsedAt).fromNow(),
+                  date: formatRelativeTime(apiKey.lastUsedAt, locale),
                 }}
               />
             ) : (

--- a/apps/web/src/app/[locale]/(space)/settings/preferences/components/date-time-preferences.tsx
+++ b/apps/web/src/app/[locale]/(space)/settings/preferences/components/date-time-preferences.tsx
@@ -17,13 +17,13 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@rallly/ui/select";
-import React from "react";
 import { useForm } from "react-hook-form";
 import * as z from "zod";
 import { TimeFormatPicker } from "@/components/time-format-picker";
 import { TimeZoneSelect } from "@/components/time-zone-picker/time-zone-select";
 import { updateLocalizationAction } from "@/features/user/actions";
 import { Trans } from "@/i18n/client";
+import { useDateTime } from "@/lib/datetime/client";
 import { getLocaleDefaults } from "@/lib/datetime/locales";
 import { useLocale } from "@/lib/locale/client";
 import { useSafeAction } from "@/lib/safe-action/client";
@@ -47,17 +47,7 @@ export const DateTimePreferences = ({
   const updateLocalization = useSafeAction(updateLocalizationAction);
   const { locale } = useLocale();
   const localeDefaults = getLocaleDefaults(locale);
-
-  // 2024-01-07 is a Sunday; formatting in UTC keeps the 0=Sunday mapping.
-  const weekdays = React.useMemo(() => {
-    const formatter = new Intl.DateTimeFormat(locale, {
-      weekday: "long",
-      timeZone: "UTC",
-    });
-    return Array.from({ length: 7 }, (_, index) =>
-      formatter.format(new Date(Date.UTC(2024, 0, 7 + index))),
-    );
-  }, [locale]);
+  const { weekdays } = useDateTime();
 
   const form = useForm({
     resolver: zodResolver(formSchema),
@@ -137,7 +127,7 @@ export const DateTimePreferences = ({
                       <SelectValue />
                     </SelectTrigger>
                     <SelectContent>
-                      {weekdays.map((day, index) => (
+                      {weekdays().map((day, index) => (
                         <SelectItem key={day} value={index.toString()}>
                           {day}
                         </SelectItem>

--- a/apps/web/src/app/[locale]/(space)/settings/preferences/components/date-time-preferences.tsx
+++ b/apps/web/src/app/[locale]/(space)/settings/preferences/components/date-time-preferences.tsx
@@ -17,6 +17,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@rallly/ui/select";
+import React from "react";
 import { useForm } from "react-hook-form";
 import * as z from "zod";
 import { TimeFormatPicker } from "@/components/time-format-picker";
@@ -24,7 +25,6 @@ import { TimeZoneSelect } from "@/components/time-zone-picker/time-zone-select";
 import { updateLocalizationAction } from "@/features/user/actions";
 import { Trans } from "@/i18n/client";
 import { getLocaleDefaults } from "@/lib/datetime/locales";
-import { dayjs } from "@/lib/dayjs";
 import { useLocale } from "@/lib/locale/client";
 import { useSafeAction } from "@/lib/safe-action/client";
 import { getBrowserTimeZone } from "@/utils/date-time-utils";
@@ -47,6 +47,17 @@ export const DateTimePreferences = ({
   const updateLocalization = useSafeAction(updateLocalizationAction);
   const { locale } = useLocale();
   const localeDefaults = getLocaleDefaults(locale);
+
+  // 2024-01-07 is a Sunday; formatting in UTC keeps the 0=Sunday mapping.
+  const weekdays = React.useMemo(() => {
+    const formatter = new Intl.DateTimeFormat(locale, {
+      weekday: "long",
+      timeZone: "UTC",
+    });
+    return Array.from({ length: 7 }, (_, index) =>
+      formatter.format(new Date(Date.UTC(2024, 0, 7 + index))),
+    );
+  }, [locale]);
 
   const form = useForm({
     resolver: zodResolver(formSchema),
@@ -126,7 +137,7 @@ export const DateTimePreferences = ({
                       <SelectValue />
                     </SelectTrigger>
                     <SelectContent>
-                      {dayjs.weekdays().map((day, index) => (
+                      {weekdays.map((day, index) => (
                         <SelectItem key={day} value={index.toString()}>
                           {day}
                         </SelectItem>

--- a/apps/web/src/app/[locale]/(space)/settings/preferences/components/date-time-preferences.tsx
+++ b/apps/web/src/app/[locale]/(space)/settings/preferences/components/date-time-preferences.tsx
@@ -127,9 +127,9 @@ export const DateTimePreferences = ({
                       <SelectValue />
                     </SelectTrigger>
                     <SelectContent>
-                      {weekdays().map((day, index) => (
-                        <SelectItem key={day} value={index.toString()}>
-                          {day}
+                      {weekdays().map(({ day, label }) => (
+                        <SelectItem key={day} value={day.toString()}>
+                          {label}
                         </SelectItem>
                       ))}
                     </SelectContent>

--- a/apps/web/src/components/time-zone-picker/time-zone-select.tsx
+++ b/apps/web/src/components/time-zone-picker/time-zone-select.tsx
@@ -9,7 +9,6 @@ import {
   useComboboxAnchor,
 } from "@rallly/ui/combobox";
 import { InputGroupAddon } from "@rallly/ui/input-group";
-import dayjs from "dayjs";
 import { GlobeIcon } from "lucide-react";
 import React from "react";
 import {
@@ -18,6 +17,7 @@ import {
   getCityFromTimezoneId,
 } from "@/components/time-zone-picker/timezone-data";
 import { useTranslation } from "@/i18n/client";
+import { Time } from "@/lib/datetime/time";
 
 const allIds = getAllTimezoneIds().sort((a, b) =>
   getCityFromTimezoneId(a).localeCompare(getCityFromTimezoneId(b)),
@@ -46,6 +46,8 @@ export function TimeZoneSelect({
   const anchorRef = useComboboxAnchor();
 
   const [isSearching, setIsSearching] = React.useState(false);
+
+  const now = new Date();
 
   return (
     <Combobox
@@ -92,7 +94,12 @@ export function TimeZoneSelect({
                 {getCityFromTimezoneId(entry)}
               </span>
               <span className="rounded-full px-1 py-0.5 text-center text-muted-foreground text-xs tabular-nums">
-                {dayjs().tz(entry).format("LT")}
+                <Time
+                  value={now}
+                  preset="time"
+                  timeZone={entry}
+                  showTimeZone={false}
+                />
               </span>
             </ComboboxItem>
           )}

--- a/apps/web/src/features/billing/components/subscription-status-label.tsx
+++ b/apps/web/src/features/billing/components/subscription-status-label.tsx
@@ -2,7 +2,8 @@
 
 import type { SubscriptionStatus } from "@rallly/database";
 import { Trans, useTranslation } from "@/i18n/client";
-import { dayjs } from "@/lib/dayjs";
+import { useDateTimeConfig } from "@/lib/datetime/client";
+import { formatDate } from "@/lib/datetime/format";
 
 interface SubscriptionStatusLabelProps {
   status: SubscriptionStatus;
@@ -16,6 +17,7 @@ export const SubscriptionStatusLabel = ({
   periodEnd,
 }: SubscriptionStatusLabelProps) => {
   const { t } = useTranslation();
+  const { locale } = useDateTimeConfig();
 
   const statusConfig: Record<
     string,
@@ -61,7 +63,7 @@ export const SubscriptionStatusLabel = ({
       <Trans
         i18nKey="subscriptionCancelOn"
         defaults="Cancels {date}"
-        values={{ date: dayjs(periodEnd).format("MMM D YYYY") }}
+        values={{ date: formatDate(periodEnd, { preset: "date", locale }) }}
       />
     );
   }

--- a/apps/web/src/features/billing/components/subscription-status-label.tsx
+++ b/apps/web/src/features/billing/components/subscription-status-label.tsx
@@ -3,7 +3,7 @@
 import type { SubscriptionStatus } from "@rallly/database";
 import { Trans, useTranslation } from "@/i18n/client";
 import { useDateTimeConfig } from "@/lib/datetime/client";
-import { formatDate } from "@/lib/datetime/format";
+import { formatDateTime } from "@/lib/datetime/format";
 
 interface SubscriptionStatusLabelProps {
   status: SubscriptionStatus;
@@ -17,7 +17,7 @@ export const SubscriptionStatusLabel = ({
   periodEnd,
 }: SubscriptionStatusLabelProps) => {
   const { t } = useTranslation();
-  const { locale } = useDateTimeConfig();
+  const { locale, timeZone } = useDateTimeConfig();
 
   const statusConfig: Record<
     string,
@@ -63,7 +63,13 @@ export const SubscriptionStatusLabel = ({
       <Trans
         i18nKey="subscriptionCancelOn"
         defaults="Cancels {date}"
-        values={{ date: formatDate(periodEnd, { preset: "date", locale }) }}
+        values={{
+          date: formatDateTime(periodEnd, {
+            preset: "date",
+            locale,
+            timeZone: timeZone ?? "UTC",
+          }),
+        }}
       />
     );
   }

--- a/apps/web/src/features/billing/components/subscription-status-label.tsx
+++ b/apps/web/src/features/billing/components/subscription-status-label.tsx
@@ -2,8 +2,7 @@
 
 import type { SubscriptionStatus } from "@rallly/database";
 import { Trans, useTranslation } from "@/i18n/client";
-import { useDateTimeConfig } from "@/lib/datetime/client";
-import { formatDateTime } from "@/lib/datetime/format";
+import { useDateTime } from "@/lib/datetime/client";
 
 interface SubscriptionStatusLabelProps {
   status: SubscriptionStatus;
@@ -17,7 +16,7 @@ export const SubscriptionStatusLabel = ({
   periodEnd,
 }: SubscriptionStatusLabelProps) => {
   const { t } = useTranslation();
-  const { locale, timeZone } = useDateTimeConfig();
+  const { formatDateTime } = useDateTime();
 
   const statusConfig: Record<
     string,
@@ -63,13 +62,7 @@ export const SubscriptionStatusLabel = ({
       <Trans
         i18nKey="subscriptionCancelOn"
         defaults="Cancels {date}"
-        values={{
-          date: formatDateTime(periodEnd, {
-            preset: "date",
-            locale,
-            timeZone: timeZone ?? "UTC",
-          }),
-        }}
+        values={{ date: formatDateTime(periodEnd, "date") }}
       />
     );
   }

--- a/apps/web/src/lib/datetime/client.tsx
+++ b/apps/web/src/lib/datetime/client.tsx
@@ -4,6 +4,12 @@ import type { TimeFormat } from "@rallly/database";
 import { defaultLocale } from "@rallly/languages";
 import { useParams } from "next/navigation";
 import React from "react";
+import type { DateInput, DateTimePreset } from "@/lib/datetime/format";
+import {
+  formatDateTime as baseFormatDateTime,
+  formatRelativeTime,
+} from "@/lib/datetime/format";
+import { getWeekdayNames } from "@/lib/datetime/locales";
 import { normalizeTimeZone } from "@/lib/datetime/utils";
 import { getBrowserTimeZone } from "@/utils/date-time-utils";
 
@@ -62,4 +68,31 @@ export function useDateTimeConfig() {
     timeZone: config?.timeZone,
     timeFormat: config?.timeFormat,
   };
+}
+
+// Formatters bound to the viewer's config so call sites don't thread
+// locale/timeZone themselves. UTC covers the pre-hydration window before the
+// browser zone is detected.
+export function useDateTime() {
+  const { locale, timeZone, timeFormat } = useDateTimeConfig();
+
+  return React.useMemo(
+    () => ({
+      formatDateTime: (
+        value: DateInput,
+        preset?: DateTimePreset,
+        opts?: { timeZone?: string; showTimeZone?: boolean },
+      ) =>
+        baseFormatDateTime(value, {
+          preset,
+          locale,
+          timeFormat,
+          timeZone: opts?.timeZone ?? timeZone ?? "UTC",
+          showTimeZone: opts?.showTimeZone,
+        }),
+      toRelativeTime: (value: DateInput) => formatRelativeTime(value, locale),
+      weekdays: () => getWeekdayNames(locale),
+    }),
+    [locale, timeZone, timeFormat],
+  );
 }

--- a/apps/web/src/lib/datetime/locales.test.ts
+++ b/apps/web/src/lib/datetime/locales.test.ts
@@ -33,24 +33,24 @@ describe("getLocaleDefaults", () => {
   });
 });
 
-// Index 0 must be Sunday regardless of the locale's own week start, to match
-// the weekStart 0-6 contract.
+// Order follows the locale's default week start; `day` stays canonical
+// (0=Sunday .. 6=Saturday) regardless of position.
 describe("getWeekdayNames", () => {
-  it("returns Sunday-first names for en", () => {
+  it("starts with Sunday for en", () => {
     expect(getWeekdayNames("en")).toEqual([
-      "Sunday",
-      "Monday",
-      "Tuesday",
-      "Wednesday",
-      "Thursday",
-      "Friday",
-      "Saturday",
+      { day: 0, label: "Sunday" },
+      { day: 1, label: "Monday" },
+      { day: 2, label: "Tuesday" },
+      { day: 3, label: "Wednesday" },
+      { day: 4, label: "Thursday" },
+      { day: 5, label: "Friday" },
+      { day: 6, label: "Saturday" },
     ]);
   });
 
-  it("stays Sunday-first for a Monday-start locale (de)", () => {
-    const names = getWeekdayNames("de");
-    expect(names[0]).toBe("Sonntag");
-    expect(names[6]).toBe("Samstag");
+  it("starts with Monday for de, keeping canonical day numbers", () => {
+    const weekdays = getWeekdayNames("de");
+    expect(weekdays[0]).toEqual({ day: 1, label: "Montag" });
+    expect(weekdays[6]).toEqual({ day: 0, label: "Sonntag" });
   });
 });

--- a/apps/web/src/lib/datetime/locales.test.ts
+++ b/apps/web/src/lib/datetime/locales.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { getLocaleDefaults } from "@/lib/datetime/locales";
+import { getLocaleDefaults, getWeekdayNames } from "@/lib/datetime/locales";
 
 // Tripwire: these lock the CLDR-derived defaults so an ICU/Node upgrade that
 // shifts one fails loudly.
@@ -30,5 +30,27 @@ describe("getLocaleDefaults", () => {
       timeFormat: "hours24",
       weekStart: 0,
     });
+  });
+});
+
+// Index 0 must be Sunday regardless of the locale's own week start, to match
+// the weekStart 0-6 contract.
+describe("getWeekdayNames", () => {
+  it("returns Sunday-first names for en", () => {
+    expect(getWeekdayNames("en")).toEqual([
+      "Sunday",
+      "Monday",
+      "Tuesday",
+      "Wednesday",
+      "Thursday",
+      "Friday",
+      "Saturday",
+    ]);
+  });
+
+  it("stays Sunday-first for a Monday-start locale (de)", () => {
+    const names = getWeekdayNames("de");
+    expect(names[0]).toBe("Sonntag");
+    expect(names[6]).toBe("Samstag");
   });
 });

--- a/apps/web/src/lib/datetime/locales.ts
+++ b/apps/web/src/lib/datetime/locales.ts
@@ -16,6 +16,24 @@ function getWeekInfo(locale: string): WeekInfo {
   return l.getWeekInfo?.() ?? l.weekInfo ?? { firstDay: 1 };
 }
 
+const weekdayCache = new Map<string, string[]>();
+
+// 2024-01-07 is a Sunday; formatting in UTC keeps the 0=Sunday mapping.
+export function getWeekdayNames(locale: string): string[] {
+  let names = weekdayCache.get(locale);
+  if (!names) {
+    const formatter = new Intl.DateTimeFormat(locale, {
+      weekday: "long",
+      timeZone: "UTC",
+    });
+    names = Array.from({ length: 7 }, (_, index) =>
+      formatter.format(new Date(Date.UTC(2024, 0, 7 + index))),
+    );
+    weekdayCache.set(locale, names);
+  }
+  return names;
+}
+
 const cache = new Map<string, LocaleDefaults>();
 
 export function getLocaleDefaults(locale: string): LocaleDefaults {

--- a/apps/web/src/lib/datetime/locales.ts
+++ b/apps/web/src/lib/datetime/locales.ts
@@ -16,22 +16,31 @@ function getWeekInfo(locale: string): WeekInfo {
   return l.getWeekInfo?.() ?? l.weekInfo ?? { firstDay: 1 };
 }
 
-const weekdayCache = new Map<string, string[]>();
+type Weekday = { day: number; label: string };
 
-// 2024-01-07 is a Sunday; formatting in UTC keeps the 0=Sunday mapping.
-export function getWeekdayNames(locale: string): string[] {
-  let names = weekdayCache.get(locale);
-  if (!names) {
+const weekdayCache = new Map<string, Weekday[]>();
+
+// 2024-01-07 is a Sunday; formatting in UTC keeps the 0=Sunday mapping. Days
+// are ordered from the locale's default week start; `day` stays canonical
+// (0=Sunday .. 6=Saturday).
+export function getWeekdayNames(locale: string): Weekday[] {
+  let weekdays = weekdayCache.get(locale);
+  if (!weekdays) {
     const formatter = new Intl.DateTimeFormat(locale, {
       weekday: "long",
       timeZone: "UTC",
     });
-    names = Array.from({ length: 7 }, (_, index) =>
-      formatter.format(new Date(Date.UTC(2024, 0, 7 + index))),
-    );
-    weekdayCache.set(locale, names);
+    const { weekStart } = getLocaleDefaults(locale);
+    weekdays = Array.from({ length: 7 }, (_, index) => {
+      const day = (weekStart + index) % 7;
+      return {
+        day,
+        label: formatter.format(new Date(Date.UTC(2024, 0, 7 + day))),
+      };
+    });
+    weekdayCache.set(locale, weekdays);
   }
-  return names;
+  return weekdays;
 }
 
 const cache = new Map<string, LocaleDefaults>();


### PR DESCRIPTION
## Why

The `DayjsProvider` was removed from the (space) layout, so any string still formatted through dayjs under that layout renders unlocalized (English defaults) regardless of the viewer's locale. This is a live regression, not just a refactor. These are the last four dayjs display call sites under (space); they now use the Intl-based datetime layer in `lib/datetime/`.

## Changes

1. **`settings/api-keys/components/api-keys-list.tsx`** — `dayjs(apiKey.lastUsedAt).fromNow()` → `formatRelativeTime(apiKey.lastUsedAt, locale)` with the locale from `useDateTimeConfig()`. Kept the `values={{ date }}` interpolation rather than switching to the `Trans` components mechanism, since existing translations for `lastUsedAt` contain the `{date}` placeholder and would desync.

2. **`features/billing/components/subscription-status-label.tsx`** — `dayjs(periodEnd).format("MMM D YYYY")` (hardcoded English pattern) → `formatDate(periodEnd, { preset: "date", locale })`.

3. **`components/time-zone-picker/time-zone-select.tsx`** — `dayjs().tz(entry).format("LT")` per-row current-time preview → `<Time value={now} preset="time" timeZone={entry} showTimeZone={false} />`. `new Date()` is captured once per render, not per row. `showTimeZone={false}` preserves the original time-only pill (the `Time` default would append a zone abbreviation to every non-viewer zone). The component is also used outside (space); `useDateTimeConfig()` inside `Time` falls back to the route locale without a provider.

4. **`settings/preferences/components/date-time-preferences.tsx`** — `dayjs.weekdays()` week-start labels → `Intl.DateTimeFormat(locale, { weekday: "long", timeZone: "UTC" })` formatted over 2024-01-07 (a Sunday) through the following Saturday, preserving the 0=Sunday index mapping.

No i18n key changes. `pnpm check`, `pnpm type-check`, and `pnpm test:unit` (164 tests) all pass.

Part of RAL-1247

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Time and date formatting now consistently uses user locale settings across settings, billing, and timezone views.
  * Timezone picker entries now render a dedicated, consistent time display per timezone.

* **Bug Fixes**
  * API key “last used” timestamps now show localized relative time.
  * Weekday labels for week-start selection are now locale-aware (UTC-based).
  * Subscription expiration dates now use fully localized date formatting with the configured timezone.

* **Tests**
  * Added coverage for locale-aware weekday name ordering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->