### PR TITLE
🐛 Always show expand/shrink controls in desktop poll

### DIFF
--- a/apps/web/src/components/poll/desktop-poll.tsx
+++ b/apps/web/src/components/poll/desktop-poll.tsx
@@ -138,46 +138,46 @@ function TableControls({
                 <Trans i18nKey="scrollRight" defaults="Scroll Right" />
               </TooltipContent>
             </Tooltip>
-            {expanded ? (
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <Button
-                    aria-label={t("shrink", { defaultValue: "Shrink" })}
-                    variant="ghost"
-                    size="icon"
-                    onClick={onCollapse}
-                  >
-                    <Icon>
-                      <ShrinkIcon />
-                    </Icon>
-                  </Button>
-                </TooltipTrigger>
-                <TooltipContent>
-                  <Trans i18nKey="shrink" defaults="Shrink" />
-                </TooltipContent>
-              </Tooltip>
-            ) : (
-              <Tooltip delayDuration={0}>
-                <TooltipTrigger asChild>
-                  <Button
-                    aria-label={t("expand", { defaultValue: "Expand" })}
-                    variant="ghost"
-                    size="icon"
-                    onClick={onExpand}
-                  >
-                    <Icon>
-                      <ExpandIcon />
-                    </Icon>
-                  </Button>
-                </TooltipTrigger>
-                <TooltipContent>
-                  <Trans i18nKey="expand" defaults="Expand" />
-                </TooltipContent>
-              </Tooltip>
-            )}
-            {expanded ? <EscapeListener onEscape={onCollapse} /> : null}
           </>
         ) : null}
+        {expanded ? (
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                aria-label={t("shrink", { defaultValue: "Shrink" })}
+                variant="ghost"
+                size="icon"
+                onClick={onCollapse}
+              >
+                <Icon>
+                  <ShrinkIcon />
+                </Icon>
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent>
+              <Trans i18nKey="shrink" defaults="Shrink" />
+            </TooltipContent>
+          </Tooltip>
+        ) : (
+          <Tooltip delayDuration={0}>
+            <TooltipTrigger asChild>
+              <Button
+                aria-label={t("expand", { defaultValue: "Expand" })}
+                variant="ghost"
+                size="icon"
+                onClick={onExpand}
+              >
+                <Icon>
+                  <ExpandIcon />
+                </Icon>
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent>
+              <Trans i18nKey="expand" defaults="Expand" />
+            </TooltipContent>
+          </Tooltip>
+        )}
+        {expanded ? <EscapeListener onEscape={onCollapse} /> : null}
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary

The expand/shrink toggle and the escape key listener in the desktop poll table controls were nested inside the `showScrollControls` conditional, so they only rendered when the options table overflowed horizontally. They should always be available regardless of overflow.

This moves them out of that conditional in `TableControls` so only the scroll left/right arrows are gated by `showScrollControls`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Reformatted poll table expand/collapse controls without changing their behavior or functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->