### PR TITLE
🐛 Match ALLOWED_EMAILS case-insensitively and trim pattern whitespace

### DIFF
--- a/apps/web/src/features/auth/utils.test.ts
+++ b/apps/web/src/features/auth/utils.test.ts
@@ -1,0 +1,48 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { isEmailBlocked } from "./utils";
+
+describe("isEmailBlocked", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("allows all emails when ALLOWED_EMAILS is not set", () => {
+    vi.stubEnv("ALLOWED_EMAILS", "");
+    expect(isEmailBlocked("anyone@example.com")).toBe(false);
+  });
+
+  it("allows an email matching a wildcard pattern", () => {
+    vi.stubEnv("ALLOWED_EMAILS", "*@company.com");
+    expect(isEmailBlocked("user@company.com")).toBe(false);
+  });
+
+  it("blocks an email that matches no pattern", () => {
+    vi.stubEnv("ALLOWED_EMAILS", "*@company.com");
+    expect(isEmailBlocked("user@other.com")).toBe(true);
+  });
+
+  it("matches case-insensitively", () => {
+    vi.stubEnv("ALLOWED_EMAILS", "*@company.com");
+    expect(isEmailBlocked("User@Company.com")).toBe(false);
+  });
+
+  it("ignores whitespace around comma-separated patterns", () => {
+    vi.stubEnv("ALLOWED_EMAILS", "*@company.com, *@example.com");
+    expect(isEmailBlocked("user@example.com")).toBe(false);
+  });
+
+  it("ignores empty entries from trailing commas", () => {
+    vi.stubEnv("ALLOWED_EMAILS", "*@company.com,");
+    expect(isEmailBlocked("user@other.com")).toBe(true);
+  });
+
+  it("allows an exact email entry regardless of case", () => {
+    vi.stubEnv("ALLOWED_EMAILS", "Admin@Company.com");
+    expect(isEmailBlocked("admin@company.com")).toBe(false);
+  });
+
+  it("does not treat pattern dots as regex wildcards", () => {
+    vi.stubEnv("ALLOWED_EMAILS", "*@company.com");
+    expect(isEmailBlocked("user@companyxcom")).toBe(true);
+  });
+});

--- a/apps/web/src/features/auth/utils.ts
+++ b/apps/web/src/features/auth/utils.ts
@@ -45,13 +45,16 @@ export const passwordQualityThresholds: Record<PasswordQuality, number> = {
 
 export function isEmailBlocked(email: string) {
   if (process.env.ALLOWED_EMAILS) {
-    const allowedEmails = process.env.ALLOWED_EMAILS.split(",");
+    const allowedEmails = process.env.ALLOWED_EMAILS.split(",")
+      .map((allowedEmail) => allowedEmail.trim())
+      .filter(Boolean);
     // Check whether the email matches enough of the patterns specified in ALLOWED_EMAILS
     const isAllowed = allowedEmails.some((allowedEmail) => {
       const regex = new RegExp(
         `^${allowedEmail
           .replace(/[.+?^${}()|[\]\\]/g, "\\$&")
           .replaceAll(/[*]/g, ".*")}$`,
+        "i",
       );
       return regex.test(email);
     });


### PR DESCRIPTION
Fixes two defects in `isEmailBlocked` (found by CodeRabbit on #2560, verified against the call site) that block legitimate users on self-hosted instances using `ALLOWED_EMAILS`. Pre-existing behavior — #2560 only relocated the function, so this ships separately as agreed there.

Fixes RAL-1311

## Defects

The Better-Auth `before` middleware passes the **raw request body** email (`ctx.body?.email ?? ctx.body?.newEmail`) with no upstream normalization, so:

1. **Case-sensitive matching** — the pattern regex had no `i` flag: `User@Company.com` failed to match `*@company.com` and was blocked. Also inconsistent with `isTemporaryEmail`, which lowercases first.
2. **Untrimmed split** — `ALLOWED_EMAILS="*@a.com, *@b.com"` produced the pattern `^ .*@b\.com$` (leading space) which can never match, silently locking out every `b.com` user.

## Fix

`.split(",").map(trim).filter(Boolean)` + the `i` regex flag. Nothing else changed.

## Tests

New `features/auth/utils.test.ts` (co-located per the feature vocabulary) with 8 cases: mixed-case emails, spaced patterns, trailing commas, wildcard matching, escaped dots, exact entries, and the unset-env default. Verified the tests bite: against the pre-fix function exactly the 3 bug-targeting cases fail; with the fix all 8 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)