### PR TITLE
🗃️ Backfill all-day event encoding and enforce invariants with CHECKs

### DIFF
--- a/apps/web/src/trpc/routers/polls.ts
+++ b/apps/web/src/trpc/routers/polls.ts
@@ -30,6 +30,7 @@ import {
 } from "../trpc";
 import { comments } from "./polls/comments";
 import { participants } from "./polls/participants";
+import { getScheduledEventTimes } from "./polls/scheduled-event-times";
 import { timeZoneInput } from "./polls/schema";
 
 const collapseNewlines = (s: string) => s.replace(/\n{3,}/g, "\n\n");
@@ -168,17 +169,19 @@ export const polls = router({
       const pollId = nanoid();
       const spaceId = activeSpace?.id;
 
-      // Date-only (all-day) polls are floating: they carry no timezone, so a
-      // falsy poll.timeZone is the single source of truth for "floating". Drop
-      // any timezone the client sent for a date-only poll so options are stored
-      // at UTC midnight and never shift across timezones.
+      // Date-only (all-day) options are floating: they are stored at UTC
+      // midnight so they never shift across timezones. A falsy poll.timeZone
+      // is the single source of truth for "floating", so date-only polls drop
+      // any timezone the client sent, and date-only options of mixed polls
+      // ignore the poll's timezone.
       const isTimePoll = input.options.some((option) => option.endDate);
       const timeZone = isTimePoll ? input.timeZone : null;
 
       const optionsData = input.options.map((option) => ({
-        startTime: timeZone
-          ? dayjs(option.startDate).tz(timeZone, true).toDate()
-          : dayjs(option.startDate).utc(true).toDate(),
+        startTime:
+          timeZone && option.endDate
+            ? dayjs(option.startDate).tz(timeZone, true).toDate()
+            : dayjs(option.startDate).utc(true).toDate(),
         duration: option.endDate
           ? dayjs(option.endDate).diff(dayjs(option.startDate), "minute")
           : 0,
@@ -792,13 +795,11 @@ export const polls = router({
         });
       }
 
-      let eventStart = dayjs(option.startTime);
-
-      if (poll.timeZone) {
-        eventStart = eventStart.tz(poll.timeZone);
-      } else {
-        eventStart = eventStart.utc();
-      }
+      const eventTimes = getScheduledEventTimes({
+        startTime: option.startTime,
+        duration: option.duration,
+        timeZone: poll.timeZone,
+      });
 
       const { spaceId } = poll;
 
@@ -822,13 +823,10 @@ export const polls = router({
         title: poll.title,
         location: poll.location ?? undefined,
         description: poll.description ?? undefined,
-        start: option.startTime,
-        end:
-          option.duration > 0
-            ? dayjs(option.startTime).add(option.duration, "minute").toDate()
-            : dayjs(option.startTime).add(1, "day").toDate(),
-        allDay: option.duration === 0,
-        timeZone: poll.timeZone ?? undefined,
+        start: eventTimes.start,
+        end: eventTimes.end,
+        allDay: eventTimes.allDay,
+        timeZone: eventTimes.timeZone ?? undefined,
         organizer: {
           name: poll.user.name,
           email: poll.user.email,
@@ -885,20 +883,17 @@ export const polls = router({
           data: {
             id: eventId,
             uid: `${eventId}@rallly.co`,
-            start: eventStart.toDate(),
-            end:
-              option.duration > 0
-                ? eventStart.add(option.duration, "minute").toDate()
-                : eventStart.add(1, "day").toDate(),
+            start: eventTimes.start,
+            end: eventTimes.end,
             title: poll.title,
             description: poll.description,
             location: poll.location
               ? { provider: "custom", address: poll.location }
               : undefined,
-            timeZone: poll.timeZone,
+            timeZone: eventTimes.timeZone,
             userId: ctx.user.id,
             spaceId,
-            allDay: option.duration === 0,
+            allDay: eventTimes.allDay,
             status: "confirmed",
             hideAttendees: poll.hideParticipants,
             invites: {

--- a/apps/web/src/trpc/routers/polls/scheduled-event-times.test.ts
+++ b/apps/web/src/trpc/routers/polls/scheduled-event-times.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from "vitest";
+import { getScheduledEventTimes } from "./scheduled-event-times";
+
+describe("getScheduledEventTimes", () => {
+  it("keeps the poll's time zone on timed events", () => {
+    const result = getScheduledEventTimes({
+      startTime: new Date("2026-03-23T14:00:00Z"),
+      duration: 60,
+      timeZone: "America/Toronto",
+    });
+    expect(result).toEqual({
+      allDay: false,
+      start: new Date("2026-03-23T14:00:00Z"),
+      end: new Date("2026-03-23T15:00:00Z"),
+      timeZone: "America/Toronto",
+    });
+  });
+
+  it("keeps a null time zone on floating timed events", () => {
+    const result = getScheduledEventTimes({
+      startTime: new Date("2026-03-23T14:00:00Z"),
+      duration: 30,
+      timeZone: null,
+    });
+    expect(result.timeZone).toBeNull();
+    expect(result.end).toEqual(new Date("2026-03-23T14:30:00Z"));
+  });
+
+  it("encodes all-day events from date-only polls as a floating UTC midnight day span", () => {
+    const result = getScheduledEventTimes({
+      startTime: new Date("2026-03-23T00:00:00Z"),
+      duration: 0,
+      timeZone: null,
+    });
+    expect(result).toEqual({
+      allDay: true,
+      start: new Date("2026-03-23T00:00:00Z"),
+      end: new Date("2026-03-24T00:00:00Z"),
+      timeZone: null,
+    });
+  });
+
+  it("drops the poll's time zone from all-day events without shifting a UTC midnight start", () => {
+    const result = getScheduledEventTimes({
+      startTime: new Date("2026-03-23T00:00:00Z"),
+      duration: 0,
+      timeZone: "America/Toronto",
+    });
+    expect(result).toEqual({
+      allDay: true,
+      start: new Date("2026-03-23T00:00:00Z"),
+      end: new Date("2026-03-24T00:00:00Z"),
+      timeZone: null,
+    });
+  });
+
+  it("snaps a legacy zone-midnight all-day option west of UTC to the zone's calendar date", () => {
+    // midnight Oct 17 in Chicago = 05:00Z
+    const result = getScheduledEventTimes({
+      startTime: new Date("2025-10-17T05:00:00Z"),
+      duration: 0,
+      timeZone: "America/Chicago",
+    });
+    expect(result).toEqual({
+      allDay: true,
+      start: new Date("2025-10-17T00:00:00Z"),
+      end: new Date("2025-10-18T00:00:00Z"),
+      timeZone: null,
+    });
+  });
+
+  it("snaps a legacy zone-midnight all-day option east of UTC to the zone's calendar date", () => {
+    // midnight Oct 17 in Tokyo = Oct 16 15:00Z
+    const result = getScheduledEventTimes({
+      startTime: new Date("2025-10-16T15:00:00Z"),
+      duration: 0,
+      timeZone: "Asia/Tokyo",
+    });
+    expect(result).toEqual({
+      allDay: true,
+      start: new Date("2025-10-17T00:00:00Z"),
+      end: new Date("2025-10-18T00:00:00Z"),
+      timeZone: null,
+    });
+  });
+});

--- a/apps/web/src/trpc/routers/polls/scheduled-event-times.ts
+++ b/apps/web/src/trpc/routers/polls/scheduled-event-times.ts
@@ -1,0 +1,47 @@
+import {
+  calendarDateToUTCMidnight,
+  getCalendarDate,
+  toISODate,
+} from "@/lib/datetime/utils";
+
+const MINUTE_MS = 60 * 1000;
+const DAY_MS = 24 * 60 * MINUTE_MS;
+
+// All-day events are floating: start/end sit at exactly UTC midnight with no
+// time zone. The upcoming-events predicate, finalize emails, and ICS files all
+// read all-day dates via UTC, so any other encoding renders off by one day.
+export function getScheduledEventTimes({
+  startTime,
+  duration,
+  timeZone,
+}: {
+  startTime: Date;
+  duration: number;
+  timeZone: string | null;
+}) {
+  if (duration > 0) {
+    return {
+      allDay: false as const,
+      start: startTime,
+      end: new Date(startTime.getTime() + duration * MINUTE_MS),
+      timeZone,
+    };
+  }
+
+  // Mixed polls used to encode date-only options at midnight in the poll's
+  // zone; snap those to the zone's calendar date. Options already at UTC
+  // midnight are correctly encoded and must not be shifted.
+  const isUtcMidnight = startTime.getTime() % DAY_MS === 0;
+  const start = calendarDateToUTCMidnight(
+    timeZone && !isUtcMidnight
+      ? getCalendarDate(startTime, timeZone)
+      : toISODate(startTime),
+  );
+
+  return {
+    allDay: true as const,
+    start,
+    end: new Date(start.getTime() + DAY_MS),
+    timeZone: null,
+  };
+}

--- a/packages/database/prisma/migrations/20260709104425_enforce_all_day_event_invariants/migration.sql
+++ b/packages/database/prisma/migrations/20260709104425_enforce_all_day_event_invariants/migration.sql
@@ -1,0 +1,43 @@
+-- All-day events must be floating (no time zone) and encoded as UTC midnight
+-- day spans: the upcoming-events predicate, finalize emails, and ICS files all
+-- read all-day dates via UTC (RAL-1257). Backfill the known violations, then
+-- enforce the invariants with CHECK constraints.
+
+-- Zoned all-day rows already at UTC midnight: drop the zone, keep the date.
+-- These must NOT be snapped to the zone's calendar date, which would shift
+-- them a day west of UTC. (2 rows in prod)
+UPDATE scheduled_events
+SET time_zone = NULL
+WHERE all_day AND time_zone IS NOT NULL AND date_trunc('day', start) = start;
+
+-- Zoned all-day rows NOT at UTC midnight were encoded at midnight in their
+-- zone: snap to the zone's calendar date. (0 rows in prod; guard for
+-- self-hosted databases)
+UPDATE scheduled_events
+SET start = date_trunc('day', start AT TIME ZONE 'UTC' AT TIME ZONE time_zone),
+    "end" = date_trunc('day', start AT TIME ZONE 'UTC' AT TIME ZONE time_zone) + interval '1 day',
+    time_zone = NULL
+WHERE all_day AND time_zone IS NOT NULL;
+
+-- Zero-length all-day rows from the end date bug fixed in #1926: restore the
+-- 1 day span. (40 rows in prod)
+UPDATE scheduled_events
+SET "end" = start + interval '1 day'
+WHERE all_day AND "end" <= start;
+
+-- Any remaining all-day row off UTC midnight: snap to the UTC calendar date.
+-- (0 rows in prod; guard for self-hosted databases so the constraints below
+-- cannot fail the migration)
+UPDATE scheduled_events
+SET start = date_trunc('day', start),
+    "end" = GREATEST(date_trunc('day', "end"), date_trunc('day', start) + interval '1 day')
+WHERE all_day
+  AND (date_trunc('day', start) <> start OR date_trunc('day', "end") <> "end");
+
+ALTER TABLE scheduled_events
+  ADD CONSTRAINT all_day_is_floating
+    CHECK (NOT all_day OR time_zone IS NULL),
+  ADD CONSTRAINT all_day_is_utc_midnight
+    CHECK (NOT all_day OR (date_trunc('day', start) = start
+                       AND date_trunc('day', "end") = "end"
+                       AND "end" > start));


### PR DESCRIPTION
Steps 1 and 3 of the RAL-1257 migration plan. Stacked on #2551 (the write fixes) — **must not merge or deploy before it**, otherwise the old finalize code can write rows the constraints reject.

## What it does

One raw SQL migration, backfill first, constraints second:

1. **Zoned all-day rows already at UTC midnight** — only null the zone, never shift the date (the trap flagged in the audit; 2 rows in prod, including `ny4Tl8CBmScc` which currently displays a day early in the event list). What invitees received by email doesn't change.
2. **Zoned all-day rows at zone midnight** — snap to the zone's calendar date (0 rows in prod; guard for self-hosted databases).
3. **Zero-length all-day rows** from the end date bug fixed in #1926 — restore the 1 day span (40 rows in prod).
4. **Catch-all**: any remaining all-day row off UTC midnight snaps to the UTC calendar date (0 rows in prod) so the constraints can never fail the migration on a self-hosted database.
5. Adds `all_day_is_floating` and `all_day_is_utc_midnight` CHECK constraints.

The catch-all (4) is an addition over the issue's plan: without it, an unexpected row in a self-hosted database would abort the migration and block startup.

## Testing

Verified against a scratch database on the dev postgres container:

- Seeded one fixture row per backfill branch plus correct all-day and timed rows; deployed the migration; every branch produced the expected result and correct rows were untouched (timed rows keep their zone)
- Post-migration inserts violating each invariant (zoned all-day, off-midnight all-day, zero-length all-day) are rejected by the matching constraint; valid all-day and timed inserts succeed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Poll scheduling now handles timed and all-day options more consistently across time zones.
  * Added improved event time handling for scheduled poll outcomes.

* **Bug Fixes**
  * Fixed mixed polls so date-only options are stored as floating UTC dates instead of being shifted by the poll time zone.
  * Corrected all-day event behavior to ensure proper start/end dates and remove invalid time zone values.
  * Existing scheduled events were normalized to prevent zero-length or misaligned all-day entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->