### PR TITLE
🗃️ Record why a poll was closed with closedReason

### DIFF
--- a/apps/web/src/app/api/house-keeping/[...method]/route.ts
+++ b/apps/web/src/app/api/house-keeping/[...method]/route.ts
@@ -99,7 +99,7 @@ app.get("/delete-inactive-polls", async (c) => {
 app.get("/auto-close-polls", async (c) => {
   const closed = await prisma.$executeRaw`
     UPDATE polls p
-    SET status = 'closed'
+    SET status = 'closed', closed_reason = 'auto'
     WHERE p.status = 'open'
       AND p.deleted = false
       AND EXISTS (SELECT 1 FROM options o WHERE o.poll_id = p.id)

--- a/apps/web/src/trpc/routers/polls.ts
+++ b/apps/web/src/trpc/routers/polls.ts
@@ -378,22 +378,15 @@ export const polls = router({
             }
           }) ?? [];
 
-        // Reopen a closed poll when new future dates are added, but only if
-        // every pre-existing option had already ended — that state matches an
-        // auto-close, whereas a manual pause with future dates stays paused.
+        // Reopen an auto-closed poll when new future dates are added. Manually
+        // closed polls stay closed — that was the organizer's decision.
         let reopen = false;
         if (newOptions.some(optionEndsInFuture)) {
           const poll = await tx.poll.findUnique({
             where: { id: pollId },
-            select: { status: true },
+            select: { status: true, closedReason: true },
           });
-          if (poll?.status === "closed") {
-            const existingOptions = await tx.option.findMany({
-              where: { pollId },
-              select: { startTime: true, duration: true },
-            });
-            reopen = !existingOptions.some(optionEndsInFuture);
-          }
+          reopen = poll?.status === "closed" && poll.closedReason === "auto";
         }
 
         if (input.optionsToDelete && input.optionsToDelete.length > 0) {
@@ -444,7 +437,7 @@ export const polls = router({
             disableComments: input.disableComments,
             requireParticipantEmail: input.requireParticipantEmail,
             kind,
-            status: reopen ? "open" : undefined,
+            ...(reopen ? { status: "open" as const, closedReason: null } : {}),
           },
         });
       });
@@ -940,6 +933,7 @@ export const polls = router({
           },
           data: {
             status: "scheduled",
+            closedReason: null,
             scheduledEventId: event.id,
           },
         });
@@ -1108,6 +1102,7 @@ export const polls = router({
           },
           data: {
             status: "open",
+            closedReason: null,
           },
         });
 
@@ -1151,6 +1146,7 @@ export const polls = router({
         },
         data: {
           status: "closed",
+          closedReason: "manual",
         },
       });
 

--- a/packages/database/prisma/migrations/20260710092341_add_poll_closed_reason/migration.sql
+++ b/packages/database/prisma/migrations/20260710092341_add_poll_closed_reason/migration.sql
@@ -1,0 +1,22 @@
+-- CreateEnum
+CREATE TYPE "poll_closed_reason" AS ENUM ('auto', 'manual');
+
+-- AlterTable
+ALTER TABLE "polls" ADD COLUMN     "closed_reason" "poll_closed_reason";
+
+-- Backfill: a closed poll whose options have all ended (the auto-close-polls
+-- condition: end = start + duration, all-day options counted as 24h) is
+-- attributed to auto-close; a closed poll with a future option can only have
+-- been closed by the organizer, since the cron never closes those.
+UPDATE polls p
+SET closed_reason = CASE
+  WHEN EXISTS (
+    SELECT 1 FROM options o
+    WHERE o.poll_id = p.id
+      AND o.start_time + (CASE WHEN o.duration_minutes = 0
+            THEN interval '24 hours'
+            ELSE make_interval(mins => o.duration_minutes) END) > (now() AT TIME ZONE 'UTC')
+  ) THEN 'manual'::poll_closed_reason
+  ELSE 'auto'::poll_closed_reason
+END
+WHERE p.status = 'closed';

--- a/packages/database/prisma/models/poll.prisma
+++ b/packages/database/prisma/models/poll.prisma
@@ -22,29 +22,37 @@ enum PollKind {
   @@map("poll_kind")
 }
 
+enum PollClosedReason {
+  auto
+  manual
+
+  @@map("poll_closed_reason")
+}
+
 model Poll {
-  id                      String     @id @unique @map("id")
-  createdAt               DateTime   @default(now()) @map("created_at")
-  updatedAt               DateTime   @updatedAt @map("updated_at")
+  id                      String            @id @unique @map("id")
+  createdAt               DateTime          @default(now()) @map("created_at")
+  updatedAt               DateTime          @updatedAt @map("updated_at")
   deadline                DateTime?
   title                   String
   description             String?
   location                String?
-  userId                  String?    @map("user_id")
-  timeZone                String?    @map("time_zone")
-  status                  PollStatus @default(open)
-  kind                    PollKind   @default(date)
-  deleted                 Boolean    @default(false)
-  deletedAt               DateTime?  @map("deleted_at")
-  participantUrlId        String     @unique @map("participant_url_id")
-  adminUrlId              String     @unique @map("admin_url_id")
-  eventId                 String?    @unique @map("event_id")
-  scheduledEventId        String?    @map("scheduled_event_id")
-  hideParticipants        Boolean    @default(false) @map("hide_participants")
-  hideScores              Boolean    @default(false) @map("hide_scores")
-  disableComments         Boolean    @default(false) @map("disable_comments")
-  requireParticipantEmail Boolean    @default(false) @map("require_participant_email")
-  muted                   Boolean    @default(false)
+  userId                  String?           @map("user_id")
+  timeZone                String?           @map("time_zone")
+  status                  PollStatus        @default(open)
+  closedReason            PollClosedReason? @map("closed_reason")
+  kind                    PollKind          @default(date)
+  deleted                 Boolean           @default(false)
+  deletedAt               DateTime?         @map("deleted_at")
+  participantUrlId        String            @unique @map("participant_url_id")
+  adminUrlId              String            @unique @map("admin_url_id")
+  eventId                 String?           @unique @map("event_id")
+  scheduledEventId        String?           @map("scheduled_event_id")
+  hideParticipants        Boolean           @default(false) @map("hide_participants")
+  hideScores              Boolean           @default(false) @map("hide_scores")
+  disableComments         Boolean           @default(false) @map("disable_comments")
+  requireParticipantEmail Boolean           @default(false) @map("require_participant_email")
+  muted                   Boolean           @default(false)
 
   user           User?           @relation(fields: [userId], references: [id], onDelete: Cascade)
   scheduledEvent ScheduledEvent? @relation(fields: [scheduledEventId], references: [id], onDelete: SetNull)

--- a/packages/database/prisma/seed.ts
+++ b/packages/database/prisma/seed.ts
@@ -98,6 +98,7 @@ async function main() {
         description: poll.description,
         location: poll.location,
         status: poll.status,
+        closedReason: poll.closedReason,
         timeZone: poll.timeZone,
         deadline: poll.deadline ? new Date(poll.deadline) : undefined,
         userId: poll.userId,

--- a/packages/database/prisma/seed/data.ts
+++ b/packages/database/prisma/seed/data.ts
@@ -1,4 +1,5 @@
 import type {
+  PollClosedReason,
   PollStatus,
   ScheduledEventInviteStatus,
   ScheduledEventStatus,
@@ -86,6 +87,7 @@ export type PollDef = {
   description?: string;
   location?: string;
   status: PollStatus;
+  closedReason?: PollClosedReason;
   timeZone?: string;
   deadline?: string;
   userId: string;
@@ -215,6 +217,7 @@ const personalPolls: PollDef[] = [
     title: "Dinner with the Johnsons",
     description: "Finding a good evening for dinner at their place.",
     status: "closed",
+    closedReason: "auto",
     timeZone: "America/New_York",
     userId: "user-1",
     spaceId: "space-1",
@@ -526,6 +529,7 @@ const acmePolls: PollDef[] = [
     description: "Reflecting on Sprint 14. What went well, what didn't.",
     location: "Zoom",
     status: "closed",
+    closedReason: "manual",
     timeZone: "America/New_York",
     userId: "user-3",
     spaceId: "space-2",
@@ -701,6 +705,7 @@ const acmePolls: PollDef[] = [
     description:
       "Our current 9am ET standup doesn't work for everyone. Let's find a better slot.",
     status: "closed",
+    closedReason: "auto",
     timeZone: "America/New_York",
     userId: "user-3",
     spaceId: "space-2",


### PR DESCRIPTION
## Problem

The `closed` poll status conflates two different things: the `auto-close-polls` house-keeping task closing an expired poll, and the organizer deliberately pausing it. Because of that, #2582 had to infer intent when deciding whether to reopen a poll on edit — reopening only if every pre-existing option had already ended. That heuristic misattributes a manual pause whose dates later expired.

## Solution

Record the reason at close time instead of inferring it later.

- New nullable `closedReason` enum (`auto` | `manual`) on `Poll`
- The auto-close cron stamps `auto`; the `close` mutation stamps `manual`
- `reopen` and finalize (`book`) clear it so it can't go stale on status transitions
- `modify` now reopens on newly added future dates only when `closedReason === "auto"`, replacing the heuristic from #2582 — a manually paused poll stays paused no matter what its options look like
- Seed data sets reasons on its closed polls so dev databases hold the same invariant

## Migration & backfill

The migration backfills existing closed polls: a closed poll with a future option can only have been closed manually (the cron never closes those), so it gets `manual`; the rest get `auto`. This applies the #2582 heuristic once at migration time, after which the field is authoritative.

Verified against the dev database: backfill attributed all expired closed polls to `auto`, a simulated manual pause with future dates to `manual`, and the updated cron SQL stamps `closed_reason` correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Polls now record whether they were closed automatically or manually.
  * Automatically closed polls can reopen when new future dates are added.
  * Reopening or scheduling a poll clears its previous closure reason.

* **Bug Fixes**
  * Poll closure reasons are now maintained consistently across automatic closing, manual closing, reopening, and scheduling.
  * Existing closed polls are assigned an appropriate closure reason.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->