### PR TITLE
♻️ Migrate Radio Group to Base UI

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -32,7 +32,6 @@
     "@next/env": "16.2.6",
     "@prisma/adapter-pg": "^7.8.0",
     "@prisma/client": "^7.8.0",
-    "@radix-ui/react-radio-group": "^1.2.3",
     "@radix-ui/react-select": "^2.2.2",
     "@radix-ui/react-slot": "^1.1.2",
     "@radix-ui/react-switch": "^1.0.2",

--- a/apps/web/src/app/[locale]/(space)/settings/preferences/components/theme-preference.tsx
+++ b/apps/web/src/app/[locale]/(space)/settings/preferences/components/theme-preference.tsx
@@ -16,7 +16,7 @@ function ThemeOption({
   return (
     <label
       key={value}
-      className="flex aspect-video flex-1 flex-col items-center justify-center gap-4 rounded-lg border border-card-border bg-card p-4 transition-colors hover:bg-card-accent has-data-[state=checked]:border-primary/50 has-data-[state=checked]:bg-linear-to-b has-data-[state=checked]:from-primary/10 has-data-[state=checked]:to-primary/5 has-data-[state=checked]:ring-primary [&>svg]:size-5"
+      className="flex aspect-video flex-1 flex-col items-center justify-center gap-4 rounded-lg border border-card-border bg-card p-4 transition-colors hover:bg-card-accent has-data-checked:border-primary/50 has-data-checked:bg-linear-to-b has-data-checked:from-primary/10 has-data-checked:to-primary/5 has-data-checked:ring-primary [&>svg]:size-5"
       htmlFor={value}
     >
       <RadioGroupItem value={value} id={value} className="peer sr-only" />

--- a/apps/web/src/features/billing/components/pay-wall-dialog.tsx
+++ b/apps/web/src/features/billing/components/pay-wall-dialog.tsx
@@ -85,7 +85,7 @@ function PlanRadioGroupItem({
   return (
     <label
       htmlFor={id}
-      className="flex cursor-pointer items-center justify-between gap-4 rounded-lg border border-popover-border p-4 transition-colors has-data-[state=checked]:border-primary has-data-[state=checked]:bg-primary/5 has-data-[state=checked]:ring-primary"
+      className="flex cursor-pointer items-center justify-between gap-4 rounded-lg border border-popover-border p-4 transition-colors has-data-checked:border-primary has-data-checked:bg-primary/5 has-data-checked:ring-primary"
     >
       <RadioGroupItem value={value} id={id} />
       <div className="flex-1">

--- a/apps/web/src/features/event-types/components/event-type-form.tsx
+++ b/apps/web/src/features/event-types/components/event-type-form.tsx
@@ -440,9 +440,9 @@ function RadioCardOption({
   return (
     <label
       htmlFor={id}
-      className="group flex cursor-pointer items-center gap-2 rounded-lg border border-input bg-card px-3 py-2.5 text-sm transition-colors hover:bg-accent has-data-[state=checked]:border-primary has-data-[state=checked]:bg-primary/5"
+      className="group flex cursor-pointer items-center gap-2 rounded-lg border border-input bg-card px-3 py-2.5 text-sm transition-colors hover:bg-accent has-data-checked:border-primary has-data-checked:bg-primary/5"
     >
-      <span className="text-muted-foreground group-has-data-[state=checked]:text-primary">
+      <span className="text-muted-foreground group-has-data-checked:text-primary">
         {icon}
       </span>
       <span className="flex-1 font-normal">{label}</span>

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -23,7 +23,6 @@
     "@radix-ui/react-dropdown-menu": "^2.0.4",
     "@radix-ui/react-popover": "^1.0.5",
     "@radix-ui/react-portal": "^1.1.6",
-    "@radix-ui/react-radio-group": "^1.2.3",
     "@radix-ui/react-select": "^2.2.2",
     "@radix-ui/react-slot": "^1.1.2",
     "@radix-ui/react-switch": "^1.0.2",

--- a/packages/ui/src/radio-group.tsx
+++ b/packages/ui/src/radio-group.tsx
@@ -1,44 +1,39 @@
 "use client";
 
-import * as RadioGroupPrimitive from "@radix-ui/react-radio-group";
+import { Radio as RadioPrimitive } from "@base-ui/react/radio";
+import { RadioGroup as RadioGroupPrimitive } from "@base-ui/react/radio-group";
 import { CircleIcon } from "lucide-react";
-import * as React from "react";
 
 import { cn } from "./lib/utils";
 
-const RadioGroup = React.forwardRef<
-  React.ElementRef<typeof RadioGroupPrimitive.Root>,
-  React.ComponentPropsWithoutRef<typeof RadioGroupPrimitive.Root>
->(({ className, ...props }, ref) => {
+function RadioGroup({ className, ...props }: RadioGroupPrimitive.Props) {
   return (
-    <RadioGroupPrimitive.Root
+    <RadioGroupPrimitive
+      data-slot="radio-group"
       className={cn("grid gap-2", className)}
       {...props}
-      ref={ref}
     />
   );
-});
-RadioGroup.displayName = RadioGroupPrimitive.Root.displayName;
+}
 
-const RadioGroupItem = React.forwardRef<
-  React.ElementRef<typeof RadioGroupPrimitive.Item>,
-  React.ComponentPropsWithoutRef<typeof RadioGroupPrimitive.Item>
->(({ className, ...props }, ref) => {
+function RadioGroupItem({ className, ...props }: RadioPrimitive.Root.Props) {
   return (
-    <RadioGroupPrimitive.Item
-      ref={ref}
+    <RadioPrimitive.Root
+      data-slot="radio-group-item"
       className={cn(
-        "aspect-square size-4 rounded-full border border-input bg-background text-primary ring-offset-background focus:outline-hidden focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
+        "flex aspect-square size-4 shrink-0 items-center justify-center rounded-full border border-input bg-background text-primary ring-offset-background focus:outline-hidden focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 data-disabled:cursor-not-allowed data-disabled:opacity-50",
         className,
       )}
       {...props}
     >
-      <RadioGroupPrimitive.Indicator className="flex items-center justify-center">
+      <RadioPrimitive.Indicator
+        data-slot="radio-group-indicator"
+        className="flex items-center justify-center"
+      >
         <CircleIcon className="h-2.5 w-2.5 fill-current text-current" />
-      </RadioGroupPrimitive.Indicator>
-    </RadioGroupPrimitive.Item>
+      </RadioPrimitive.Indicator>
+    </RadioPrimitive.Root>
   );
-});
-RadioGroupItem.displayName = RadioGroupPrimitive.Item.displayName;
+}
 
 export { RadioGroup, RadioGroupItem };

--- a/packages/ui/src/radio-pills.tsx
+++ b/packages/ui/src/radio-pills.tsx
@@ -1,35 +1,31 @@
 "use client";
 
-import * as Primitive from "@radix-ui/react-radio-group";
-import * as React from "react";
+import { Radio as RadioPrimitive } from "@base-ui/react/radio";
+import { RadioGroup as RadioGroupPrimitive } from "@base-ui/react/radio-group";
 
 import { cn } from "./lib/utils";
 
-const RadioPills = React.forwardRef<
-  React.ElementRef<typeof Primitive.Root>,
-  React.ComponentPropsWithoutRef<typeof Primitive.Root>
->(({ className, ...props }, ref) => (
-  <Primitive.Root
-    ref={ref}
-    className={cn("display flex items-center gap-x-2", className)}
-    {...props}
-  />
-));
-RadioPills.displayName = Primitive.Root.displayName;
+function RadioPills({ className, ...props }: RadioGroupPrimitive.Props) {
+  return (
+    <RadioGroupPrimitive
+      data-slot="radio-pills"
+      className={cn("display flex items-center gap-x-2", className)}
+      {...props}
+    />
+  );
+}
 
-const RadioPillsItem = React.forwardRef<
-  React.ElementRef<typeof Primitive.Item>,
-  React.ComponentPropsWithoutRef<typeof Primitive.Item>
->(({ className, ...props }, ref) => (
-  <Primitive.Item
-    ref={ref}
-    className={cn(
-      "h-8 rounded-full border px-3 font-medium text-muted-foreground text-sm data-[state=checked]:border-primary data-[state=checked]:text-primary data-[state=unchecked]:hover:text-foreground",
-      className,
-    )}
-    {...props}
-  />
-));
-RadioPillsItem.displayName = Primitive.Item.displayName;
+function RadioPillsItem({ className, ...props }: RadioPrimitive.Root.Props) {
+  return (
+    <RadioPrimitive.Root
+      data-slot="radio-pills-item"
+      className={cn(
+        "inline-flex h-8 cursor-pointer items-center rounded-full border px-3 font-medium text-muted-foreground text-sm data-checked:border-primary data-checked:text-primary data-unchecked:hover:text-foreground",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
 
 export { RadioPills as RadioCards, RadioPillsItem as RadioCardsItem };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -228,9 +228,6 @@ importers:
       '@prisma/client':
         specifier: ^7.8.0
         version: 7.8.0(prisma@7.8.0(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@5.9.3))(typescript@5.9.3)
-      '@radix-ui/react-radio-group':
-        specifier: ^1.2.3
-        version: 1.3.8(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@radix-ui/react-select':
         specifier: ^2.2.2
         version: 2.2.6(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
@@ -782,9 +779,6 @@ importers:
       '@radix-ui/react-portal':
         specifier: ^1.1.6
         version: 1.1.10(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@radix-ui/react-radio-group':
-        specifier: ^1.2.3
-        version: 1.3.8(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@radix-ui/react-select':
         specifier: ^2.2.2
         version: 2.2.6(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)


### PR DESCRIPTION
Resolves RAL-1300

## Changes

- `packages/ui/src/radio-group.tsx` — Base UI splits the primitive into `RadioGroup` (from `@base-ui/react/radio-group`) and `Radio.Root`/`Radio.Indicator` (from `@base-ui/react/radio`). Exported `RadioGroup`/`RadioGroupItem` names and props are unchanged; adds `data-slot` attributes.
- `packages/ui/src/radio-pills.tsx` — same primitive swap for the `RadioCards`/`RadioCardsItem` wrapper; state selectors `data-[state=checked]`/`data-[state=unchecked]` become `data-checked`/`data-unchecked`.
- App code styling radio state via `has-data-[state=checked]:` / `group-has-data-[state=checked]:` updated to `has-data-checked:` / `group-has-data-checked:`:
  - `pay-wall-dialog.tsx` (plan picker cards)
  - `event-type-form.tsx` (location option cards)
  - `theme-preference.tsx` (theme picker cards)
- `@radix-ui/react-radio-group` removed from `packages/ui/package.json` and from `apps/web/package.json` (stale — no source imports there).

## Behavior changes

- **DOM structure:** items render as `<span>` + hidden `<input type="radio">` instead of Radix's `<button role="radio">`. The root span is still the focusable element, so the existing `focus-visible:` ring styles keep working, and the `id` prop lands on the hidden input so `<label htmlFor>` click-to-select keeps working (pay-wall, event-type form, theme picker all use this pattern).
- Because the item is no longer a button, explicit display classes were added where the browser default button styling was previously doing the work: `flex … items-center justify-center shrink-0` on `RadioGroupItem`, `inline-flex items-center cursor-pointer` on `RadioCardsItem`.
- `disabled:` pseudo-class selectors became `data-disabled:`.
- `onValueChange` is now generic in the value type and gains a second `eventDetails` argument; all consumers pass single-argument handlers and infer the same value type, so no call sites change.

## Verification

- `tsc --noEmit` clean in `packages/ui` and `apps/web`
- Biome clean; lockfile updated
- `grep -rn "@radix-ui/react-radio-group" packages apps` returns nothing
- Consumers audited: time-format-picker, schedule-poll-dialog, event-type-form, pay-wall-dialog, theme-preference, month-calendar (RadioCards)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XdQE6gMxnDapmhGd1aCbEA

---
_Generated by [Claude Code](https://claude.ai/code/session_01XdQE6gMxnDapmhGd1aCbEA)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Updated radio buttons, radio cards, and radio pills to use a refreshed component foundation.
  * Improved consistency for selected and disabled visual states across preferences, billing, and event-type forms.
  * Preserved existing selection behavior and appearance while refining state-based styling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->