### PR TITLE
🔧 Prepare tsconfigs and dependency graph for TypeScript 7

### DIFF
--- a/apps/landing/tsconfig.json
+++ b/apps/landing/tsconfig.json
@@ -1,10 +1,9 @@
 {
   "extends": "@rallly/tsconfig/next.json",
   "compilerOptions": {
-    "baseUrl": ".",
     "paths": {
-      "@/*": ["src/*"],
-      "~/*": ["public/*"]
+      "@/*": ["./src/*"],
+      "~/*": ["./public/*"]
     },
     "checkJs": false,
     "strictNullChecks": true,

--- a/apps/web/tests/create-delete-poll.spec.ts
+++ b/apps/web/tests/create-delete-poll.spec.ts
@@ -1,7 +1,7 @@
 import type { Page } from "@playwright/test";
 import { expect, test } from "@playwright/test";
 import { deleteAllMessages } from "@rallly/test-helpers";
-import { NewPollPage } from "tests/new-poll-page";
+import { NewPollPage } from "./new-poll-page";
 
 test.describe.serial(() => {
   let page: Page;

--- a/apps/web/tests/edit-options.spec.ts
+++ b/apps/web/tests/edit-options.spec.ts
@@ -1,7 +1,7 @@
 import type { Page } from "@playwright/test";
 import { expect, test } from "@playwright/test";
-import type { EditOptionsPage } from "tests/edit-options-page";
-import { NewPollPage } from "tests/new-poll-page";
+import type { EditOptionsPage } from "./edit-options-page";
+import { NewPollPage } from "./new-poll-page";
 
 test.describe("edit options", () => {
   let page: Page;

--- a/apps/web/tests/guest-to-user-migration.spec.ts
+++ b/apps/web/tests/guest-to-user-migration.spec.ts
@@ -1,8 +1,8 @@
 import { expect, test } from "@playwright/test";
 import { prisma } from "@rallly/database";
 import { deleteAllMessages } from "@rallly/test-helpers";
-import { NewPollPage } from "tests/new-poll-page";
 import { LoginPage } from "./login-page";
+import { NewPollPage } from "./new-poll-page";
 import { RegisterPage } from "./register-page";
 
 const testUser = {

--- a/apps/web/tests/new-poll-page.ts
+++ b/apps/web/tests/new-poll-page.ts
@@ -1,5 +1,5 @@
 import type { Locator, Page } from "@playwright/test";
-import { PollPage } from "tests/poll-page";
+import { PollPage } from "./poll-page";
 
 export class CreatePollSuccessDialog {
   constructor(private readonly page: Page) {}

--- a/apps/web/tests/poll-page.ts
+++ b/apps/web/tests/poll-page.ts
@@ -1,6 +1,6 @@
 import type { Page } from "@playwright/test";
-import { EditOptionsPage } from "tests/edit-options-page";
-import { InvitePage } from "tests/invite-page";
+import { EditOptionsPage } from "./edit-options-page";
+import { InvitePage } from "./invite-page";
 
 export class PollPage {
   constructor(public readonly page: Page) {}

--- a/apps/web/tests/vote-and-comment.spec.ts
+++ b/apps/web/tests/vote-and-comment.spec.ts
@@ -2,8 +2,8 @@ import type { Page } from "@playwright/test";
 import { expect, test } from "@playwright/test";
 import { captureOne } from "@rallly/test-helpers";
 import { load } from "cheerio";
-import type { PollPage } from "tests/poll-page";
 import { NewPollPage } from "./new-poll-page";
+import type { PollPage } from "./poll-page";
 
 test.describe(() => {
   let page: Page;

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -1,9 +1,8 @@
 {
   "extends": "@rallly/tsconfig/next.json",
   "compilerOptions": {
-    "baseUrl": ".",
     "paths": {
-      "@/*": ["src/*"]
+      "@/*": ["./src/*"]
     },
     "strictNullChecks": true,
     "types": ["vitest/globals"],

--- a/packages/ui/tsconfig.json
+++ b/packages/ui/tsconfig.json
@@ -1,8 +1,5 @@
 {
   "extends": "@rallly/tsconfig/next.json",
-  "compilerOptions": {
-    "baseUrl": "."
-  },
   "include": ["**/*.ts", "**/*.tsx"],
   "exclude": ["node_modules"]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,7 +4,7 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
-packageExtensionsChecksum: sha256-7EyWhva5Lcamo6pe18OzfUc27A7xbWt39+G/ofluF9k=
+packageExtensionsChecksum: sha256-MiHZ3mgtOUb60KfpkAkui5ad/9eLmcQda0MiZKaTRqA=
 
 importers:
 
@@ -94,7 +94,7 @@ importers:
         version: 8.1.0(typescript@5.9.3)
       '@vercel/analytics':
         specifier: ^1.5.0
-        version: 1.6.1(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)
+        version: 1.6.1(next@16.2.6(@opentelemetry/api@1.9.0)(@playwright/test@1.58.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)
       dayjs:
         specifier: ^1.11.13
         version: 1.11.19
@@ -133,7 +133,7 @@ importers:
         version: 6.0.0(@types/react@19.2.13)(react@19.2.6)
       next-seo:
         specifier: ^6.1.0
-        version: 6.8.0(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        version: 6.8.0(next@16.2.6(@opentelemetry/api@1.9.0)(@playwright/test@1.58.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       pg:
         specifier: ^8.17.1
         version: 8.18.0
@@ -2474,6 +2474,9 @@ packages:
     peerDependencies:
       react-hook-form: ^7.55.0
       zod: '*'
+    peerDependenciesMeta:
+      zod:
+        optional: true
 
   '@img/colour@1.0.0':
     resolution: {integrity: sha512-A5P/LfWGFSl6nsckYtjw9da+19jB8hkJ6ACTGcDfEJ0aE+l2n2El7dsVM7UVHZQ9s2lmYMWlrS21YLy2IR1LUw==}
@@ -13490,6 +13493,7 @@ snapshots:
     dependencies:
       '@standard-schema/utils': 0.3.0
       react-hook-form: 7.71.1(react@19.2.6)
+    optionalDependencies:
       zod: 4.3.6
 
   '@img/colour@1.0.0': {}
@@ -18200,7 +18204,7 @@ snapshots:
     dependencies:
       uncrypto: 0.1.3
 
-  '@vercel/analytics@1.6.1(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)':
+  '@vercel/analytics@1.6.1(next@16.2.6(@opentelemetry/api@1.9.0)(@playwright/test@1.58.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)':
     optionalDependencies:
       next: 16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react: 19.2.6
@@ -21958,7 +21962,7 @@ snapshots:
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
 
-  next-seo@6.8.0(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
+  next-seo@6.8.0(next@16.2.6(@opentelemetry/api@1.9.0)(@playwright/test@1.58.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
     dependencies:
       next: 16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react: 19.2.6

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,8 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+packageExtensionsChecksum: sha256-7EyWhva5Lcamo6pe18OzfUc27A7xbWt39+G/ofluF9k=
+
 importers:
 
   .:
@@ -213,7 +215,7 @@ importers:
         version: 0.7.6(hono@4.11.7)(zod@4.3.6)
       '@hookform/resolvers':
         specifier: ^5.2.2
-        version: 5.2.2(react-hook-form@7.71.1(react@19.2.6))
+        version: 5.2.2(react-hook-form@7.71.1(react@19.2.6))(zod@4.3.6)
       '@marsidev/react-turnstile':
         specifier: ^1.4.2
         version: 1.4.2(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
@@ -2471,6 +2473,7 @@ packages:
     resolution: {integrity: sha512-A/IxlMLShx3KjV/HeTcTfaMxdwy690+L/ZADoeaTltLx+CVuzkeVIPuybK3jrRfw7YZnmdKsVVHAlEPIAEUNlA==}
     peerDependencies:
       react-hook-form: ^7.55.0
+      zod: '*'
 
   '@img/colour@1.0.0':
     resolution: {integrity: sha512-A5P/LfWGFSl6nsckYtjw9da+19jB8hkJ6ACTGcDfEJ0aE+l2n2El7dsVM7UVHZQ9s2lmYMWlrS21YLy2IR1LUw==}
@@ -13483,10 +13486,11 @@ snapshots:
       hono: 4.11.7
       zod: 4.3.6
 
-  '@hookform/resolvers@5.2.2(react-hook-form@7.71.1(react@19.2.6))':
+  '@hookform/resolvers@5.2.2(react-hook-form@7.71.1(react@19.2.6))(zod@4.3.6)':
     dependencies:
       '@standard-schema/utils': 0.3.0
       react-hook-form: 7.71.1(react@19.2.6)
+      zod: 4.3.6
 
   '@img/colour@1.0.0': {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -11,3 +11,6 @@ packageExtensions:
   '@hookform/resolvers':
     peerDependencies:
       zod: '*'
+    peerDependenciesMeta:
+      zod:
+        optional: true

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -4,3 +4,10 @@ packages:
 
 onlyBuiltDependencies:
   - '@prisma/client'
+
+# @hookform/resolvers imports zod/v4/core without declaring zod as a peer,
+# relying on pnpm's hoisted fallback which can flip to zod@3 on re-resolution
+packageExtensions:
+  '@hookform/resolvers':
+    peerDependencies:
+      zod: '*'


### PR DESCRIPTION
Refs RAL-1282

Preparation for the TypeScript 7 upgrade, extracted from #2548. The upgrade itself is deferred until TS 7.1 ships the programmatic API and Next.js supports it (Next.js loads the `typescript` JS API for typegen and its tsserver plugin, and TS 7.0 doesn't have one). Everything here is fully compatible with our current TS 5.8 and stands on its own:

- **Remove `baseUrl`** from `apps/web`, `apps/landing`, and `packages/ui` tsconfigs — it's a hard error in TS 7. `paths` entries are now tsconfig-relative, which behaves identically.
- **Convert Playwright test imports** that relied on `baseUrl` (`from "tests/x"`) to relative imports.
- **Declare `zod` as a peer of `@hookform/resolvers`** via `packageExtensions`. It imports `zod/v4/core` without declaring zod and currently resolves through pnpm's hidden hoisted fallback — which can flip to zod@3 on any unrelated lockfile re-resolution and break `next build` (this actually happened while testing the TS 7 upgrade). With the peer declared it resolves properly against our zod@4.

With this merged, the eventual TS 7 upgrade becomes a one-line dependency bump.

## Verified

- `pnpm type-check` — 8/8 packages
- `pnpm build` (web) — succeeds, resolvers correctly linked against zod@4.3.6
- `pnpm test:unit` — 205 tests pass
- `pnpm check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved TypeScript import path resolution across the landing, web, and UI apps to be more consistent.
  - Updated package installation rules to prevent unexpected dependency/version resolution issues.
- **Tests**
  - Updated end-to-end test imports to use local relative paths, keeping the suite aligned with the current test page layout.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->