### PR TITLE
♻️ Migrate Dropdown Menu to Base UI

### DIFF
--- a/apps/web/src/app/[locale]/(space)/settings/api-keys/components/revoke-api-key-button.tsx
+++ b/apps/web/src/app/[locale]/(space)/settings/api-keys/components/revoke-api-key-button.tsx
@@ -38,16 +38,18 @@ export function RevokeApiKeyButton({
   return (
     <>
       <DropdownMenu>
-        <DropdownMenuTrigger asChild>
-          <Button
-            aria-label={t("moreOptions", { defaultValue: "More options" })}
-            variant="ghost"
-            size="icon"
-          >
-            <Icon>
-              <MoreVerticalIcon />
-            </Icon>
-          </Button>
+        <DropdownMenuTrigger
+          render={
+            <Button
+              aria-label={t("moreOptions", { defaultValue: "More options" })}
+              variant="ghost"
+              size="icon"
+            />
+          }
+        >
+          <Icon>
+            <MoreVerticalIcon />
+          </Icon>
         </DropdownMenuTrigger>
         <DropdownMenuContent align="end">
           <DropdownMenuItem

--- a/apps/web/src/app/[locale]/(space)/settings/calendars/components/calendar-connection-list.tsx
+++ b/apps/web/src/app/[locale]/(space)/settings/calendars/components/calendar-connection-list.tsx
@@ -103,23 +103,25 @@ export function CalendarConnectionList() {
                 </TooltipContent>
               </Tooltip>
               <DropdownMenu>
-                <DropdownMenuTrigger asChild>
-                  <Button
-                    aria-label={t("moreOptions", {
-                      defaultValue: "More options",
-                    })}
-                    variant="ghost"
-                    size="icon"
-                  >
-                    <Icon>
-                      <MoreVerticalIcon />
-                    </Icon>
-                  </Button>
+                <DropdownMenuTrigger
+                  render={
+                    <Button
+                      aria-label={t("moreOptions", {
+                        defaultValue: "More options",
+                      })}
+                      variant="ghost"
+                      size="icon"
+                    />
+                  }
+                >
+                  <Icon>
+                    <MoreVerticalIcon />
+                  </Icon>
                 </DropdownMenuTrigger>
                 <DropdownMenuContent align="end">
                   <DropdownMenuItem
                     variant="destructive"
-                    onSelect={() => {
+                    onClick={() => {
                       toast.promise(
                         disconnectCalendar.mutateAsync({
                           id: calendar.id,

--- a/apps/web/src/app/[locale]/(space)/settings/calendars/components/connect-calendar-dropdown.tsx
+++ b/apps/web/src/app/[locale]/(space)/settings/calendars/components/connect-calendar-dropdown.tsx
@@ -16,16 +16,14 @@ import { Trans } from "@/i18n/client";
 export function ConnectCalendarDropdown() {
   return (
     <DropdownMenu>
-      <DropdownMenuTrigger asChild>
-        <Button>
-          <PlusIcon data-icon="inline-start" />
-          <Trans i18nKey="connectCalendar" defaults="Connect Calendar" />
-          <ChevronDownIcon data-icon="inline-end" />
-        </Button>
+      <DropdownMenuTrigger render={<Button />}>
+        <PlusIcon data-icon="inline-start" />
+        <Trans i18nKey="connectCalendar" defaults="Connect Calendar" />
+        <ChevronDownIcon data-icon="inline-end" />
       </DropdownMenuTrigger>
       <DropdownMenuContent align="end">
         <DropdownMenuItem
-          onSelect={() => {
+          onClick={() => {
             connectToCalendar("google-calendar");
           }}
         >
@@ -38,7 +36,7 @@ export function ConnectCalendarDropdown() {
           <Trans i18nKey="connectGoogleCalendar" defaults="Google Calendar" />
         </DropdownMenuItem>
         <DropdownMenuItem
-          onSelect={() => {
+          onClick={() => {
             connectToCalendar("outlook");
           }}
         >

--- a/apps/web/src/app/[locale]/(space)/settings/event-types/event-types-settings-page.tsx
+++ b/apps/web/src/app/[locale]/(space)/settings/event-types/event-types-settings-page.tsx
@@ -103,19 +103,21 @@ function EventTypeCard({
         <div className="flex items-start justify-between gap-2">
           <OptimizedAvatarImage size="md" src={hostImage} name={hostName} />
           <DropdownMenu>
-            <DropdownMenuTrigger asChild>
-              <Button variant="ghost" size="icon">
-                <Icon>
-                  <MoreVerticalIcon />
-                </Icon>
-                <span className="sr-only">
-                  <Trans
-                    i18nKey="eventTypeActionsLabel"
-                    defaults="Event type actions"
-                  />
-                </span>
-              </Button>
-            </DropdownMenuTrigger>
+            <DropdownMenuTrigger
+              render={
+                <Button variant="ghost" size="icon">
+                  <Icon>
+                    <MoreVerticalIcon />
+                  </Icon>
+                  <span className="sr-only">
+                    <Trans
+                      i18nKey="eventTypeActionsLabel"
+                      defaults="Event type actions"
+                    />
+                  </span>
+                </Button>
+              }
+            />
             <DropdownMenuContent align="end">
               <DropdownMenuItem onClick={onEdit}>
                 <PencilIcon className="size-4" />

--- a/apps/web/src/app/[locale]/(space)/settings/members/components/invite-dropdown-menu.tsx
+++ b/apps/web/src/app/[locale]/(space)/settings/members/components/invite-dropdown-menu.tsx
@@ -44,16 +44,18 @@ export function InviteDropdownMenu({ invite }: { invite: SpaceMemberInvite }) {
   return (
     <>
       <DropdownMenu>
-        <DropdownMenuTrigger asChild>
-          <Button
-            aria-label={t("moreOptions", { defaultValue: "More options" })}
-            variant="ghost"
-            size="icon"
-          >
-            <Icon>
-              <MoreVerticalIcon />
-            </Icon>
-          </Button>
+        <DropdownMenuTrigger
+          render={
+            <Button
+              aria-label={t("moreOptions", { defaultValue: "More options" })}
+              variant="ghost"
+              size="icon"
+            />
+          }
+        >
+          <Icon>
+            <MoreVerticalIcon />
+          </Icon>
         </DropdownMenuTrigger>
         <DropdownMenuContent align="end">
           <DropdownMenuItem

--- a/apps/web/src/app/[locale]/(space)/settings/members/components/member-dropdown-menu.tsx
+++ b/apps/web/src/app/[locale]/(space)/settings/members/components/member-dropdown-menu.tsx
@@ -66,16 +66,18 @@ export function MemberDropdownMenu({ member }: { member: MemberDTO }) {
   return (
     <>
       <DropdownMenu>
-        <DropdownMenuTrigger asChild>
-          <Button
-            aria-label={t("moreOptions", { defaultValue: "More options" })}
-            variant="ghost"
-            size="icon"
-          >
-            <Icon>
-              <MoreVerticalIcon />
-            </Icon>
-          </Button>
+        <DropdownMenuTrigger
+          render={
+            <Button
+              aria-label={t("moreOptions", { defaultValue: "More options" })}
+              variant="ghost"
+              size="icon"
+            />
+          }
+        >
+          <Icon>
+            <MoreVerticalIcon />
+          </Icon>
         </DropdownMenuTrigger>
         <DropdownMenuContent align="end">
           {member.role === "member" ? (

--- a/apps/web/src/app/[locale]/(space)/settings/spaces/components/spaces-list.tsx
+++ b/apps/web/src/app/[locale]/(space)/settings/spaces/components/spaces-list.tsx
@@ -97,18 +97,20 @@ export function SpacesList({ spaces, currentUserId }: SpacesListProps) {
                 </div>
               </div>
               <DropdownMenu>
-                <DropdownMenuTrigger asChild>
-                  <Button
-                    aria-label={t("moreOptions", {
-                      defaultValue: "More options",
-                    })}
-                    variant="ghost"
-                    size="icon"
-                  >
-                    <Icon>
-                      <MoreVerticalIcon />
-                    </Icon>
-                  </Button>
+                <DropdownMenuTrigger
+                  render={
+                    <Button
+                      aria-label={t("moreOptions", {
+                        defaultValue: "More options",
+                      })}
+                      variant="ghost"
+                      size="icon"
+                    />
+                  }
+                >
+                  <Icon>
+                    <MoreVerticalIcon />
+                  </Icon>
                 </DropdownMenuTrigger>
                 <DropdownMenuContent align="end">
                   <DropdownMenuItem

--- a/apps/web/src/app/[locale]/control-panel/users/user-row.tsx
+++ b/apps/web/src/app/[locale]/control-panel/users/user-row.tsx
@@ -65,16 +65,20 @@ export function UserRow({
         <div className="flex items-center gap-4">
           <span className="capitalize">{role}</span>
           <DropdownMenu>
-            <DropdownMenuTrigger asChild>
-              <Button
-                aria-label={t("moreOptions", { defaultValue: "More options" })}
-                variant="ghost"
-                size="icon"
-              >
-                <Icon>
-                  <MoreHorizontal />
-                </Icon>
-              </Button>
+            <DropdownMenuTrigger
+              render={
+                <Button
+                  aria-label={t("moreOptions", {
+                    defaultValue: "More options",
+                  })}
+                  variant="ghost"
+                  size="icon"
+                />
+              }
+            >
+              <Icon>
+                <MoreHorizontal />
+              </Icon>
             </DropdownMenuTrigger>
             <DropdownMenuContent align="end">
               <DropdownMenuSub>

--- a/apps/web/src/app/[locale]/e/[id]/components/user-dropdown.tsx
+++ b/apps/web/src/app/[locale]/e/[id]/components/user-dropdown.tsx
@@ -33,15 +33,18 @@ export function UserDropdown({
 
   return (
     <DropdownMenu modal={false}>
-      <DropdownMenuTrigger asChild className={cn("group min-w-0", className)}>
-        <Button
-          aria-label={t("accountMenu", { defaultValue: "Account menu" })}
-          variant="ghost"
-          className="rounded-full"
-          size="icon"
-        >
-          <OptimizedAvatarImage src={image} name={name} size="sm" />
-        </Button>
+      <DropdownMenuTrigger
+        className={cn("group min-w-0", className)}
+        render={
+          <Button
+            aria-label={t("accountMenu", { defaultValue: "Account menu" })}
+            variant="ghost"
+            className="rounded-full"
+            size="icon"
+          />
+        }
+      >
+        <OptimizedAvatarImage src={image} name={name} size="sm" />
       </DropdownMenuTrigger>
       <DropdownMenuContent align="end" className="min-w-48">
         <DropdownMenuLabel className="flex items-center gap-2">
@@ -56,20 +59,27 @@ export function UserDropdown({
           </div>
         </DropdownMenuLabel>
         <DropdownMenuSeparator />
-        <DropdownMenuItem asChild>
-          <Link href="/settings/profile" className="flex items-center gap-x-2">
-            <UserIcon className="size-4 text-muted-foreground" />
-            <Trans i18nKey="profile" defaults="Profile" />
-          </Link>
+        <DropdownMenuItem
+          render={
+            <Link
+              href="/settings/profile"
+              className="flex items-center gap-x-2"
+            />
+          }
+        >
+          <UserIcon className="size-4 text-muted-foreground" />
+          <Trans i18nKey="profile" defaults="Profile" />
         </DropdownMenuItem>
-        <DropdownMenuItem asChild>
-          <Link
-            href="/settings/preferences"
-            className="flex items-center gap-x-2"
-          >
-            <Settings2Icon className="size-4 text-muted-foreground" />
-            <Trans i18nKey="preferences" defaults="Preferences" />
-          </Link>
+        <DropdownMenuItem
+          render={
+            <Link
+              href="/settings/preferences"
+              className="flex items-center gap-x-2"
+            />
+          }
+        >
+          <Settings2Icon className="size-4 text-muted-foreground" />
+          <Trans i18nKey="preferences" defaults="Preferences" />
         </DropdownMenuItem>
         <DropdownMenuSeparator />
         <DropdownMenuItem

--- a/apps/web/src/components/add-to-calendar-button.tsx
+++ b/apps/web/src/components/add-to-calendar-button.tsx
@@ -29,61 +29,69 @@ export function AddToCalendarButton({
 }) {
   return (
     <DropdownMenu modal={false}>
-      <DropdownMenuTrigger asChild>
-        <Button size={size} className={className}>
-          <PlusIcon data-icon="inline-start" />
-          <Trans i18nKey="addToCalendar" defaults="Add to Calendar" />
-        </Button>
+      <DropdownMenuTrigger
+        render={<Button size={size} className={className} />}
+      >
+        <PlusIcon data-icon="inline-start" />
+        <Trans i18nKey="addToCalendar" defaults="Add to Calendar" />
       </DropdownMenuTrigger>
       <DropdownMenuContent align="start">
-        <DropdownMenuItem asChild>
-          <a
-            href={`/api/event/${eventId}/google-calendar`}
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            <GoogleCalendarIcon className="size-4" />
-            Google Calendar
-          </a>
+        <DropdownMenuItem
+          render={
+            <a
+              href={`/api/event/${eventId}/google-calendar`}
+              target="_blank"
+              rel="noopener noreferrer"
+            />
+          }
+        >
+          <GoogleCalendarIcon className="size-4" />
+          Google Calendar
         </DropdownMenuItem>
-        <DropdownMenuItem asChild>
-          <a
-            href={`/api/event/${eventId}/office365`}
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            <Microsoft365Icon className="size-4" />
-            <Trans i18nKey="microsoft365" defaults="Microsoft 365" />
-          </a>
+        <DropdownMenuItem
+          render={
+            <a
+              href={`/api/event/${eventId}/office365`}
+              target="_blank"
+              rel="noopener noreferrer"
+            />
+          }
+        >
+          <Microsoft365Icon className="size-4" />
+          <Trans i18nKey="microsoft365" defaults="Microsoft 365" />
         </DropdownMenuItem>
-        <DropdownMenuItem asChild>
-          <a
-            href={`/api/event/${eventId}/outlook`}
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            <OutlookIcon className="size-4" />
-            <Trans i18nKey="outlook" defaults="Outlook" />
-          </a>
+        <DropdownMenuItem
+          render={
+            <a
+              href={`/api/event/${eventId}/outlook`}
+              target="_blank"
+              rel="noopener noreferrer"
+            />
+          }
+        >
+          <OutlookIcon className="size-4" />
+          <Trans i18nKey="outlook" defaults="Outlook" />
         </DropdownMenuItem>
-        <DropdownMenuItem asChild>
-          <a
-            href={`/api/event/${eventId}/yahoo`}
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            <YahooIcon className="size-4" />
-            <Trans i18nKey="yahoo" defaults="Yahoo" />
-          </a>
+        <DropdownMenuItem
+          render={
+            <a
+              href={`/api/event/${eventId}/yahoo`}
+              target="_blank"
+              rel="noopener noreferrer"
+            />
+          }
+        >
+          <YahooIcon className="size-4" />
+          <Trans i18nKey="yahoo" defaults="Yahoo" />
         </DropdownMenuItem>
         <DropdownMenuSeparator />
-        <DropdownMenuItem asChild>
-          <a href={`/api/event/${eventId}/ics`} download>
-            <Icon>
-              <DownloadIcon />
-            </Icon>
-            <Trans i18nKey="downloadICSFile" defaults="Download ICS File" />
-          </a>
+        <DropdownMenuItem
+          render={<a href={`/api/event/${eventId}/ics`} download />}
+        >
+          <Icon>
+            <DownloadIcon />
+          </Icon>
+          <Trans i18nKey="downloadICSFile" defaults="Download ICS File" />
         </DropdownMenuItem>
       </DropdownMenuContent>
     </DropdownMenu>

--- a/apps/web/src/components/discussion/discussion.tsx
+++ b/apps/web/src/components/discussion/discussion.tsx
@@ -204,16 +204,18 @@ function DiscussionInner() {
                         </div>
                         {canDelete && (
                           <DropdownMenu>
-                            <DropdownMenuTrigger asChild>
-                              <Button
-                                aria-label={t("moreOptions", {
-                                  defaultValue: "More options",
-                                })}
-                                variant="ghost"
-                                size="icon-xs"
-                              >
-                                <MoreHorizontalIcon />
-                              </Button>
+                            <DropdownMenuTrigger
+                              render={
+                                <Button
+                                  aria-label={t("moreOptions", {
+                                    defaultValue: "More options",
+                                  })}
+                                  variant="ghost"
+                                  size="icon-xs"
+                                />
+                              }
+                            >
+                              <MoreHorizontalIcon />
                             </DropdownMenuTrigger>
                             <DropdownMenuContent align="start">
                               <DropdownMenuItem

--- a/apps/web/src/components/forms/poll-options-form/month-calendar/month-calendar.tsx
+++ b/apps/web/src/components/forms/poll-options-form/month-calendar/month-calendar.tsx
@@ -474,16 +474,18 @@ const MonthCalendar: React.FunctionComponent<DateTimePickerProps> = ({
                               {t("addTimeOption")}
                             </Button>
                             <DropdownMenu>
-                              <DropdownMenuTrigger asChild={true}>
-                                <Button
-                                  aria-label={t("moreOptions", {
-                                    defaultValue: "More options",
-                                  })}
-                                  variant="ghost"
-                                  size="icon"
-                                >
-                                  <MoreVerticalIcon />
-                                </Button>
+                              <DropdownMenuTrigger
+                                render={
+                                  <Button
+                                    aria-label={t("moreOptions", {
+                                      defaultValue: "More options",
+                                    })}
+                                    variant="ghost"
+                                    size="icon"
+                                  />
+                                }
+                              >
+                                <MoreVerticalIcon />
                               </DropdownMenuTrigger>
                               <DropdownMenuContent align="start">
                                 <DropdownMenuItem

--- a/apps/web/src/components/nav-user.tsx
+++ b/apps/web/src/components/nav-user.tsx
@@ -6,7 +6,6 @@ import {
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuLabel,
-  DropdownMenuPortal,
   DropdownMenuRadioGroup,
   DropdownMenuRadioItem,
   DropdownMenuSeparator,
@@ -50,43 +49,41 @@ export function NavUser() {
     <>
       {isPending && <RouterLoadingIndicator />}
       <DropdownMenu>
-        <DropdownMenuTrigger asChild>
-          <Button className="flex h-auto w-full gap-2 p-2" variant="ghost">
-            <OptimizedAvatarImage size="lg" src={user.image} name={user.name} />
-            <div className="flex-1 truncate text-left">
-              <div className="font-medium">{user.name}</div>
-              <div className="mt-0.5 truncate font-normal text-muted-foreground text-xs">
-                {user.email}
-              </div>
+        <DropdownMenuTrigger
+          render={
+            <Button className="flex h-auto w-full gap-2 p-2" variant="ghost" />
+          }
+        >
+          <OptimizedAvatarImage size="lg" src={user.image} name={user.name} />
+          <div className="flex-1 truncate text-left">
+            <div className="font-medium">{user.name}</div>
+            <div className="mt-0.5 truncate font-normal text-muted-foreground text-xs">
+              {user.email}
             </div>
-            <Icon>
-              <ChevronDownIcon />
-            </Icon>
-          </Button>
+          </div>
+          <Icon>
+            <ChevronDownIcon />
+          </Icon>
         </DropdownMenuTrigger>
         <DropdownMenuContent
-          className="w-(--radix-dropdown-menu-trigger-width)"
+          className="w-(--anchor-width)"
           align="end"
           side="top"
         >
           <DropdownMenuLabel>
             <Trans i18nKey="account" defaults="Account" />
           </DropdownMenuLabel>
-          <DropdownMenuItem asChild>
-            <Link href="/settings/profile">
-              <Icon>
-                <UserIcon />
-              </Icon>
-              <Trans i18nKey="profile" defaults="Profile" />
-            </Link>
+          <DropdownMenuItem render={<Link href="/settings/profile" />}>
+            <Icon>
+              <UserIcon />
+            </Icon>
+            <Trans i18nKey="profile" defaults="Profile" />
           </DropdownMenuItem>
-          <DropdownMenuItem asChild>
-            <Link href="/settings/preferences">
-              <Icon>
-                <Settings2Icon />
-              </Icon>
-              <Trans i18nKey="preferences" defaults="Preferences" />
-            </Link>
+          <DropdownMenuItem render={<Link href="/settings/preferences" />}>
+            <Icon>
+              <Settings2Icon />
+            </Icon>
+            <Trans i18nKey="preferences" defaults="Preferences" />
           </DropdownMenuItem>
           <DropdownMenuSeparator />
           <DropdownMenuSub>
@@ -96,30 +93,28 @@ export function NavUser() {
               </Icon>
               <Trans i18nKey="theme" defaults="Theme" />
             </DropdownMenuSubTrigger>
-            <DropdownMenuPortal>
-              <DropdownMenuSubContent>
-                <DropdownMenuRadioGroup value={theme} onValueChange={setTheme}>
-                  <DropdownMenuRadioItem value="system">
-                    <Icon>
-                      <MonitorIcon />
-                    </Icon>
-                    <Trans i18nKey="themeSystem" defaults="System" />
-                  </DropdownMenuRadioItem>
-                  <DropdownMenuRadioItem value="light">
-                    <Icon>
-                      <SunIcon />
-                    </Icon>
-                    <Trans i18nKey="themeLight" defaults="Light" />
-                  </DropdownMenuRadioItem>
-                  <DropdownMenuRadioItem value="dark">
-                    <Icon>
-                      <MoonIcon />
-                    </Icon>
-                    <Trans i18nKey="themeDark" defaults="Dark" />
-                  </DropdownMenuRadioItem>
-                </DropdownMenuRadioGroup>
-              </DropdownMenuSubContent>
-            </DropdownMenuPortal>
+            <DropdownMenuSubContent>
+              <DropdownMenuRadioGroup value={theme} onValueChange={setTheme}>
+                <DropdownMenuRadioItem value="system">
+                  <Icon>
+                    <MonitorIcon />
+                  </Icon>
+                  <Trans i18nKey="themeSystem" defaults="System" />
+                </DropdownMenuRadioItem>
+                <DropdownMenuRadioItem value="light">
+                  <Icon>
+                    <SunIcon />
+                  </Icon>
+                  <Trans i18nKey="themeLight" defaults="Light" />
+                </DropdownMenuRadioItem>
+                <DropdownMenuRadioItem value="dark">
+                  <Icon>
+                    <MoonIcon />
+                  </Icon>
+                  <Trans i18nKey="themeDark" defaults="Dark" />
+                </DropdownMenuRadioItem>
+              </DropdownMenuRadioGroup>
+            </DropdownMenuSubContent>
           </DropdownMenuSub>
           <DropdownMenuSeparator />
           <DropdownMenuItem

--- a/apps/web/src/components/participant-dropdown.tsx
+++ b/apps/web/src/components/participant-dropdown.tsx
@@ -58,7 +58,7 @@ export const ParticipantDropdown = ({
   };
   align?: "start" | "end";
   onEdit: () => void;
-  children: React.ReactNode;
+  children: React.ReactElement;
 }) => {
   const [isChangeNameModalVisible, setIsChangeNameModalVisible] =
     React.useState(false);
@@ -70,11 +70,9 @@ export const ParticipantDropdown = ({
       <DropdownMenu modal={false}>
         <DropdownMenuTrigger
           disabled={disabled}
-          asChild={true}
           data-testid="participant-menu"
-        >
-          {children}
-        </DropdownMenuTrigger>
+          render={children}
+        />
         <DropdownMenuContent align={align}>
           <DropdownMenuLabel>
             <div className="grid gap-0.5">

--- a/apps/web/src/components/poll/manage-poll.tsx
+++ b/apps/web/src/components/poll/manage-poll.tsx
@@ -130,35 +130,35 @@ const ManagePoll: React.FunctionComponent<{
   return (
     <>
       <DropdownMenu modal={false}>
-        <DropdownMenuTrigger asChild={true}>
-          <Button variant="ghost" disabled={disabled}>
-            <span>
-              <Trans i18nKey="manage" />
-            </span>
-            <ChevronDownIcon data-icon="inline-end" />
-          </Button>
+        <DropdownMenuTrigger
+          render={<Button variant="ghost" disabled={disabled} />}
+        >
+          <span>
+            <Trans i18nKey="manage" />
+          </span>
+          <ChevronDownIcon data-icon="inline-end" />
         </DropdownMenuTrigger>
         <DropdownMenuContent align="end">
-          <DropdownMenuItem asChild>
-            <Link href={`/poll/${poll.id}/edit-details`}>
-              <DropdownMenuItemIconLabel icon={PencilIcon}>
-                <Trans i18nKey="editDetails" />
-              </DropdownMenuItemIconLabel>
-            </Link>
+          <DropdownMenuItem
+            render={<Link href={`/poll/${poll.id}/edit-details`} />}
+          >
+            <DropdownMenuItemIconLabel icon={PencilIcon}>
+              <Trans i18nKey="editDetails" />
+            </DropdownMenuItemIconLabel>
           </DropdownMenuItem>
-          <DropdownMenuItem asChild>
-            <Link href={`/poll/${poll.id}/edit-options`}>
-              <DropdownMenuItemIconLabel icon={TableIcon}>
-                <Trans i18nKey="editOptions" />
-              </DropdownMenuItemIconLabel>
-            </Link>
+          <DropdownMenuItem
+            render={<Link href={`/poll/${poll.id}/edit-options`} />}
+          >
+            <DropdownMenuItemIconLabel icon={TableIcon}>
+              <Trans i18nKey="editOptions" />
+            </DropdownMenuItemIconLabel>
           </DropdownMenuItem>
-          <DropdownMenuItem asChild>
-            <Link href={`/poll/${poll.id}/edit-settings`}>
-              <DropdownMenuItemIconLabel icon={Settings2Icon}>
-                <Trans i18nKey="editSettings" defaults="Edit settings" />
-              </DropdownMenuItemIconLabel>
-            </Link>
+          <DropdownMenuItem
+            render={<Link href={`/poll/${poll.id}/edit-settings`} />}
+          >
+            <DropdownMenuItemIconLabel icon={Settings2Icon}>
+              <Trans i18nKey="editSettings" defaults="Edit settings" />
+            </DropdownMenuItemIconLabel>
           </DropdownMenuItem>
           <DropdownMenuSeparator />
           {poll.status === "scheduled" || poll.status === "canceled" ? null : (

--- a/apps/web/src/components/user-dropdown.tsx
+++ b/apps/web/src/components/user-dropdown.tsx
@@ -6,7 +6,6 @@ import {
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuLabel,
-  DropdownMenuPortal,
   DropdownMenuRadioGroup,
   DropdownMenuRadioItem,
   DropdownMenuSeparator,
@@ -72,17 +71,17 @@ export const UserDropdown = ({ className }: { className?: string }) => {
     <DropdownMenu modal={false}>
       <DropdownMenuTrigger
         data-testid="user-dropdown"
-        asChild
         className={cn("group min-w-0", className)}
+        render={
+          <Button
+            aria-label={t("accountMenu", { defaultValue: "Account menu" })}
+            variant="ghost"
+            className="rounded-full"
+            size="icon"
+          />
+        }
       >
-        <Button
-          aria-label={t("accountMenu", { defaultValue: "Account menu" })}
-          variant="ghost"
-          className="rounded-full"
-          size="icon"
-        >
-          <OptimizedAvatarImage src={image} name={name} size="sm" />
-        </Button>
+        <OptimizedAvatarImage src={image} name={name} size="sm" />
       </DropdownMenuTrigger>
       <DropdownMenuContent align="end" className="min-w-48">
         <DropdownMenuLabel className="flex items-center gap-2">
@@ -97,40 +96,54 @@ export const UserDropdown = ({ className }: { className?: string }) => {
           </div>
         </DropdownMenuLabel>
         <DropdownMenuSeparator />
-        <DropdownMenuItem asChild={true}>
-          <Link href="/polls" className="flex items-center gap-x-2 sm:hidden">
-            <ListIcon className="size-4 text-muted-foreground" />
-            <Trans i18nKey="polls" defaults="Polls" />
-          </Link>
+        <DropdownMenuItem
+          render={
+            <Link
+              href="/polls"
+              className="flex items-center gap-x-2 sm:hidden"
+            />
+          }
+        >
+          <ListIcon className="size-4 text-muted-foreground" />
+          <Trans i18nKey="polls" defaults="Polls" />
         </DropdownMenuItem>
-        <DropdownMenuItem asChild={true}>
-          <Link href="/settings/profile" className="flex items-center gap-x-2">
-            <UserIcon className="size-4 text-muted-foreground" />
-            <Trans i18nKey="profile" defaults="Profile" />
-          </Link>
+        <DropdownMenuItem
+          render={
+            <Link
+              href="/settings/profile"
+              className="flex items-center gap-x-2"
+            />
+          }
+        >
+          <UserIcon className="size-4 text-muted-foreground" />
+          <Trans i18nKey="profile" defaults="Profile" />
         </DropdownMenuItem>
-        <DropdownMenuItem asChild={true}>
-          <Link
-            href="/settings/preferences"
-            className="flex items-center gap-x-2"
-          >
-            <Settings2Icon className="size-4 text-muted-foreground" />
-            <Trans i18nKey="preferences" defaults="Preferences" />
-          </Link>
+        <DropdownMenuItem
+          render={
+            <Link
+              href="/settings/preferences"
+              className="flex items-center gap-x-2"
+            />
+          }
+        >
+          <Settings2Icon className="size-4 text-muted-foreground" />
+          <Trans i18nKey="preferences" defaults="Preferences" />
         </DropdownMenuItem>
 
-        <DropdownMenuItem asChild={true}>
-          <Link
-            target="_blank"
-            href="https://support.rallly.co"
-            className="flex items-center gap-x-2"
-          >
-            <LifeBuoyIcon className="size-4 text-muted-foreground" />
-            <Trans i18nKey="support" defaults="Support" />
-            <Icon>
-              <ArrowUpRight />
-            </Icon>
-          </Link>
+        <DropdownMenuItem
+          render={
+            <Link
+              target="_blank"
+              href="https://support.rallly.co"
+              className="flex items-center gap-x-2"
+            />
+          }
+        >
+          <LifeBuoyIcon className="size-4 text-muted-foreground" />
+          <Trans i18nKey="support" defaults="Support" />
+          <Icon>
+            <ArrowUpRight />
+          </Icon>
         </DropdownMenuItem>
         <DropdownMenuSeparator />
         <DropdownMenuSub>
@@ -140,30 +153,28 @@ export const UserDropdown = ({ className }: { className?: string }) => {
             </Icon>
             <Trans i18nKey="theme" defaults="Theme" />
           </DropdownMenuSubTrigger>
-          <DropdownMenuPortal>
-            <DropdownMenuSubContent>
-              <DropdownMenuRadioGroup value={theme} onValueChange={setTheme}>
-                <DropdownMenuRadioItem value="system">
-                  <Icon>
-                    <MonitorIcon />
-                  </Icon>
-                  <Trans i18nKey="themeSystem" defaults="System" />
-                </DropdownMenuRadioItem>
-                <DropdownMenuRadioItem value="light">
-                  <Icon>
-                    <SunIcon />
-                  </Icon>
-                  <Trans i18nKey="themeLight" defaults="Light" />
-                </DropdownMenuRadioItem>
-                <DropdownMenuRadioItem value="dark">
-                  <Icon>
-                    <MoonIcon />
-                  </Icon>
-                  <Trans i18nKey="themeDark" defaults="Dark" />
-                </DropdownMenuRadioItem>
-              </DropdownMenuRadioGroup>
-            </DropdownMenuSubContent>
-          </DropdownMenuPortal>
+          <DropdownMenuSubContent>
+            <DropdownMenuRadioGroup value={theme} onValueChange={setTheme}>
+              <DropdownMenuRadioItem value="system">
+                <Icon>
+                  <MonitorIcon />
+                </Icon>
+                <Trans i18nKey="themeSystem" defaults="System" />
+              </DropdownMenuRadioItem>
+              <DropdownMenuRadioItem value="light">
+                <Icon>
+                  <SunIcon />
+                </Icon>
+                <Trans i18nKey="themeLight" defaults="Light" />
+              </DropdownMenuRadioItem>
+              <DropdownMenuRadioItem value="dark">
+                <Icon>
+                  <MoonIcon />
+                </Icon>
+                <Trans i18nKey="themeDark" defaults="Dark" />
+              </DropdownMenuRadioItem>
+            </DropdownMenuRadioGroup>
+          </DropdownMenuSubContent>
         </DropdownMenuSub>
         <DropdownMenuSeparator />
         <DropdownMenuItem

--- a/apps/web/src/features/poll/components/polls-infinite-list.tsx
+++ b/apps/web/src/features/poll/components/polls-infinite-list.tsx
@@ -129,19 +129,23 @@ function PollListItem({
           )}
           <CopyLinkButton href={shortUrl(`/invite/${id}`)} />
           <DropdownMenu>
-            <DropdownMenuTrigger asChild>
-              <Button
-                aria-label={t("moreOptions", { defaultValue: "More options" })}
-                variant="ghost"
-                size="icon"
-              >
-                <MoreVerticalIcon />
-              </Button>
+            <DropdownMenuTrigger
+              render={
+                <Button
+                  aria-label={t("moreOptions", {
+                    defaultValue: "More options",
+                  })}
+                  variant="ghost"
+                  size="icon"
+                />
+              }
+            >
+              <MoreVerticalIcon />
             </DropdownMenuTrigger>
             <DropdownMenuContent align="end">
               {status === "open" && (
                 <DropdownMenuItem
-                  onSelect={() => {
+                  onClick={() => {
                     toast.promise(closePoll.mutateAsync({ pollId: id }), {
                       loading: <Trans i18nKey="loading" defaults="Loading…" />,
                       success: (
@@ -158,7 +162,7 @@ function PollListItem({
               )}
               {status === "closed" && (
                 <DropdownMenuItem
-                  onSelect={() => {
+                  onClick={() => {
                     toast.promise(reopenPoll.mutateAsync({ pollId: id }), {
                       loading: <Trans i18nKey="loading" defaults="Loading…" />,
                       success: (
@@ -176,7 +180,7 @@ function PollListItem({
                   <Trans i18nKey="reopenPoll" defaults="Reopen" />
                 </DropdownMenuItem>
               )}
-              <DropdownMenuItem onSelect={() => deletePollDialog.trigger()}>
+              <DropdownMenuItem onClick={() => deletePollDialog.trigger()}>
                 <Icon>
                   <TrashIcon />
                 </Icon>

--- a/apps/web/src/features/scheduled-event/components/scheduled-event-list.tsx
+++ b/apps/web/src/features/scheduled-event/components/scheduled-event-list.tsx
@@ -153,16 +153,20 @@ export function ScheduledEventListItem({
         )}
         {status !== "canceled" ? (
           <DropdownMenu>
-            <DropdownMenuTrigger asChild>
-              <Button
-                aria-label={t("moreOptions", { defaultValue: "More options" })}
-                variant="ghost"
-                size="icon"
-              >
-                <Icon>
-                  <MoreVerticalIcon />
-                </Icon>
-              </Button>
+            <DropdownMenuTrigger
+              render={
+                <Button
+                  aria-label={t("moreOptions", {
+                    defaultValue: "More options",
+                  })}
+                  variant="ghost"
+                  size="icon"
+                />
+              }
+            >
+              <Icon>
+                <MoreVerticalIcon />
+              </Icon>
             </DropdownMenuTrigger>
             <DropdownMenuContent align="end">
               <DropdownMenuItem

--- a/apps/web/src/features/space/components/space-dropdown.tsx
+++ b/apps/web/src/features/space/components/space-dropdown.tsx
@@ -51,35 +51,34 @@ export function SpaceDropdown() {
   return (
     <>
       <DropdownMenu>
-        <DropdownMenuTrigger asChild={true}>
-          <Button
-            className={cn("flex h-auto w-full gap-2.5 p-2", {
-              "pointer-events-none animate-pulse": setActiveSpace.isExecuting,
-            })}
-            variant="ghost"
-          >
-            <SpaceIcon
-              src={activeSpace.image}
-              name={activeSpace.name}
-              size="lg"
+        <DropdownMenuTrigger
+          render={
+            <Button
+              className={cn("flex h-auto w-full gap-2.5 p-2", {
+                "pointer-events-none animate-pulse": setActiveSpace.isExecuting,
+              })}
+              variant="ghost"
             />
-            <div className="min-w-0 flex-1 px-0.5 text-left">
-              <div className="truncate font-medium text-sm">
-                {activeSpace.name}
-              </div>
-              <div className="text-xs">
-                <SpaceTierLabel tier={activeSpace.tier} />
-              </div>
-            </div>
-            <Icon>
-              <ChevronsUpDownIcon />
-            </Icon>
-          </Button>
-        </DropdownMenuTrigger>
-        <DropdownMenuContent
-          className="min-w-[var(--radix-dropdown-menu-trigger-width)]"
-          align="start"
+          }
         >
+          <SpaceIcon
+            src={activeSpace.image}
+            name={activeSpace.name}
+            size="lg"
+          />
+          <div className="min-w-0 flex-1 px-0.5 text-left">
+            <div className="truncate font-medium text-sm">
+              {activeSpace.name}
+            </div>
+            <div className="text-xs">
+              <SpaceTierLabel tier={activeSpace.tier} />
+            </div>
+          </div>
+          <Icon>
+            <ChevronsUpDownIcon />
+          </Icon>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent className="min-w-(--anchor-width)" align="start">
           <DropdownMenuLabel>
             <Trans i18nKey="spaces" defaults="Spaces" />
           </DropdownMenuLabel>
@@ -108,21 +107,17 @@ export function SpaceDropdown() {
             <Trans i18nKey="createSpace" defaults="Create Space" />
           </DropdownMenuItem>
           <DropdownMenuSeparator />
-          <DropdownMenuItem asChild>
-            <Link href="/settings/general">
-              <Icon>
-                <SettingsIcon />
-              </Icon>
-              <Trans i18nKey="spaceSettings" defaults="Space Settings" />
-            </Link>
+          <DropdownMenuItem render={<Link href="/settings/general" />}>
+            <Icon>
+              <SettingsIcon />
+            </Icon>
+            <Trans i18nKey="spaceSettings" defaults="Space Settings" />
           </DropdownMenuItem>
-          <DropdownMenuItem asChild>
-            <Link href="/settings/members">
-              <Icon>
-                <UserPlusIcon />
-              </Icon>
-              <Trans i18nKey="spaceInviteMember" defaults="Invite Member" />
-            </Link>
+          <DropdownMenuItem render={<Link href="/settings/members" />}>
+            <Icon>
+              <UserPlusIcon />
+            </Icon>
+            <Trans i18nKey="spaceInviteMember" defaults="Invite Member" />
           </DropdownMenuItem>
         </DropdownMenuContent>
       </DropdownMenu>

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -20,7 +20,6 @@
     "@base-ui/react": "^1.2.0",
     "@radix-ui/react-avatar": "^1.1.0",
     "@radix-ui/react-dialog": "^1.1.11",
-    "@radix-ui/react-dropdown-menu": "^2.0.4",
     "@radix-ui/react-popover": "^1.0.5",
     "@radix-ui/react-portal": "^1.1.6",
     "@radix-ui/react-radio-group": "^1.2.3",

--- a/packages/ui/src/dropdown-menu.tsx
+++ b/packages/ui/src/dropdown-menu.tsx
@@ -1,101 +1,137 @@
 "use client";
 
-import * as DropdownMenuPrimitive from "@radix-ui/react-dropdown-menu";
+import { Menu as MenuPrimitive } from "@base-ui/react/menu";
 import type { VariantProps } from "class-variance-authority";
 import { cva } from "class-variance-authority";
 import { CheckIcon, ChevronRightIcon } from "lucide-react";
-import * as React from "react";
+import type * as React from "react";
 
 import { Icon } from "./icon";
 import { cn } from "./lib/utils";
 
-const DropdownMenu = DropdownMenuPrimitive.Root;
+function DropdownMenu(props: MenuPrimitive.Root.Props) {
+  return <MenuPrimitive.Root {...props} />;
+}
 
-const DropdownMenuTrigger = React.forwardRef<
-  React.ComponentRef<typeof DropdownMenuPrimitive.Trigger>,
-  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Trigger>
->(({ ...props }, ref) => (
-  <DropdownMenuPrimitive.Trigger
-    ref={ref}
-    {...props}
-    onFocusCapture={(e) => {
-      e.stopPropagation();
-    }}
-  />
-));
-DropdownMenuTrigger.displayName = DropdownMenuPrimitive.Trigger.displayName;
-const DropdownMenuGroup = DropdownMenuPrimitive.Group;
+function DropdownMenuTrigger(props: MenuPrimitive.Trigger.Props) {
+  return (
+    <MenuPrimitive.Trigger
+      data-slot="dropdown-menu-trigger"
+      {...props}
+      onFocusCapture={(e) => {
+        e.stopPropagation();
+      }}
+    />
+  );
+}
 
-const DropdownMenuPortal = DropdownMenuPrimitive.Portal;
+function DropdownMenuGroup(props: MenuPrimitive.Group.Props) {
+  return <MenuPrimitive.Group data-slot="dropdown-menu-group" {...props} />;
+}
 
-const DropdownMenuSub = DropdownMenuPrimitive.Sub;
+function DropdownMenuPortal(props: MenuPrimitive.Portal.Props) {
+  return <MenuPrimitive.Portal {...props} />;
+}
 
-const DropdownMenuRadioGroup = DropdownMenuPrimitive.RadioGroup;
+function DropdownMenuSub(props: MenuPrimitive.SubmenuRoot.Props) {
+  return <MenuPrimitive.SubmenuRoot {...props} />;
+}
 
-const DropdownMenuSubTrigger = React.forwardRef<
-  React.ComponentRef<typeof DropdownMenuPrimitive.SubTrigger>,
-  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.SubTrigger> & {
-    inset?: boolean;
-  }
->(({ className, inset, children, ...props }, ref) => (
-  <DropdownMenuPrimitive.SubTrigger
-    ref={ref}
-    className={cn(
-      dropdownMenuItemVariants({ variant: "default" }),
-      inset && "pl-8",
-      className,
-    )}
-    {...props}
-  >
-    {children}
-    <ChevronRightIcon className="ml-auto size-4" />
-  </DropdownMenuPrimitive.SubTrigger>
-));
-DropdownMenuSubTrigger.displayName =
-  DropdownMenuPrimitive.SubTrigger.displayName;
+function DropdownMenuRadioGroup(props: MenuPrimitive.RadioGroup.Props) {
+  return (
+    <MenuPrimitive.RadioGroup
+      data-slot="dropdown-menu-radio-group"
+      {...props}
+    />
+  );
+}
 
-const DropdownMenuSubContent = React.forwardRef<
-  React.ComponentRef<typeof DropdownMenuPrimitive.SubContent>,
-  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.SubContent>
->(({ className, ...props }, ref) => (
-  <DropdownMenuPrimitive.SubContent
-    ref={ref}
-    className={cn(
-      "data-[side=bottom]:slide-in-from-top-1 data-[side=left]:slide-in-from-right-1 data-[side=right]:slide-in-from-left-1 data-[side=top]:slide-in-from-bottom-1 z-50 min-w-32 animate-in overflow-hidden rounded-xl border border-popover-border bg-popover p-1 text-popover-foreground shadow-md",
-      className,
-    )}
-    {...props}
-  />
-));
-DropdownMenuSubContent.displayName =
-  DropdownMenuPrimitive.SubContent.displayName;
-
-const DropdownMenuContent = React.forwardRef<
-  React.ComponentRef<typeof DropdownMenuPrimitive.Content>,
-  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Content>
->(({ className, sideOffset = 4, ...props }, ref) => (
-  <DropdownMenuPrimitive.Portal>
-    <DropdownMenuPrimitive.Content
-      ref={ref}
-      sideOffset={sideOffset}
+function DropdownMenuSubTrigger({
+  className,
+  inset,
+  children,
+  ...props
+}: MenuPrimitive.SubmenuTrigger.Props & {
+  inset?: boolean;
+}) {
+  return (
+    <MenuPrimitive.SubmenuTrigger
+      data-slot="dropdown-menu-sub-trigger"
       className={cn(
-        "data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 min-w-[100px] animate-in overflow-hidden rounded-xl border border-popover-border bg-popover p-1 text-popover-foreground shadow-md",
+        dropdownMenuItemVariants({ variant: "default" }),
+        inset && "pl-8",
         className,
       )}
       {...props}
-    />
-  </DropdownMenuPrimitive.Portal>
-));
-DropdownMenuContent.displayName = DropdownMenuPrimitive.Content.displayName;
+    >
+      {children}
+      <ChevronRightIcon className="ml-auto size-4" />
+    </MenuPrimitive.SubmenuTrigger>
+  );
+}
+
+function DropdownMenuSubContent({
+  className,
+  ...props
+}: MenuPrimitive.Popup.Props) {
+  return (
+    <MenuPrimitive.Portal>
+      <MenuPrimitive.Positioner className="isolate z-50">
+        <MenuPrimitive.Popup
+          data-slot="dropdown-menu-sub-content"
+          className={cn(
+            "data-[side=bottom]:slide-in-from-top-1 data-[side=left]:slide-in-from-right-1 data-[side=right]:slide-in-from-left-1 data-[side=top]:slide-in-from-bottom-1 z-50 min-w-32 animate-in overflow-hidden rounded-xl border border-popover-border bg-popover p-1 text-popover-foreground shadow-md",
+            className,
+          )}
+          {...props}
+        />
+      </MenuPrimitive.Positioner>
+    </MenuPrimitive.Portal>
+  );
+}
+
+function DropdownMenuContent({
+  className,
+  align,
+  alignOffset,
+  side,
+  sideOffset = 4,
+  ...props
+}: MenuPrimitive.Popup.Props &
+  Pick<
+    MenuPrimitive.Positioner.Props,
+    "align" | "alignOffset" | "side" | "sideOffset"
+  >) {
+  return (
+    <MenuPrimitive.Portal>
+      <MenuPrimitive.Positioner
+        align={align}
+        alignOffset={alignOffset}
+        side={side}
+        sideOffset={sideOffset}
+        className="isolate z-50"
+      >
+        <MenuPrimitive.Popup
+          data-slot="dropdown-menu-content"
+          className={cn(
+            "data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 min-w-[100px] animate-in overflow-hidden rounded-xl border border-popover-border bg-popover p-1 text-popover-foreground shadow-md",
+            className,
+          )}
+          {...props}
+        />
+      </MenuPrimitive.Positioner>
+    </MenuPrimitive.Portal>
+  );
+}
 
 export const dropdownMenuItemVariants = cva(
-  "relative flex cursor-default select-none items-center gap-x-2.5 rounded-lg px-2 py-1.5 text-sm outline-hidden focus:bg-popover-accent focus:ring-1 focus:ring-menu-item-outline focus:ring-inset data-disabled:pointer-events-none data-disabled:opacity-50",
+  "relative flex cursor-default select-none items-center gap-x-2.5 rounded-lg px-2 py-1.5 text-sm outline-hidden data-disabled:pointer-events-none data-highlighted:bg-popover-accent data-disabled:opacity-50 data-highlighted:ring-1 data-highlighted:ring-menu-item-outline data-highlighted:ring-inset",
 
   {
     variants: {
       variant: {
         default: "",
-        destructive: "text-destructive focus:bg-popover-accent",
+        destructive: "text-destructive data-highlighted:bg-popover-accent",
       },
     },
     defaultVariants: {
@@ -104,98 +140,114 @@ export const dropdownMenuItemVariants = cva(
   },
 );
 
-const DropdownMenuItem = React.forwardRef<
-  React.ComponentRef<typeof DropdownMenuPrimitive.Item>,
-  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Item> &
-    VariantProps<typeof dropdownMenuItemVariants> & {
-      inset?: boolean;
-    }
->(({ className, inset, variant, ...props }, ref) => (
-  <DropdownMenuPrimitive.Item
-    ref={ref}
-    className={cn(
-      dropdownMenuItemVariants({ variant }),
-      inset && "pl-8",
-      className,
-    )}
-    {...props}
-  />
-));
-DropdownMenuItem.displayName = DropdownMenuPrimitive.Item.displayName;
-
-const DropdownMenuCheckboxItem = React.forwardRef<
-  React.ComponentRef<typeof DropdownMenuPrimitive.CheckboxItem>,
-  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.CheckboxItem>
->(({ className, children, checked, ...props }, ref) => (
-  <DropdownMenuPrimitive.CheckboxItem
-    ref={ref}
-    className={cn(dropdownMenuItemVariants({ variant: "default" }), className)}
-    checked={checked}
-    {...props}
-  >
-    <span className="absolute left-2 flex h-3.5 w-3.5 items-center justify-center">
-      <DropdownMenuPrimitive.ItemIndicator>
-        <Icon>
-          <CheckIcon />
-        </Icon>
-      </DropdownMenuPrimitive.ItemIndicator>
-    </span>
-    <span className="flex items-center gap-2 text-sm">{children}</span>
-  </DropdownMenuPrimitive.CheckboxItem>
-));
-DropdownMenuCheckboxItem.displayName =
-  DropdownMenuPrimitive.CheckboxItem.displayName;
-
-const DropdownMenuRadioItem = React.forwardRef<
-  React.ComponentRef<typeof DropdownMenuPrimitive.RadioItem>,
-  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.RadioItem>
->(({ className, children, ...props }, ref) => (
-  <DropdownMenuPrimitive.RadioItem
-    ref={ref}
-    className={cn(dropdownMenuItemVariants({ variant: "default" }), className)}
-    {...props}
-  >
-    <span className="absolute right-2 flex h-3.5 w-3.5 items-center justify-center">
-      <DropdownMenuPrimitive.ItemIndicator>
-        <Icon>
-          <CheckIcon />
-        </Icon>
-      </DropdownMenuPrimitive.ItemIndicator>
-    </span>
-    {children}
-  </DropdownMenuPrimitive.RadioItem>
-));
-DropdownMenuRadioItem.displayName = DropdownMenuPrimitive.RadioItem.displayName;
-
-const DropdownMenuLabel = React.forwardRef<
-  React.ComponentRef<typeof DropdownMenuPrimitive.Label>,
-  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Label> & {
+function DropdownMenuItem({
+  className,
+  inset,
+  variant,
+  ...props
+}: MenuPrimitive.Item.Props &
+  VariantProps<typeof dropdownMenuItemVariants> & {
     inset?: boolean;
-  }
->(({ className, inset, ...props }, ref) => (
-  <DropdownMenuPrimitive.Label
-    ref={ref}
-    className={cn(
-      "px-2 py-1.5 text-muted-foreground text-xs",
-      inset && "pl-8",
-      className,
-    )}
-    {...props}
-  />
-));
-DropdownMenuLabel.displayName = DropdownMenuPrimitive.Label.displayName;
+  }) {
+  return (
+    <MenuPrimitive.Item
+      data-slot="dropdown-menu-item"
+      className={cn(
+        dropdownMenuItemVariants({ variant }),
+        inset && "pl-8",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
 
-const DropdownMenuSeparator = React.forwardRef<
-  React.ComponentRef<typeof DropdownMenuPrimitive.Separator>,
-  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Separator>
->(({ className, ...props }, ref) => (
-  <DropdownMenuPrimitive.Separator
-    ref={ref}
-    className={cn("-mx-1 my-1 h-px bg-popover-border", className)}
-    {...props}
-  />
-));
-DropdownMenuSeparator.displayName = DropdownMenuPrimitive.Separator.displayName;
+function DropdownMenuCheckboxItem({
+  className,
+  children,
+  checked,
+  ...props
+}: MenuPrimitive.CheckboxItem.Props) {
+  return (
+    <MenuPrimitive.CheckboxItem
+      data-slot="dropdown-menu-checkbox-item"
+      className={cn(
+        dropdownMenuItemVariants({ variant: "default" }),
+        className,
+      )}
+      checked={checked}
+      {...props}
+    >
+      <span className="absolute left-2 flex h-3.5 w-3.5 items-center justify-center">
+        <MenuPrimitive.CheckboxItemIndicator>
+          <Icon>
+            <CheckIcon />
+          </Icon>
+        </MenuPrimitive.CheckboxItemIndicator>
+      </span>
+      <span className="flex items-center gap-2 text-sm">{children}</span>
+    </MenuPrimitive.CheckboxItem>
+  );
+}
+
+function DropdownMenuRadioItem({
+  className,
+  children,
+  ...props
+}: MenuPrimitive.RadioItem.Props) {
+  return (
+    <MenuPrimitive.RadioItem
+      data-slot="dropdown-menu-radio-item"
+      className={cn(
+        dropdownMenuItemVariants({ variant: "default" }),
+        className,
+      )}
+      {...props}
+    >
+      <span className="absolute right-2 flex h-3.5 w-3.5 items-center justify-center">
+        <MenuPrimitive.RadioItemIndicator>
+          <Icon>
+            <CheckIcon />
+          </Icon>
+        </MenuPrimitive.RadioItemIndicator>
+      </span>
+      {children}
+    </MenuPrimitive.RadioItem>
+  );
+}
+
+function DropdownMenuLabel({
+  className,
+  inset,
+  ...props
+}: MenuPrimitive.GroupLabel.Props & {
+  inset?: boolean;
+}) {
+  return (
+    <MenuPrimitive.GroupLabel
+      data-slot="dropdown-menu-label"
+      className={cn(
+        "px-2 py-1.5 text-muted-foreground text-xs",
+        inset && "pl-8",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function DropdownMenuSeparator({
+  className,
+  ...props
+}: MenuPrimitive.Separator.Props) {
+  return (
+    <MenuPrimitive.Separator
+      data-slot="dropdown-menu-separator"
+      className={cn("-mx-1 my-1 h-px bg-popover-border", className)}
+      {...props}
+    />
+  );
+}
 
 const DropdownMenuShortcut = ({
   className,
@@ -208,7 +260,6 @@ const DropdownMenuShortcut = ({
     />
   );
 };
-DropdownMenuShortcut.displayName = "DropdownMenuShortcut";
 
 export {
   DropdownMenu,

--- a/packages/ui/src/sidebar.tsx
+++ b/packages/ui/src/sidebar.tsx
@@ -507,7 +507,7 @@ const SidebarMenuItem = React.forwardRef<
 SidebarMenuItem.displayName = "SidebarMenuItem";
 
 const sidebarMenuButtonVariants = cva(
-  "peer/menu-button flex w-full items-center gap-2.5 overflow-hidden rounded-lg p-2 text-left text-sm transition-[width,height,padding] active:text-sidebar-accent-foreground disabled:pointer-events-none disabled:opacity-50 group-has-data-[sidebar=menu-action]/menu-item:pr-8 aria-disabled:pointer-events-none aria-disabled:opacity-50 data-[active=true]:bg-sidebar-accent data-[active=true]:text-sidebar-accent-foreground data-[state=open]:hover:bg-sidebar-accent data-[state=open]:hover:text-sidebar-accent-foreground group-data-[collapsible=icon]:size-8! group-data-[collapsible=icon]:p-2! [&>span:last-child]:truncate [&>svg]:size-4 [&>svg]:shrink-0",
+  "peer/menu-button flex w-full items-center gap-2.5 overflow-hidden rounded-lg p-2 text-left text-sm transition-[width,height,padding] active:text-sidebar-accent-foreground disabled:pointer-events-none disabled:opacity-50 group-has-data-[sidebar=menu-action]/menu-item:pr-8 aria-disabled:pointer-events-none aria-disabled:opacity-50 data-[active=true]:bg-sidebar-accent data-[active=true]:text-sidebar-accent-foreground data-popup-open:hover:bg-sidebar-accent data-popup-open:hover:text-sidebar-accent-foreground group-data-[collapsible=icon]:size-8! group-data-[collapsible=icon]:p-2! [&>span:last-child]:truncate [&>svg]:size-4 [&>svg]:shrink-0",
   {
     variants: {
       variant: {
@@ -612,7 +612,7 @@ const SidebarMenuAction = React.forwardRef<
         "peer-data-[size=lg]/menu-button:top-2.5",
         "group-data-[collapsible=icon]:hidden",
         showOnHover &&
-          "group-focus-within/menu-item:opacity-100 group-hover/menu-item:opacity-100 data-[state=open]:opacity-100 peer-data-[active=true]/menu-button:text-sidebar-accent-foreground md:opacity-0",
+          "group-focus-within/menu-item:opacity-100 group-hover/menu-item:opacity-100 data-popup-open:opacity-100 peer-data-[active=true]/menu-button:text-sidebar-accent-foreground md:opacity-0",
         className,
       )}
       {...props}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -773,9 +773,6 @@ importers:
       '@radix-ui/react-dialog':
         specifier: ^1.1.11
         version: 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@radix-ui/react-dropdown-menu':
-        specifier: ^2.0.4
-        version: 2.1.16(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@radix-ui/react-popover':
         specifier: ^1.0.5
         version: 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
@@ -3610,19 +3607,6 @@ packages:
       '@types/react-dom':
         optional: true
 
-  '@radix-ui/react-dropdown-menu@2.1.16':
-    resolution: {integrity: sha512-1PLGQEynI/3OX/ftV54COn+3Sud/Mn8vALg2rWnBLnRaGtJDduNW/22XjlGgPdpcIbiQxjKtb7BkcjP00nqfJw==}
-    peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-      '@types/react-dom':
-        optional: true
-
   '@radix-ui/react-focus-guards@1.1.3':
     resolution: {integrity: sha512-0rFg/Rj2Q62NCm62jZw0QX7a3sz6QCQU0LpZdNrJX8byRGaGVTqbrW9jAoIAHyMQqsNpeZ81YgSizOt5WXq0Pw==}
     peerDependencies:
@@ -3652,19 +3636,6 @@ packages:
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
     peerDependenciesMeta:
       '@types/react':
-        optional: true
-
-  '@radix-ui/react-menu@2.1.16':
-    resolution: {integrity: sha512-72F2T+PLlphrqLcAotYPp0uJMr5SjP5SL01wfEspJbru5Zs5vQaSHb4VB3ZMJPimgHHCHG7gMOeOB9H3Hdmtxg==}
-    peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-      '@types/react-dom':
         optional: true
 
   '@radix-ui/react-popover@1.1.15':
@@ -14932,21 +14903,6 @@ snapshots:
       '@types/react': 19.2.13
       '@types/react-dom': 19.2.3(@types/react@19.2.13)
 
-  '@radix-ui/react-dropdown-menu@2.1.16(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
-    dependencies:
-      '@radix-ui/primitive': 1.1.3
-      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.13)(react@19.2.6)
-      '@radix-ui/react-context': 1.1.2(@types/react@19.2.13)(react@19.2.6)
-      '@radix-ui/react-id': 1.1.1(@types/react@19.2.13)(react@19.2.6)
-      '@radix-ui/react-menu': 2.1.16(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.13)(react@19.2.6)
-      react: 19.2.6
-      react-dom: 19.2.6(react@19.2.6)
-    optionalDependencies:
-      '@types/react': 19.2.13
-      '@types/react-dom': 19.2.3(@types/react@19.2.13)
-
   '@radix-ui/react-focus-guards@1.1.3(@types/react@19.2.13)(react@19.2.6)':
     dependencies:
       react: 19.2.6
@@ -14970,32 +14926,6 @@ snapshots:
       react: 19.2.6
     optionalDependencies:
       '@types/react': 19.2.13
-
-  '@radix-ui/react-menu@2.1.16(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
-    dependencies:
-      '@radix-ui/primitive': 1.1.3
-      '@radix-ui/react-collection': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.13)(react@19.2.6)
-      '@radix-ui/react-context': 1.1.2(@types/react@19.2.13)(react@19.2.6)
-      '@radix-ui/react-direction': 1.1.1(@types/react@19.2.13)(react@19.2.6)
-      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@radix-ui/react-focus-guards': 1.1.3(@types/react@19.2.13)(react@19.2.6)
-      '@radix-ui/react-focus-scope': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@radix-ui/react-id': 1.1.1(@types/react@19.2.13)(react@19.2.6)
-      '@radix-ui/react-popper': 1.2.8(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@radix-ui/react-portal': 1.1.9(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@radix-ui/react-roving-focus': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@radix-ui/react-slot': 1.2.3(@types/react@19.2.13)(react@19.2.6)
-      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.13)(react@19.2.6)
-      aria-hidden: 1.2.6
-      react: 19.2.6
-      react-dom: 19.2.6(react@19.2.6)
-      react-remove-scroll: 2.7.2(@types/react@19.2.13)(react@19.2.6)
-    optionalDependencies:
-      '@types/react': 19.2.13
-      '@types/react-dom': 19.2.3(@types/react@19.2.13)
 
   '@radix-ui/react-popover@1.1.15(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
     dependencies:


### PR DESCRIPTION
Resolves RAL-1305

Largest API surface in the migration. Base UI calls this component `Menu`; all exported `DropdownMenu*` names are unchanged.

## Changes — `packages/ui/src/dropdown-menu.tsx`

- `Portal > Positioner > Popup` anatomy for both `DropdownMenuContent` and `DropdownMenuSubContent`; positioning props (`align`, `alignOffset`, `side`, `sideOffset`) forward to the Positioner (default `sideOffset={4}` kept). Submenu positioning uses Base UI's automatic `inline-end`/`start` defaults.
- Submenus: `Menu.SubmenuRoot`/`Menu.SubmenuTrigger` replace `Sub`/`SubTrigger`; `DropdownMenuSubContent` is a Popup like the root content.
- Item highlight styling moved from `focus:` to `data-highlighted:` in `dropdownMenuItemVariants` — Base UI highlights items via `data-highlighted` instead of moving DOM focus. `data-disabled:` selectors were already compatible.
- Checkbox/radio items use `Menu.CheckboxItem(Indicator)`/`Menu.RadioItem(Indicator)`; `Label` → `Menu.GroupLabel`.
- The `onFocusCapture` stopPropagation hack on the trigger is preserved.
- `@radix-ui/react-dropdown-menu` removed from `packages/ui/package.json`.

## App call-site changes (RAL-1305 decision: update call sites, no `asChild` shim — consistent with #2588/#2589)

- **19 `DropdownMenuTrigger asChild` → `render`** across 19 files.
- **18 `DropdownMenuItem asChild` → `render`** (menu items wrapping `<Link>`/`<a>`) across 6 files — Base UI items have no `asChild` either.
- **`onSelect` → `onClick` on menu items (6 sites)** in polls-infinite-list, calendar-connection-list, connect-calendar-dropdown — Base UI `Menu.Item` has no `onSelect`. cmdk `CommandItem onSelect` untouched.
- **`DropdownMenuPortal` wrappers removed** (nav-user, user-dropdown) — content components portal themselves now.
- **Radix CSS vars replaced**: `--radix-dropdown-menu-trigger-width` → Base UI's `--anchor-width` (space-dropdown min-width, nav-user width) so those menus keep matching their trigger width.
- `sidebar.tsx`: trigger-state selectors `data-[state=open]:*` → `data-popup-open:*` on SidebarMenuButton/SidebarMenuAction (Base UI trigger attribute).
- `participant-dropdown.tsx`: `children` prop narrowed to `React.ReactElement` (passed straight into `render`).
- `event-types-settings-page.tsx`: the icon + sr-only label moved inside the `render` Button so the a11y lint rule can see the button's accessible name (same rendered DOM).

## Behavior notes

- `modal={false}` menus (manage-poll, add-to-calendar, participant/user dropdowns) map to Base UI's `modal` prop directly.
- `DropdownMenuRadioGroup` `onValueChange` gains an `eventDetails` argument; all consumers pass single-argument handlers (e.g. `setTheme`), so no call sites change.

## Verification

- `tsc --noEmit` clean in `packages/ui` and `apps/web`
- Biome clean (including the icon-button accessible-name plugin); lockfile updated
- `grep -rn "@radix-ui/react-dropdown-menu" packages apps` returns nothing; no `asChild` remains on any DropdownMenu element; no `--radix-dropdown-menu-*` vars remain

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XdQE6gMxnDapmhGd1aCbEA

---
_Generated by [Claude Code](https://claude.ai/code/session_01XdQE6gMxnDapmhGd1aCbEA)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Updated dropdown menus across the app for more consistent interactions and accessibility.
  * Preserved existing menu actions, labels, icons, and navigation behavior.
  * Improved visual states for highlighted menu items and sidebar controls.
  * Calendar, poll, account, member, space, and settings menus now respond more reliably to selections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->