### PR TITLE
♻️ Use hourCycle instead of the hour12 boolean

### DIFF
--- a/apps/web/src/lib/datetime/format.ts
+++ b/apps/web/src/lib/datetime/format.ts
@@ -53,14 +53,20 @@ function presetOptions(
   preset: DateTimePreset,
   timeFormat?: TimeFormat,
 ): Intl.DateTimeFormatOptions {
-  // Leave hour12 undefined when there's no preference so the locale decides.
-  const hour12 = timeFormat ? timeFormat === "hours12" : undefined;
+  // Leave hourCycle undefined when there's no preference so the locale
+  // decides. h23/h12 rather than hour12: false, which legacy engines can
+  // resolve to h24 ("24:00" instead of "00:00").
+  const hourCycle = timeFormat
+    ? timeFormat === "hours12"
+      ? ("h12" as const)
+      : ("h23" as const)
+    : undefined;
   switch (preset) {
     case "time":
       return {
-        hour: hour12 === false ? "2-digit" : "numeric",
+        hour: hourCycle === "h23" ? "2-digit" : "numeric",
         minute: "2-digit",
-        hour12,
+        hourCycle,
       };
     case "date":
       return {
@@ -94,9 +100,9 @@ function presetOptions(
         year: "numeric",
         month: "short",
         day: "numeric",
-        hour: hour12 === false ? "2-digit" : "numeric",
+        hour: hourCycle === "h23" ? "2-digit" : "numeric",
         minute: "2-digit",
-        hour12,
+        hourCycle,
       };
   }
 }


### PR DESCRIPTION
Fixes RAL-1259 (part of RAL-1253).

`presetOptions` now maps the time format preference to `hourCycle: "h12" / "h23"` instead of the `hour12` boolean — `hour12: false` resolves to `h24` on some legacy engines, producing `24:00` instead of `00:00` at midnight. Still undefined when no preference is set, so the locale decides.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved time and date-time formatting to better respect locale preferences.
  * Updated 12-hour and 24-hour display handling for more consistent results across regions.
  * Preserved locale-based default behavior when no time format is selected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->