### PR TITLE
🔇 Only record Sentry session replays when an error occurs

### DIFF
--- a/apps/web/instrumentation-client.ts
+++ b/apps/web/instrumentation-client.ts
@@ -18,9 +18,8 @@ Sentry.init({
 
   replaysOnErrorSampleRate: 1.0,
 
-  // This sets the sample rate to be 10%. You may want this to be 100% while
-  // in development and sample at a lower rate in production
-  replaysSessionSampleRate: 0.1,
+  // Only record replays for sessions with errors
+  replaysSessionSampleRate: 0,
 
   // You can remove this option if you're not planning to use the Sentry Session Replay feature:
   integrations: [


### PR DESCRIPTION
## Summary
Sets `replaysSessionSampleRate` to 0 while keeping `replaysOnErrorSampleRate` at 1.0. The Sentry SDK now runs replay in buffering mode: it records into memory and only uploads a replay when an error occurs, so replay quota is consumed only by error sessions.

We never look at plain session replays and were going over quota.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted session replay recording so replays are only captured for sessions that encounter errors, reducing unnecessary data collection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->