### PR TITLE
♻️ Migrate Separator to Base UI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,5 @@ next-env.d.ts
 
 # Claude worktrees
 .claude/worktrees
+# Radix -> Base UI migration reports (local skill state)
+.migration/

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -30,7 +30,6 @@
     "@radix-ui/react-progress": "^1.1.2",
     "@radix-ui/react-radio-group": "^1.2.3",
     "@radix-ui/react-select": "^2.2.2",
-    "@radix-ui/react-separator": "^1.1.2",
     "@radix-ui/react-slot": "^1.1.2",
     "@radix-ui/react-switch": "^1.0.2",
     "@radix-ui/react-tabs": "^1.0.4",

--- a/packages/ui/src/separator.tsx
+++ b/packages/ui/src/separator.tsx
@@ -1,21 +1,17 @@
 "use client";
 
-import * as SeparatorPrimitive from "@radix-ui/react-separator";
-import * as React from "react";
+import { Separator as SeparatorPrimitive } from "@base-ui/react/separator";
 
 import { cn } from "./lib/utils";
 
-const Separator = React.forwardRef<
-  React.ElementRef<typeof SeparatorPrimitive.Root>,
-  React.ComponentPropsWithoutRef<typeof SeparatorPrimitive.Root>
->(
-  (
-    { className, orientation = "horizontal", decorative = true, ...props },
-    ref,
-  ) => (
-    <SeparatorPrimitive.Root
-      ref={ref}
-      decorative={decorative}
+function Separator({
+  className,
+  orientation = "horizontal",
+  ...props
+}: SeparatorPrimitive.Props) {
+  return (
+    <SeparatorPrimitive
+      data-slot="separator"
       orientation={orientation}
       className={cn(
         "shrink-0 bg-border",
@@ -24,8 +20,7 @@ const Separator = React.forwardRef<
       )}
       {...props}
     />
-  ),
-);
-Separator.displayName = SeparatorPrimitive.Root.displayName;
+  );
+}
 
 export { Separator };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -800,9 +800,6 @@ importers:
       '@radix-ui/react-select':
         specifier: ^2.2.2
         version: 2.2.6(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@radix-ui/react-separator':
-        specifier: ^1.1.2
-        version: 1.1.8(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@radix-ui/react-slot':
         specifier: ^1.1.2
         version: 1.2.4(@types/react@19.2.13)(react@19.2.6)
@@ -3864,19 +3861,6 @@ packages:
 
   '@radix-ui/react-select@2.2.6':
     resolution: {integrity: sha512-I30RydO+bnn2PQztvo25tswPH+wFBjehVGtmagkU78yMdwTwVf12wnAOF+AeP8S2N8xD+5UPbGhkUfPyvT+mwQ==}
-    peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-      '@types/react-dom':
-        optional: true
-
-  '@radix-ui/react-separator@1.1.8':
-    resolution: {integrity: sha512-sDvqVY4itsKwwSMEe0jtKgfTh+72Sy3gPmQpjqcQneqQ4PFmr/1I0YA+2/puilhggCe2gJcx5EBAYFkWkdpa5g==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -15304,15 +15288,6 @@ snapshots:
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
       react-remove-scroll: 2.7.2(@types/react@19.2.13)(react@19.2.6)
-    optionalDependencies:
-      '@types/react': 19.2.13
-      '@types/react-dom': 19.2.3(@types/react@19.2.13)
-
-  '@radix-ui/react-separator@1.1.8(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
-    dependencies:
-      '@radix-ui/react-primitive': 2.1.4(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      react: 19.2.6
-      react-dom: 19.2.6(react@19.2.6)
     optionalDependencies:
       '@types/react': 19.2.13
       '@types/react-dom': 19.2.3(@types/react@19.2.13)


### PR DESCRIPTION
Resolves RAL-1293

First component migration in the Radix → Base UI project, run through the shadcn `migrate-radix-to-base` skill.

## Changes

- `packages/ui/src/separator.tsx` now wraps `@base-ui/react/separator` instead of `@radix-ui/react-separator`. Classes unchanged; `forwardRef` dropped in favor of the plain function component pattern already used by `avatar.tsx`; adds `data-slot="separator"`.
- `@radix-ui/react-separator` removed from `packages/ui/package.json` (this file was its only importer).
- Migration report in `.migration/separator.md`.

## Behavior change

The wrapper previously defaulted `decorative={true}` (Radix rendered `role="none"`). Base UI separators are always semantic, so they now render `role="separator"` and are announced by screen readers. This matches the shadcn base registry behavior. No consumer passed `decorative`.

## Verification

- `tsc --noEmit` clean in `packages/ui` and `apps/web` (clean baseline before the change)
- Biome clean
- `grep -rn "@radix-ui" packages/ui/src/separator.tsx` returns nothing
- Consumers checked: `field.tsx` (FieldSeparator) and `sidebar.tsx` (SidebarSeparator) pass `className`/ref only

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated the separator UI to use a newer underlying implementation, with consistent horizontal default behavior and improved component markup.
* **Chores**
  * Cleaned up ignored files so local workspace and migration artifacts won’t be tracked.
  * Removed an unused UI package dependency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->