### PR TITLE
♻️ Migrate Tooltip to Base UI

### DIFF
--- a/apps/web/src/app/[locale]/(space)/settings/calendars/components/calendar-connection-list.tsx
+++ b/apps/web/src/app/[locale]/(space)/settings/calendars/components/calendar-connection-list.tsx
@@ -67,36 +67,38 @@ export function CalendarConnectionList() {
             </div>
             <div className="flex items-center gap-2">
               <Tooltip>
-                <TooltipTrigger asChild>
-                  <Button
-                    aria-label={t("syncCalendar", {
-                      defaultValue: "Sync calendar",
-                    })}
-                    loading={syncCalendar.isPending}
-                    variant="ghost"
-                    size="icon"
-                    onClick={() => {
-                      toast.promise(
-                        syncCalendar.mutateAsync({ id: calendar.id }),
-                        {
-                          loading: t("syncCalendarLoading", {
-                            defaultValue: "Syncing calendar…",
-                          }),
-                          success: t("syncCalendarSuccess", {
-                            defaultValue: "Calendar synced",
-                          }),
-                          error: t("syncCalendarError", {
-                            defaultValue:
-                              "There was an issue syncing your calendar",
-                          }),
-                        },
-                      );
-                    }}
-                  >
-                    <Icon>
-                      <RefreshCcwIcon />
-                    </Icon>
-                  </Button>
+                <TooltipTrigger
+                  render={
+                    <Button
+                      aria-label={t("syncCalendar", {
+                        defaultValue: "Sync calendar",
+                      })}
+                      loading={syncCalendar.isPending}
+                      variant="ghost"
+                      size="icon"
+                      onClick={() => {
+                        toast.promise(
+                          syncCalendar.mutateAsync({ id: calendar.id }),
+                          {
+                            loading: t("syncCalendarLoading", {
+                              defaultValue: "Syncing calendar…",
+                            }),
+                            success: t("syncCalendarSuccess", {
+                              defaultValue: "Calendar synced",
+                            }),
+                            error: t("syncCalendarError", {
+                              defaultValue:
+                                "There was an issue syncing your calendar",
+                            }),
+                          },
+                        );
+                      }}
+                    />
+                  }
+                >
+                  <Icon>
+                    <RefreshCcwIcon />
+                  </Icon>
                 </TooltipTrigger>
                 <TooltipContent>
                   <Trans i18nKey="syncCalendar" defaults="Sync calendar" />

--- a/apps/web/src/components/copy-link-button.tsx
+++ b/apps/web/src/components/copy-link-button.tsx
@@ -21,22 +21,24 @@ export function CopyLinkButton({
   const { t } = useTranslation();
   return (
     <Tooltip open={didCopy ? true : undefined}>
-      <TooltipTrigger asChild>
-        <Button
-          aria-label={t("copyLink", { defaultValue: "Copy link" })}
-          className={className}
-          variant="ghost"
-          size="icon"
-          onClick={() => {
-            copy(href);
-            setDidCopy(true);
-            setTimeout(() => setDidCopy(false), 1000);
-          }}
-        >
-          <Icon>
-            <CopyIcon />
-          </Icon>
-        </Button>
+      <TooltipTrigger
+        render={
+          <Button
+            aria-label={t("copyLink", { defaultValue: "Copy link" })}
+            className={className}
+            variant="ghost"
+            size="icon"
+            onClick={() => {
+              copy(href);
+              setDidCopy(true);
+              setTimeout(() => setDidCopy(false), 1000);
+            }}
+          />
+        }
+      >
+        <Icon>
+          <CopyIcon />
+        </Icon>
       </TooltipTrigger>
       <TooltipContent>
         {didCopy ? (

--- a/apps/web/src/components/poll/desktop-poll.tsx
+++ b/apps/web/src/components/poll/desktop-poll.tsx
@@ -94,45 +94,51 @@ function TableControls({
         {showScrollControls ? (
           <>
             <Tooltip>
-              <TooltipTrigger asChild>
-                <Button
-                  aria-label={t("scrollLeft", { defaultValue: "Scroll Left" })}
-                  variant="ghost"
-                  size="icon"
-                  disabled={!canScrollPrev}
-                  onClick={onGoToPreviousPage}
-                >
-                  <Icon>
-                    <ArrowLeftIcon />
-                  </Icon>
-                </Button>
+              <TooltipTrigger
+                render={
+                  <Button
+                    aria-label={t("scrollLeft", {
+                      defaultValue: "Scroll Left",
+                    })}
+                    variant="ghost"
+                    size="icon"
+                    disabled={!canScrollPrev}
+                    onClick={onGoToPreviousPage}
+                  />
+                }
+              >
+                <Icon>
+                  <ArrowLeftIcon />
+                </Icon>
               </TooltipTrigger>
               <TooltipContent>
                 <Trans i18nKey="scrollLeft" defaults="Scroll Left" />
               </TooltipContent>
             </Tooltip>
             <Tooltip>
-              <TooltipTrigger asChild>
-                <Button
-                  aria-label={t("scrollRight", {
-                    defaultValue: "Scroll Right",
-                  })}
-                  className="relative"
-                  variant="ghost"
-                  size="icon"
-                  disabled={!canScrollNext}
-                  onClick={onGoToNextPage}
-                >
-                  <Icon>
-                    <ArrowRightIcon />
-                  </Icon>
-                  {showScrollIndicator ? (
-                    <span className="absolute -top-0.5 -right-0.5 flex size-2">
-                      <span className="absolute top-0 right-0 inline-flex h-full w-full animate-ping rounded-full bg-rose-400 opacity-75" />
-                      <span className="relative inline-flex size-2 rounded-full bg-rose-500" />
-                    </span>
-                  ) : null}
-                </Button>
+              <TooltipTrigger
+                render={
+                  <Button
+                    aria-label={t("scrollRight", {
+                      defaultValue: "Scroll Right",
+                    })}
+                    className="relative"
+                    variant="ghost"
+                    size="icon"
+                    disabled={!canScrollNext}
+                    onClick={onGoToNextPage}
+                  />
+                }
+              >
+                <Icon>
+                  <ArrowRightIcon />
+                </Icon>
+                {showScrollIndicator ? (
+                  <span className="absolute -top-0.5 -right-0.5 flex size-2">
+                    <span className="absolute top-0 right-0 inline-flex h-full w-full animate-ping rounded-full bg-rose-400 opacity-75" />
+                    <span className="relative inline-flex size-2 rounded-full bg-rose-500" />
+                  </span>
+                ) : null}
               </TooltipTrigger>
               <TooltipContent>
                 <Trans i18nKey="scrollRight" defaults="Scroll Right" />
@@ -140,35 +146,40 @@ function TableControls({
             </Tooltip>
             {expanded ? (
               <Tooltip>
-                <TooltipTrigger asChild>
-                  <Button
-                    aria-label={t("shrink", { defaultValue: "Shrink" })}
-                    variant="ghost"
-                    size="icon"
-                    onClick={onCollapse}
-                  >
-                    <Icon>
-                      <ShrinkIcon />
-                    </Icon>
-                  </Button>
+                <TooltipTrigger
+                  render={
+                    <Button
+                      aria-label={t("shrink", { defaultValue: "Shrink" })}
+                      variant="ghost"
+                      size="icon"
+                      onClick={onCollapse}
+                    />
+                  }
+                >
+                  <Icon>
+                    <ShrinkIcon />
+                  </Icon>
                 </TooltipTrigger>
                 <TooltipContent>
                   <Trans i18nKey="shrink" defaults="Shrink" />
                 </TooltipContent>
               </Tooltip>
             ) : (
-              <Tooltip delayDuration={0}>
-                <TooltipTrigger asChild>
-                  <Button
-                    aria-label={t("expand", { defaultValue: "Expand" })}
-                    variant="ghost"
-                    size="icon"
-                    onClick={onExpand}
-                  >
-                    <Icon>
-                      <ExpandIcon />
-                    </Icon>
-                  </Button>
+              <Tooltip>
+                <TooltipTrigger
+                  delay={0}
+                  render={
+                    <Button
+                      aria-label={t("expand", { defaultValue: "Expand" })}
+                      variant="ghost"
+                      size="icon"
+                      onClick={onExpand}
+                    />
+                  }
+                >
+                  <Icon>
+                    <ExpandIcon />
+                  </Icon>
                 </TooltipTrigger>
                 <TooltipContent>
                   <Trans i18nKey="expand" defaults="Expand" />

--- a/apps/web/src/components/poll/desktop-poll/participant-row-form.tsx
+++ b/apps/web/src/components/poll/desktop-poll/participant-row-form.tsx
@@ -1,11 +1,6 @@
 import { cn } from "@rallly/ui";
 import { Button } from "@rallly/ui/button";
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipPortal,
-  TooltipTrigger,
-} from "@rallly/ui/tooltip";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@rallly/ui/tooltip";
 import { UndoIcon } from "lucide-react";
 import * as React from "react";
 import { Controller } from "react-hook-form";
@@ -77,23 +72,23 @@ const ParticipantRowForm = ({
           {!isNew ? (
             <div className="flex items-center gap-1">
               <Tooltip>
-                <TooltipTrigger asChild>
-                  <Button
-                    aria-label={t("cancel", { defaultValue: "Cancel" })}
-                    variant="ghost"
-                    onClick={() => {
-                      form.cancel();
-                    }}
-                    size="icon-sm"
-                  >
-                    <UndoIcon />
-                  </Button>
+                <TooltipTrigger
+                  render={
+                    <Button
+                      aria-label={t("cancel", { defaultValue: "Cancel" })}
+                      variant="ghost"
+                      onClick={() => {
+                        form.cancel();
+                      }}
+                      size="icon-sm"
+                    />
+                  }
+                >
+                  <UndoIcon />
                 </TooltipTrigger>
-                <TooltipPortal>
-                  <TooltipContent>
-                    <Trans i18nKey="cancel" />
-                  </TooltipContent>
-                </TooltipPortal>
+                <TooltipContent>
+                  <Trans i18nKey="cancel" />
+                </TooltipContent>
               </Tooltip>
               <Button
                 variant="primary"

--- a/apps/web/src/components/poll/desktop-poll/poll-header.tsx
+++ b/apps/web/src/components/poll/desktop-poll/poll-header.tsx
@@ -1,10 +1,5 @@
 import { cn } from "@rallly/ui";
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipPortal,
-  TooltipTrigger,
-} from "@rallly/ui/tooltip";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@rallly/ui/tooltip";
 import { ClockIcon } from "lucide-react";
 import type * as React from "react";
 import { ConnectedScoreSummary } from "@/components/poll/score-summary";
@@ -25,16 +20,14 @@ const TimeRange: React.FunctionComponent<{
       )}
     >
       <span data-testid="option-start-time">{start}</span>
-      <Tooltip delayDuration={0}>
-        <TooltipTrigger className="flex items-center gap-x-1">
+      <Tooltip>
+        <TooltipTrigger delay={0} className="flex items-center gap-x-1">
           <ClockIcon className="size-3" />
           {duration}
         </TooltipTrigger>
-        <TooltipPortal>
-          <TooltipContent className="text-xs">
-            {start} - {end}
-          </TooltipContent>
-        </TooltipPortal>
+        <TooltipContent className="text-xs">
+          {start} - {end}
+        </TooltipContent>
       </Tooltip>
     </div>
   );

--- a/apps/web/src/components/poll/notification-toggle.tsx
+++ b/apps/web/src/components/poll/notification-toggle.tsx
@@ -1,12 +1,7 @@
 "use client";
 
 import { Button } from "@rallly/ui/button";
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipPortal,
-  TooltipTrigger,
-} from "@rallly/ui/tooltip";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@rallly/ui/tooltip";
 import { BellIcon, BellOffIcon } from "lucide-react";
 
 import { useUser } from "@/components/user-provider";
@@ -37,43 +32,43 @@ export function NotificationToggle() {
 
   return (
     <Tooltip>
-      <TooltipTrigger asChild>
-        <Button
-          variant="ghost"
-          aria-pressed={poll.muted}
-          aria-label={
-            poll.muted
-              ? t("unmuteNotifications", {
-                  defaultValue: "Unmute notifications",
-                })
-              : t("muteNotifications", { defaultValue: "Mute notifications" })
-          }
-          onClick={() => {
-            toggleMuted.mutate({ pollId: poll.id, muted: !poll.muted });
-          }}
-        >
-          {poll.muted ? <BellOffIcon /> : <BellIcon />}
-          <span className="sr-only">
-            {poll.muted
-              ? t("unmuteNotifications", {
-                  defaultValue: "Unmute notifications",
-                })
-              : t("muteNotifications", { defaultValue: "Mute notifications" })}
-          </span>
-        </Button>
+      <TooltipTrigger
+        render={
+          <Button
+            variant="ghost"
+            aria-pressed={poll.muted}
+            aria-label={
+              poll.muted
+                ? t("unmuteNotifications", {
+                    defaultValue: "Unmute notifications",
+                  })
+                : t("muteNotifications", { defaultValue: "Mute notifications" })
+            }
+            onClick={() => {
+              toggleMuted.mutate({ pollId: poll.id, muted: !poll.muted });
+            }}
+          />
+        }
+      >
+        {poll.muted ? <BellOffIcon /> : <BellIcon />}
+        <span className="sr-only">
+          {poll.muted
+            ? t("unmuteNotifications", {
+                defaultValue: "Unmute notifications",
+              })
+            : t("muteNotifications", { defaultValue: "Mute notifications" })}
+        </span>
       </TooltipTrigger>
-      <TooltipPortal>
-        <TooltipContent>
-          {poll.muted ? (
-            <Trans
-              i18nKey="unmuteNotifications"
-              defaults="Unmute notifications"
-            />
-          ) : (
-            <Trans i18nKey="muteNotifications" defaults="Mute notifications" />
-          )}
-        </TooltipContent>
-      </TooltipPortal>
+      <TooltipContent>
+        {poll.muted ? (
+          <Trans
+            i18nKey="unmuteNotifications"
+            defaults="Unmute notifications"
+          />
+        ) : (
+          <Trans i18nKey="muteNotifications" defaults="Mute notifications" />
+        )}
+      </TooltipContent>
     </Tooltip>
   );
 }

--- a/apps/web/src/components/poll/truncated-linkify.tsx
+++ b/apps/web/src/components/poll/truncated-linkify.tsx
@@ -27,15 +27,17 @@ export const truncateLink = (href: string, text: string, key: number) => {
     finalText += "…";
     return (
       <Tooltip>
-        <TooltipTrigger asChild>
-          <Link
-            className="text-link"
-            target="_blank"
-            href={href}
-            rel="nofollow noreferrer noopener"
-          >
-            {finalText}
-          </Link>
+        <TooltipTrigger
+          render={
+            <Link
+              className="text-link"
+              target="_blank"
+              href={href}
+              rel="nofollow noreferrer noopener"
+            />
+          }
+        >
+          {finalText}
         </TooltipTrigger>
         <TooltipContent className="max-w-md break-all text-xs">
           {href}

--- a/apps/web/src/components/vote-summary-progress-bar.tsx
+++ b/apps/web/src/components/vote-summary-progress-bar.tsx
@@ -29,40 +29,46 @@ export const VoteSummaryProgressBar = (props: {
   return (
     <div className="flex h-1.5 grow overflow-hidden rounded-sm bg-muted">
       <Tooltip>
-        <TooltipTrigger asChild>
-          <div
-            className="h-full bg-green-500 opacity-75 hover:opacity-100"
-            style={{
-              width: `${(props.yes.length / props.total) * 100}%`,
-            }}
-          />
-        </TooltipTrigger>
+        <TooltipTrigger
+          render={
+            <div
+              className="h-full bg-green-500 opacity-75 hover:opacity-100"
+              style={{
+                width: `${(props.yes.length / props.total) * 100}%`,
+              }}
+            />
+          }
+        />
         <TooltipContent side="bottom">
           <ListNames participantIds={props.yes} />
         </TooltipContent>
       </Tooltip>
       <Tooltip>
-        <TooltipTrigger asChild>
-          <div
-            className="h-full bg-amber-400 opacity-75 hover:opacity-100"
-            style={{
-              width: `${(props.ifNeedBe.length / props.total) * 100}%`,
-            }}
-          />
-        </TooltipTrigger>
+        <TooltipTrigger
+          render={
+            <div
+              className="h-full bg-amber-400 opacity-75 hover:opacity-100"
+              style={{
+                width: `${(props.ifNeedBe.length / props.total) * 100}%`,
+              }}
+            />
+          }
+        />
         <TooltipContent side="bottom">
           <ListNames participantIds={props.ifNeedBe} />
         </TooltipContent>
       </Tooltip>
       <Tooltip>
-        <TooltipTrigger asChild>
-          <div
-            className="h-full bg-transparent opacity-75 hover:opacity-100"
-            style={{
-              width: `${(props.no.length / props.total) * 100}%`,
-            }}
-          />
-        </TooltipTrigger>
+        <TooltipTrigger
+          render={
+            <div
+              className="h-full bg-transparent opacity-75 hover:opacity-100"
+              style={{
+                width: `${(props.no.length / props.total) * 100}%`,
+              }}
+            />
+          }
+        />
         <TooltipContent side="bottom">
           <ListNames participantIds={props.no} />
         </TooltipContent>

--- a/apps/web/src/features/licensing/components/refresh-license-button.tsx
+++ b/apps/web/src/features/licensing/components/refresh-license-button.tsx
@@ -13,19 +13,21 @@ export function RefreshLicenseButton() {
 
   return (
     <Tooltip>
-      <TooltipTrigger asChild>
-        <Button
-          variant="ghost"
-          loading={refreshInstanceLicense.isExecuting}
-          onClick={async () => await refreshInstanceLicense.executeAsync()}
-        >
-          <Icon>
-            <RefreshCwIcon />
-          </Icon>
-          <span className="sr-only">
-            <Trans i18nKey="refreshLicense" defaults="Refresh License" />
-          </span>
-        </Button>
+      <TooltipTrigger
+        render={
+          <Button
+            variant="ghost"
+            loading={refreshInstanceLicense.isExecuting}
+            onClick={async () => await refreshInstanceLicense.executeAsync()}
+          />
+        }
+      >
+        <Icon>
+          <RefreshCwIcon />
+        </Icon>
+        <span className="sr-only">
+          <Trans i18nKey="refreshLicense" defaults="Refresh License" />
+        </span>
       </TooltipTrigger>
       <TooltipContent>
         <Trans i18nKey="refreshLicense" defaults="Refresh License" />

--- a/apps/web/src/features/licensing/components/remove-license-button.tsx
+++ b/apps/web/src/features/licensing/components/remove-license-button.tsx
@@ -27,16 +27,18 @@ export function RemoveLicenseButton() {
   return (
     <Dialog {...dialog.dialogProps}>
       <Tooltip>
-        <TooltipTrigger asChild>
-          <DialogTrigger asChild>
-            <Button variant="ghost" onClick={() => dialog.trigger()}>
-              <XIcon data-icon="inline-start" />
-              <span className="sr-only">
-                <Trans i18nKey="removeLicense" defaults="Remove License" />
-              </span>
-            </Button>
-          </DialogTrigger>
-        </TooltipTrigger>
+        <TooltipTrigger
+          render={
+            <DialogTrigger asChild>
+              <Button variant="ghost" onClick={() => dialog.trigger()}>
+                <XIcon data-icon="inline-start" />
+                <span className="sr-only">
+                  <Trans i18nKey="removeLicense" defaults="Remove License" />
+                </span>
+              </Button>
+            </DialogTrigger>
+          }
+        />
         <TooltipContent>
           <Trans i18nKey="removeLicense" defaults="Remove License" />
         </TooltipContent>

--- a/apps/web/src/features/poll/components/poll-status-icon.tsx
+++ b/apps/web/src/features/poll/components/poll-status-icon.tsx
@@ -56,8 +56,10 @@ export function PollStatusIcon({
     return (
       <TooltipProvider>
         <Tooltip>
-          <TooltipTrigger asChild>
-            <span className={cn("inline-flex", className)}>{icon}</span>
+          <TooltipTrigger
+            render={<span className={cn("inline-flex", className)} />}
+          >
+            {icon}
           </TooltipTrigger>
           <TooltipContent>
             <p>{label}</p>

--- a/apps/web/src/features/poll/components/polls-infinite-list.tsx
+++ b/apps/web/src/features/poll/components/polls-infinite-list.tsx
@@ -80,14 +80,16 @@ function PollListItem({
         <div className="hidden items-center justify-end gap-4 sm:flex">
           {participants.length > 0 ? (
             <Tooltip>
-              <TooltipTrigger asChild>
-                <span className="cursor-help text-muted-foreground text-sm">
-                  <Trans
-                    i18nKey="participantCount"
-                    defaults="{count, plural, =0 {No participants} =1 {1 participant} other {# participants}}"
-                    values={{ count: participants.length }}
-                  />
-                </span>
+              <TooltipTrigger
+                render={
+                  <span className="cursor-help text-muted-foreground text-sm" />
+                }
+              >
+                <Trans
+                  i18nKey="participantCount"
+                  defaults="{count, plural, =0 {No participants} =1 {1 participant} other {# participants}}"
+                  values={{ count: participants.length }}
+                />
               </TooltipTrigger>
               <TooltipContent>
                 <ul>

--- a/apps/web/src/features/scheduled-event/components/scheduled-event-list.tsx
+++ b/apps/web/src/features/scheduled-event/components/scheduled-event-list.tsx
@@ -82,14 +82,12 @@ export function ScheduledEventListItem({
               <div className="text-muted-foreground text-sm">
                 {invites.length > 0 ? (
                   <Tooltip>
-                    <TooltipTrigger asChild>
-                      <span className="cursor-help">
-                        <Trans
-                          i18nKey="attendeeCount"
-                          defaults="{count, plural, =0 {No attendees} one {1 attendee} other {# attendees}}"
-                          values={{ count: invites.length }}
-                        />
-                      </span>
+                    <TooltipTrigger render={<span className="cursor-help" />}>
+                      <Trans
+                        i18nKey="attendeeCount"
+                        defaults="{count, plural, =0 {No attendees} one {1 attendee} other {# attendees}}"
+                        values={{ count: invites.length }}
+                      />
                     </TooltipTrigger>
                     <TooltipContent>
                       <ul>

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -28,7 +28,6 @@
     "@radix-ui/react-slot": "^1.1.2",
     "@radix-ui/react-switch": "^1.0.2",
     "@radix-ui/react-tabs": "^1.0.4",
-    "@radix-ui/react-tooltip": "^1.1.8",
     "@rallly/languages": "workspace:*",
     "@rallly/tailwind-config": "workspace:*",
     "@react-aria/color": "^3.1.5",

--- a/packages/ui/src/sidebar.tsx
+++ b/packages/ui/src/sidebar.tsx
@@ -123,7 +123,7 @@ const SidebarProvider = React.forwardRef<
 
     return (
       <SidebarContext.Provider value={contextValue}>
-        <TooltipProvider delayDuration={0}>
+        <TooltipProvider delay={0}>
           <div
             style={
               {
@@ -577,7 +577,7 @@ const SidebarMenuButton = React.forwardRef<
 
     return (
       <Tooltip>
-        <TooltipTrigger asChild>{button}</TooltipTrigger>
+        <TooltipTrigger render={button} />
         <TooltipContent
           side="right"
           align="center"

--- a/packages/ui/src/tooltip.tsx
+++ b/packages/ui/src/tooltip.tsx
@@ -1,41 +1,53 @@
 "use client";
 
-import * as TooltipPrimitive from "@radix-ui/react-tooltip";
-import * as React from "react";
+import { Tooltip as TooltipPrimitive } from "@base-ui/react/tooltip";
 
 import { cn } from "./lib/utils";
 
-const TooltipProvider = TooltipPrimitive.Provider;
+function TooltipProvider(props: TooltipPrimitive.Provider.Props) {
+  return <TooltipPrimitive.Provider {...props} />;
+}
 
-const Tooltip = TooltipPrimitive.Root;
+function Tooltip(props: TooltipPrimitive.Root.Props) {
+  return <TooltipPrimitive.Root {...props} />;
+}
 
-const TooltipTrigger = TooltipPrimitive.Trigger;
+function TooltipTrigger(props: TooltipPrimitive.Trigger.Props) {
+  return <TooltipPrimitive.Trigger data-slot="tooltip-trigger" {...props} />;
+}
 
-const TooltipPortal = TooltipPrimitive.Portal;
+function TooltipContent({
+  className,
+  align = "center",
+  alignOffset = 0,
+  side = "bottom",
+  sideOffset = 4,
+  ...props
+}: TooltipPrimitive.Popup.Props &
+  Pick<
+    TooltipPrimitive.Positioner.Props,
+    "align" | "alignOffset" | "side" | "sideOffset"
+  >) {
+  return (
+    <TooltipPrimitive.Portal>
+      <TooltipPrimitive.Positioner
+        align={align}
+        alignOffset={alignOffset}
+        side={side}
+        sideOffset={sideOffset}
+        className="isolate z-50"
+      >
+        <TooltipPrimitive.Popup
+          data-slot="tooltip-content"
+          className={cn(
+            "z-50 overflow-hidden rounded-md bg-gray-800 px-2 py-1.5 text-gray-50 text-sm shadow-2xs",
+            className,
+          )}
+          {...props}
+        />
+      </TooltipPrimitive.Positioner>
+    </TooltipPrimitive.Portal>
+  );
+}
 
-const TooltipContent = React.forwardRef<
-  React.ElementRef<typeof TooltipPrimitive.Content>,
-  React.ComponentPropsWithoutRef<typeof TooltipPrimitive.Content>
->(({ className, sideOffset = 4, side = "bottom", ...props }, ref) => (
-  <TooltipPrimitive.Content
-    ref={ref}
-    sideOffset={sideOffset}
-    side={side}
-    className={cn(
-      "z-50 overflow-hidden rounded-md bg-gray-800 px-2 py-1.5 text-gray-50 text-sm shadow-2xs",
-      className,
-    )}
-    {...props}
-  >
-    {props.children}
-  </TooltipPrimitive.Content>
-));
-TooltipContent.displayName = TooltipPrimitive.Content.displayName;
-
-export {
-  Tooltip,
-  TooltipContent,
-  TooltipPortal,
-  TooltipProvider,
-  TooltipTrigger,
-};
+export { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -797,9 +797,6 @@ importers:
       '@radix-ui/react-tabs':
         specifier: ^1.0.4
         version: 1.1.13(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@radix-ui/react-tooltip':
-        specifier: ^1.1.8
-        version: 1.2.8(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@rallly/languages':
         specifier: workspace:*
         version: link:../languages
@@ -3843,19 +3840,6 @@ packages:
 
   '@radix-ui/react-toggle@1.1.10':
     resolution: {integrity: sha512-lS1odchhFTeZv3xwHH31YPObmJn8gOg7Lq12inrr0+BH/l3Tsq32VfjqH1oh80ARM3mlkfMic15n0kg4sD1poQ==}
-    peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-      '@types/react-dom':
-        optional: true
-
-  '@radix-ui/react-tooltip@1.2.8':
-    resolution: {integrity: sha512-tY7sVt1yL9ozIxvmbtN5qtmH2krXcBCfjEiCgKGLqunJHvgvZG2Pcl2oQ3kbcZARb1BGEHdkLzcYGO8ynVlieg==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -15200,26 +15184,6 @@ snapshots:
       '@radix-ui/primitive': 1.1.3
       '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.13)(react@19.2.6)
-      react: 19.2.6
-      react-dom: 19.2.6(react@19.2.6)
-    optionalDependencies:
-      '@types/react': 19.2.13
-      '@types/react-dom': 19.2.3(@types/react@19.2.13)
-
-  '@radix-ui/react-tooltip@1.2.8(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
-    dependencies:
-      '@radix-ui/primitive': 1.1.3
-      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.13)(react@19.2.6)
-      '@radix-ui/react-context': 1.1.2(@types/react@19.2.13)(react@19.2.6)
-      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@radix-ui/react-id': 1.1.1(@types/react@19.2.13)(react@19.2.6)
-      '@radix-ui/react-popper': 1.2.8(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@radix-ui/react-portal': 1.1.9(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@radix-ui/react-slot': 1.2.3(@types/react@19.2.13)(react@19.2.6)
-      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.13)(react@19.2.6)
-      '@radix-ui/react-visually-hidden': 1.2.3(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
     optionalDependencies:


### PR DESCRIPTION
Resolves RAL-1302

First popup component in the migration.

## Changes

- `packages/ui/src/tooltip.tsx` now wraps `@base-ui/react/tooltip` following the anatomy already established by `popover.tsx`: `TooltipContent` renders `Portal > Positioner > Popup` internally, with `side`/`sideOffset`/`align`/`alignOffset` forwarded to the Positioner (defaults unchanged: `side="bottom"`, `sideOffset={4}`).
- **`TooltipPortal` export removed** — content is now always portalled. The three consumers that wrapped `TooltipContent` in `TooltipPortal` (notification-toggle, poll-header, participant-row-form) drop the wrapper; all other tooltips, which previously rendered inline, are now portalled too.
- **All 18 `TooltipTrigger asChild` sites converted to the Base UI `render` prop** across 12 app files + `sidebar.tsx`, keeping trigger children as children (e.g. `render={<Button …/>}` with the icon/label as trigger children). `remove-license-button` nests the still-Radix `DialogTrigger asChild` inside `render` — prop merging works across the two libraries.
- **Delay props renamed:** Radix `delayDuration` → Base UI `delay`, which now lives on the Trigger rather than the Root. `<Tooltip delayDuration={0}>` (poll-header, desktop-poll) became `<TooltipTrigger delay={0} …>`; `<TooltipProvider delayDuration={0}>` (sidebar) became `delay={0}`.
- `@radix-ui/react-tooltip` removed from `packages/ui/package.json`.

## Behavior changes

- Tooltips that previously rendered inline (no `TooltipPortal`) are now portalled to the body — this fixes potential clipping inside `overflow-hidden` containers but is technically a stacking-context change. All content keeps `z-50`.
- `onOpenChange` gains a second `eventDetails` argument (no consumers affected).
- The sidebar menu tooltip still uses `hidden` on the content when the sidebar is expanded — the attribute passes through to the Base UI Popup the same way it did to Radix Content.

## Verification

- `tsc --noEmit` clean in `packages/ui` and `apps/web`
- Biome clean; lockfile updated
- `grep -rn "TooltipPortal\|delayDuration\|TooltipTrigger asChild"` over `apps/web/src` and `packages/ui/src` returns nothing
- `grep -rn "@radix-ui/react-tooltip" packages apps` returns nothing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XdQE6gMxnDapmhGd1aCbEA

---
_Generated by [Claude Code](https://claude.ai/code/session_01XdQE6gMxnDapmhGd1aCbEA)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Improvements**
  * Updated tooltips across calendars, polls, licensing, scheduled events, voting, and navigation for more consistent behavior.
  * Preserved existing tooltip content, labels, actions, loading states, and accessibility support.
  * Improved tooltip positioning and display behavior, including immediate tooltips where applicable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->