### PR TITLE
🐛 Show unconfirmed badge for unconfirmed events on public event page

### DIFF
--- a/apps/web/public/locales/en/app.json
+++ b/apps/web/public/locales/en/app.json
@@ -261,6 +261,7 @@
   "events": "Events",
   "eventStatusCanceled": "Canceled",
   "eventStatusPast": "Past",
+  "eventStatusUnconfirmed": "Unconfirmed",
   "eventStatusUpcoming": "Upcoming",
   "eventTypeActionsLabel": "Event type actions",
   "eventTypeDescriptionPlaceholder": "What is this event about?",

--- a/apps/web/src/app/[locale]/e/[id]/components/event-header.tsx
+++ b/apps/web/src/app/[locale]/e/[id]/components/event-header.tsx
@@ -61,6 +61,13 @@ export function EventStatus({
       </Badge>
     );
   }
+  if (status === "unconfirmed") {
+    return (
+      <Badge variant="default">
+        <Trans i18nKey="eventStatusUnconfirmed" defaults="Unconfirmed" />
+      </Badge>
+    );
+  }
   if (hasEnded) {
     return (
       <Badge variant="default">


### PR DESCRIPTION
## Summary

`EventStatus` on the public event page (`/e/[id]`) only branched on `canceled` and `hasEnded`, so `unconfirmed` events fell through to the green "Upcoming" badge. This adds an explicit `unconfirmed` branch with a neutral badge and a new `eventStatusUnconfirmed` translation key (generated via `pnpm i18n:scan`).

The `unconfirmed` check takes precedence over `hasEnded`, matching the dashboard where unconfirmed is its own bucket regardless of whether the event time has passed.

Fixes RAL-1214

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new event status label for “Unconfirmed” in the app.
  * Events with this status now display a dedicated badge instead of being grouped with past or upcoming events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->