### PR TITLE
📝 Add Cursor Cloud dev environment setup notes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,39 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+Standard dev commands (install, db, lint, test, build, run) live in `CLAUDE.md` and `package.json`.
+The notes below only cover non-obvious cloud-environment caveats.
+
+### Node / pnpm
+- The repo requires **Node 24** and has `engine-strict=true` (in `.npmrc`), so `pnpm install` fails on
+  other Node versions. Node 24 is installed via `nvm` and symlinked into `/usr/local/cargo/bin`
+  (`node`/`npm`/`npx`/`corepack`) so it wins over the daemon's bundled Node. `pnpm` is provided by
+  corepack (pinned to the `packageManager` field). These persist in the VM snapshot; the update script
+  only runs `pnpm install` + `pnpm db:generate`.
+
+### Docker / dev services
+- There is **no systemd** in this VM. Start the Docker daemon manually before using compose:
+  `sudo dockerd &` (logs to your terminal), then `sudo chmod 666 /var/run/docker.sock` if you hit
+  permission errors. The daemon is configured for `fuse-overlayfs` + `iptables-legacy` (required here).
+- Start backing services with `pnpm docker:up` (Postgres on `5450`, Mailpit on `1025`/UI `8025`,
+  Redis, Garage). These are NOT started by the update script.
+
+### Database
+- Do **not** use `pnpm db:reset` — Prisma 7 blocks AI agents from running `migrate reset` and it is
+  destructive. On a fresh DB use `pnpm db:deploy` (applies migrations) followed by `pnpm db:seed`
+  (loads sample data), which is equivalent and non-destructive.
+
+### Env files
+- `apps/web/.env` and `packages/database/.env` are gitignored. Copy from the `.env.sample` files.
+  `SECRET_PASSWORD` must be at least 32 chars. For cloud use, set `NEXT_PUBLIC_BASE_URL=http://localhost:3000`.
+
+### Running the web app
+- The default `pnpm dev` script runs `portless web.rallly next dev`, which serves the app over
+  `https://web.rallly.test` and needs the portless proxy + a trusted CA. In the cloud it is simpler to
+  run Next directly on localhost: `cd apps/web && PORT=3000 pnpm exec next dev` (with
+  `NEXT_PUBLIC_BASE_URL=http://localhost:3000` in `apps/web/.env`).
+
+### Auth / testing
+- Login is **email OTP** (no passwords). The verification email is captured by the local Mailpit
+  instance — read the 6-digit code from its web UI at http://localhost:8025. Seeded user: `dev@rallly.co`.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

Sets up the Cloud Agent development environment for Rallly and documents non-obvious startup caveats. The only tracked change is a new `AGENTS.md`; all other setup (Node 24 via nvm, Docker, env files, DB) is applied to the VM/snapshot and captured by the update script.

**What was set up**
- Node 24 (repo requires it; `engine-strict=true`) via nvm, symlinked into `/usr/local/cargo/bin` so it beats the daemon's bundled Node; pnpm via corepack.
- Docker CE (fuse-overlayfs + iptables-legacy, started manually since there's no systemd).
- Dev services via `pnpm docker:up` (Postgres, Mailpit, Redis, Garage).
- Env files from samples; schema applied with `pnpm db:deploy` + seeded with `pnpm db:seed`.
- Web app run directly with `next dev` on `http://localhost:3000` (avoids the portless HTTPS proxy).

**Update script** (dependency refresh only): `pnpm install` then `pnpm db:generate`.

**Verification**
- ✅ `pnpm check` (Biome, 997 files clean), `pnpm type-check` (8/8), `pnpm test:unit` (180 passed).
- ✅ Logged in via email OTP (code from Mailpit) and created a poll end-to-end.

[rallly_create_poll_demo.mp4](https://cursor.com/agents/bc-3df617b9-7f4b-4b45-8fd3-828f923417c6/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Frallly_create_poll_demo.mp4)

[Created poll page](https://cursor.com/agents/bc-3df617b9-7f4b-4b45-8fd3-828f923417c6/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Frallly_created_poll.webp)

## Checklist

- [x] I have performed a self-review of my code
- [x] My code follows the code style of this project
- [ ] I have commented my code, particularly in hard-to-understand areas


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3df617b9-7f4b-4b45-8fd3-828f923417c6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3df617b9-7f4b-4b45-8fd3-828f923417c6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

