### PR TITLE
docs: add Zenith Hosting deploy option

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,10 @@ Prefer to run your own instance? Rallly ships as a Docker image and can be self-
 
 See the [self-hosting docs](https://support.rallly.co/self-hosting) for installation and [configuration options](https://support.rallly.co/self-hosting/configuration-options).
 
+Or deploy a managed instance without running your own server:
+
+[![Deploy with Zenith](https://cdn.zenith.hosting/buttons/deploy-with-zenith.svg)](https://zenith.hosting/host/rallly)
+
 ## 🛠️ Built with
 
 [Next.js](https://github.com/vercel/next.js/) · [Prisma](https://github.com/prisma/prisma) · [tRPC](https://github.com/trpc/trpc) · [TailwindCSS](https://github.com/tailwindlabs/tailwindcss)


### PR DESCRIPTION
hey, i work on Zenith Hosting, a startup doing one-click hosting for open source apps. we added
Rallly to our marketplace, so this PR adds a small "Deploy with Zenith" badge under the self-hosting
section (links to https://zenith.hosting/host/rallly).

we share a cut of revenue with the projects we host. happy to explain if you're curious: hello@zenith.hosting

## Checklist

- [x] I have performed a self-review of my code
- [x] My code follows the code style of this project
- [x] I have commented my code, particularly in hard-to-understand areas


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added a “Deploy with Zenith” call-to-action to the self-hosting documentation.
  - Readers can now access a managed deployment option without setting up their own server.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->