### PR TITLE
👷 Enforce datetime formatting boundaries with lint rules

### DIFF
--- a/biome-plugins/no-raw-datetime-formatting.grit
+++ b/biome-plugins/no-raw-datetime-formatting.grit
@@ -1,0 +1,22 @@
+// Datetime formatting must go through lib/datetime so locale, timezone,
+// and hour-cycle preferences are applied consistently (RAL-1244).
+// The allowlist below is the escape hatch: lib/datetime itself, zone
+// detection (timezone-schema), zone abbreviations (timezone-utils), and
+// files still pending migration. Shrink it as RAL-1247 proceeds.
+language js
+
+or {
+  `new Intl.DateTimeFormat($_)` as $match,
+  `Intl.DateTimeFormat($_)` as $match,
+  `$obj.toLocaleString($_)` as $match,
+  `$obj.toLocaleDateString($_)` as $match,
+  `$obj.toLocaleTimeString($_)` as $match
+} where {
+  $filename <: not or {
+    r".*/src/lib/datetime/.*",
+    r".*/src/utils/timezone-schema\.ts",
+    r".*/src/components/time-zone-picker/timezone-utils\.ts",
+    r".*/src/components/poll/manage-poll/use-csv-exporter\.ts"
+  },
+  register_diagnostic(span=$match, message="Do not format dates inline. Use the formatters in `@/lib/datetime` so locale, timezone, and hour-cycle preferences are applied consistently.")
+}

--- a/biome.json
+++ b/biome.json
@@ -1,13 +1,31 @@
 {
   "$schema": "https://biomejs.dev/schemas/2.3.14/schema.json",
   "root": true,
-  "plugins": ["./biome-plugins/use-icon-button-label.grit"],
-  "assist": { "actions": { "source": { "organizeImports": "on" } } },
+  "plugins": [
+    "./biome-plugins/use-icon-button-label.grit",
+    "./biome-plugins/no-raw-datetime-formatting.grit"
+  ],
+  "assist": {
+    "actions": {
+      "source": {
+        "organizeImports": "on"
+      }
+    }
+  },
   "linter": {
     "enabled": true,
     "rules": {
       "recommended": true,
       "style": {
+        "noRestrictedImports": {
+          "level": "error",
+          "options": {
+            "paths": {
+              "dayjs": "Use the formatters in `@/lib/datetime` for display. dayjs is only allowed in files on the migration allowlist (see overrides in biome.json).",
+              "@/lib/dayjs": "Use the formatters in `@/lib/datetime` for display. dayjs is only allowed in files on the migration allowlist (see overrides in biome.json)."
+            }
+          }
+        },
         "noUselessElse": "off",
         "noParameterAssign": "error",
         "useAsConstAssertion": "error",
@@ -42,6 +60,34 @@
       }
     }
   },
+  "overrides": [
+    {
+      "includes": [
+        "**/src/lib/dayjs.ts",
+        "**/src/lib/datetime/**",
+        "**/src/components/forms/poll-options-form/**",
+        "**/src/components/headless-date-picker.tsx",
+        "**/edit-options/page.tsx",
+        "**/src/trpc/routers/polls.ts",
+        "**/src/trpc/routers/index.ts",
+        "**/api/private/utils/time-slots.ts",
+        "**/src/utils/date-time-utils.ts",
+        "**/src/components/poll/manage-poll/use-csv-exporter.ts",
+        "**/src/app/**/blog/post-preview.tsx",
+        "**/src/components/blog/date-formatter.tsx",
+        "**/src/test/setup.ts",
+        "**/tests/**",
+        "packages/screenshots/**"
+      ],
+      "linter": {
+        "rules": {
+          "style": {
+            "noRestrictedImports": "off"
+          }
+        }
+      }
+    }
+  ],
   "formatter": {
     "enabled": true,
     "formatWithErrors": false,


### PR DESCRIPTION
Closes [RAL-1254](https://linear.app/rallly/issue/RAL-1254/enforce-datetime-formatting-boundaries-with-lint-rules)

## What

Two lint-level escape hatches closed so datetime formatting has to go through `lib/datetime`:

1. **`noRestrictedImports`** — bans `dayjs` and `@/lib/dayjs` imports everywhere except an explicit migration allowlist (biome.json `overrides`). Note: the issue says `@/utils/dayjs`, but the actual module path is `@/lib/dayjs`.
2. **Grit plugin** (`biome-plugins/no-raw-datetime-formatting.grit`) — bans `new Intl.DateTimeFormat(`, `Intl.DateTimeFormat(` (the no-`new` `resolvedOptions()` idiom is just as much a bypass), `.toLocaleString(`, `.toLocaleDateString(`, and `.toLocaleTimeString(` outside `lib/datetime`.

## Allowlists

The issue asked for a single allowlist. Biome overrides **merge** the `plugins` array rather than replace it, so a plugin cannot be disabled per-path from biome.json — the Intl exceptions therefore live in the grit file (via `$filename`), while import exceptions live in biome.json overrides. Each documents the other; both shrink as RAL-1247 proceeds.

**dayjs imports** (biome.json overrides):
- `lib/dayjs.ts` itself + `lib/datetime/**`
- poll options form cluster: `poll-options-form/**` (incl. the react-big-calendar dayjs localizer), `headless-date-picker.tsx`, `edit-options/page.tsx`
- `trpc/routers/polls.ts` (timezone-aware option parsing), `trpc/routers/index.ts` + `src/test/setup.ts` (side-effect import that installs dayjs plugins)
- `api/private/utils/time-slots.ts`, `utils/date-time-utils.ts`, `use-csv-exporter.ts`
- landing blog (`post-preview.tsx`, `date-formatter.tsx`)
- test/tooling code (`**/tests/**`, `packages/screenshots/**`) — not display path

**Raw Intl calls** (grit file):
- `lib/datetime/**` (the implementation)
- `utils/timezone-schema.ts` (zone detection), `time-zone-picker/timezone-utils.ts` (zone abbreviations)
- `use-csv-exporter.ts` (zone detection via `resolvedOptions().timeZone`; already on the migration list)

## Verification

- `pnpm check` passes clean on the current tree (998 files).
- Adding `import { dayjs } from "@/lib/dayjs"` + `date.toLocaleDateString()` to a component makes `pnpm check` fail with both diagnostics.
- Gotcha found along the way: nested `biome.json` files (`"extends": "//"`) resolve override globs relative to the *nested* config, so allowlist globs are `**/`-anchored rather than repo-root-relative.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a lint rule that flags inline date/time formatting calls and encourages using the app’s shared date/time formatters.
  * Expanded lint configuration to discourage direct `dayjs` imports in most code paths, with limited exceptions for approved files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->