### PR TITLE
🐛 Fix theme preference radio group not showing selected value

### DIFF
--- a/apps/web/src/app/[locale]/(space)/settings/preferences/components/theme-preference.tsx
+++ b/apps/web/src/app/[locale]/(space)/settings/preferences/components/theme-preference.tsx
@@ -38,7 +38,10 @@ export function ThemePreference() {
   }, []);
 
   return (
+    // Base UI locks in uncontrolled mode when value is undefined on first
+    // render, so remount the group once the theme is known after hydration
     <RadioGroup
+      key={mounted ? "mounted" : "ssr"}
       value={mounted ? theme : undefined}
       onValueChange={setTheme}
       className="flex flex-wrap gap-2"


### PR DESCRIPTION
Fixes [RAL-1316](https://linear.app/rallly/issue/RAL-1316/theme-preference-radio-group-shows-no-selected-value-after-base-ui)

## Problem

Since the Radio Group migration to Base UI (#2586), the theme selector on `/settings/preferences` never shows a selected option.

`ThemePreference` uses the next-themes hydration guard and passes `value={mounted ? theme : undefined}`. Base UI's `useControlled` latches the controlled/uncontrolled decision in a ref on first render, so the group is permanently locked as uncontrolled with no default value — the `value` prop is ignored once `mounted` flips to true. Radix re-evaluated `value !== undefined` on every render, which is why this worked before.

## Fix

Remount the group via `key` once mounted, so it initializes as controlled with the resolved theme. This keeps the hydration guard (server markup and first client render both render unchecked) and restores the exact pre-migration behavior: layout is stable and the selection highlight appears after hydration.

## Verification

- `pnpm type-check` and Biome pass
- Root cause confirmed against `@base-ui/utils/useControlled` source (`isControlled` captured in a `useRef` on first render)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved theme preference rendering after hydration to ensure the selected theme displays correctly and consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->