### PR TITLE
♻️ Migrate event email datetime formatting to Intl

### DIFF
--- a/apps/web/src/features/scheduled-event/utils.test.ts
+++ b/apps/web/src/features/scheduled-event/utils.test.ts
@@ -60,6 +60,18 @@ describe("formatEventDateTime", () => {
     expect(result.time).not.toMatch(/GMT|UTC|[A-Z]{3,4}$/);
   });
 
+  it("respects the recipient's preferred time format", () => {
+    const result = formatEventDateTime({
+      start,
+      end,
+      allDay: false,
+      timeZone: "Europe/London",
+      timeFormat: "hours24",
+    });
+    expect(result.time).toContain("14:00");
+    expect(result.time).not.toMatch(/PM/i);
+  });
+
   it("formats in the recipient's locale", () => {
     const result = formatEventDateTime({
       start,

--- a/apps/web/src/features/scheduled-event/utils.test.ts
+++ b/apps/web/src/features/scheduled-event/utils.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vitest";
+import { formatEventDateTime } from "./utils";
+
+// 26 Jun 2026, 13:00–14:00 UTC.
+const start = new Date(Date.UTC(2026, 5, 26, 13));
+const end = new Date(Date.UTC(2026, 5, 26, 14));
+
+describe("formatEventDateTime", () => {
+  it("formats all-day events in UTC with no time", () => {
+    const result = formatEventDateTime({
+      start: new Date(Date.UTC(2026, 5, 26)),
+      end: new Date(Date.UTC(2026, 5, 27)),
+      allDay: true,
+      timeZone: null,
+      inviteeTimeZone: "America/New_York",
+    });
+    expect(result).toEqual({
+      date: "June 26, 2026",
+      day: "26",
+      dow: "Fri",
+      time: undefined,
+    });
+  });
+
+  it("renders fixed events in the invitee's zone with a zone name", () => {
+    const result = formatEventDateTime({
+      start,
+      end,
+      allDay: false,
+      timeZone: "Europe/London",
+      inviteeTimeZone: "America/New_York",
+    });
+    expect(result.date).toBe("June 26, 2026");
+    expect(result.time).toContain("9:00");
+    expect(result.time).toMatch(/10:00\sAM/);
+    expect(result.time).toContain("EDT");
+  });
+
+  it("falls back to the event zone when the invitee zone is unknown", () => {
+    const result = formatEventDateTime({
+      start,
+      end,
+      allDay: false,
+      timeZone: "Europe/London",
+    });
+    expect(result.time).toContain("2:00");
+    expect(result.time).toMatch(/3:00\sPM/);
+  });
+
+  it("renders floating events as UTC wall time with no zone name", () => {
+    const result = formatEventDateTime({
+      start,
+      end,
+      allDay: false,
+      timeZone: null,
+      inviteeTimeZone: "America/New_York",
+    });
+    expect(result.time).toContain("1:00");
+    expect(result.time).toMatch(/2:00\sPM/);
+    expect(result.time).not.toMatch(/GMT|UTC|[A-Z]{3,4}$/);
+  });
+
+  it("formats in the recipient's locale", () => {
+    const result = formatEventDateTime({
+      start,
+      end,
+      allDay: false,
+      timeZone: "Europe/Berlin",
+      locale: "de",
+    });
+    expect(result.date).toBe("26. Juni 2026");
+    expect(result.time).toContain("15:00");
+  });
+});

--- a/apps/web/src/features/scheduled-event/utils.ts
+++ b/apps/web/src/features/scheduled-event/utils.ts
@@ -1,3 +1,4 @@
+import type { TimeFormat } from "@rallly/database";
 import {
   formatDateParts,
   formatDateTime,
@@ -20,6 +21,8 @@ interface FormatEventDateTimeOptions {
   inviteeTimeZone?: string | null;
   /** Must match the locale the email template renders in. */
   locale?: string;
+  /** The recipient's preferred hour cycle; the locale decides when unset. */
+  timeFormat?: TimeFormat | null;
 }
 
 /**
@@ -41,6 +44,7 @@ export const formatEventDateTime = ({
   timeZone,
   inviteeTimeZone,
   locale = "en",
+  timeFormat,
 }: FormatEventDateTimeOptions): FormattedEventDateTime => {
   const displayTimeZone =
     allDay || !timeZone ? "UTC" : inviteeTimeZone || timeZone;
@@ -62,6 +66,7 @@ export const formatEventDateTime = ({
       : formatDateTimeRange(start, end, {
           preset: "time",
           locale,
+          timeFormat: timeFormat ?? undefined,
           timeZone: displayTimeZone,
           showTimeZone: Boolean(timeZone),
         }),

--- a/apps/web/src/features/scheduled-event/utils.ts
+++ b/apps/web/src/features/scheduled-event/utils.ts
@@ -1,10 +1,15 @@
-import { dayjs } from "@/lib/dayjs";
+import {
+  formatDateParts,
+  formatDateTime,
+  formatDateTimeRange,
+} from "@/lib/datetime/format";
 
 export interface FormattedEventDateTime {
   date: string;
   day: string;
   dow: string;
-  time: string;
+  /** Undefined for all-day events; the email templates render a localized "All day" label. */
+  time?: string;
 }
 
 interface FormatEventDateTimeOptions {
@@ -13,15 +18,21 @@ interface FormatEventDateTimeOptions {
   allDay: boolean;
   timeZone?: string | null;
   inviteeTimeZone?: string | null;
+  /** Must match the locale the email template renders in. */
+  locale?: string;
 }
 
 /**
- * Formats event date and time based on event type and timezone settings
+ * Builds the date/time display strings for the finalized/canceled email
+ * templates.
  *
- * Handles three scenarios:
- * 1. All-day events (same date for everyone)
- * 2. Events with a timezone (adjust to invitee's timezone if available)
- * 3. Events without a timezone (floating time - show in UTC)
+ * Zone semantics:
+ * - All-day events are stored as UTC midnight and format in UTC, so every
+ *   recipient sees the same date.
+ * - Fixed events (with a zone) render in the recipient's zone when known,
+ *   falling back to the event's zone, with the zone name appended.
+ * - Floating events (no zone) render their wall time, stored as UTC, with no
+ *   zone name.
  */
 export const formatEventDateTime = ({
   start,
@@ -29,40 +40,30 @@ export const formatEventDateTime = ({
   allDay,
   timeZone,
   inviteeTimeZone,
+  locale = "en",
 }: FormatEventDateTimeOptions): FormattedEventDateTime => {
-  if (allDay) {
-    // For all-day events, show the same date to everyone
-    const eventDate = dayjs(start).utc();
-    return {
-      date: eventDate.format("MMMM D, YYYY"),
-      day: eventDate.format("D"),
-      dow: eventDate.format("ddd"),
-      time: "All day",
-    };
-  }
-
-  if (timeZone) {
-    // If event has a timezone, adjust to invitee's timezone if available
-    const targetTimeZone = inviteeTimeZone || timeZone;
-
-    const startTime = dayjs(start).tz(targetTimeZone);
-    const endTime = dayjs(end).tz(targetTimeZone);
-
-    return {
-      date: startTime.format("MMMM D, YYYY"),
-      day: startTime.format("D"),
-      dow: startTime.format("ddd"),
-      time: `${startTime.format("HH:mm")} - ${endTime.format("HH:mm z")}`,
-    };
-  }
-
-  const startTime = dayjs(start).utc();
-  const endTime = dayjs(end).utc();
+  const displayTimeZone =
+    allDay || !timeZone ? "UTC" : inviteeTimeZone || timeZone;
+  const { weekday, day } = formatDateParts(start, {
+    locale,
+    timeZone: displayTimeZone,
+  });
 
   return {
-    date: startTime.format("MMMM D, YYYY"),
-    day: startTime.format("D"),
-    dow: startTime.format("ddd"),
-    time: `${startTime.format("HH:mm")} - ${endTime.format("HH:mm")}`,
+    date: formatDateTime(start, {
+      preset: "dateLong",
+      locale,
+      timeZone: displayTimeZone,
+    }),
+    day,
+    dow: weekday,
+    time: allDay
+      ? undefined
+      : formatDateTimeRange(start, end, {
+          preset: "time",
+          locale,
+          timeZone: displayTimeZone,
+          showTimeZone: Boolean(timeZone),
+        }),
   };
 };

--- a/apps/web/src/trpc/routers/events.ts
+++ b/apps/web/src/trpc/routers/events.ts
@@ -175,11 +175,13 @@ export const events = router({
             allDay: updatedEvent.allDay,
             timeZone: updatedEvent.timeZone,
             inviteeTimeZone: invite.inviteeTimeZone,
+            locale: invite.inviteeLocale ?? undefined,
           });
 
           after(async () =>
             sendEventCanceledEmail({
               to: invite.inviteeEmail,
+              locale: invite.inviteeLocale ?? undefined,
               branding: await getInstanceBranding(),
               icalEvent: {
                 filename: "cancel.ics",

--- a/apps/web/src/trpc/routers/polls.ts
+++ b/apps/web/src/trpc/routers/polls.ts
@@ -966,16 +966,18 @@ export const polls = router({
           });
         }
 
+        const hostEmail = poll.user.email;
+        const hostName = poll.user.name;
+        const hostLocale = poll.user.locale ?? undefined;
+
         const { date, day, dow, time } = formatEventDateTime({
           start: scheduledEvent.start,
           end: scheduledEvent.end,
           allDay: scheduledEvent.allDay,
           timeZone: scheduledEvent.timeZone,
+          locale: hostLocale,
         });
 
-        const hostEmail = poll.user.email;
-        const hostName = poll.user.name;
-        const hostLocale = poll.user.locale ?? undefined;
         const space = poll.space;
         after(async () =>
           sendFinalizeHostEmail({
@@ -1014,6 +1016,7 @@ export const polls = router({
             allDay: scheduledEvent.allDay,
             timeZone: scheduledEvent.timeZone,
             inviteeTimeZone: p.timeZone,
+            locale: p.locale,
           });
           after(async () =>
             sendFinalizeParticipantEmail({

--- a/apps/web/src/trpc/routers/polls.ts
+++ b/apps/web/src/trpc/routers/polls.ts
@@ -731,6 +731,7 @@ export const polls = router({
               name: true,
               email: true,
               locale: true,
+              timeFormat: true,
             },
           },
           participants: {
@@ -976,6 +977,7 @@ export const polls = router({
           allDay: scheduledEvent.allDay,
           timeZone: scheduledEvent.timeZone,
           locale: hostLocale,
+          timeFormat: poll.user.timeFormat,
         });
 
         const space = poll.space;

--- a/packages/emails/locales/en/emails.json
+++ b/packages/emails/locales/en/emails.json
@@ -1,4 +1,5 @@
 {
+  "allDay": "All day",
   "changeEmail_codeValid": "This code is valid for 15 minutes",
   "changeEmail_content2": "You're receiving this email because a request was made to change the email address of an account on <domain />. If this wasn't you contact <a>{supportEmail}</a>.",
   "changeEmail_heading": "Verify your new email address",

--- a/packages/emails/src/templates/event-canceled.tsx
+++ b/packages/emails/src/templates/event-canceled.tsx
@@ -33,7 +33,7 @@ export type EventCanceledEmailProps = {
   day: string;
   dow: string;
   date: string;
-  time: string;
+  time?: string;
 };
 
 async function EventCanceledEmail({
@@ -114,7 +114,7 @@ async function EventCanceledEmail({
               <Column style={{ paddingLeft: 16 }} align="left">
                 <Text style={{ margin: 0, fontWeight: "bold" }}>{date}</Text>
                 <Text light={true} style={{ margin: 0 }}>
-                  {time}
+                  {time ?? t("allDay", { defaultValue: "All day" })}
                 </Text>
               </Column>
             </Row>

--- a/packages/emails/src/templates/finalized-host.tsx
+++ b/packages/emails/src/templates/finalized-host.tsx
@@ -32,7 +32,7 @@ type FinalizeHostEmailProps = {
   date: string;
   day: string;
   dow: string;
-  time: string;
+  time?: string;
   name: string;
   title: string;
   location: string | null;
@@ -118,7 +118,7 @@ async function FinalizeHostEmail({
               <Column style={{ paddingLeft: 16 }} align="left">
                 <Text style={{ margin: 0, fontWeight: "bold" }}>{date}</Text>
                 <Text light={true} style={{ margin: 0 }}>
-                  {time}
+                  {time ?? t("allDay", { defaultValue: "All day" })}
                 </Text>
               </Column>
             </Row>

--- a/packages/emails/src/templates/finalized-participant.tsx
+++ b/packages/emails/src/templates/finalized-participant.tsx
@@ -32,7 +32,7 @@ type FinalizeParticipantEmailProps = {
   date: string;
   day: string;
   dow: string;
-  time: string;
+  time?: string;
   title: string;
   hostName: string;
   pollUrl: string;
@@ -117,7 +117,7 @@ async function FinalizeParticipantEmail({
               <Column style={{ paddingLeft: 16 }} align="left">
                 <Text style={{ margin: 0, fontWeight: "bold" }}>{date}</Text>
                 <Text light={true} style={{ margin: 0 }}>
-                  {time}
+                  {time ?? t("allDay", { defaultValue: "All day" })}
                 </Text>
               </Column>
             </Row>


### PR DESCRIPTION
Part of RAL-1247 — the last consumer migration: `formatEventDateTime` now builds the finalized/canceled email strings with the pure `lib/datetime` functions instead of hardcoded English dayjs patterns.

## Changes

- **`formatEventDateTime`** takes the recipient's `locale` (default `en`, matching the email templates' fallback) and formats with `formatDateTime` / `formatDateTimeRange` / `formatDateParts`. Zone semantics, now documented on the function:
  - all-day → UTC, same date for everyone
  - fixed (has a zone) → `inviteeTimeZone ?? event.timeZone`, zone name appended (`9:00 – 10:00 AM EDT`)
  - floating (no zone) → UTC wall time, no zone name
- **All-day label moved into the templates**: `time` is now optional; when absent, the finalized-host / finalized-participant / event-canceled templates render `t("allDay")` via their own i18n, so it localizes with the rest of the email instead of the hardcoded English "All day".
- **Cancellation emails now use `inviteeLocale`** — it was stored but never passed, so those emails always rendered in English and the old formatter's output was English regardless of recipient.
- Unit tests pin all four zone scenarios plus locale output.

## Behavior notes

- Times now follow the recipient locale's hour cycle (en → 12h) instead of hardcoded `HH:mm`.
- `Intl.DateTimeFormat.formatRange` adds the date when a range crosses midnight in the display zone, removing the old ambiguous `18:00 - 00:00` output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Event date/time formatting now respects each recipient’s locale (including 24-hour `timeFormat` when set).
  * All-day events are shown as a localized “All day” in event views and email templates.
* **Bug Fixes**
  * Cancelation and finalization emails now use matching locale/time formatting for hosts and invitees.
  * Time zone display and fallback behavior are more consistent for UTC, fixed-time, and floating events.
* **Tests**
  * Added formatting tests covering all-day, fixed-time, floating, time-zone, 24-hour, and localized scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->