### PR TITLE
🐛 Make redirectIfLoggedIn bypass the session cookie cache

### DIFF
--- a/apps/web/src/lib/auth.ts
+++ b/apps/web/src/lib/auth.ts
@@ -552,8 +552,19 @@ export const getUserIdIfLoggedIn = async () => {
 };
 
 export const redirectIfLoggedIn = async () => {
-  const session = await getSession();
-  if (session?.user && !session.user.isGuest) {
+  // Bypass the cookie cache so a revoked or banned session can't bounce the
+  // user back to "/" (RAL-1313).
+  const session = await authLib.api
+    .getSession({
+      headers: await headers(),
+      query: { disableCookieCache: true },
+    })
+    .catch((error) => {
+      logger.error({ error }, "Failed to get session");
+      return null;
+    });
+
+  if (session?.user && !session.user.isAnonymous && !session.user.banned) {
     redirect("/");
   }
 };


### PR DESCRIPTION
## Summary

Part 1 of [RAL-1313](https://linear.app/rallly/issue/RAL-1313/fix-infinite-redirect-loop-between-login-and-for-stalebanned-sessions): PostHog shows users bouncing between `/login` and `/` in an infinite loop. One leg of that loop is `redirectIfLoggedIn`, which trusted the 5 minute session cookie cache and ignored ban status, so `/login` kept redirecting banned or revoked sessions to `/` where they immediately fail and get pushed back.

This makes `/login` (and `/register`, `/forgot-password`, `/login/verify`) authoritative:

- Calls `authLib.api.getSession` with `disableCookieCache: true` so the redirect decision is backed by a DB read instead of a possibly stale cookie cache.
- Only redirects when the user is non-anonymous **and** not banned.
- A failed session lookup logs and renders the page instead of throwing, since these pages are the fallback destination when auth is broken.

These pages are low traffic, so the extra DB hit per render is negligible.

Follow-ups (separate PRs): revoke sessions on ban, replace the client-side auto sign-out redirect with a toast, and make the `INVALID_SESSION` error boundary a static page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved session validation during sign-in redirects.
  * Anonymous, banned, or revoked sessions are no longer incorrectly redirected to the home page.
  * Added safer handling when session information cannot be retrieved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->