### PR TITLE
🐛 Normalize empty string time zones to null

### DIFF
--- a/apps/web/src/app/[locale]/(optional-space)/poll/[urlId]/edit-options/page.tsx
+++ b/apps/web/src/app/[locale]/(optional-space)/poll/[urlId]/edit-options/page.tsx
@@ -109,7 +109,7 @@ const Page = () => {
             updatePollMutation(
               {
                 pollId: poll.id,
-                timeZone: data.timeZone,
+                timeZone: data.timeZone || null,
                 optionsToDelete: optionsToDelete.map(({ id }) => id),
                 optionsToAdd,
               },

--- a/apps/web/src/components/create-poll.tsx
+++ b/apps/web/src/components/create-poll.tsx
@@ -94,7 +94,7 @@ export const CreatePoll: React.FunctionComponent = () => {
             title: title,
             location: formData?.location?.trim(),
             description: formData?.description?.trim(),
-            timeZone: formData?.timeZone,
+            timeZone: formData?.timeZone || null,
             hideParticipants: formData?.hideParticipants,
             disableComments: formData?.disableComments,
             hideScores: formData?.hideScores,

--- a/apps/web/src/trpc/routers/polls.ts
+++ b/apps/web/src/trpc/routers/polls.ts
@@ -30,6 +30,7 @@ import {
 } from "../trpc";
 import { comments } from "./polls/comments";
 import { participants } from "./polls/participants";
+import { timeZoneInput } from "./polls/schema";
 
 const collapseNewlines = (s: string) => s.replace(/\n{3,}/g, "\n\n");
 
@@ -98,7 +99,7 @@ export const polls = router({
     .input(
       z.object({
         title: z.string().trim().min(1),
-        timeZone: z.string().optional(),
+        timeZone: timeZoneInput,
         location: z.string().trim().optional(),
         description: z.string().trim().transform(collapseNewlines).optional(),
         hideParticipants: z.boolean().optional(),
@@ -288,7 +289,7 @@ export const polls = router({
       z.object({
         pollId: z.string(),
         title: z.string().trim().optional(),
-        timeZone: z.string().optional(),
+        timeZone: timeZoneInput,
         location: z.string().trim().optional(),
         description: z.string().trim().transform(collapseNewlines).optional(),
         optionsToDelete: z.string().array().optional(),

--- a/apps/web/src/trpc/routers/polls/schema.test.ts
+++ b/apps/web/src/trpc/routers/polls/schema.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+import { timeZoneInput } from "./schema";
+
+describe("timeZoneInput", () => {
+  it("normalizes an empty string to null", () => {
+    expect(timeZoneInput.parse("")).toBeNull();
+  });
+
+  it("passes a timezone through unchanged", () => {
+    expect(timeZoneInput.parse("Europe/Berlin")).toBe("Europe/Berlin");
+  });
+
+  it("keeps undefined as undefined so modify can mean 'leave unchanged'", () => {
+    expect(timeZoneInput.parse(undefined)).toBeUndefined();
+  });
+
+  it("keeps null as null", () => {
+    expect(timeZoneInput.parse(null)).toBeNull();
+  });
+});

--- a/apps/web/src/trpc/routers/polls/schema.ts
+++ b/apps/web/src/trpc/routers/polls/schema.ts
@@ -1,0 +1,10 @@
+import * as z from "zod";
+
+// A falsy poll timeZone means "floating". Clients historically sent "" for
+// floating time polls; normalize it to null at the boundary so it can never
+// be persisted. undefined must pass through untouched: in `modify` it means
+// "leave the current value unchanged".
+export const timeZoneInput = z
+  .string()
+  .transform((value) => value || null)
+  .nullish();

--- a/packages/database/prisma/migrations/20260708131500_normalize_empty_string_time_zones/migration.sql
+++ b/packages/database/prisma/migrations/20260708131500_normalize_empty_string_time_zones/migration.sql
@@ -1,0 +1,10 @@
+-- A falsy time zone means "floating" in app code, but '' is NOT NULL in SQL:
+-- AT TIME ZONE '' errors and '' rows would fail the CHECK constraints planned
+-- in RAL-1257. Normalize every time zone column so past rows match the
+-- normalized writes.
+UPDATE polls SET time_zone = NULL WHERE time_zone = '';
+UPDATE scheduled_events SET time_zone = NULL WHERE time_zone = '';
+UPDATE participants SET time_zone = NULL WHERE time_zone = '';
+UPDATE scheduled_event_invites SET invitee_time_zone = NULL WHERE invitee_time_zone = '';
+UPDATE users SET time_zone = NULL WHERE time_zone = '';
+UPDATE provider_calendars SET time_zone = NULL WHERE time_zone = '';


### PR DESCRIPTION
Fixes [RAL-1276](https://linear.app/rallly/issue/RAL-1276/empty-string-time-zones-normalize-writes-to-null-and-backfill-existing). Blocks the CHECK constraints planned in RAL-1257.

## Problem

Floating **time** polls persist `time_zone = ''` while date polls persist `NULL`. The options form models floating as `timeZone: ""`, and neither `polls.make` nor `polls.modify` normalized it: `timeZone ?? null` doesn't catch `''` because it isn't nullish. Finalizing a poll then copies `''` onto `scheduled_events` (115 rows in prod) and into the invite fallback chain.

App code treats any falsy time zone as floating so rendering is unaffected, but SQL treats `''` as NOT NULL: `AT TIME ZONE ''` raises an error and the `all_day_is_floating` CHECK planned in RAL-1257 would reject those rows.

## Changes

- **Server boundary:** new `timeZoneInput` schema shared by `polls.make` and `polls.modify` transforms `''` to `null`. `undefined` passes through untouched so `modify` keeps its "leave unchanged" semantics. This covers API callers, not just our UI.
- **Clients:** the create poll and edit options submit paths now send `null` instead of `''`.
- **Backfill migration:** `''` → `NULL` on every time zone column (`polls`, `scheduled_events`, `participants`, `scheduled_event_invites.invitee_time_zone`, `users`, `provider_calendars`). Only `scheduled_events` is confirmed affected in prod; the rest are no ops if clean.
- Unit test pinning the normalization semantics, including that `undefined` stays `undefined` (regressing that would silently wipe time zones on every `modify` call).

## Verification

- `vitest run src/trpc/routers/polls/schema.test.ts` — 4 passed
- `pnpm type-check`, `pnpm check` — clean
- Migration SQL dry-run against the dev database in a rolled-back transaction — all six updates execute

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Poll time zone submissions are now normalized so empty inputs are saved as `NULL` rather than blank strings.
  * Existing records with blank time zone values are migrated to `NULL` to keep updates consistent.

* **New Features**
  * Improved time zone handling across poll creation and editing, including correct behavior when the field is left unset.

* **Tests**
  * Added automated coverage for time zone input normalization (empty string, valid value, `null`, and `undefined`).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->