### PR TITLE
♻️ Migrate license page purchase date to Intl

### DIFF
--- a/apps/web/src/app/[locale]/(auth)/layout.tsx
+++ b/apps/web/src/app/[locale]/(auth)/layout.tsx
@@ -3,6 +3,7 @@ import {
   QuickCreateButton,
   QuickCreateWidget,
 } from "@/features/quick-create";
+import { getLocale } from "@/i18n/server/get-locale";
 import { DeviceDateTimeProvider } from "@/lib/datetime/device";
 import { getDeviceDateTimeConfig } from "@/lib/datetime/server";
 
@@ -11,10 +12,14 @@ export default async function Layout({
 }: {
   children: React.ReactNode;
 }) {
-  const deviceDateTimeConfig = await getDeviceDateTimeConfig();
+  const [locale, deviceDateTimeConfig] = await Promise.all([
+    getLocale(),
+    getDeviceDateTimeConfig(),
+  ]);
 
   return (
     <DeviceDateTimeProvider
+      locale={locale}
       timeZone={deviceDateTimeConfig.timeZone}
       timeFormat={deviceDateTimeConfig.timeFormat}
     >

--- a/apps/web/src/app/[locale]/(optional-space)/layout.tsx
+++ b/apps/web/src/app/[locale]/(optional-space)/layout.tsx
@@ -2,6 +2,7 @@ import { dehydrate, HydrationBoundary } from "@tanstack/react-query";
 import { SessionRefresher } from "@/components/session-refresher";
 import { PayWall } from "@/features/billing/components/pay-wall";
 import { isQuickCreateEnabled } from "@/features/quick-create";
+import { getLocale } from "@/i18n/server/get-locale";
 import { DeviceDateTimeProvider } from "@/lib/datetime/device";
 import { getDeviceDateTimeConfig } from "@/lib/datetime/server";
 import { LocaleSync } from "@/lib/locale/client";
@@ -19,7 +20,8 @@ export default async function Layout({
     ? await createPublicSSRHelper()
     : await createPrivateSSRHelper();
 
-  const [deviceDateTimeConfig, user] = await Promise.all([
+  const [locale, deviceDateTimeConfig, user] = await Promise.all([
+    getLocale(),
     getDeviceDateTimeConfig(),
     helpers.user.getMe.fetch(),
     helpers.billing.getTier.prefetch(),
@@ -30,6 +32,7 @@ export default async function Layout({
       <SessionRefresher />
       <LocaleSync userLocale={user?.locale ?? undefined} />
       <DeviceDateTimeProvider
+        locale={locale}
         timeZone={user?.timeZone ?? deviceDateTimeConfig.timeZone ?? undefined}
         timeFormat={
           user?.timeFormat ?? deviceDateTimeConfig.timeFormat ?? undefined

--- a/apps/web/src/app/[locale]/(space)/layout.tsx
+++ b/apps/web/src/app/[locale]/(space)/layout.tsx
@@ -4,6 +4,7 @@ import { SessionRefresher } from "@/components/session-refresher";
 import { PayWall } from "@/features/billing/components/pay-wall";
 import { SpaceProvider } from "@/features/space/client";
 import { TimeZoneMismatchDialog } from "@/features/user/components/timezone-mismatch-dialog";
+import { getLocale } from "@/i18n/server/get-locale";
 import { DateTimeProvider } from "@/lib/datetime/client";
 import { LocaleSync } from "@/lib/locale/client";
 import { getPathname } from "@/lib/pathname";
@@ -17,7 +18,8 @@ export default async function Layout({
 }) {
   const helpers = await createPrivateSSRHelper();
 
-  const [user, space] = await Promise.all([
+  const [locale, user, space] = await Promise.all([
+    getLocale(),
     helpers.user.getMe.fetch(),
     helpers.spaces.getCurrent.fetch(),
   ]);
@@ -35,6 +37,7 @@ export default async function Layout({
       <LocaleSync userLocale={user?.locale} />
       <TimeZoneMismatchDialog homeTimeZone={user?.timeZone} />
       <DateTimeProvider
+        locale={locale}
         timeZone={user?.timeZone}
         timeFormat={user?.timeFormat}
         weekStart={user?.weekStart ?? undefined}

--- a/apps/web/src/app/[locale]/control-panel/layout.tsx
+++ b/apps/web/src/app/[locale]/control-panel/layout.tsx
@@ -7,6 +7,7 @@ import { LicenseLimitWarning } from "@/features/licensing/components/license-lim
 import { CommandMenu } from "@/features/navigation/command-menu";
 import { Trans } from "@/i18n/client";
 import { getTranslation } from "@/i18n/server";
+import { DateTimeProvider } from "@/lib/datetime/client";
 import { createAdminSSRHelper } from "@/trpc/server/create-ssr-helper";
 import { ControlPanelSidebarProvider } from "./control-panel-sidebar-provider";
 import { ControlPanelSidebar } from "./sidebar";
@@ -17,33 +18,39 @@ export default async function AdminLayout({
   children: React.ReactNode;
 }) {
   const { helpers } = await createAdminSSRHelper();
-  await helpers.user.getAuthed.prefetch();
+  const user = await helpers.user.getAuthed.fetch();
 
   return (
     <HydrationBoundary state={dehydrate(helpers.queryClient)}>
-      <ControlPanelSidebarProvider>
-        <CommandMenu />
-        <ControlPanelSidebar />
-        <SidebarInset id="main-content" tabIndex={-1}>
-          <LicenseLimitWarning />
-          <div className="flex flex-1 flex-col">
-            <header className="sticky top-0 z-10 border-b bg-background/90 p-3 backdrop-blur-xs md:hidden">
-              <div className="flex items-center gap-4">
-                <SidebarTrigger />
-                <div className="flex items-center gap-2">
-                  <Icon>
-                    <GaugeIcon />
-                  </Icon>
-                  <span className="font-medium text-sm">
-                    <Trans i18nKey="controlPanel" defaults="Control Panel" />
-                  </span>
+      <DateTimeProvider
+        timeZone={user.timeZone}
+        timeFormat={user.timeFormat}
+        weekStart={user.weekStart}
+      >
+        <ControlPanelSidebarProvider>
+          <CommandMenu />
+          <ControlPanelSidebar />
+          <SidebarInset id="main-content" tabIndex={-1}>
+            <LicenseLimitWarning />
+            <div className="flex flex-1 flex-col">
+              <header className="sticky top-0 z-10 border-b bg-background/90 p-3 backdrop-blur-xs md:hidden">
+                <div className="flex items-center gap-4">
+                  <SidebarTrigger />
+                  <div className="flex items-center gap-2">
+                    <Icon>
+                      <GaugeIcon />
+                    </Icon>
+                    <span className="font-medium text-sm">
+                      <Trans i18nKey="controlPanel" defaults="Control Panel" />
+                    </span>
+                  </div>
                 </div>
-              </div>
-            </header>
-            <div className="flex-1 p-4 lg:py-12">{children}</div>
-          </div>
-        </SidebarInset>
-      </ControlPanelSidebarProvider>
+              </header>
+              <div className="flex-1 p-4 lg:py-12">{children}</div>
+            </div>
+          </SidebarInset>
+        </ControlPanelSidebarProvider>
+      </DateTimeProvider>
     </HydrationBoundary>
   );
 }

--- a/apps/web/src/app/[locale]/control-panel/layout.tsx
+++ b/apps/web/src/app/[locale]/control-panel/layout.tsx
@@ -7,6 +7,7 @@ import { LicenseLimitWarning } from "@/features/licensing/components/license-lim
 import { CommandMenu } from "@/features/navigation/command-menu";
 import { Trans } from "@/i18n/client";
 import { getTranslation } from "@/i18n/server";
+import { getLocale } from "@/i18n/server/get-locale";
 import { DateTimeProvider } from "@/lib/datetime/client";
 import { createAdminSSRHelper } from "@/trpc/server/create-ssr-helper";
 import { ControlPanelSidebarProvider } from "./control-panel-sidebar-provider";
@@ -18,11 +19,15 @@ export default async function AdminLayout({
   children: React.ReactNode;
 }) {
   const { helpers } = await createAdminSSRHelper();
-  const user = await helpers.user.getAuthed.fetch();
+  const [locale, user] = await Promise.all([
+    getLocale(),
+    helpers.user.getAuthed.fetch(),
+  ]);
 
   return (
     <HydrationBoundary state={dehydrate(helpers.queryClient)}>
       <DateTimeProvider
+        locale={locale}
         timeZone={user.timeZone}
         timeFormat={user.timeFormat}
         weekStart={user.weekStart}

--- a/apps/web/src/app/[locale]/control-panel/license/page.tsx
+++ b/apps/web/src/app/[locale]/control-panel/license/page.tsx
@@ -43,19 +43,14 @@ import { RemoveLicenseButton } from "@/features/licensing/components/remove-lice
 import { loadInstanceLicense } from "@/features/licensing/data";
 import { Trans } from "@/i18n/client";
 import { getTranslation } from "@/i18n/server";
-import { formatDate } from "@/lib/datetime/format";
+import { Time } from "@/lib/datetime/time";
 
 async function loadData() {
   const license = await loadInstanceLicense();
   return { license };
 }
 
-export default async function LicensePage({
-  params,
-}: {
-  params: Promise<{ locale: string }>;
-}) {
-  const { locale } = await params;
+export default async function LicensePage() {
   const { license } = await loadData();
 
   return (
@@ -120,7 +115,7 @@ export default async function LicensePage({
                     <Trans i18nKey="purchaseDate" defaults="Purchase Date" />
                   </DescriptionListTitle>
                   <DescriptionListValue>
-                    {formatDate(license.issuedAt, { locale, preset: "date" })}
+                    <Time value={license.issuedAt} preset="date" />
                   </DescriptionListValue>
                 </DescriptionList>
                 <div className="flex gap-2">

--- a/apps/web/src/app/[locale]/control-panel/license/page.tsx
+++ b/apps/web/src/app/[locale]/control-panel/license/page.tsx
@@ -43,14 +43,19 @@ import { RemoveLicenseButton } from "@/features/licensing/components/remove-lice
 import { loadInstanceLicense } from "@/features/licensing/data";
 import { Trans } from "@/i18n/client";
 import { getTranslation } from "@/i18n/server";
-import { dayjs } from "@/lib/dayjs";
+import { formatDate } from "@/lib/datetime/format";
 
 async function loadData() {
   const license = await loadInstanceLicense();
   return { license };
 }
 
-export default async function LicensePage() {
+export default async function LicensePage({
+  params,
+}: {
+  params: Promise<{ locale: string }>;
+}) {
+  const { locale } = await params;
   const { license } = await loadData();
 
   return (
@@ -115,7 +120,7 @@ export default async function LicensePage() {
                     <Trans i18nKey="purchaseDate" defaults="Purchase Date" />
                   </DescriptionListTitle>
                   <DescriptionListValue>
-                    {dayjs(license.issuedAt).format("YYYY-MM-DD")}
+                    {formatDate(license.issuedAt, { locale, preset: "date" })}
                   </DescriptionListValue>
                 </DescriptionList>
                 <div className="flex gap-2">

--- a/apps/web/src/app/[locale]/e/[id]/page.tsx
+++ b/apps/web/src/app/[locale]/e/[id]/page.tsx
@@ -29,6 +29,7 @@ import {
 import { getSpaceBranding } from "@/features/space/data";
 import { getUserProfile } from "@/features/user/data";
 import { getTranslation } from "@/i18n/server";
+import { getLocale } from "@/i18n/server/get-locale";
 import { getSession } from "@/lib/auth";
 import { DeviceDateTimeProvider } from "@/lib/datetime/device";
 import { getDeviceDateTimeConfig } from "@/lib/datetime/server";
@@ -100,10 +101,14 @@ export default async function EventPage({
 
   const session = await getSession();
   const { t } = await getTranslation();
-  const deviceDateTimeConfig = await getDeviceDateTimeConfig();
+  const [locale, deviceDateTimeConfig] = await Promise.all([
+    getLocale(),
+    getDeviceDateTimeConfig(),
+  ]);
 
   return (
     <DeviceDateTimeProvider
+      locale={locale}
       timeZone={deviceDateTimeConfig.timeZone}
       timeFormat={deviceDateTimeConfig.timeFormat}
     >

--- a/apps/web/src/app/[locale]/invite/[urlId]/page.tsx
+++ b/apps/web/src/app/[locale]/invite/[urlId]/page.tsx
@@ -6,6 +6,7 @@ import { notFound } from "next/navigation";
 import { cache } from "react";
 import { SessionRefresher } from "@/components/session-refresher";
 import { PermissionProvider } from "@/contexts/permissions";
+import { getLocale } from "@/i18n/server/get-locale";
 import { DeviceDateTimeProvider } from "@/lib/datetime/device";
 import { getDeviceDateTimeConfig } from "@/lib/datetime/server";
 import { LocaleSync } from "@/lib/locale/client";
@@ -48,7 +49,8 @@ export default async function Page(props: {
 
   const token = (await props.searchParams).token;
 
-  const [user, deviceDateTimeConfig] = await Promise.all([
+  const [locale, user, deviceDateTimeConfig] = await Promise.all([
+    getLocale(),
     trpc.user.getMe.fetch(),
     getDeviceDateTimeConfig(),
     trpc.polls.get.prefetch({ urlId: params.urlId }),
@@ -69,6 +71,7 @@ export default async function Page(props: {
       <SessionRefresher />
       <LocaleSync userLocale={user?.locale ?? undefined} />
       <DeviceDateTimeProvider
+        locale={locale}
         timeZone={deviceDateTimeConfig.timeZone}
         timeFormat={deviceDateTimeConfig.timeFormat}
       >

--- a/apps/web/src/app/[locale]/quick-create/page.tsx
+++ b/apps/web/src/app/[locale]/quick-create/page.tsx
@@ -10,6 +10,7 @@ import {
   QuickCreateWidget,
 } from "@/features/quick-create";
 import { getTranslation } from "@/i18n/server";
+import { getLocale } from "@/i18n/server/get-locale";
 import { DeviceDateTimeProvider } from "@/lib/datetime/device";
 import { getDeviceDateTimeConfig } from "@/lib/datetime/server";
 
@@ -19,10 +20,14 @@ export default async function QuickCreatePage() {
   }
 
   const { t } = await getTranslation();
-  const deviceDateTimeConfig = await getDeviceDateTimeConfig();
+  const [locale, deviceDateTimeConfig] = await Promise.all([
+    getLocale(),
+    getDeviceDateTimeConfig(),
+  ]);
 
   return (
     <DeviceDateTimeProvider
+      locale={locale}
       timeZone={deviceDateTimeConfig.timeZone}
       timeFormat={deviceDateTimeConfig.timeFormat}
     >

--- a/apps/web/src/i18n/server/get-locale.ts
+++ b/apps/web/src/i18n/server/get-locale.ts
@@ -5,8 +5,5 @@ export async function getLocale() {
   const headersList = await headers();
   const localeFromHeader = headersList.get("x-locale");
 
-  if (!localeFromHeader) {
-    return defaultLocale;
-  }
-  return localeFromHeader;
+  return localeFromHeader ?? defaultLocale;
 }

--- a/apps/web/src/lib/datetime/client.tsx
+++ b/apps/web/src/lib/datetime/client.tsx
@@ -2,7 +2,6 @@
 
 import type { TimeFormat } from "@rallly/database";
 import { defaultLocale } from "@rallly/languages";
-import { useParams } from "next/navigation";
 import React from "react";
 import type { DateInput, DateTimePreset } from "@/lib/datetime/format";
 import {
@@ -15,7 +14,7 @@ import { normalizeTimeZone } from "@/lib/datetime/utils";
 import { getBrowserTimeZone } from "@/utils/date-time-utils";
 
 type DateTimeConfig = {
-  locale?: string;
+  locale: string;
   timeZone?: string;
   timeFormat?: TimeFormat;
   weekStart?: number;
@@ -26,9 +25,11 @@ const DateTimeContext = React.createContext<DateTimeConfig | undefined>(
 );
 
 // Merges with any parent provider so a nested provider can override a single
-// field (e.g. a time zone switcher) without restating the rest. Falls back to
-// the browser zone when no zone is known; detected in an effect so the server
-// and first client render match.
+// field (e.g. a time zone switcher) without restating the rest — except
+// locale, which is always passed explicitly (from getLocale on the server) so
+// formatting never falls back to the wrong language. Falls back to the
+// browser zone when no zone is known; detected in an effect so the server and
+// first client render match.
 export function DateTimeProvider({
   locale,
   timeZone,
@@ -45,7 +46,7 @@ export function DateTimeProvider({
 
   const value = React.useMemo(
     () => ({
-      locale: locale ?? parent?.locale,
+      locale,
       // Stored zones can be empty or corrupt; parent and browser zones are
       // already normalized.
       timeZone:
@@ -65,8 +66,7 @@ export function DateTimeProvider({
 
 export function useDateTimeConfig() {
   const config = React.useContext(DateTimeContext);
-  const params = useParams<{ locale?: string }>();
-  const locale = config?.locale ?? params?.locale ?? defaultLocale;
+  const locale = config?.locale ?? defaultLocale;
 
   return {
     locale,

--- a/apps/web/src/lib/datetime/device.tsx
+++ b/apps/web/src/lib/datetime/device.tsx
@@ -51,11 +51,13 @@ const DeviceDateTimeContext = React.createContext<DeviceDateTime | null>(null);
  * getDeviceDateTimeConfig.
  */
 export function DeviceDateTimeProvider({
+  locale,
   timeZone: initialTimeZone,
   timeFormat: initialTimeFormat,
   weekStart,
   children,
 }: {
+  locale: string;
   timeZone?: string;
   timeFormat?: TimeFormat;
   weekStart?: number;
@@ -81,6 +83,7 @@ export function DeviceDateTimeProvider({
   return (
     <DeviceDateTimeContext.Provider value={value}>
       <DateTimeProvider
+        locale={locale}
         timeZone={timeZone}
         timeFormat={timeFormat}
         weekStart={weekStart}


### PR DESCRIPTION
Part of RAL-1247.

Replaces the last user-facing dayjs format string in the control panel: the license purchase date now renders with `formatDate` from `lib/datetime` in the request locale (`Jul 6, 2026` style instead of hardcoded `YYYY-MM-DD`). All-day/UTC semantics apply since it's a date-only value.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dates and times in the control panel now consistently follow your account settings, and align more reliably with your active locale across the app.
* **Bug Fixes**
  * Improved the license “Purchase Date” display to use the correct account date formatting for clearer, consistent results.
* **Refactor**
  * License and date/time information is loaded before rendering to ensure the correct values are shown immediately.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->