### PR TITLE
♻️ Untangle file-level import cycles in components/forms and lib/datetime

### DIFF
--- a/apps/web/src/components/forms/index.ts
+++ b/apps/web/src/components/forms/index.ts
@@ -1,5 +1,3 @@
-export type { PollDetailsData } from "./poll-details-form";
 export { PollDetailsForm } from "./poll-details-form";
-export type { PollOptionsData } from "./poll-options-form/poll-options-form";
 export { default as PollOptionsForm } from "./poll-options-form/poll-options-form";
 export * from "./types";

--- a/apps/web/src/components/forms/poll-details-form.tsx
+++ b/apps/web/src/components/forms/poll-details-form.tsx
@@ -8,12 +8,6 @@ import { useFormValidation } from "@/utils/form-validation";
 
 import type { NewEventData } from "./types";
 
-export interface PollDetailsData {
-  title: string;
-  location: string;
-  description: string;
-}
-
 export const PollDetailsForm = () => {
   const { t } = useTranslation();
   const form = useFormContext<NewEventData>();

--- a/apps/web/src/components/forms/poll-options-form/month-calendar/month-calendar.tsx
+++ b/apps/web/src/components/forms/poll-options-form/month-calendar/month-calendar.tsx
@@ -26,7 +26,7 @@ import {
   EmptyStateIcon,
   EmptyStateTitle,
 } from "@/components/empty-state";
-import type { NewEventData } from "@/components/forms";
+import type { NewEventData } from "@/components/forms/types";
 import { Trans, useTranslation } from "@/i18n/client";
 import { useDateTime, useDateTimeConfig } from "@/lib/datetime/client";
 import { formatDateParts } from "@/lib/datetime/format";
@@ -38,8 +38,7 @@ import {
 } from "../../../../utils/date-time-utils";
 import DateCard from "../../../date-card";
 import { useHeadlessDatePicker } from "../../../headless-date-picker";
-import type { DateTimeOption } from "..";
-import type { DateTimePickerProps } from "../types";
+import type { DateTimeOption, DateTimePickerProps } from "../types";
 import { formatDateWithoutTime, formatDateWithoutTz } from "../utils";
 import TimePicker from "./time-picker";
 

--- a/apps/web/src/components/forms/poll-options-form/poll-options-form.tsx
+++ b/apps/web/src/components/forms/poll-options-form/poll-options-form.tsx
@@ -24,16 +24,7 @@ import { Trans, useTranslation } from "@/i18n/client";
 import { getBrowserTimeZone } from "../../../utils/date-time-utils";
 import type { NewEventData } from "../types";
 import MonthCalendar from "./month-calendar";
-import type { DateTimeOption } from "./types";
 import WeekCalendar from "./week-calendar";
-
-export type PollOptionsData = {
-  navigationDate: string; // used to navigate to the right part of the calendar
-  duration: number; // duration of the event in minutes
-  timeZone: string;
-  view: string;
-  options: DateTimeOption[];
-};
 
 const PollOptionsForm = ({
   children,

--- a/apps/web/src/components/forms/poll-settings.tsx
+++ b/apps/web/src/components/forms/poll-settings.tsx
@@ -11,17 +11,11 @@ import { Switch } from "@rallly/ui/switch";
 import { AtSignIcon, EyeIcon, MessageCircleIcon, VoteIcon } from "lucide-react";
 import type React from "react";
 import { useFormContext } from "react-hook-form";
+import type { PollSettingsFormData } from "@/components/forms/types";
 import { ProBadge } from "@/components/pro-badge";
 import { useIsFree } from "@/features/billing/client";
 import { showPayWall } from "@/features/billing/paywall-store";
 import { Trans } from "@/i18n/client";
-
-export type PollSettingsFormData = {
-  requireParticipantEmail: boolean;
-  hideParticipants: boolean;
-  hideScores: boolean;
-  disableComments: boolean;
-};
 
 const PollSetting = ({
   name,

--- a/apps/web/src/components/forms/types.ts
+++ b/apps/web/src/components/forms/types.ts
@@ -1,7 +1,25 @@
-import type { PollSettingsFormData } from "@/components/forms/poll-settings";
+import type { DateTimeOption } from "./poll-options-form/types";
 
-import type { PollDetailsData } from "./poll-details-form";
-import type { PollOptionsData } from "./poll-options-form/poll-options-form";
+export interface PollDetailsData {
+  title: string;
+  location: string;
+  description: string;
+}
+
+export type PollOptionsData = {
+  navigationDate: string; // used to navigate to the right part of the calendar
+  duration: number; // duration of the event in minutes
+  timeZone: string;
+  view: string;
+  options: DateTimeOption[];
+};
+
+export type PollSettingsFormData = {
+  requireParticipantEmail: boolean;
+  hideParticipants: boolean;
+  hideScores: boolean;
+  disableComments: boolean;
+};
 
 export type NewEventData = PollDetailsData &
   PollOptionsData &

--- a/apps/web/src/components/participants-provider.tsx
+++ b/apps/web/src/components/participants-provider.tsx
@@ -1,8 +1,6 @@
 import type { VoteType } from "@rallly/database";
 import { useParams, useSearchParams } from "next/navigation";
 import * as React from "react";
-import { useVisibility } from "@/components/visibility";
-import { usePermissions } from "@/contexts/permissions";
 import { useTranslation } from "@/i18n/client";
 import { trpc } from "@/trpc/client";
 
@@ -42,21 +40,4 @@ export const useParticipants = () => {
   }, [rawParticipants, t]);
 
   return { participants };
-};
-
-export const useVisibleParticipants = () => {
-  const { canSeeScores } = useVisibility();
-  const { canEditParticipant } = usePermissions();
-  const { participants } = useParticipants();
-
-  const filteredParticipants = React.useMemo(() => {
-    if (!canSeeScores) {
-      return participants.filter((participant) =>
-        canEditParticipant(participant.id),
-      );
-    }
-    return participants;
-  }, [canEditParticipant, canSeeScores, participants]);
-
-  return filteredParticipants;
 };

--- a/apps/web/src/components/poll/desktop-poll.tsx
+++ b/apps/web/src/components/poll/desktop-poll.tsx
@@ -30,10 +30,8 @@ import { ScrollContainer } from "@/components/scroll-container";
 import { usePermissions } from "@/contexts/permissions";
 import { usePoll } from "@/contexts/poll";
 import { Trans, useTranslation } from "@/i18n/client";
-import {
-  useParticipants,
-  useVisibleParticipants,
-} from "../participants-provider";
+import { useParticipants } from "../participants-provider";
+import { useVisibleParticipants } from "../visibility";
 import ParticipantRow from "./desktop-poll/participant-row";
 import ParticipantRowForm from "./desktop-poll/participant-row-form";
 import PollHeader from "./desktop-poll/poll-header";

--- a/apps/web/src/components/poll/mobile-poll.tsx
+++ b/apps/web/src/components/poll/mobile-poll.tsx
@@ -24,9 +24,8 @@ import { YouAvatar } from "@/components/poll/you-avatar";
 import { useOptions, usePoll } from "@/components/poll-context";
 import { usePermissions } from "@/contexts/permissions";
 import { Trans, useTranslation } from "@/i18n/client";
-
-import { useVisibleParticipants } from "../participants-provider";
 import { useUser } from "../user-provider";
+import { useVisibleParticipants } from "../visibility";
 import GroupedOptions from "./mobile-poll/grouped-options";
 
 if (typeof window !== "undefined") {

--- a/apps/web/src/components/visibility.tsx
+++ b/apps/web/src/components/visibility.tsx
@@ -27,6 +27,23 @@ const VisibilityContext = React.createContext<{
   canSeeScores: true,
 });
 
+export const useVisibleParticipants = () => {
+  const { canSeeScores } = useVisibility();
+  const { canEditParticipant } = usePermissions();
+  const { participants } = useParticipants();
+
+  const filteredParticipants = React.useMemo(() => {
+    if (!canSeeScores) {
+      return participants.filter((participant) =>
+        canEditParticipant(participant.id),
+      );
+    }
+    return participants;
+  }, [canEditParticipant, canSeeScores, participants]);
+
+  return filteredParticipants;
+};
+
 export const VisibilityProvider = ({ children }: React.PropsWithChildren) => {
   const poll = usePoll();
   const { participants } = useParticipants();

--- a/apps/web/src/features/scheduled-event/components/event-date-time.tsx
+++ b/apps/web/src/features/scheduled-event/components/event-date-time.tsx
@@ -8,9 +8,10 @@ import {
 import { Trans } from "@/i18n/client";
 import { CalendarDate } from "@/lib/datetime/calendar-date";
 import { useDateTimeConfig } from "@/lib/datetime/client";
-import type { DateInput, DatePreset } from "@/lib/datetime/format";
+import type { DatePreset } from "@/lib/datetime/format";
 import { formatDateParts } from "@/lib/datetime/format";
 import { Time, TimeRange } from "@/lib/datetime/time";
+import type { DateInput } from "@/lib/datetime/types";
 import { useHydrated } from "@/lib/datetime/use-hydrated";
 
 /**

--- a/apps/web/src/features/scheduled-event/utils.ts
+++ b/apps/web/src/features/scheduled-event/utils.ts
@@ -3,7 +3,7 @@ import {
   formatDateTime,
   formatDateTimeRange,
 } from "@/lib/datetime/format";
-import type { TimeFormat } from "@/lib/datetime/schema";
+import type { TimeFormat } from "@/lib/datetime/types";
 
 export interface FormattedEventDateTime {
   date: string;

--- a/apps/web/src/lib/datetime/calendar-date.tsx
+++ b/apps/web/src/lib/datetime/calendar-date.tsx
@@ -1,8 +1,9 @@
 "use client";
 
 import { useDateTimeConfig } from "@/lib/datetime/client";
-import type { DateInput, DatePreset } from "@/lib/datetime/format";
+import type { DatePreset } from "@/lib/datetime/format";
 import { formatDate } from "@/lib/datetime/format";
+import type { DateInput } from "@/lib/datetime/types";
 import { useHydrated } from "@/lib/datetime/use-hydrated";
 import { toISODate } from "./utils";
 

--- a/apps/web/src/lib/datetime/client.tsx
+++ b/apps/web/src/lib/datetime/client.tsx
@@ -2,14 +2,14 @@
 
 import { defaultLocale } from "@rallly/languages";
 import React from "react";
-import type { DateInput, DateTimePreset } from "@/lib/datetime/format";
+import type { DateTimePreset } from "@/lib/datetime/format";
 import {
   formatDateTime as baseFormatDateTime,
   formatDuration as baseFormatDuration,
   formatRelativeTime,
 } from "@/lib/datetime/format";
 import { getLocaleDefaults, getWeekdayNames } from "@/lib/datetime/locales";
-import type { TimeFormat } from "@/lib/datetime/schema";
+import type { DateInput, TimeFormat } from "@/lib/datetime/types";
 import { normalizeTimeZone } from "@/lib/datetime/utils";
 import { getBrowserTimeZone } from "@/utils/date-time-utils";
 

--- a/apps/web/src/lib/datetime/device.tsx
+++ b/apps/web/src/lib/datetime/device.tsx
@@ -8,7 +8,7 @@ import {
   TIME_ZONE_COOKIE_NAME,
   TIME_ZONE_OVERRIDE_COOKIE_NAME,
 } from "@/lib/datetime/constants";
-import type { TimeFormat } from "@/lib/datetime/schema";
+import type { TimeFormat } from "@/lib/datetime/types";
 
 const cookieAttributes = {
   path: "/",

--- a/apps/web/src/lib/datetime/format.test.ts
+++ b/apps/web/src/lib/datetime/format.test.ts
@@ -5,7 +5,7 @@ import {
   formatDateTimeRange,
   formatRelativeTime,
 } from "@/lib/datetime/format";
-import type { TimeFormat } from "@/lib/datetime/schema";
+import type { TimeFormat } from "@/lib/datetime/types";
 
 // Fri 26 Jun 2026, in UTC.
 const at = (hour: number, minute = 0) =>

--- a/apps/web/src/lib/datetime/format.ts
+++ b/apps/web/src/lib/datetime/format.ts
@@ -1,6 +1,4 @@
-import type { TimeFormat } from "@/lib/datetime/schema";
-
-export type DateInput = Date | number;
+import type { DateInput, TimeFormat } from "@/lib/datetime/types";
 
 export type DatePreset =
   | "date"

--- a/apps/web/src/lib/datetime/locales.ts
+++ b/apps/web/src/lib/datetime/locales.ts
@@ -1,4 +1,4 @@
-import type { TimeFormat } from "@/lib/datetime/schema";
+import type { TimeFormat } from "@/lib/datetime/types";
 
 type LocaleDefaults = {
   weekStart: number;

--- a/apps/web/src/lib/datetime/relative-time.tsx
+++ b/apps/web/src/lib/datetime/relative-time.tsx
@@ -1,8 +1,8 @@
 "use client";
 
 import { useDateTimeConfig } from "@/lib/datetime/client";
-import type { DateInput } from "@/lib/datetime/format";
 import { formatRelativeTime } from "@/lib/datetime/format";
+import type { DateInput } from "@/lib/datetime/types";
 import { useHydrated } from "@/lib/datetime/use-hydrated";
 import { toISO } from "./utils";
 

--- a/apps/web/src/lib/datetime/schema.ts
+++ b/apps/web/src/lib/datetime/schema.ts
@@ -1,11 +1,11 @@
 import * as z from "zod";
+import type { TimeFormat } from "./types";
 import { normalizeTimeZone } from "./utils";
 
-export const timeFormatSchema = z.enum(["hours12", "hours24"]);
-
-// The formatting layer's own TimeFormat; same literals as the Prisma enum so
-// user records assign directly, without coupling this layer to the database.
-export type TimeFormat = z.infer<typeof timeFormatSchema>;
+export const timeFormatSchema = z.enum([
+  "hours12",
+  "hours24",
+]) satisfies z.ZodType<TimeFormat>;
 
 export const timeZoneSchema = z
   .string()

--- a/apps/web/src/lib/datetime/time.tsx
+++ b/apps/web/src/lib/datetime/time.tsx
@@ -1,8 +1,9 @@
 "use client";
 
 import { useDateTimeConfig } from "@/lib/datetime/client";
-import type { DateInput, DateTimePreset } from "@/lib/datetime/format";
+import type { DateTimePreset } from "@/lib/datetime/format";
 import { formatDateTime, formatDateTimeRange } from "@/lib/datetime/format";
+import type { DateInput } from "@/lib/datetime/types";
 import { useHydrated } from "@/lib/datetime/use-hydrated";
 import { toISO } from "./utils";
 

--- a/apps/web/src/lib/datetime/types.ts
+++ b/apps/web/src/lib/datetime/types.ts
@@ -1,0 +1,5 @@
+export type DateInput = Date | number;
+
+// The formatting layer's own TimeFormat; same literals as the Prisma enum so
+// user records assign directly, without coupling this layer to the database.
+export type TimeFormat = "hours12" | "hours24";

--- a/apps/web/src/lib/datetime/utils.ts
+++ b/apps/web/src/lib/datetime/utils.ts
@@ -1,5 +1,4 @@
-import type { DateInput } from "@/lib/datetime/format";
-import type { TimeFormat } from "@/lib/datetime/schema";
+import type { DateInput, TimeFormat } from "@/lib/datetime/types";
 
 function toDate(value: DateInput) {
   return value instanceof Date ? value : new Date(value);

--- a/apps/web/src/utils/date-time-utils.ts
+++ b/apps/web/src/utils/date-time-utils.ts
@@ -3,7 +3,7 @@ import { dayjs } from "@/lib/dayjs";
 import type {
   DateTimeOption,
   TimeOption,
-} from "../components/forms/poll-options-form";
+} from "../components/forms/poll-options-form/types";
 
 export function getBrowserTimeZone() {
   return dayjs.tz.guess();


### PR DESCRIPTION
Fixes [RAL-1292](https://linear.app/rallly/issue/RAL-1292/untangle-file-level-import-cycles-in-componentsforms-and-libdatetime)

`madge --circular --extensions ts,tsx --ts-config tsconfig.json src` (run from `apps/web`) now reports **zero cycles**, down from 16. All edges broken were type imports or a misplaced hook; no behavior changes.

## Changes

**`lib/datetime`** — `format.ts`, `schema.ts` and `utils.ts` formed a triangle held together by shared types. `DateInput` and `TimeFormat` now live in a new leaf `lib/datetime/types.ts` that everything imports one-way. `timeFormatSchema` keeps its literals bound to `TimeFormat` via `satisfies z.ZodType<TimeFormat>`.

**`components/forms`** — `types.ts` imported the form data types from the three form components while they imported `NewEventData` back from it. The data type definitions (`PollDetailsData`, `PollOptionsData`, `PollSettingsFormData`) moved into `types.ts`, making it a leaf. `month-calendar.tsx` and `utils/date-time-utils.ts` now import types from their defining module instead of going through the `components/forms` and `poll-options-form` barrels, which is what closed the long loops through `lib/datetime/client` and `features/billing`.

**`participants-provider` / `visibility` / `permissions`** — the one runtime (non type-only) cycle. `useVisibleParticipants` composes `useVisibility` and `usePermissions`, so it moved from `participants-provider.tsx` into `visibility.tsx`; the provider no longer imports either module. This cluster wasn't listed in the issue but it's the same disease and was the only cycle with runtime edges.

The `components/forms` area is still legacy poll UI headed for `features/poll` (RAL-1291); these are minimal in-place fixes so the graph is clean in the meantime.

## Verification

- madge: 0 circular dependencies (was 16)
- `tsc --noEmit`: clean
- `biome check`: clean
- `pnpm test:unit`: 221 passed
- Dev server smoke test: `/invite/[urlId]` and `/new` render identically to the unmodified branch (A/B compared via git stash)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved participant visibility so people only see the participant list they’re allowed to access.
  * Streamlined event form behavior by keeping poll details, options, and settings data handling consistent across the app.

* **Refactor**
  * Consolidated shared date/time and poll form types for better maintainability.
  * Cleaned up internal component imports without changing existing user-facing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->