### PR TITLE
♻️ Migrate Progress to Base UI

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -26,7 +26,6 @@
     "@radix-ui/react-dropdown-menu": "^2.0.4",
     "@radix-ui/react-popover": "^1.0.5",
     "@radix-ui/react-portal": "^1.1.6",
-    "@radix-ui/react-progress": "^1.1.2",
     "@radix-ui/react-radio-group": "^1.2.3",
     "@radix-ui/react-select": "^2.2.2",
     "@radix-ui/react-slot": "^1.1.2",

--- a/packages/ui/src/progress.tsx
+++ b/packages/ui/src/progress.tsx
@@ -1,28 +1,35 @@
 "use client";
 
-import * as ProgressPrimitive from "@radix-ui/react-progress";
-import * as React from "react";
+import { Progress as ProgressPrimitive } from "@base-ui/react/progress";
 
 import { cn } from "./lib/utils";
 
-const Progress = React.forwardRef<
-  React.ElementRef<typeof ProgressPrimitive.Root>,
-  React.ComponentPropsWithoutRef<typeof ProgressPrimitive.Root>
->(({ className, value, ...props }, ref) => (
-  <ProgressPrimitive.Root
-    ref={ref}
-    className={cn(
-      "relative h-1 w-full overflow-hidden rounded-full bg-secondary",
-      className,
-    )}
-    {...props}
-  >
-    <ProgressPrimitive.Indicator
-      className="h-full w-full flex-1 bg-linear-to-r from-primary/50 to-primary transition-all"
-      style={{ transform: `translateX(-${100 - (value || 0)}%)` }}
-    />
-  </ProgressPrimitive.Root>
-));
-Progress.displayName = ProgressPrimitive.Root.displayName;
+function Progress({
+  className,
+  value,
+  ...props
+}: ProgressPrimitive.Root.Props) {
+  return (
+    <ProgressPrimitive.Root
+      data-slot="progress"
+      value={value}
+      className={cn(
+        "relative h-1 w-full overflow-hidden rounded-full bg-secondary",
+        className,
+      )}
+      {...props}
+    >
+      <ProgressPrimitive.Track
+        data-slot="progress-track"
+        className="h-full w-full"
+      >
+        <ProgressPrimitive.Indicator
+          data-slot="progress-indicator"
+          className="h-full bg-linear-to-r from-primary/50 to-primary transition-all"
+        />
+      </ProgressPrimitive.Track>
+    </ProgressPrimitive.Root>
+  );
+}
 
 export { Progress };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -788,9 +788,6 @@ importers:
       '@radix-ui/react-portal':
         specifier: ^1.1.6
         version: 1.1.10(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@radix-ui/react-progress':
-        specifier: ^1.1.2
-        version: 1.1.8(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@radix-ui/react-radio-group':
         specifier: ^1.2.3
         version: 1.3.8(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
@@ -3793,19 +3790,6 @@ packages:
 
   '@radix-ui/react-primitive@2.1.4':
     resolution: {integrity: sha512-9hQc4+GNVtJAIEPEqlYqW5RiYdrr8ea5XQ0ZOnD6fgru+83kqT15mq2OCcbe8KnjRZl5vF3ks69AKz3kh1jrhg==}
-    peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-      '@types/react-dom':
-        optional: true
-
-  '@radix-ui/react-progress@1.1.8':
-    resolution: {integrity: sha512-+gISHcSPUJ7ktBy9RnTqbdKW78bcGke3t6taawyZ71pio1JewwGSJizycs7rLhGTvMJYCQB1DBK4KQsxs7U8dA==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -15187,16 +15171,6 @@ snapshots:
   '@radix-ui/react-primitive@2.1.4(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
     dependencies:
       '@radix-ui/react-slot': 1.2.4(@types/react@19.2.13)(react@19.2.6)
-      react: 19.2.6
-      react-dom: 19.2.6(react@19.2.6)
-    optionalDependencies:
-      '@types/react': 19.2.13
-      '@types/react-dom': 19.2.3(@types/react@19.2.13)
-
-  '@radix-ui/react-progress@1.1.8(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
-    dependencies:
-      '@radix-ui/react-context': 1.1.3(@types/react@19.2.13)(react@19.2.6)
-      '@radix-ui/react-primitive': 2.1.4(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
     optionalDependencies:


### PR DESCRIPTION
Resolves RAL-1295

Third migration in the Radix → Base UI project.

## Changes

- `packages/ui/src/progress.tsx` — Base UI `Root > Track > Indicator` anatomy (Track is mandatory). Root keeps the exact old classes so consumer `className` overrides still land on the visible bar. The manual `translateX` inline style is deleted; the primitive computes the Indicator width itself.
- `@radix-ui/react-progress` removed from `packages/ui/package.json`.

## Behavior changes

- **A11y fix:** the old wrapper destructured `value` and never forwarded it to the primitive, so the progressbar always read as indeterminate to screen readers. It now reports real `aria-valuenow`.
- **Subtle visual difference:** the fill gradient (`from-primary/50 to-primary`) now compresses into the filled portion instead of showing the right-hand slice of a full-width gradient, so low percentages start lighter than before.
- `value` is required in Base UI (`null` = indeterminate); the only consumer (router loading indicator) already passes it.

## Verification

- `tsc --noEmit` clean in `packages/ui` and `apps/web`
- Biome clean; leftover Radix grep clean
- Single consumer checked: `router-loading-indicator.tsx` needs no changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the progress indicator to render with a more consistent track-and-fill layout.
  * Improved progress bar styling for a smoother visual appearance.
* **Chores**
  * Removed an unused UI dependency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->