### PR TITLE
♻️ Migrate Select to Base UI

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -33,7 +33,6 @@
     "@prisma/adapter-pg": "^7.8.0",
     "@prisma/client": "^7.8.0",
     "@radix-ui/react-radio-group": "^1.2.3",
-    "@radix-ui/react-select": "^2.2.2",
     "@radix-ui/react-slot": "^1.1.2",
     "@radix-ui/react-switch": "^1.0.2",
     "@rallly/billing": "workspace:*",

--- a/apps/web/src/app/[locale]/(space)/settings/calendars/components/default-calendar-select.tsx
+++ b/apps/web/src/app/[locale]/(space)/settings/calendars/components/default-calendar-select.tsx
@@ -42,8 +42,28 @@ export function DefaultCalendarSelect() {
 
   return (
     <Select
+      items={{
+        [NONE_VALUE]: (
+          <Trans
+            i18nKey="defaultCalendarNone"
+            defaults="No calendar selected"
+          />
+        ),
+        ...Object.fromEntries(
+          (connections ?? []).flatMap((connection) =>
+            connection.providerCalendars.map((calendar) => [
+              calendar.id,
+              calendar.name,
+            ]),
+          ),
+        ),
+      }}
       defaultValue={defaultCalendar?.defaultDestinationCalendarId ?? NONE_VALUE}
-      onValueChange={onValueChange}
+      onValueChange={(value) => {
+        if (value) {
+          onValueChange(value);
+        }
+      }}
       disabled={setDefaultCalendar.isPending}
     >
       <SelectTrigger>

--- a/apps/web/src/app/[locale]/(space)/settings/members/components/invite-member-dialog.tsx
+++ b/apps/web/src/app/[locale]/(space)/settings/members/components/invite-member-dialog.tsx
@@ -185,7 +185,14 @@ export function InviteMemberForm({ onSuccess }: { onSuccess?: () => void }) {
                   </Tooltip>
                 </div>
                 <FormControl>
-                  <Select onValueChange={field.onChange} value={field.value}>
+                  <Select
+                    items={Object.values(memberRoleSchema.enum).map((role) => ({
+                      value: role,
+                      label: <SpaceRole role={role} />,
+                    }))}
+                    onValueChange={field.onChange}
+                    value={field.value}
+                  >
                     <SelectTrigger className="w-full">
                       <SelectValue
                         placeholder={t("rolePlaceholder", {

--- a/apps/web/src/app/[locale]/(space)/settings/preferences/components/date-time-preferences.tsx
+++ b/apps/web/src/app/[locale]/(space)/settings/preferences/components/date-time-preferences.tsx
@@ -112,24 +112,31 @@ export const DateTimePreferences = ({
             control={form.control}
             name="weekStart"
             render={({ field }) => {
+              const options = weekdays().map(({ day, label }) => ({
+                value: day.toString(),
+                label,
+              }));
               return (
                 <FormItem>
                   <FormLabel>
                     <Trans i18nKey="startOfWeek" />
                   </FormLabel>
                   <Select
+                    items={options}
                     value={field.value.toString()}
                     onValueChange={(value) => {
-                      field.onChange(Number.parseInt(value, 10));
+                      if (value) {
+                        field.onChange(Number.parseInt(value, 10));
+                      }
                     }}
                   >
                     <SelectTrigger className="w-fit min-w-32">
                       <SelectValue />
                     </SelectTrigger>
                     <SelectContent>
-                      {weekdays().map(({ day, label }) => (
-                        <SelectItem key={day} value={day.toString()}>
-                          {label}
+                      {options.map((option) => (
+                        <SelectItem key={option.value} value={option.value}>
+                          {option.label}
                         </SelectItem>
                       ))}
                     </SelectContent>

--- a/apps/web/src/app/[locale]/control-panel/settings/instance-settings-form.tsx
+++ b/apps/web/src/app/[locale]/control-panel/settings/instance-settings-form.tsx
@@ -61,8 +61,16 @@ export function InstanceSettingsForm({
           </p>
         </div>
         <Select
+          items={{
+            enabled: <Trans i18nKey="enabled" defaults="Enabled" />,
+            disabled: <Trans i18nKey="disabled" defaults="Disabled" />,
+          }}
           value={disableUserRegistration ? "disabled" : "enabled"}
-          onValueChange={handleChange}
+          onValueChange={(value) => {
+            if (value) {
+              handleChange(value);
+            }
+          }}
           disabled={!isRegistrationEnabled}
         >
           <SelectTrigger id="userRegistration" className="w-32">

--- a/apps/web/src/components/forms/poll-options-form/month-calendar/time-picker.tsx
+++ b/apps/web/src/components/forms/poll-options-form/month-calendar/time-picker.tsx
@@ -70,7 +70,22 @@ const TimePicker: React.FunctionComponent<TimePickerProps> = ({
       onOpenChange={setOpen}
     >
       <SelectTrigger className={className}>
-        <SelectValue placeholder="Select time" />
+        <SelectValue placeholder="Select time">
+          {(selected: string | null | undefined) =>
+            selected ? (
+              <div className="flex items-center gap-2">
+                <span>{formatTime(selected)}</span>
+                {after ? (
+                  <span className="text-muted-foreground text-sm">
+                    {formatDuration(dayjs(selected).diff(after, "minute"))}
+                  </span>
+                ) : null}
+              </div>
+            ) : (
+              "Select time"
+            )
+          }
+        </SelectValue>
       </SelectTrigger>
       <SelectContent>
         {open ? (

--- a/apps/web/src/components/member-selector.tsx
+++ b/apps/web/src/components/member-selector.tsx
@@ -42,36 +42,53 @@ export function MemberSelector({ members }: MemberSelectorProps) {
     });
   };
 
+  const options = [
+    {
+      value: "all",
+      label: (
+        <div className="flex items-center gap-2">
+          <Icon>
+            <UsersIcon />
+          </Icon>
+          <span>
+            <Trans i18nKey="allMembers" defaults="All Members" />
+          </span>
+        </div>
+      ),
+    },
+    ...members.map((member) => ({
+      value: member.userId,
+      label: (
+        <div className="flex items-center gap-2">
+          <OptimizedAvatarImage
+            size="sm"
+            name={member.name}
+            src={member.image}
+          />
+          <span>{member.name}</span>
+        </div>
+      ),
+    })),
+  ];
+
   return (
     <Select
+      items={options}
       value={optimisticMember}
-      onValueChange={handleMemberChange}
+      onValueChange={(memberId) => {
+        if (memberId) {
+          handleMemberChange(memberId);
+        }
+      }}
       disabled={isPending}
     >
       <SelectTrigger className="min-w-48">
         <SelectValue />
       </SelectTrigger>
       <SelectContent>
-        <SelectItem value="all">
-          <div className="flex items-center gap-2">
-            <Icon>
-              <UsersIcon />
-            </Icon>
-            <span>
-              <Trans i18nKey="allMembers" defaults="All Members" />
-            </span>
-          </div>
-        </SelectItem>
-        {members.map((member) => (
-          <SelectItem key={member.userId} value={member.userId}>
-            <div className="flex items-center gap-2">
-              <OptimizedAvatarImage
-                size="sm"
-                name={member.name}
-                src={member.image}
-              />
-              <span>{member.name}</span>
-            </div>
+        {options.map((option) => (
+          <SelectItem key={option.value} value={option.value}>
+            {option.label}
           </SelectItem>
         ))}
       </SelectContent>

--- a/apps/web/src/components/poll/language-selector.tsx
+++ b/apps/web/src/components/poll/language-selector.tsx
@@ -15,7 +15,15 @@ export const LanguageSelect: React.FunctionComponent<{
   onChange?: (language: string) => void;
 }> = ({ className, value, onChange }) => {
   return (
-    <Select value={value} onValueChange={onChange}>
+    <Select
+      items={languages}
+      value={value}
+      onValueChange={(language) => {
+        if (language) {
+          onChange?.(language);
+        }
+      }}
+    >
       <SelectTrigger className={className}>
         <Icon>
           <LanguagesIcon />

--- a/apps/web/src/components/poll/mobile-poll.tsx
+++ b/apps/web/src/components/poll/mobile-poll.tsx
@@ -59,16 +59,57 @@ const MobilePoll: React.FunctionComponent = () => {
 
   const isEditing = votingForm.watch("mode") !== "view";
 
+  const participantOptions = [
+    {
+      value: "all",
+      label: (
+        <div className="flex items-center gap-x-2.5">
+          <div>
+            <Icon>
+              <UsersIcon />
+            </Icon>
+          </div>
+          <span>
+            {t("allParticipants", {
+              defaultValue: "All Participants",
+            })}
+          </span>
+        </div>
+      ),
+    },
+    ...visibleParticipants.map((participant) => ({
+      value: participant.id,
+      label: (
+        <Participant>
+          <OptimizedAvatarImage
+            name={participant.name}
+            src={participant.image ?? undefined}
+            size="sm"
+          />
+          <ParticipantName>{participant.name}</ParticipantName>
+          {session.ownsObject(participant) && (
+            <Badge>
+              <Trans i18nKey="you" />
+            </Badge>
+          )}
+        </Participant>
+      ),
+    })),
+  ];
+
   return (
     <Card>
       <div className="flex flex-col space-y-2 border-b p-2">
         <div className="flex gap-x-2.5">
           {selectedParticipantId || !isEditing ? (
             <Select
+              items={participantOptions}
               defaultValue="all"
               value={selectedParticipantId}
               onValueChange={(participantId) => {
-                votingForm.setValue("participantId", participantId);
+                if (participantId) {
+                  votingForm.setValue("participantId", participantId);
+                }
               }}
               disabled={isEditing}
             >
@@ -76,35 +117,9 @@ const MobilePoll: React.FunctionComponent = () => {
                 <SelectValue />
               </SelectTrigger>
               <SelectContent>
-                <SelectItem value="all">
-                  <div className="flex items-center gap-x-2.5">
-                    <div>
-                      <Icon>
-                        <UsersIcon />
-                      </Icon>
-                    </div>
-                    <span>
-                      {t("allParticipants", {
-                        defaultValue: "All Participants",
-                      })}
-                    </span>
-                  </div>
-                </SelectItem>
-                {visibleParticipants.map((participant) => (
-                  <SelectItem key={participant.id} value={participant.id}>
-                    <Participant>
-                      <OptimizedAvatarImage
-                        name={participant.name}
-                        src={participant.image ?? undefined}
-                        size="sm"
-                      />
-                      <ParticipantName>{participant.name}</ParticipantName>
-                      {session.ownsObject(participant) && (
-                        <Badge>
-                          <Trans i18nKey="you" />
-                        </Badge>
-                      )}
-                    </Participant>
+                {participantOptions.map((option) => (
+                  <SelectItem key={option.value} value={option.value}>
+                    {option.label}
                   </SelectItem>
                 ))}
               </SelectContent>

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -24,7 +24,6 @@
     "@radix-ui/react-popover": "^1.0.5",
     "@radix-ui/react-portal": "^1.1.6",
     "@radix-ui/react-radio-group": "^1.2.3",
-    "@radix-ui/react-select": "^2.2.2",
     "@radix-ui/react-slot": "^1.1.2",
     "@radix-ui/react-switch": "^1.0.2",
     "@radix-ui/react-tabs": "^1.0.4",

--- a/packages/ui/src/select.tsx
+++ b/packages/ui/src/select.tsx
@@ -1,129 +1,134 @@
 "use client";
 
-import * as SelectPrimitive from "@radix-ui/react-select";
+import { Select as SelectPrimitive } from "@base-ui/react/select";
 import { CheckIcon, ChevronsUpDownIcon } from "lucide-react";
-import * as React from "react";
 
 import { buttonVariants } from "./button-variants";
 import { Icon } from "./icon";
 import { cn } from "./lib/utils";
 
-const Select = SelectPrimitive.Root;
+function Select<Value, Multiple extends boolean | undefined = false>(
+  props: SelectPrimitive.Root.Props<Value, Multiple>,
+) {
+  return <SelectPrimitive.Root {...props} />;
+}
 
-const SelectGroup = SelectPrimitive.Group;
+function SelectGroup(props: SelectPrimitive.Group.Props) {
+  return <SelectPrimitive.Group data-slot="select-group" {...props} />;
+}
 
-const SelectValue = React.forwardRef<
-  React.ComponentRef<typeof SelectPrimitive.Value>,
-  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Value>
->(({ ...props }, ref) => {
+function SelectValue(props: SelectPrimitive.Value.Props) {
   return (
     <div className="flex w-full items-center justify-between gap-x-2.5">
-      <SelectPrimitive.Value {...props} ref={ref} />
-      <SelectPrimitive.Icon asChild>
-        <ChevronsUpDownIcon className="size-4 opacity-50" />
-      </SelectPrimitive.Icon>
+      <SelectPrimitive.Value data-slot="select-value" {...props} />
+      <SelectPrimitive.Icon
+        render={<ChevronsUpDownIcon className="size-4 opacity-50" />}
+      />
     </div>
   );
-});
-SelectValue.displayName = SelectPrimitive.Value.displayName;
+}
 
-const SelectTrigger = React.forwardRef<
-  React.ComponentRef<typeof SelectPrimitive.Trigger>,
-  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Trigger>
->(({ className, children, ...props }, ref) => (
-  <SelectPrimitive.Trigger
-    ref={ref}
-    className={cn(
-      buttonVariants({ variant: "default" }),
-      "shadow-none",
-      className,
-    )}
-    {...props}
-  >
-    {children}
-  </SelectPrimitive.Trigger>
-));
-SelectTrigger.displayName = SelectPrimitive.Trigger.displayName;
-
-const SelectContent = React.forwardRef<
-  React.ComponentRef<typeof SelectPrimitive.Content>,
-  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Content>
->(({ className, children, position = "popper", ...props }, ref) => (
-  <SelectPrimitive.Portal>
-    <SelectPrimitive.Content
-      ref={ref}
+function SelectTrigger({
+  className,
+  children,
+  ...props
+}: SelectPrimitive.Trigger.Props) {
+  return (
+    <SelectPrimitive.Trigger
+      data-slot="select-trigger"
       className={cn(
-        "relative z-50 max-h-[300px] min-w-32 animate-in overflow-hidden rounded-xl border border-popover-border bg-popover shadow-sm",
-        position === "popper" && "translate-y-1",
+        buttonVariants({ variant: "default" }),
+        "shadow-none",
         className,
       )}
-      position={position}
       {...props}
     >
-      <SelectPrimitive.Viewport
-        className={cn(
-          "p-1",
-          position === "popper" &&
-            "h-(--radix-select-trigger-height) w-full min-w-(--radix-select-trigger-width)",
-        )}
+      {children}
+    </SelectPrimitive.Trigger>
+  );
+}
+
+function SelectContent({
+  className,
+  children,
+  ...props
+}: SelectPrimitive.Popup.Props) {
+  return (
+    <SelectPrimitive.Portal>
+      <SelectPrimitive.Positioner
+        alignItemWithTrigger={false}
+        sideOffset={4}
+        className="isolate z-50"
       >
-        {children}
-      </SelectPrimitive.Viewport>
-    </SelectPrimitive.Content>
-  </SelectPrimitive.Portal>
-));
-SelectContent.displayName = SelectPrimitive.Content.displayName;
+        <SelectPrimitive.Popup
+          data-slot="select-content"
+          className={cn(
+            "relative z-50 max-h-[300px] w-full min-w-(--anchor-width) min-w-32 animate-in overflow-y-auto rounded-xl border border-popover-border bg-popover p-1 shadow-sm",
+            className,
+          )}
+          {...props}
+        >
+          {children}
+        </SelectPrimitive.Popup>
+      </SelectPrimitive.Positioner>
+    </SelectPrimitive.Portal>
+  );
+}
 
-const SelectLabel = React.forwardRef<
-  React.ComponentRef<typeof SelectPrimitive.Label>,
-  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Label>
->(({ className, ...props }, ref) => (
-  <SelectPrimitive.Label
-    ref={ref}
-    className={cn(
-      "px-2 py-1.5 font-semibold text-muted-foreground text-xs",
-      className,
-    )}
-    {...props}
-  />
-));
-SelectLabel.displayName = SelectPrimitive.Label.displayName;
+function SelectLabel({
+  className,
+  ...props
+}: SelectPrimitive.GroupLabel.Props) {
+  return (
+    <SelectPrimitive.GroupLabel
+      data-slot="select-label"
+      className={cn(
+        "px-2 py-1.5 font-semibold text-muted-foreground text-xs",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
 
-const SelectItem = React.forwardRef<
-  React.ComponentRef<typeof SelectPrimitive.Item>,
-  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Item>
->(({ className, children, ...props }, ref) => (
-  <SelectPrimitive.Item
-    ref={ref}
-    className={cn(
-      "relative flex w-full cursor-default select-none items-center rounded-lg py-1.5 pr-2 pl-8 text-sm outline-hidden focus:bg-popover-accent focus:ring-1 focus:ring-black/5 focus:ring-inset data-disabled:pointer-events-none data-disabled:opacity-50 dark:focus:ring-white/5",
-      className,
-    )}
-    {...props}
-  >
-    <span className="absolute left-2 flex h-3.5 w-3.5 items-center justify-center">
-      <SelectPrimitive.ItemIndicator>
-        <Icon>
-          <CheckIcon className="size-4" />
-        </Icon>
-      </SelectPrimitive.ItemIndicator>
-    </span>
-    <SelectPrimitive.ItemText>{children}</SelectPrimitive.ItemText>
-  </SelectPrimitive.Item>
-));
-SelectItem.displayName = SelectPrimitive.Item.displayName;
+function SelectItem({
+  className,
+  children,
+  ...props
+}: SelectPrimitive.Item.Props) {
+  return (
+    <SelectPrimitive.Item
+      data-slot="select-item"
+      className={cn(
+        "relative flex w-full cursor-default select-none items-center rounded-lg py-1.5 pr-2 pl-8 text-sm outline-hidden data-disabled:pointer-events-none data-highlighted:bg-popover-accent data-disabled:opacity-50 data-highlighted:ring-1 data-highlighted:ring-black/5 data-highlighted:ring-inset dark:data-highlighted:ring-white/5",
+        className,
+      )}
+      {...props}
+    >
+      <span className="absolute left-2 flex h-3.5 w-3.5 items-center justify-center">
+        <SelectPrimitive.ItemIndicator>
+          <Icon>
+            <CheckIcon className="size-4" />
+          </Icon>
+        </SelectPrimitive.ItemIndicator>
+      </span>
+      <SelectPrimitive.ItemText>{children}</SelectPrimitive.ItemText>
+    </SelectPrimitive.Item>
+  );
+}
 
-const SelectSeparator = React.forwardRef<
-  React.ComponentRef<typeof SelectPrimitive.Separator>,
-  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Separator>
->(({ className, ...props }, ref) => (
-  <SelectPrimitive.Separator
-    ref={ref}
-    className={cn("-mx-1 my-1 h-px bg-muted", className)}
-    {...props}
-  />
-));
-SelectSeparator.displayName = SelectPrimitive.Separator.displayName;
+function SelectSeparator({
+  className,
+  ...props
+}: SelectPrimitive.Separator.Props) {
+  return (
+    <SelectPrimitive.Separator
+      data-slot="select-separator"
+      className={cn("-mx-1 my-1 h-px bg-muted", className)}
+      {...props}
+    />
+  );
+}
 
 export {
   Select,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -231,9 +231,6 @@ importers:
       '@radix-ui/react-radio-group':
         specifier: ^1.2.3
         version: 1.3.8(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@radix-ui/react-select':
-        specifier: ^2.2.2
-        version: 2.2.6(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@radix-ui/react-slot':
         specifier: ^1.1.2
         version: 1.2.4(@types/react@19.2.13)(react@19.2.6)
@@ -785,9 +782,6 @@ importers:
       '@radix-ui/react-radio-group':
         specifier: ^1.2.3
         version: 1.3.8(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@radix-ui/react-select':
-        specifier: ^2.2.2
-        version: 2.2.6(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@radix-ui/react-slot':
         specifier: ^1.1.2
         version: 1.2.4(@types/react@19.2.13)(react@19.2.6)
@@ -3503,9 +3497,6 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
-  '@radix-ui/number@1.1.1':
-    resolution: {integrity: sha512-MkKCwxlXTgz6CFoJx3pCwn07GKp36+aZyu/u2Ln2VrA5DcdyCZkASEDBTd8x5whTQQL5CiYf4prXKLcgQdv29g==}
-
   '@radix-ui/primitive@1.1.3':
     resolution: {integrity: sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg==}
 
@@ -3773,19 +3764,6 @@ packages:
 
   '@radix-ui/react-roving-focus@1.1.11':
     resolution: {integrity: sha512-7A6S9jSgm/S+7MdtNDSb+IU859vQqJ/QAtcYQcfFC6W8RS4IxIZDldLR0xqCFZ6DCyrQLjLPsxtTNch5jVA4lA==}
-    peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-      '@types/react-dom':
-        optional: true
-
-  '@radix-ui/react-select@2.2.6':
-    resolution: {integrity: sha512-I30RydO+bnn2PQztvo25tswPH+wFBjehVGtmagkU78yMdwTwVf12wnAOF+AeP8S2N8xD+5UPbGhkUfPyvT+mwQ==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -14835,8 +14813,6 @@ snapshots:
       - react-native-b4a
       - supports-color
 
-  '@radix-ui/number@1.1.1': {}
-
   '@radix-ui/primitive@1.1.3': {}
 
   '@radix-ui/react-arrow@1.1.7(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
@@ -15117,35 +15093,6 @@ snapshots:
       '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.13)(react@19.2.6)
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
-    optionalDependencies:
-      '@types/react': 19.2.13
-      '@types/react-dom': 19.2.3(@types/react@19.2.13)
-
-  '@radix-ui/react-select@2.2.6(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
-    dependencies:
-      '@radix-ui/number': 1.1.1
-      '@radix-ui/primitive': 1.1.3
-      '@radix-ui/react-collection': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.13)(react@19.2.6)
-      '@radix-ui/react-context': 1.1.2(@types/react@19.2.13)(react@19.2.6)
-      '@radix-ui/react-direction': 1.1.1(@types/react@19.2.13)(react@19.2.6)
-      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@radix-ui/react-focus-guards': 1.1.3(@types/react@19.2.13)(react@19.2.6)
-      '@radix-ui/react-focus-scope': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@radix-ui/react-id': 1.1.1(@types/react@19.2.13)(react@19.2.6)
-      '@radix-ui/react-popper': 1.2.8(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@radix-ui/react-portal': 1.1.9(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@radix-ui/react-slot': 1.2.3(@types/react@19.2.13)(react@19.2.6)
-      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.13)(react@19.2.6)
-      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.13)(react@19.2.6)
-      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.13)(react@19.2.6)
-      '@radix-ui/react-use-previous': 1.1.1(@types/react@19.2.13)(react@19.2.6)
-      '@radix-ui/react-visually-hidden': 1.2.3(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      aria-hidden: 1.2.6
-      react: 19.2.6
-      react-dom: 19.2.6(react@19.2.6)
-      react-remove-scroll: 2.7.2(@types/react@19.2.13)(react@19.2.6)
     optionalDependencies:
       '@types/react': 19.2.13
       '@types/react-dom': 19.2.3(@types/react@19.2.13)


### PR DESCRIPTION
Resolves RAL-1306

## Changes — `packages/ui/src/select.tsx`

- Wraps `@base-ui/react/select`: `Portal > Positioner > Popup` anatomy, `Label` → `GroupLabel`, `SelectValue` keeps its chevron-icon layout (Radix `Icon asChild` → `render`). Exported names unchanged; `Select` is generic over the value type like the underlying Root.
- **`alignItemWithTrigger={false}`** on the Positioner preserves Radix's `position="popper"` dropdown behavior (Base UI's default aligns the popup over the selected item); the old `translate-y-1` offset became `sideOffset={4}`.
- Item highlight styling `focus:` → `data-highlighted:`; trigger-width sizing `--radix-select-trigger-width` → `--anchor-width`.
- `@radix-ui/react-select` removed from `packages/ui/package.json` and from `apps/web/package.json` (stale).

## The important behavior difference: `SelectValue` label resolution

Radix's `SelectValue` rendered a snapshot of the selected item's rendered content. Base UI resolves the label from the Root's **`items` prop** — without it, the trigger shows the raw serialized value (e.g. `en` instead of `English`, a calendar ID instead of its name). Every consumer whose labels differ from values now passes `items`:

- `language-selector` — `items={languages}` (existing code→name record)
- `member-selector`, `mobile-poll` — options array (avatar/badge JSX labels) built once and used for both `items` and the item list, removing the duplicated markup
- `invite-member-dialog` — role→`<SpaceRole/>` items
- `date-time-preferences` — weekday options array
- `default-calendar-select` — record including the "No calendar selected" null-ish option and grouped calendar names
- `instance-settings-form` — enabled/disabled record
- `time-picker` — uses a `SelectValue` children render function instead (options are generated lazily on open, so an `items` prop can't cover the closed state); trigger shows the formatted time + duration exactly as before

## Other call-site changes

- `onValueChange` is now typed `(value: Value | null, eventDetails)`. Six handlers that assumed non-null now guard (`if (value) …`) — none of these selects has a clearable/null item, so behavior is unchanged; `time-picker` already guarded.

## Verification

- `tsc --noEmit` clean in `packages/ui` and `apps/web`
- Biome clean; lockfile updated
- `grep -rn "@radix-ui/react-select" packages apps` returns nothing; no `--radix-select-*` vars remain
- All 8 consumer files audited for the label-resolution change

Worth a manual pass on poll participant selects and the time picker (`pnpm dev`) since dropdown positioning is the flagged behavioral risk in RAL-1306.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XdQE6gMxnDapmhGd1aCbEA

---
_Generated by [Claude Code](https://claude.ai/code/session_01XdQE6gMxnDapmhGd1aCbEA)_