### PR TITLE
👷 Add standing axe-core accessibility check to CI (WCAG 2.1 A/AA)

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -107,6 +107,7 @@
     "zxcvbn": "^4.4.2"
   },
   "devDependencies": {
+    "@axe-core/playwright": "^4.12.1",
     "@babel/core": "^7.26.10",
     "@next/bundle-analyzer": "16.2.6",
     "@playwright/test": "^1.57.0",

--- a/apps/web/src/components/poll/desktop-poll/poll-header.tsx
+++ b/apps/web/src/components/poll/desktop-poll/poll-header.tsx
@@ -26,7 +26,7 @@ const TimeRange: React.FunctionComponent<{
     >
       <span data-testid="option-start-time">{start}</span>
       <Tooltip delayDuration={0}>
-        <TooltipTrigger className="flex items-center gap-x-1 opacity-50">
+        <TooltipTrigger className="flex items-center gap-x-1">
           <ClockIcon className="size-3" />
           {duration}
         </TooltipTrigger>
@@ -165,7 +165,7 @@ const PollHeader = () => {
                     duration={option.duration}
                   />
                 ) : (
-                  <p className="font-normal text-muted-foreground text-xs opacity-50">
+                  <p className="font-normal text-muted-foreground text-xs">
                     <Trans i18nKey="allDay" defaults="All-Day" />
                   </p>
                 )}

--- a/apps/web/src/components/poll/mobile-poll/time-slot-option.tsx
+++ b/apps/web/src/components/poll/mobile-poll/time-slot-option.tsx
@@ -19,7 +19,7 @@ const TimeSlotOption: React.FunctionComponent<TimeSlotOptionProps> = ({
     <PollOption {...rest}>
       <div className="flex items-center gap-x-4 text-sm">
         <div>{startTime}</div>
-        <div className="flex items-center gap-x-1.5 opacity-50">
+        <div className="flex items-center gap-x-1.5 text-muted-foreground">
           <ClockIcon className="size-4" />
           {duration}
         </div>

--- a/apps/web/tests/accessibility.spec.ts
+++ b/apps/web/tests/accessibility.spec.ts
@@ -1,0 +1,73 @@
+import AxeBuilder from "@axe-core/playwright";
+import type { Page } from "@playwright/test";
+import { expect, test } from "@playwright/test";
+import { NewPollPage } from "./new-poll-page";
+
+/**
+ * Standing accessibility regression check (RAL-1233).
+ *
+ * Runs axe-core against the pages covered by the ACR evidence scans. Scope is
+ * WCAG 2.1 A/AA. If this fails, either fix the violation or — only for issues
+ * already documented in the ACR remediation backlog — add a scoped exclusion
+ * with a reference to the relevant finding.
+ */
+const WCAG_TAGS = ["wcag2a", "wcag2aa", "wcag21a", "wcag21aa"];
+
+async function scan(page: Page) {
+  // Settle animations and in-flight requests so contrast sampling is
+  // deterministic.
+  await page.emulateMedia({ reducedMotion: "reduce" });
+  await page.waitForLoadState("networkidle");
+  const results = await new AxeBuilder({ page }).withTags(WCAG_TAGS).analyze();
+  return results.violations.map((violation) => ({
+    id: violation.id,
+    impact: violation.impact,
+    help: violation.help,
+    nodes: violation.nodes.map((node) => node.target.join(" ")),
+  }));
+}
+
+test.describe("accessibility (axe-core, WCAG 2.1 A/AA)", () => {
+  test("login page", async ({ page }) => {
+    await page.goto("/login");
+    await page.getByText("Welcome").waitFor();
+    expect(await scan(page)).toEqual([]);
+  });
+
+  test("register page", async ({ page }) => {
+    await page.goto("/register");
+    await page.getByRole("heading", { name: "Create Your Account" }).waitFor();
+    expect(await scan(page)).toEqual([]);
+  });
+
+  test.describe("invite page", () => {
+    let inviteUrl: string;
+
+    test.beforeAll(async ({ browser }) => {
+      const page = await browser.newPage();
+      const newPollPage = new NewPollPage(page);
+      await newPollPage.goto();
+      const dialog = await newPollPage.create({ name: "Accessibility Scan" });
+      await dialog.goToPollPage();
+      const match = page.url().match(/\/poll\/([a-zA-Z0-9]+)/);
+      if (!match) {
+        throw new Error(`could not extract poll id from ${page.url()}`);
+      }
+      inviteUrl = `/invite/${match[1]}`;
+      await page.close();
+    });
+
+    test("desktop layout", async ({ page }) => {
+      await page.goto(inviteUrl);
+      await page.getByTestId("vote-selector").first().waitFor();
+      expect(await scan(page)).toEqual([]);
+    });
+
+    test("mobile layout", async ({ page }) => {
+      await page.setViewportSize({ width: 375, height: 667 });
+      await page.goto(inviteUrl);
+      await page.getByTestId("vote-selector").first().waitFor();
+      expect(await scan(page)).toEqual([]);
+    });
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -448,6 +448,9 @@ importers:
         specifier: ^4.4.2
         version: 4.4.2
     devDependencies:
+      '@axe-core/playwright':
+        specifier: ^4.12.1
+        version: 4.12.1(playwright-core@1.58.1)
       '@babel/core':
         specifier: ^7.26.10
         version: 7.29.0
@@ -1120,6 +1123,11 @@ packages:
   '@aws/lambda-invoke-store@0.2.3':
     resolution: {integrity: sha512-oLvsaPMTBejkkmHhjf09xTgk71mOqyr/409NKhRIL08If7AhVfUsJhVsx386uJaqNd42v9kWamQ9lFbkoC2dYw==}
     engines: {node: '>=18.0.0'}
+
+  '@axe-core/playwright@4.12.1':
+    resolution: {integrity: sha512-rMd7xriptqKpP+w5265i4Hdkv2X5kbu6uiBi/B2I7uf3hieRBM3qDCfaKPtxfiYb2mKXfF+yLODJwIx+Jv1GDw==}
+    peerDependencies:
+      playwright-core: '>= 1.0.0'
 
   '@babel/code-frame@7.29.0':
     resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
@@ -6503,6 +6511,10 @@ packages:
   aws-ssl-profiles@1.1.2:
     resolution: {integrity: sha512-NZKeq9AfyQvEeNlN0zSYAaWrmBffJh3IELMZfRpJVWgrpEbtEpnjvzqBPf+mxoI287JohRDoa+/nsfqqiZmF6g==}
     engines: {node: '>= 6.0.0'}
+
+  axe-core@4.12.1:
+    resolution: {integrity: sha512-s7iGf5GaVMxEG0ENN9x+xTr7GFZCb1ZP/1uATUpCEK2X78nDB3RwbtFCo9pGAf9ru+VwoQ464DkaLEeRM08wJA==}
+    engines: {node: '>=4'}
 
   axios@1.10.0:
     resolution: {integrity: sha512-/1xYAC4MP/HEG+3duIhFr4ZQXR4sQXOIe+o6sdqzeykGLx6Upp/1p8MHqhINOvGeP7xyNHe7tsiJByc4SSVUxw==}
@@ -12202,6 +12214,11 @@ snapshots:
       tslib: 2.8.1
 
   '@aws/lambda-invoke-store@0.2.3': {}
+
+  '@axe-core/playwright@4.12.1(playwright-core@1.58.1)':
+    dependencies:
+      axe-core: 4.12.1
+      playwright-core: 1.58.1
 
   '@babel/code-frame@7.29.0':
     dependencies:
@@ -18478,6 +18495,8 @@ snapshots:
   avsc@5.7.9: {}
 
   aws-ssl-profiles@1.1.2: {}
+
+  axe-core@4.12.1: {}
 
   axios@1.10.0:
     dependencies:


### PR DESCRIPTION
## Context

Closes the "standing automated-accessibility check" item on RAL-1233, building on #2565.

## Changes

- **New `accessibility.spec.ts`** in the integration suite: runs axe-core (`@axe-core/playwright`, WCAG 2.1 A/AA tags) against the pages covered by the ACR evidence scans — `/login`, `/register`, and a live invite page in both desktop and mobile viewports. Any violation fails CI with the rule id, impact, and offending nodes in the diff output.
- **Fixes the one live violation** that blocked a green gate (WCAG 1.4.3): time-slot duration labels were dimmed with `opacity-50` → 3.06:1 contrast on white. Now `text-muted-foreground`, which meets AA. Same fix applied to the equivalent desktop poll-header labels.

## Verification

Against a production build of this branch (rebased on main incl. #2565): all 4 scans pass, stable across `--repeat-each 3` (the scan settles animations + network first to keep contrast sampling deterministic). `vote-and-comment` spec still passes. Biome + `tsc` clean.

## Notes

- Login, register, and desktop invite already scanned clean on main — the gate starts green.
- Scope is intentionally the ACR evidence pages; add routes to the same spec as they're remediated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved readability of poll time-related UI by removing overly dim styling for the time range trigger and “all day” label.
  * Refined mobile duration styling by switching from dimmed opacity to muted text styling.
* **Tests**
  * Added an accessibility regression suite using automated axe checks for login, registration, and poll invite pages, validating both desktop and mobile renderings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->