### PR TITLE
♻️ Migrate Label to native label element

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -24,7 +24,6 @@
     "@radix-ui/react-collapsible": "^1.1.3",
     "@radix-ui/react-dialog": "^1.1.11",
     "@radix-ui/react-dropdown-menu": "^2.0.4",
-    "@radix-ui/react-label": "^2.0.1",
     "@radix-ui/react-popover": "^1.0.5",
     "@radix-ui/react-portal": "^1.1.6",
     "@radix-ui/react-progress": "^1.1.2",

--- a/packages/ui/src/form.tsx
+++ b/packages/ui/src/form.tsx
@@ -1,4 +1,3 @@
-import type * as LabelPrimitive from "@radix-ui/react-label";
 import { Slot } from "@radix-ui/react-slot";
 import * as React from "react";
 import type { ControllerProps, FieldPath, FieldValues } from "react-hook-form";
@@ -79,8 +78,8 @@ const FormItem = React.forwardRef<
 FormItem.displayName = "FormItem";
 
 const FormLabel = React.forwardRef<
-  React.ElementRef<typeof LabelPrimitive.Root>,
-  React.ComponentPropsWithoutRef<typeof LabelPrimitive.Root>
+  HTMLLabelElement,
+  React.ComponentPropsWithoutRef<typeof Label>
 >(({ className, ...props }, ref) => {
   const { formItemId } = useFormField();
 

--- a/packages/ui/src/label.tsx
+++ b/packages/ui/src/label.tsx
@@ -1,9 +1,8 @@
 "use client";
 
-import * as LabelPrimitive from "@radix-ui/react-label";
 import type { VariantProps } from "class-variance-authority";
 import { cva } from "class-variance-authority";
-import * as React from "react";
+import type * as React from "react";
 
 import { cn } from "./lib/utils";
 
@@ -11,17 +10,18 @@ const labelVariants = cva(
   "text-foreground text-sm leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70",
 );
 
-const Label = React.forwardRef<
-  React.ElementRef<typeof LabelPrimitive.Root>,
-  React.ComponentPropsWithoutRef<typeof LabelPrimitive.Root> &
-    VariantProps<typeof labelVariants>
->(({ className, ...props }, ref) => (
-  <LabelPrimitive.Root
-    ref={ref}
-    className={cn(labelVariants(), className)}
-    {...props}
-  />
-));
-Label.displayName = LabelPrimitive.Root.displayName;
+function Label({
+  className,
+  ...props
+}: React.ComponentProps<"label"> & VariantProps<typeof labelVariants>) {
+  return (
+    // biome-ignore lint/a11y/noLabelWithoutControl: htmlFor and children arrive via props
+    <label
+      data-slot="label"
+      className={cn(labelVariants(), className)}
+      {...props}
+    />
+  );
+}
 
 export { Label };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -782,9 +782,6 @@ importers:
       '@radix-ui/react-dropdown-menu':
         specifier: ^2.0.4
         version: 2.1.16(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@radix-ui/react-label':
-        specifier: ^2.0.1
-        version: 2.1.8(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@radix-ui/react-popover':
         specifier: ^1.0.5
         version: 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
@@ -3701,19 +3698,6 @@ packages:
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
     peerDependenciesMeta:
       '@types/react':
-        optional: true
-
-  '@radix-ui/react-label@2.1.8':
-    resolution: {integrity: sha512-FmXs37I6hSBVDlO4y764TNz1rLgKwjJMQ0EGte6F3Cb3f4bIuHB/iLa/8I9VKkmOy+gNHq8rql3j686ACVV21A==}
-    peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-      '@types/react-dom':
         optional: true
 
   '@radix-ui/react-menu@2.1.16':
@@ -15093,15 +15077,6 @@ snapshots:
       react: 19.2.6
     optionalDependencies:
       '@types/react': 19.2.13
-
-  '@radix-ui/react-label@2.1.8(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
-    dependencies:
-      '@radix-ui/react-primitive': 2.1.4(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      react: 19.2.6
-      react-dom: 19.2.6(react@19.2.6)
-    optionalDependencies:
-      '@types/react': 19.2.13
-      '@types/react-dom': 19.2.3(@types/react@19.2.13)
 
   '@radix-ui/react-menu@2.1.16(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
     dependencies:


### PR DESCRIPTION
Resolves RAL-1294

Second migration in the Radix → Base UI project. Base UI has no standalone Label primitive (its label behavior lives in `Field.Label`), so per the migration skill's mapping this wrapper becomes a native `<label>`.

## Changes

- `packages/ui/src/label.tsx` — native `<label>` with the exact same cva classes; plain function component with `data-slot="label"` (matches the migrated `avatar.tsx`/`separator.tsx` pattern). One `biome-ignore` for `noLabelWithoutControl` since `htmlFor`/children arrive via the props spread.
- `packages/ui/src/form.tsx` — drops the `@radix-ui/react-label` type import; `FormLabel` is typed off our `Label` instead. No runtime change. The remaining `@radix-ui/react-slot` import there is RAL-1307's scope.
- `@radix-ui/react-label` removed from `packages/ui/package.json`.

## Behavior change

Radix Label prevented text selection on double click; a native `<label>` doesn't, so double clicking a form label can now select its text. Not patched — this matches the shadcn base registry behavior.

## Verification

- `tsc --noEmit` clean in `packages/ui` and `apps/web` (clean baselines)
- Biome clean
- 6 consumer files checked: none pass `asChild` or ref
- `htmlFor` focus wiring unchanged via `FormLabel`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved form label handling in the UI components, keeping label styling and behavior consistent.
  * Simplified label rendering to use standard HTML label elements for better compatibility.
* **Chores**
  * Removed an unused UI dependency from the package setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->