### PR TITLE
👷 Enforce directory layering boundaries with lint rules

### DIFF
--- a/apps/web/biome.json
+++ b/apps/web/biome.json
@@ -1,4 +1,148 @@
 {
   "$schema": "https://biomejs.dev/schemas/2.3.14/schema.json",
-  "extends": "//"
+  "extends": "//",
+  "overrides": [
+    {
+      "includes": ["src/**", "!src/app/**"],
+      "linter": {
+        "rules": {
+          "style": {
+            "noRestrictedImports": {
+              "level": "error",
+              "options": {
+                "paths": {
+                  "dayjs": "Use the formatters in `@/lib/datetime` for display. dayjs is only allowed in files on the migration allowlist (see overrides in biome.json).",
+                  "@/lib/dayjs": "Use the formatters in `@/lib/datetime` for display. dayjs is only allowed in files on the migration allowlist (see overrides in biome.json)."
+                },
+                "patterns": [
+                  {
+                    "group": ["@/app", "@/app/**"],
+                    "message": "Only files inside app/ may import from app/. Routes are thin adapters; shared code belongs in features/, components/, or lib/. Existing violations are on the migration allowlist (see overrides in apps/web/biome.json)."
+                  }
+                ]
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "includes": ["src/components/**"],
+      "linter": {
+        "rules": {
+          "style": {
+            "noRestrictedImports": {
+              "level": "error",
+              "options": {
+                "paths": {
+                  "dayjs": "Use the formatters in `@/lib/datetime` for display. dayjs is only allowed in files on the migration allowlist (see overrides in biome.json).",
+                  "@/lib/dayjs": "Use the formatters in `@/lib/datetime` for display. dayjs is only allowed in files on the migration allowlist (see overrides in biome.json)."
+                },
+                "patterns": [
+                  {
+                    "group": ["@/features/**"],
+                    "message": "components/ is domain-agnostic UI and must not depend on features/. Move domain components into features/<domain>/components/ (RAL-1291). Existing violations are on the migration allowlist (see overrides in apps/web/biome.json)."
+                  },
+                  {
+                    "group": ["@/app", "@/app/**"],
+                    "message": "Only files inside app/ may import from app/. Routes are thin adapters; shared code belongs in features/, components/, or lib/."
+                  }
+                ]
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "includes": ["src/lib/**"],
+      "linter": {
+        "rules": {
+          "style": {
+            "noRestrictedImports": {
+              "level": "error",
+              "options": {
+                "paths": {
+                  "dayjs": "Use the formatters in `@/lib/datetime` for display. dayjs is only allowed in files on the migration allowlist (see overrides in biome.json).",
+                  "@/lib/dayjs": "Use the formatters in `@/lib/datetime` for display. dayjs is only allowed in files on the migration allowlist (see overrides in biome.json)."
+                },
+                "patterns": [
+                  {
+                    "group": ["@/features/**", "@/components/**"],
+                    "message": "lib/ is the bottom layer (app -> features -> components -> lib) and must not import from features/ or components/. If this code needs domain logic, it belongs in a feature. Existing violations are on the migration allowlist (see overrides in apps/web/biome.json)."
+                  },
+                  {
+                    "group": ["@/app", "@/app/**"],
+                    "message": "Only files inside app/ may import from app/. Routes are thin adapters; shared code belongs in features/, components/, or lib/."
+                  }
+                ]
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "includes": [
+        "src/components/add-to-calendar-button.tsx",
+        "src/components/event-card.tsx",
+        "src/components/forms/poll-settings.tsx",
+        "src/components/logo.tsx",
+        "src/components/nav-user.tsx",
+        "src/components/poll-status.tsx",
+        "src/components/poll/manage-poll.tsx",
+        "src/components/poll/manage-poll/schedule-poll-dialog.tsx",
+        "src/components/poll/poll-branding.tsx",
+        "src/components/poll/poll-footer.tsx",
+        "src/components/poll/responsive-results.tsx",
+        "src/components/pro-badge.tsx",
+        "src/components/upgrade-button.tsx",
+        "src/components/user-dropdown.tsx",
+        "src/components/user-provider.tsx",
+        "src/features/billing/components/pay-wall-dialog.tsx",
+        "src/features/navigation/command-menu/command-menu.tsx",
+        "src/features/quick-create/quick-create-widget.tsx",
+        "src/lib/auth.ts",
+        "src/lib/feature-flags/config.ts",
+        "src/lib/safe-action/server.ts"
+      ],
+      "linter": {
+        "rules": {
+          "style": {
+            "noRestrictedImports": {
+              "level": "error",
+              "options": {
+                "paths": {
+                  "dayjs": "Use the formatters in `@/lib/datetime` for display. dayjs is only allowed in files on the migration allowlist (see overrides in biome.json).",
+                  "@/lib/dayjs": "Use the formatters in `@/lib/datetime` for display. dayjs is only allowed in files on the migration allowlist (see overrides in biome.json)."
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "includes": [
+        "src/lib/dayjs.ts",
+        "src/lib/datetime/**",
+        "src/components/forms/poll-options-form/**",
+        "src/components/headless-date-picker.tsx",
+        "src/**/edit-options/page.tsx",
+        "src/trpc/routers/polls.ts",
+        "src/trpc/routers/index.ts",
+        "src/app/api/private/utils/time-slots.ts",
+        "src/utils/date-time-utils.ts",
+        "src/components/poll/manage-poll/use-csv-exporter.ts",
+        "src/test/setup.ts"
+      ],
+      "linter": {
+        "rules": {
+          "style": {
+            "noRestrictedImports": "off"
+          }
+        }
+      }
+    }
+  ]
 }

--- a/biome.json
+++ b/biome.json
@@ -63,19 +63,8 @@
   "overrides": [
     {
       "includes": [
-        "**/src/lib/dayjs.ts",
-        "**/src/lib/datetime/**",
-        "**/src/components/forms/poll-options-form/**",
-        "**/src/components/headless-date-picker.tsx",
-        "**/edit-options/page.tsx",
-        "**/src/trpc/routers/polls.ts",
-        "**/src/trpc/routers/index.ts",
-        "**/api/private/utils/time-slots.ts",
-        "**/src/utils/date-time-utils.ts",
-        "**/src/components/poll/manage-poll/use-csv-exporter.ts",
         "**/src/app/**/blog/post-preview.tsx",
         "**/src/components/blog/date-formatter.tsx",
-        "**/src/test/setup.ts",
         "**/tests/**",
         "packages/screenshots/**"
       ],


### PR DESCRIPTION
Encodes the import direction `app → features → components → lib` as `noRestrictedImports` rules, following the same pattern as the datetime boundary rules (#2541). Current violators are on a migration allowlist that only shrinks. Part of the directory structure cleanup project.

Fixes RAL-1283

## Rules

All layer rules live in `apps/web/biome.json` (not the root config): it is a nested Biome config (`"extends": "//"`), and override globs for files under it resolve relative to `apps/web`, so root-level `apps/web/src/**` globs silently never match. As ordered overrides:

1. `src/**` except `src/app/**` — bans `@/app` imports; routes are thin adapters, nothing outside `app/` may reach into it
2. `src/components/**` — additionally bans `@/features/**`; components/ is domain-agnostic UI
3. `src/lib/**` — additionally bans `@/features/**` and `@/components/**`; lib/ is the bottom layer
4. Migration allowlist: 21 current violators (15 in components/, 3 in features/, 3 in lib/) exempt from the layer patterns but still subject to the dayjs restriction

## Root config change

Nested overrides take precedence over root overrides and replace rule options wholesale, so the root's dayjs "off" allowlist stopped protecting web files once the nested overrides existed. The 11 web-specific dayjs allowlist entries moved into the nested config's final "off" override; the root allowlist keeps only the landing blog files, `**/tests/**`, and `packages/screenshots/**`. Verified none of the moved globs match anything in landing or docs.

## Verification

- `pnpm check` passes on a clean tree (proving the allowlist covers all existing violators)
- Temp violation files in `components/`, `lib/`, and `features/` each fail with the layer-specific message
- `@/app` imports inside `app/` still pass
- A dayjs import in a fresh file still fails (no regression from moving the allowlist)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Tightened code quality checks to better enforce consistent import boundaries across the web app.
  * Expanded exceptions for a few date- and utility-related paths so valid patterns continue to work.
  * Narrowed one lint rule to apply only where it’s needed, reducing unnecessary warnings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->