### PR TITLE
♻️ Migrate schedule poll dialog to Intl datetime formatting

### DIFF
--- a/apps/web/src/components/date-icon.tsx
+++ b/apps/web/src/components/date-icon.tsx
@@ -1,7 +1,4 @@
 import { cn } from "@rallly/ui";
-import type { Dayjs } from "dayjs";
-
-import { dayjs } from "@/lib/dayjs";
 
 export const DateIconInner = (props: {
   dow?: React.ReactNode;
@@ -23,16 +20,5 @@ export const DateIconInner = (props: {
         {props.day}
       </div>
     </div>
-  );
-};
-
-export const DateIcon = (props: { date: Dayjs; className?: string }) => {
-  return (
-    <DateIconInner
-      className={props.className}
-      dow={dayjs(props.date).format("ddd")}
-      day={dayjs(props.date).format("D")}
-      month={dayjs(props.date).format("MMM")}
-    />
   );
 };

--- a/apps/web/src/components/poll/manage-poll/schedule-poll-dialog.tsx
+++ b/apps/web/src/components/poll/manage-poll/schedule-poll-dialog.tsx
@@ -27,10 +27,14 @@ import { useParticipants } from "@/components/participants-provider";
 import { ConnectedScoreSummary } from "@/components/poll/score-summary";
 import { VoteSummaryProgressBar } from "@/components/vote-summary-progress-bar";
 import { usePoll } from "@/contexts/poll";
+import {
+  EventDate,
+  EventTimeRange,
+} from "@/features/scheduled-event/components/event-date-time";
 import { Trans } from "@/i18n/client";
-import { dayjs } from "@/lib/dayjs";
+import { useDateTimeConfig } from "@/lib/datetime/client";
+import { formatDateParts } from "@/lib/datetime/format";
 import { trpc } from "@/trpc/client";
-import { useDayjs } from "@/utils/dayjs";
 
 const formSchema = z.object({
   selectedOptionId: z.string(),
@@ -71,9 +75,13 @@ const useScoreByOptionId = () => {
 
 function DateIcon({ start }: { start: Date }) {
   const poll = usePoll();
-  const { adjustTimeZone } = useDayjs();
-  const d = adjustTimeZone(start, !poll.timeZone);
-  return <DateIconInner dow={d.format("ddd")} day={d.format("D")} />;
+  const config = useDateTimeConfig();
+  const parts = formatDateParts(start, {
+    locale: config.locale,
+    // Floating times are stored as UTC wall times; read them unshifted.
+    timeZone: poll.timeZone ? config.timeZone : "UTC",
+  });
+  return <DateIconInner dow={parts.weekday} day={parts.day} />;
 }
 
 export const SchedulePollForm = ({
@@ -85,7 +93,6 @@ export const SchedulePollForm = ({
 }) => {
   const poll = usePoll();
 
-  const { adjustTimeZone } = useDayjs();
   const scoreByOptionId = useScoreByOptionId();
   const { participants } = useParticipants();
 
@@ -146,15 +153,7 @@ export const SchedulePollForm = ({
                     className="grid max-h-96 gap-2 overflow-y-auto rounded-xl bg-gray-100 p-2 dark:bg-gray-900"
                   >
                     {options.map((option) => {
-                      const start = adjustTimeZone(
-                        option.startTime,
-                        !poll.timeZone,
-                      );
-
-                      const end = adjustTimeZone(
-                        dayjs(option.startTime).add(option.duration, "minute"),
-                        !poll.timeZone,
-                      );
+                      const allDay = option.duration === 0;
 
                       return (
                         <label
@@ -171,19 +170,24 @@ export const SchedulePollForm = ({
                               <DateIcon start={option.startTime} />
                               <div className="grow whitespace-nowrap">
                                 <div className="font-medium text-sm">
-                                  {start.format("LL")}
+                                  <EventDate
+                                    value={option.startTime}
+                                    allDay={allDay}
+                                    timeZone={poll.timeZone}
+                                  />
                                 </div>
                                 <div className="text-muted-foreground text-sm">
-                                  {option.duration > 0 ? (
-                                    `${start.format("LT")} - ${end.format(
-                                      "LT",
-                                    )}`
-                                  ) : (
-                                    <Trans
-                                      i18nKey="allDay"
-                                      defaults="All day"
-                                    />
-                                  )}
+                                  <EventTimeRange
+                                    start={option.startTime}
+                                    end={
+                                      new Date(
+                                        option.startTime.getTime() +
+                                          option.duration * 60_000,
+                                      )
+                                    }
+                                    allDay={allDay}
+                                    timeZone={poll.timeZone}
+                                  />
                                 </div>
                               </div>
                               <div>


### PR DESCRIPTION
Part of RAL-1247. Removes the last `useDayjs` consumer in the app.

- The schedule dialog's option rows render their date and time range with `EventDate`/`EventTimeRange`, which already own the fixed/floating/all-day semantics — replacing the `adjustTimeZone` + `LL`/`LT` formatting.
- The date icon derives its weekday/day parts from `formatDateParts` in the poll's display zone (viewer zone for fixed polls, UTC for floating).
- Drops the unused dayjs-based `DateIcon` export from `date-icon.tsx`, leaving the purely presentational `DateIconInner`.

After this, `useDayjs` has zero consumers. `DayjsProvider` survives only for its global `dayjs.locale()` side effect, which the poll options form's raw `dayjs().format()` calls still rely on — that's the next slice (RAL-1247 §4), after which the whole legacy stack in §5 can be deleted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated poll scheduling displays to use consistent date and time formatting across time zones.
  * Improved event date rendering for scheduled poll options, including clearer handling of all-day options and time ranges.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->