### PR TITLE
✅ Fix flaky integration tests caused by races in loginWithEmail

### DIFF
--- a/apps/web/tests/admin-setup.spec.ts
+++ b/apps/web/tests/admin-setup.spec.ts
@@ -105,9 +105,14 @@ test.describe("Admin Setup Page Access", () => {
 
     await page.goto("/admin-setup");
     await expect(page.getByText("Are you the admin?")).toBeVisible();
-    await page.getByRole("button", { name: "Make me an admin" }).click();
 
-    await expect(page).toHaveURL("/control-panel", { timeout: 10000 });
+    // The button is visible before React hydrates it and its onClick
+    // handler is attached, so a click that lands too early is silently
+    // lost. Retry until the action redirects.
+    await expect(async () => {
+      await page.getByRole("button", { name: "Make me an admin" }).click();
+      await page.waitForURL("/control-panel", { timeout: 5000 });
+    }).toPass();
 
     const user = await prisma.user.findUnique({
       where: { email: INITIAL_ADMIN_TEST_EMAIL },

--- a/packages/test-helpers/src/login.ts
+++ b/packages/test-helpers/src/login.ts
@@ -1,4 +1,5 @@
 import type { Page } from "@playwright/test";
+import { expect } from "@playwright/test";
 
 import { getCode } from "./email";
 
@@ -9,17 +10,31 @@ export async function loginWithEmail(
   await page.goto("/login");
   await page.getByText("Welcome").waitFor();
 
-  await page.getByPlaceholder("jessie.smith@example.com").fill(email);
-  await page.getByRole("button", { name: "Continue with email" }).click();
+  // The login form is visible before React has hydrated it, so input that
+  // lands too early can be silently lost. Retry until the next screen
+  // appears. The OTP is reused across resends (resendStrategy: "reuse"),
+  // so submitting more than once is safe.
+  await expect(async () => {
+    await page.getByPlaceholder("jessie.smith@example.com").fill(email);
+    await page.getByRole("button", { name: "Continue with email" }).click();
+    await page
+      .getByRole("heading", { name: "Finish Logging In" })
+      .or(page.getByLabel("Password"))
+      .first()
+      .waitFor({ timeout: 5000 });
+  }).toPass();
 
   if (password) {
     await page.getByLabel("Password").fill(password);
     await page.getByRole("button", { name: "Login with password" }).click();
   } else {
-    await page.getByRole("heading", { name: "Finish Logging In" }).waitFor();
     const code = await getCode(email);
     await page.getByLabel("Enter your 6-digit code").fill(code);
   }
 
-  await page.waitForLoadState("networkidle");
+  // Wait until the login flow navigates away before handing control back
+  // to the test. Waiting for "networkidle" returned too early — while the
+  // verification request was still in flight — so tests could navigate
+  // before the session cookie was set.
+  await page.waitForURL((url) => !url.pathname.startsWith("/login"));
 }


### PR DESCRIPTION
## Problem

Integration tests around login failed intermittently (~1 in 6 local runs of `admin-setup.spec.ts`; also on CI for #2538). Three races, all the same disease — Playwright interacting with server-rendered UI before React hydrates it, or proceeding before an async flow completes:

1. Clicks on the login form landed before hydration and were silently lost — the OTP screen never appeared.
2. `loginWithEmail` ended with `waitForLoadState("networkidle")`, which can fire while the OTP verification request is still in flight — tests navigated before the session cookie was set and got bounced back to `/login`.
3. The "Make me an admin" click landed before the button's `onClick` handler was attached (it's a client handler, not a form action, so there's no progressive-enhancement fallback).

## Fix

- `loginWithEmail`: retry the fill + submit until the next screen (OTP heading or password field) appears — double submits are safe because the OTP `resendStrategy` is `"reuse"` — and wait for the login flow to navigate away from `/login` instead of `networkidle`, so the helper only returns once the session exists.
- `admin-setup.spec.ts`: retry the make-me-admin click until the action redirects to `/control-panel`.

## Test plan

- [x] `admin-setup.spec.ts`: 11 green runs locally across both fixes (previously ~1 in 6 failed)
- [x] `control-panel.spec.ts` passes
- [x] Password branch of the helper kept intact (currently no callers use it)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sign-in reliability by retrying critical UI steps until the correct next fields and headings are available.
  * Replaced fragile login completion waits with a more dependable check that confirms the app has left the login flow.
* **Tests**
  * Updated admin-setup flow verification to retry the redirect until hydration has fully attached interactive handlers, reducing intermittent test failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->