### PR TITLE
♿️ Tie vote buttons to their date/time option and remove fake-clickable wrappers

### DIFF
--- a/apps/web/src/components/poll/desktop-poll/participant-row-form.tsx
+++ b/apps/web/src/components/poll/desktop-poll/participant-row-form.tsx
@@ -15,9 +15,10 @@ import { Participant, ParticipantName } from "@/components/participant";
 import { useVotingForm } from "@/components/poll/voting-form";
 import { YouAvatar } from "@/components/poll/you-avatar";
 import { Trans, useTranslation } from "@/i18n/client";
+import { getOptionDateTimeLabel } from "@/lib/utils/date-time-utils";
 
-import { usePoll } from "../../poll-context";
-import { toggleVote, VoteSelector } from "../vote-selector";
+import { useOptions, usePoll } from "../../poll-context";
+import { VoteSelector } from "../vote-selector";
 
 export interface ParticipantRowFormProps {
   name?: string;
@@ -37,6 +38,7 @@ const ParticipantRowForm = ({
   const { t } = useTranslation();
 
   const { optionIds } = usePoll();
+  const { options } = useOptions();
   const form = useVotingForm();
 
   React.useEffect(() => {
@@ -107,6 +109,7 @@ const ParticipantRowForm = ({
         </div>
       </td>
       {optionIds.map((optionId, i) => {
+        const option = options[i];
         return (
           <td
             key={optionId}
@@ -116,21 +119,17 @@ const ParticipantRowForm = ({
               control={form.control}
               name={`votes.${i}`}
               render={({ field }) => (
-                // biome-ignore lint/a11y/useKeyWithClickEvents: Fix later
-                // biome-ignore lint/a11y/noStaticElementInteractions: Fix later
                 <div
-                  onClick={() => {
-                    field.onChange({
-                      optionId,
-                      type: toggleVote(field.value?.type),
-                    });
-                  }}
                   className={cn(
-                    "absolute inset-0 flex cursor-pointer items-center justify-center transition-colors",
+                    "absolute inset-0 flex items-center justify-center transition-colors",
                     "hover:bg-gray-50 active:bg-gray-100 active:ring-1 active:ring-gray-200 active:ring-inset dark:active:bg-gray-700/50 dark:active:ring-gray-700 dark:active:ring-inset dark:hover:bg-gray-800",
                   )}
                 >
                   <VoteSelector
+                    className="after:absolute after:inset-0"
+                    optionLabel={
+                      option ? getOptionDateTimeLabel(option) : undefined
+                    }
                     value={field.value?.type}
                     onChange={(vote) => {
                       field.onChange({ optionId, type: vote });

--- a/apps/web/src/components/poll/mobile-poll/poll-option.tsx
+++ b/apps/web/src/components/poll/mobile-poll/poll-option.tsx
@@ -1,13 +1,10 @@
-/** biome-ignore-all lint/a11y/useSemanticElements: fix later */
-/** biome-ignore-all lint/a11y/useKeyWithClickEvents: fix later */
-/** biome-ignore-all lint/a11y/useFocusableInteractive: fix later */
 "use client";
 import type { VoteType } from "@rallly/database";
 import { cn } from "@rallly/ui";
 import { Button } from "@rallly/ui/button";
 import { Icon } from "@rallly/ui/icon";
 import { ChevronDownIcon, ChevronUpIcon } from "lucide-react";
-import * as React from "react";
+import type * as React from "react";
 import { useToggle } from "react-use";
 
 import { OptimizedAvatarImage } from "@/components/optimized-avatar-image";
@@ -30,6 +27,7 @@ export interface PollOptionProps {
   onChange: (vote: VoteType) => void;
   selectedParticipantId?: string;
   optionId: string;
+  optionLabel: string;
 }
 
 const PollOptionVoteSummary: React.FunctionComponent<{ optionId: string }> = ({
@@ -133,24 +131,17 @@ const PollOption: React.FunctionComponent<PollOptionProps> = ({
   onChange,
   editable = false,
   optionId,
+  optionLabel,
 }) => {
   const showVotes = !!(selectedParticipantId || editable);
-  const selectorRef = React.useRef<HTMLButtonElement>(null);
-  const [active, setActive] = React.useState(false);
   const [isExpanded, toggle] = useToggle(false);
   return (
     <div
-      role="button"
-      className={cn("space-y-4 bg-background p-4 transition-colors", {
-        "bg-accent/50": editable && active,
-      })}
-      onPointerDown={() => setActive(editable)}
-      onPointerUp={() => setActive(false)}
-      onPointerOut={() => setActive(false)}
+      className={cn(
+        "relative space-y-4 bg-background p-4 transition-colors",
+        editable && "active:bg-accent/50",
+      )}
       data-testid="poll-option"
-      onClick={() => {
-        selectorRef.current?.click();
-      }}
     >
       <div className="flex h-7 items-center justify-between gap-x-4">
         <div className="shrink-0">{children}</div>
@@ -158,20 +149,19 @@ const PollOption: React.FunctionComponent<PollOptionProps> = ({
           <Button
             size="sm"
             variant="ghost"
-            onClick={(e) => {
-              e.stopPropagation();
-              toggle();
-            }}
+            className="relative z-10"
+            onClick={() => toggle()}
           >
             <ConnectedScoreSummary optionId={optionId} />
             <Icon>{isExpanded ? <ChevronUpIcon /> : <ChevronDownIcon />}</Icon>
           </Button>
 
           {showVotes ? (
-            <div className="relative flex size-7 items-center justify-center">
+            <div className="flex size-7 items-center justify-center">
               {editable ? (
                 <VoteSelector
-                  ref={selectorRef}
+                  className="after:absolute after:inset-0"
+                  optionLabel={optionLabel}
                   value={vote}
                   onChange={onChange}
                 />

--- a/apps/web/src/components/poll/mobile-poll/poll-options.tsx
+++ b/apps/web/src/components/poll/mobile-poll/poll-options.tsx
@@ -5,6 +5,7 @@ import { useParticipants } from "@/components/participants-provider";
 import { useVotingForm } from "@/components/poll/voting-form";
 import { usePoll } from "@/components/poll-context";
 import type { ParsedDateTimeOpton } from "@/lib/utils/date-time-utils";
+import { getOptionDateTimeLabel } from "@/lib/utils/date-time-utils";
 import DateOption from "./date-option";
 import TimeSlotOption from "./time-slot-option";
 
@@ -59,6 +60,7 @@ const PollOptions: React.FunctionComponent<PollOptions> = ({
                     <TimeSlotOption
                       onChange={handleChange}
                       optionId={option.optionId}
+                      optionLabel={getOptionDateTimeLabel(option)}
                       yesScore={score.yes}
                       ifNeedBeScore={score.ifNeedBe}
                       vote={vote}
@@ -74,6 +76,7 @@ const PollOptions: React.FunctionComponent<PollOptions> = ({
                     <DateOption
                       onChange={handleChange}
                       optionId={option.optionId}
+                      optionLabel={getOptionDateTimeLabel(option)}
                       yesScore={score.yes}
                       ifNeedBeScore={score.ifNeedBe}
                       vote={vote}

--- a/apps/web/src/components/poll/vote-selector.tsx
+++ b/apps/web/src/components/poll/vote-selector.tsx
@@ -2,10 +2,18 @@ import type { VoteType } from "@rallly/database";
 import { cn } from "@rallly/ui";
 import * as React from "react";
 
+import { useTranslation } from "@/i18n/client";
+
 import VoteIcon from "./vote-icon";
 
 export interface VoteSelectorProps {
   value?: VoteType;
+  /**
+   * Accessible description of the option being voted on (e.g. "Tue 30 Jun
+   * 2026, 1:00 PM – 2:00 PM") so screen readers can tie the vote to its
+   * date/time.
+   */
+  optionLabel?: string;
   onChange?: (value: VoteType) => void;
   onFocus?: React.FocusEventHandler<HTMLButtonElement>;
   onBlur?: React.FocusEventHandler<HTMLButtonElement>;
@@ -26,18 +34,34 @@ export const VoteSelector = React.forwardRef<
   HTMLButtonElement,
   VoteSelectorProps
 >(function VoteSelector(
-  { value, onChange, onFocus, onBlur, onKeyDown, className },
+  { value, optionLabel, onChange, onFocus, onBlur, onKeyDown, className },
   ref,
 ) {
+  const { t } = useTranslation();
+
+  const voteLabel = (() => {
+    switch (value) {
+      case "yes":
+        return t("yes", { defaultValue: "Yes" });
+      case "ifNeedBe":
+        return t("ifNeedBe", { defaultValue: "If need be" });
+      case "no":
+        return t("no", { defaultValue: "No" });
+      default:
+        return t("pending", { defaultValue: "Pending" });
+    }
+  })();
+
   return (
     <button
       data-testid="vote-selector"
       type="button"
+      aria-label={optionLabel ? `${optionLabel}, ${voteLabel}` : voteLabel}
       onFocus={onFocus}
       onBlur={onBlur}
       onKeyDown={onKeyDown}
       className={cn(
-        "flex size-7 items-center justify-center rounded-lg border border-input bg-background ring-ring focus-visible:ring-2",
+        "flex size-7 cursor-pointer items-center justify-center rounded-lg border border-input bg-background ring-ring focus-visible:ring-2",
         className,
       )}
       onClick={() => {

--- a/apps/web/src/lib/utils/date-time-utils.ts
+++ b/apps/web/src/lib/utils/date-time-utils.ts
@@ -37,6 +37,13 @@ export interface ParsedTimeSlotOption {
 
 export type ParsedDateTimeOpton = ParsedDateOption | ParsedTimeSlotOption;
 
+export const getOptionDateTimeLabel = (option: ParsedDateTimeOpton) => {
+  const date = `${option.dow} ${option.day} ${option.month} ${option.year}`;
+  return option.type === "timeSlot"
+    ? `${date}, ${option.startTime} – ${option.endTime}`
+    : date;
+};
+
 export const removeAllOptionsForDay = (
   options: DateTimeOption[],
   date: Date,


### PR DESCRIPTION
## Context

Closes out the two remaining component fixes from RAL-1233 (WCAG 2.1 AA ACR for UT Southwestern) — findings #1 and #3 in the accessibility audit.

## Changes

- **Vote buttons announce their option and state (WCAG 1.3.1 / 4.1.2).** Every vote button now has an `aria-label` of the form "Wed 5 Aug 2026, 12:00 PM – 2:00 PM, Pending" — option date, time range, then current vote state — on both desktop and mobile layouts. `VoteSelector` owns the state→label mapping; a new `getOptionDateTimeLabel` helper builds the date part from the parsed option.
- **Native buttons own all interaction (WCAG 2.1.1 / 4.1.2).** The redundant `<div onClick>` (desktop vote cells) and `<div role="button">` without keyboard handlers (mobile option cards) are removed. The previous full-cell/full-card hit area is preserved with a `::after` overlay on the button, and the mobile pressed style now uses CSS `:active` instead of pointer-handler state. All five Biome a11y suppressions in these files are removed.
- Mobile expand/collapse button no longer needs `stopPropagation` and can't accidentally change a vote.

## Verification

Against a production build (`build:test` + `next start`):
- `vote-and-comment` Playwright spec passes (desktop voting, editing, comments)
- Ad-hoc spec confirmed the exact label strings, that clicking the cell/card **outside** the button still toggles votes on both layouts, and that the expand button leaves votes untouched (the mobile voting spec is permanently skipped upstream, so this had no existing coverage)
- Biome + `tsc` clean

## Notes for the ACR

The VoiceOver pass (checks 8/9/14 in `accessibility/VOICEOVER-TEST-GUIDE.md` on `worktree-vpat-acr`) should run after this deploys — guide expectations are already updated to match the new announcements.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Poll options now show clearer date/time labels, making it easier to understand each choice.
  * Vote controls now include better accessibility labels that combine the option label with the vote status.

* **Improvements**
  * Mobile and desktop poll views now use the same label formatting for date and time options.
  * Poll voting interactions were streamlined for a more consistent tap/click experience across devices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->