### PR TITLE
♻️ Decouple TimeFormat from @rallly/database in the formatting layer

### DIFF
--- a/apps/web/src/features/scheduled-event/utils.ts
+++ b/apps/web/src/features/scheduled-event/utils.ts
@@ -1,9 +1,9 @@
-import type { TimeFormat } from "@rallly/database";
 import {
   formatDateParts,
   formatDateTime,
   formatDateTimeRange,
 } from "@/lib/datetime/format";
+import type { TimeFormat } from "@/lib/datetime/schema";
 
 export interface FormattedEventDateTime {
   date: string;

--- a/apps/web/src/lib/datetime/client.tsx
+++ b/apps/web/src/lib/datetime/client.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import type { TimeFormat } from "@rallly/database";
 import { defaultLocale } from "@rallly/languages";
 import React from "react";
 import type { DateInput, DateTimePreset } from "@/lib/datetime/format";
@@ -10,6 +9,7 @@ import {
   formatRelativeTime,
 } from "@/lib/datetime/format";
 import { getLocaleDefaults, getWeekdayNames } from "@/lib/datetime/locales";
+import type { TimeFormat } from "@/lib/datetime/schema";
 import { normalizeTimeZone } from "@/lib/datetime/utils";
 import { getBrowserTimeZone } from "@/utils/date-time-utils";
 

--- a/apps/web/src/lib/datetime/device.tsx
+++ b/apps/web/src/lib/datetime/device.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import type { TimeFormat } from "@rallly/database";
 import Cookies from "js-cookie";
 import React from "react";
 import { DateTimeProvider } from "@/lib/datetime/client";
@@ -9,6 +8,7 @@ import {
   TIME_ZONE_COOKIE_NAME,
   TIME_ZONE_OVERRIDE_COOKIE_NAME,
 } from "@/lib/datetime/constants";
+import type { TimeFormat } from "@/lib/datetime/schema";
 
 const cookieAttributes = {
   path: "/",

--- a/apps/web/src/lib/datetime/format.test.ts
+++ b/apps/web/src/lib/datetime/format.test.ts
@@ -1,4 +1,3 @@
-import type { TimeFormat } from "@rallly/database";
 import { describe, expect, it } from "vitest";
 import {
   formatDate,
@@ -6,6 +5,7 @@ import {
   formatDateTimeRange,
   formatRelativeTime,
 } from "@/lib/datetime/format";
+import type { TimeFormat } from "@/lib/datetime/schema";
 
 // Fri 26 Jun 2026, in UTC.
 const at = (hour: number, minute = 0) =>

--- a/apps/web/src/lib/datetime/format.ts
+++ b/apps/web/src/lib/datetime/format.ts
@@ -1,4 +1,4 @@
-import type { TimeFormat } from "@rallly/database";
+import type { TimeFormat } from "@/lib/datetime/schema";
 
 export type DateInput = Date | string | number;
 

--- a/apps/web/src/lib/datetime/locales.ts
+++ b/apps/web/src/lib/datetime/locales.ts
@@ -1,4 +1,4 @@
-import type { TimeFormat } from "@rallly/database";
+import type { TimeFormat } from "@/lib/datetime/schema";
 
 type LocaleDefaults = {
   weekStart: number;

--- a/apps/web/src/lib/datetime/schema.ts
+++ b/apps/web/src/lib/datetime/schema.ts
@@ -3,6 +3,10 @@ import { normalizeTimeZone } from "./utils";
 
 export const timeFormatSchema = z.enum(["hours12", "hours24"]);
 
+// The formatting layer's own TimeFormat; same literals as the Prisma enum so
+// user records assign directly, without coupling this layer to the database.
+export type TimeFormat = z.infer<typeof timeFormatSchema>;
+
 export const timeZoneSchema = z
   .string()
   .refine((value) => normalizeTimeZone(value) !== undefined, {

--- a/apps/web/src/lib/datetime/utils.ts
+++ b/apps/web/src/lib/datetime/utils.ts
@@ -1,5 +1,5 @@
-import type { TimeFormat } from "@rallly/database";
 import type { DateInput } from "@/lib/datetime/format";
+import type { TimeFormat } from "@/lib/datetime/schema";
 
 function toDate(value: DateInput) {
   return value instanceof Date ? value : new Date(value);


### PR DESCRIPTION
Fixes RAL-1260 (part of RAL-1253).

`lib/datetime/schema.ts` now exports `type TimeFormat = z.infer<typeof timeFormatSchema>`, and everything in `lib/datetime/` plus `features/scheduled-event/utils.ts` imports it from there instead of `@rallly/database` — the pure formatting layer no longer depends on Prisma. Same string literals as the Prisma enum, so user records assign without casts; feature-layer files that genuinely sit at the DB boundary keep the Prisma type.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated datetime time-format typing to a single app-level source.
  * Updated datetime formatting and scheduling utilities to use the shared type consistently.
  * No user-facing behavior or formatting output changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->