### PR TITLE
🚨 Exempt tests from the raw datetime formatting lint rule

### DIFF
--- a/biome-plugins/no-raw-datetime-formatting.grit
+++ b/biome-plugins/no-raw-datetime-formatting.grit
@@ -1,8 +1,10 @@
 // Datetime formatting must go through lib/datetime so locale, timezone,
 // and hour-cycle preferences are applied consistently (RAL-1244).
 // The allowlist below is the escape hatch: lib/datetime itself, zone
-// detection (timezone-schema), zone abbreviations (timezone-utils), and
-// files still pending migration. Shrink it as RAL-1247 proceeds.
+// detection (timezone-schema), zone abbreviations (timezone-utils), tests
+// (which format independently of the app to act as an oracle, matching the
+// tests exemption in the biome.json overrides), and files still pending
+// migration. Shrink it as RAL-1247 proceeds.
 language js
 
 or {
@@ -16,7 +18,8 @@ or {
     r".*/src/lib/datetime/.*",
     r".*/src/utils/timezone-schema\.ts",
     r".*/src/components/time-zone-picker/timezone-utils\.ts",
-    r".*/src/components/poll/manage-poll/use-csv-exporter\.ts"
+    r".*/src/components/poll/manage-poll/use-csv-exporter\.ts",
+    r".*/tests/.*"
   },
   register_diagnostic(span=$match, message="Do not format dates inline. Use the formatters in `@/lib/datetime` so locale, timezone, and hour-cycle preferences are applied consistently.")
 }


### PR DESCRIPTION
## Problem

Lint is failing on `main`. Two PRs merged independently and conflict:

- #2541 added the `no-raw-datetime-formatting` Grit plugin, which bans inline `Intl.DateTimeFormat` outside `lib/datetime`.
- #2542 added cross-timezone Playwright tests that call `Intl.DateTimeFormat` inside `page.evaluate`.

## Why exempt tests rather than change the test

The test formats dates with the page's own Intl engine on purpose: it acts as an independent oracle for what the app renders, and code inside `page.evaluate` runs in the browser context where `@/lib/datetime` cannot be imported anyway.

Tests are already exempt from the sibling `noRestrictedImports` (dayjs) rule via the `**/tests/**` override in `biome.json`, but Grit plugins do not respect `biome.json` overrides, so the exemption has to live in the plugin's own filename allowlist.

## Change

Add `.*/tests/.*` to the allowlist in `biome-plugins/no-raw-datetime-formatting.grit` and note the rationale in the header comment.

`pnpm check` passes with this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Expanded the formatting rule’s exceptions so diagnostics are suppressed in test files as well as an existing allowed case.
  * Updated the rule guidance to better reflect the current set of allowed scenarios, including timezone-related handling and pending migration cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->