### PR TITLE
♻️ Narrow DateInput to Date | number

### DIFF
--- a/apps/web/src/components/forms/poll-options-form/month-calendar/time-picker.tsx
+++ b/apps/web/src/components/forms/poll-options-form/month-calendar/time-picker.tsx
@@ -30,7 +30,7 @@ const TimePicker: React.FunctionComponent<TimePickerProps> = ({
 
   // The form works in naive local times, so options format in the system zone.
   const formatTime = (time: string | Date) =>
-    formatDateTime(time, { preset: "time", locale, timeFormat });
+    formatDateTime(new Date(time), { preset: "time", locale, timeFormat });
 
   const getOptions = React.useCallback(() => {
     if (!open) {

--- a/apps/web/src/lib/datetime/format.test.ts
+++ b/apps/web/src/lib/datetime/format.test.ts
@@ -123,13 +123,7 @@ describe("formatDateTime", () => {
     expect(out).toContain("EDT");
   });
 
-  it("accepts ISO strings and timestamps", () => {
-    expect(
-      formatDateTime(at(13).toISOString(), {
-        preset: "time",
-        ...ctx("en", "hours24"),
-      }),
-    ).toBe("13:00");
+  it("accepts timestamps", () => {
     expect(
       formatDateTime(at(13).getTime(), {
         preset: "time",

--- a/apps/web/src/lib/datetime/format.ts
+++ b/apps/web/src/lib/datetime/format.ts
@@ -1,6 +1,6 @@
 import type { TimeFormat } from "@rallly/database";
 
-export type DateInput = Date | string | number;
+export type DateInput = Date | number;
 
 export type DatePreset =
   | "date"


### PR DESCRIPTION
Fixes RAL-1258 (part of RAL-1253).

`DateInput` no longer accepts strings, killing the naive-string footgun: `new Date("2026-07-01T10:00:00")` parses as local time while `new Date("2026-07-01")` parses as UTC, so string inputs made `<Time timeZone="UTC">` output depend on the machine's zone.

Fallout was exactly two call sites, confirming the survey on the issue (superjson keeps tRPC dates as `Date`; the poll form's naive wire strings never reach the formatters):

- `time-picker.tsx` converts its full-ISO (`Z`-suffixed, unambiguous) strings via `new Date()` at the call site
- the `format.test.ts` case asserting string acceptance now asserts timestamps only

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Time formatting is now normalized through a proper date value, improving consistency for displayed times.
  * Date/time formatting now supports timestamps and Date values only; ISO string handling was removed.
  * Updated date formatting behavior to match the supported input types, keeping displayed times consistent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->