### PR TITLE
🐛 Encode all-day scheduled events at UTC midnight with no time zone

### DIFF
--- a/apps/web/src/trpc/routers/polls.ts
+++ b/apps/web/src/trpc/routers/polls.ts
@@ -30,6 +30,7 @@ import {
 } from "../trpc";
 import { comments } from "./polls/comments";
 import { participants } from "./polls/participants";
+import { getScheduledEventTimes } from "./polls/scheduled-event-times";
 import { timeZoneInput } from "./polls/schema";
 
 const collapseNewlines = (s: string) => s.replace(/\n{3,}/g, "\n\n");
@@ -168,17 +169,19 @@ export const polls = router({
       const pollId = nanoid();
       const spaceId = activeSpace?.id;
 
-      // Date-only (all-day) polls are floating: they carry no timezone, so a
-      // falsy poll.timeZone is the single source of truth for "floating". Drop
-      // any timezone the client sent for a date-only poll so options are stored
-      // at UTC midnight and never shift across timezones.
+      // Date-only (all-day) options are floating: they are stored at UTC
+      // midnight so they never shift across timezones. A falsy poll.timeZone
+      // is the single source of truth for "floating", so date-only polls drop
+      // any timezone the client sent, and date-only options of mixed polls
+      // ignore the poll's timezone.
       const isTimePoll = input.options.some((option) => option.endDate);
       const timeZone = isTimePoll ? input.timeZone : null;
 
       const optionsData = input.options.map((option) => ({
-        startTime: timeZone
-          ? dayjs(option.startDate).tz(timeZone, true).toDate()
-          : dayjs(option.startDate).utc(true).toDate(),
+        startTime:
+          timeZone && option.endDate
+            ? dayjs(option.startDate).tz(timeZone, true).toDate()
+            : dayjs(option.startDate).utc(true).toDate(),
         duration: option.endDate
           ? dayjs(option.endDate).diff(dayjs(option.startDate), "minute")
           : 0,
@@ -792,13 +795,11 @@ export const polls = router({
         });
       }
 
-      let eventStart = dayjs(option.startTime);
-
-      if (poll.timeZone) {
-        eventStart = eventStart.tz(poll.timeZone);
-      } else {
-        eventStart = eventStart.utc();
-      }
+      const eventTimes = getScheduledEventTimes({
+        startTime: option.startTime,
+        duration: option.duration,
+        timeZone: poll.timeZone,
+      });
 
       const { spaceId } = poll;
 
@@ -822,13 +823,10 @@ export const polls = router({
         title: poll.title,
         location: poll.location ?? undefined,
         description: poll.description ?? undefined,
-        start: option.startTime,
-        end:
-          option.duration > 0
-            ? dayjs(option.startTime).add(option.duration, "minute").toDate()
-            : dayjs(option.startTime).add(1, "day").toDate(),
-        allDay: option.duration === 0,
-        timeZone: poll.timeZone ?? undefined,
+        start: eventTimes.start,
+        end: eventTimes.end,
+        allDay: eventTimes.allDay,
+        timeZone: eventTimes.timeZone ?? undefined,
         organizer: {
           name: poll.user.name,
           email: poll.user.email,
@@ -885,20 +883,17 @@ export const polls = router({
           data: {
             id: eventId,
             uid: `${eventId}@rallly.co`,
-            start: eventStart.toDate(),
-            end:
-              option.duration > 0
-                ? eventStart.add(option.duration, "minute").toDate()
-                : eventStart.add(1, "day").toDate(),
+            start: eventTimes.start,
+            end: eventTimes.end,
             title: poll.title,
             description: poll.description,
             location: poll.location
               ? { provider: "custom", address: poll.location }
               : undefined,
-            timeZone: poll.timeZone,
+            timeZone: eventTimes.timeZone,
             userId: ctx.user.id,
             spaceId,
-            allDay: option.duration === 0,
+            allDay: eventTimes.allDay,
             status: "confirmed",
             hideAttendees: poll.hideParticipants,
             invites: {

--- a/apps/web/src/trpc/routers/polls/scheduled-event-times.test.ts
+++ b/apps/web/src/trpc/routers/polls/scheduled-event-times.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from "vitest";
+import { getScheduledEventTimes } from "./scheduled-event-times";
+
+describe("getScheduledEventTimes", () => {
+  it("keeps the poll's time zone on timed events", () => {
+    const result = getScheduledEventTimes({
+      startTime: new Date("2026-03-23T14:00:00Z"),
+      duration: 60,
+      timeZone: "America/Toronto",
+    });
+    expect(result).toEqual({
+      allDay: false,
+      start: new Date("2026-03-23T14:00:00Z"),
+      end: new Date("2026-03-23T15:00:00Z"),
+      timeZone: "America/Toronto",
+    });
+  });
+
+  it("keeps a null time zone on floating timed events", () => {
+    const result = getScheduledEventTimes({
+      startTime: new Date("2026-03-23T14:00:00Z"),
+      duration: 30,
+      timeZone: null,
+    });
+    expect(result.timeZone).toBeNull();
+    expect(result.end).toEqual(new Date("2026-03-23T14:30:00Z"));
+  });
+
+  it("encodes all-day events from date-only polls as a floating UTC midnight day span", () => {
+    const result = getScheduledEventTimes({
+      startTime: new Date("2026-03-23T00:00:00Z"),
+      duration: 0,
+      timeZone: null,
+    });
+    expect(result).toEqual({
+      allDay: true,
+      start: new Date("2026-03-23T00:00:00Z"),
+      end: new Date("2026-03-24T00:00:00Z"),
+      timeZone: null,
+    });
+  });
+
+  it("drops the poll's time zone from all-day events without shifting a UTC midnight start", () => {
+    const result = getScheduledEventTimes({
+      startTime: new Date("2026-03-23T00:00:00Z"),
+      duration: 0,
+      timeZone: "America/Toronto",
+    });
+    expect(result).toEqual({
+      allDay: true,
+      start: new Date("2026-03-23T00:00:00Z"),
+      end: new Date("2026-03-24T00:00:00Z"),
+      timeZone: null,
+    });
+  });
+
+  it("snaps a legacy zone-midnight all-day option west of UTC to the zone's calendar date", () => {
+    // midnight Oct 17 in Chicago = 05:00Z
+    const result = getScheduledEventTimes({
+      startTime: new Date("2025-10-17T05:00:00Z"),
+      duration: 0,
+      timeZone: "America/Chicago",
+    });
+    expect(result).toEqual({
+      allDay: true,
+      start: new Date("2025-10-17T00:00:00Z"),
+      end: new Date("2025-10-18T00:00:00Z"),
+      timeZone: null,
+    });
+  });
+
+  it("snaps a legacy zone-midnight all-day option east of UTC to the zone's calendar date", () => {
+    // midnight Oct 17 in Tokyo = Oct 16 15:00Z
+    const result = getScheduledEventTimes({
+      startTime: new Date("2025-10-16T15:00:00Z"),
+      duration: 0,
+      timeZone: "Asia/Tokyo",
+    });
+    expect(result).toEqual({
+      allDay: true,
+      start: new Date("2025-10-17T00:00:00Z"),
+      end: new Date("2025-10-18T00:00:00Z"),
+      timeZone: null,
+    });
+  });
+});

--- a/apps/web/src/trpc/routers/polls/scheduled-event-times.ts
+++ b/apps/web/src/trpc/routers/polls/scheduled-event-times.ts
@@ -1,0 +1,47 @@
+import {
+  calendarDateToUTCMidnight,
+  getCalendarDate,
+  toISODate,
+} from "@/lib/datetime/utils";
+
+const MINUTE_MS = 60 * 1000;
+const DAY_MS = 24 * 60 * MINUTE_MS;
+
+// All-day events are floating: start/end sit at exactly UTC midnight with no
+// time zone. The upcoming-events predicate, finalize emails, and ICS files all
+// read all-day dates via UTC, so any other encoding renders off by one day.
+export function getScheduledEventTimes({
+  startTime,
+  duration,
+  timeZone,
+}: {
+  startTime: Date;
+  duration: number;
+  timeZone: string | null;
+}) {
+  if (duration > 0) {
+    return {
+      allDay: false as const,
+      start: startTime,
+      end: new Date(startTime.getTime() + duration * MINUTE_MS),
+      timeZone,
+    };
+  }
+
+  // Mixed polls used to encode date-only options at midnight in the poll's
+  // zone; snap those to the zone's calendar date. Options already at UTC
+  // midnight are correctly encoded and must not be shifted.
+  const isUtcMidnight = startTime.getTime() % DAY_MS === 0;
+  const start = calendarDateToUTCMidnight(
+    timeZone && !isUtcMidnight
+      ? getCalendarDate(startTime, timeZone)
+      : toISODate(startTime),
+  );
+
+  return {
+    allDay: true as const,
+    start,
+    end: new Date(start.getTime() + DAY_MS),
+    timeZone: null,
+  };
+}


### PR DESCRIPTION
Part of RAL-1257 (step 2 of the migration plan: the write fixes, ahead of the backfill and CHECK constraints).

## Problem

The date-to-date comparison in `upcomingScheduledEventWhere`, `formatEventDateTime`, and `createIcsEvent` all assume all-day rows are exactly UTC midnight and floating (`timeZone` null). Two write paths could violate that:

- **Poll creation**: `isTimePoll` is true if *any* option has an end date, so a mixed poll keeps its `timeZone` and its date-only options were encoded at midnight in the poll's zone instead of UTC midnight.
- **Finalizing**: the book mutation copied `poll.timeZone` onto the event unconditionally, so finalizing a date-only option of a mixed poll produced a zoned all-day event. The two zoned all-day rows in prod came from this path.

## Fix

- Poll creation encodes each option independently: date-only options are stored at UTC midnight even when the poll has a time zone.
- The finalize path goes through a new `getScheduledEventTimes` helper: all-day events are written as floating (`timeZone: null`) UTC midnight day spans, and legacy date-only options that were encoded at zone midnight are snapped to the zone's calendar date so finalizing them can no longer produce an off-by-one date in emails or the ICS file. Options already at UTC midnight are never shifted (the trap flagged in the RAL-1257 audit).
- Timed events are unchanged.

The helper uses the `Intl`-based primitives from `@/lib/datetime/utils` (no new dayjs usage).

## Testing

- New unit tests cover timed/floating/all-day encoding, the no-shift guarantee for UTC midnight starts, and legacy zone-midnight snapping both west and east of UTC
- `pnpm test:unit`, `pnpm check`, `pnpm type-check` all pass

The backfill for the existing rows (2 zoned + 40 zero-length) and the CHECK constraints land separately per the RAL-1257 plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved how scheduled event times are calculated for polls, including better handling of all-day, floating, and timezone-based events.
  * Fixed booking and calendar export timing so event start/end values are stored consistently and more accurately.
  * Added support for legacy midnight-based all-day options to keep dates aligned correctly across time zones.

* **Tests**
  * Added coverage for scheduled event timing scenarios, including all-day and timezone edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->