### PR TITLE
🐛 Merge duplicate ignoreErrors keys in Sentry client config

### DIFF
--- a/apps/web/instrumentation-client.ts
+++ b/apps/web/instrumentation-client.ts
@@ -13,28 +13,27 @@ Sentry.init({
   // Adjust this value in production, or use tracesSampler for greater control
   tracesSampleRate: 0.2,
 
-  // Filter out transient browser network errors (offline, aborted navigation,
-  // connection blips, ad blockers). These surface as generic `TypeError`s from
-  // background fetches (e.g. better-auth's session poll) and are unactionable
-  // noise rather than real application bugs.
   ignoreErrors: [
+    // Transient browser network errors (offline, aborted navigation,
+    // connection blips, ad blockers). These surface as generic `TypeError`s
+    // from background fetches (e.g. better-auth's session poll) and are
+    // unactionable noise rather than real application bugs.
     "Failed to fetch",
     "NetworkError when attempting to fetch resource",
     "Load failed",
     "The network connection was lost",
     "The Internet connection appears to be offline",
+    // Known upstream Firefox error thrown from inside the bundled rrweb
+    // session-replay code (@sentry-internal/replay): when a replay starts
+    // recording on error, rrweb can touch a DOM node the browser has already
+    // garbage-collected, throwing "TypeError: can't access dead object". This
+    // originates in vendored code, not our own logic, and only clutters error
+    // tracking. https://bugzilla.mozilla.org/show_bug.cgi?id=695480
+    "can't access dead object",
   ],
 
   // Setting this option to true will print useful information to the console while you're setting up Sentry.
   debug: false,
-
-  // Suppress a known upstream Firefox error thrown from inside the bundled
-  // rrweb session-replay code (@sentry-internal/replay): when a replay starts
-  // recording on error, rrweb can touch a DOM node the browser has already
-  // garbage-collected, throwing "TypeError: can't access dead object". This
-  // originates in vendored code, not our own logic, and only clutters error
-  // tracking. https://bugzilla.mozilla.org/show_bug.cgi?id=695480
-  ignoreErrors: ["can't access dead object"],
 
   replaysOnErrorSampleRate: 1.0,
 


### PR DESCRIPTION
#2581 and #2580 each added an `ignoreErrors` key to `apps/web/instrumentation-client.ts`. Both passed CI on their own branches, but merged together the object has a duplicate key — Biome fails main's lint, and at runtime the second key wins so the network error filters from #2581 were silently dead.

This merges both lists into a single `ignoreErrors` array, preserving each entry's explanatory comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)