### PR TITLE
♻️ Migrate Tabs to Base UI

### DIFF
--- a/apps/web/src/features/billing/components/pay-wall-dialog.tsx
+++ b/apps/web/src/features/billing/components/pay-wall-dialog.tsx
@@ -148,272 +148,274 @@ export function PayWallDialog({
         size="4xl"
         className="overflow-hidden p-0 lg:min-h-[500px]"
       >
-        <Tabs value={selectedPlan} onValueChange={handleChangePlan} asChild>
-          <div className="grid min-h-0 grid-cols-1 md:grid-cols-2">
-            <div className="flex flex-col p-6">
-              <DialogHeader>
-                <div className="flex items-center gap-3">
-                  <PageIcon size="sm" color="primary">
-                    <SparklesIcon />
-                  </PageIcon>
-                  <DialogTitle>
-                    <Trans i18nKey="upgradePromptTitle" />
-                  </DialogTitle>
-                </div>
-              </DialogHeader>
-              <div className="mt-6 flex flex-1 flex-col gap-4">
-                <Label htmlFor="plan">
-                  <Trans i18nKey="selectPlan" defaults="Select Plan:" />
-                </Label>
-                <RadioGroup
-                  id="plan"
-                  value={selectedPlan}
-                  onValueChange={handleChangePlan}
-                >
-                  <PlanRadioGroupItem
-                    value="hobby"
-                    id="hobby"
-                    title={PLAN_NAMES.HOBBY}
-                    price={<Trans i18nKey="planFree" defaults="Free" />}
-                  />
-                  <PlanRadioGroupItem
-                    value="pro"
-                    id="pro"
-                    title={PLAN_NAMES.PRO}
-                    price={getProPrice()}
-                    priceLabel={
-                      <Trans i18nKey="perSeatMonth" defaults="/seat/mo" />
-                    }
-                  />
-                </RadioGroup>
+        <Tabs
+          value={selectedPlan}
+          onValueChange={handleChangePlan}
+          className="grid min-h-0 grid-cols-1 md:grid-cols-2"
+        >
+          <div className="flex flex-col p-6">
+            <DialogHeader>
+              <div className="flex items-center gap-3">
+                <PageIcon size="sm" color="primary">
+                  <SparklesIcon />
+                </PageIcon>
+                <DialogTitle>
+                  <Trans i18nKey="upgradePromptTitle" />
+                </DialogTitle>
               </div>
+            </DialogHeader>
+            <div className="mt-6 flex flex-1 flex-col gap-4">
+              <Label htmlFor="plan">
+                <Trans i18nKey="selectPlan" defaults="Select Plan:" />
+              </Label>
+              <RadioGroup
+                id="plan"
+                value={selectedPlan}
+                onValueChange={handleChangePlan}
+              >
+                <PlanRadioGroupItem
+                  value="hobby"
+                  id="hobby"
+                  title={PLAN_NAMES.HOBBY}
+                  price={<Trans i18nKey="planFree" defaults="Free" />}
+                />
+                <PlanRadioGroupItem
+                  value="pro"
+                  id="pro"
+                  title={PLAN_NAMES.PRO}
+                  price={getProPrice()}
+                  priceLabel={
+                    <Trans i18nKey="perSeatMonth" defaults="/seat/mo" />
+                  }
+                />
+              </RadioGroup>
+            </div>
 
-              <div className="space-y-4 pt-4">
-                {selectedPlan === "pro" && (
-                  <label
-                    htmlFor="annual-switch"
-                    className="relative flex select-none items-start justify-between gap-4 overflow-hidden rounded-lg bg-gray-50 p-4 ring ring-button-outline ring-inset hover:bg-gray-100 dark:bg-gray-700/50 dark:hover:bg-gray-700"
-                  >
-                    <BadgeDollarSignIcon className="pointer-events-none absolute -top-5 right-16 size-24 opacity-5" />
+            <div className="space-y-4 pt-4">
+              {selectedPlan === "pro" && (
+                <label
+                  htmlFor="annual-switch"
+                  className="relative flex select-none items-start justify-between gap-4 overflow-hidden rounded-lg bg-gray-50 p-4 ring ring-button-outline ring-inset hover:bg-gray-100 dark:bg-gray-700/50 dark:hover:bg-gray-700"
+                >
+                  <BadgeDollarSignIcon className="pointer-events-none absolute -top-5 right-16 size-24 opacity-5" />
 
-                    <div className="flex-1">
-                      <div className="text-sm">
-                        <Trans
-                          defaults="Save {amount} with yearly billing"
-                          i18nKey="annualSavings"
-                          values={{
-                            amount: currencyFormatter.format(
-                              (pricingData.monthly.amount * 12 -
-                                pricingData.yearly.amount) /
-                                100,
-                            ),
-                          }}
-                        />
-                      </div>
-                      <div className="text-muted-foreground text-sm">
-                        <Trans
-                          defaults="Pay for {payMonths, number} months, get 12."
-                          i18nKey="annualDiscount"
-                          values={{
-                            payMonths: 8,
-                          }}
-                        />
-                      </div>
-                    </div>
-                    <div className="mt-1">
-                      <Switch
-                        checked={isAnnual}
-                        onCheckedChange={setIsAnnual}
-                        id="annual-switch"
+                  <div className="flex-1">
+                    <div className="text-sm">
+                      <Trans
+                        defaults="Save {amount} with yearly billing"
+                        i18nKey="annualSavings"
+                        values={{
+                          amount: currencyFormatter.format(
+                            (pricingData.monthly.amount * 12 -
+                              pricingData.yearly.amount) /
+                              100,
+                          ),
+                        }}
                       />
                     </div>
-                  </label>
-                )}
-                {selectedPlan === "pro" ? (
-                  <TabsContent value="pro">
-                    <UpgradeButton className="w-full" annual={isAnnual}>
-                      <Trans i18nKey="upgrade" defaults="Upgrade" />
-                    </UpgradeButton>
-                  </TabsContent>
-                ) : (
-                  <Button disabled={true} size="xl" className="w-full">
-                    <Trans i18nKey="currentPlan" defaults="Current Plan" />
-                  </Button>
-                )}
-              </div>
+                    <div className="text-muted-foreground text-sm">
+                      <Trans
+                        defaults="Pay for {payMonths, number} months, get 12."
+                        i18nKey="annualDiscount"
+                        values={{
+                          payMonths: 8,
+                        }}
+                      />
+                    </div>
+                  </div>
+                  <div className="mt-1">
+                    <Switch
+                      checked={isAnnual}
+                      onCheckedChange={setIsAnnual}
+                      id="annual-switch"
+                    />
+                  </div>
+                </label>
+              )}
+              {selectedPlan === "pro" ? (
+                <TabsContent value="pro">
+                  <UpgradeButton className="w-full" annual={isAnnual}>
+                    <Trans i18nKey="upgrade" defaults="Upgrade" />
+                  </UpgradeButton>
+                </TabsContent>
+              ) : (
+                <Button disabled={true} size="xl" className="w-full">
+                  <Trans i18nKey="currentPlan" defaults="Current Plan" />
+                </Button>
+              )}
             </div>
+          </div>
 
-            {/* Right Side - Plan Benefits */}
-            <div className="hidden overflow-y-auto bg-gray-100 px-6 py-6 md:block dark:bg-gray-900">
-              <TabsContent value="hobby" className="space-y-6">
-                <DialogHeader>
-                  <DialogTitle>{PLAN_NAMES.HOBBY}</DialogTitle>
-                  <DialogDescription>
-                    <Trans
-                      i18nKey="planHobbyDescription"
-                      defaults="For casual users"
-                    />
-                  </DialogDescription>
-                </DialogHeader>
-                <div className="space-y-3">
-                  <SubHeading>
-                    <Trans i18nKey="keyBenefits" defaults="Key Benefits" />
-                  </SubHeading>
-                  <KeyBenefits>
-                    <KeyBenefitsItem
-                      icon={<CalendarSearchIcon />}
-                      title={
-                        <Trans i18nKey="basicPolls" defaults="Basic polls" />
-                      }
-                      description={
-                        <Trans
-                          i18nKey="basicPollsDescription"
-                          defaults="Create simple scheduling polls"
-                        />
-                      }
-                    />
-                    <KeyBenefitsItem
-                      icon={<TimerResetIcon />}
-                      title={
-                        <Trans
-                          i18nKey="limitedPollLifetime"
-                          defaults="Limited Poll Lifetime"
-                        />
-                      }
-                      description={
-                        <Trans
-                          i18nKey="limitedPollLifetimeDescription"
-                          defaults="Inactive polls are automatically deleted"
-                        />
-                      }
-                    />
-                  </KeyBenefits>
-                </div>
-              </TabsContent>
-              <TabsContent value="pro" className="space-y-6">
-                <DialogHeader>
-                  <DialogTitle>{PLAN_NAMES.PRO}</DialogTitle>
-                  <DialogDescription>
-                    <Trans
-                      i18nKey="planProDescription"
-                      defaults="For professionals and power users"
-                    />
-                  </DialogDescription>
-                </DialogHeader>
-                <div className="space-y-3">
-                  <SubHeading>
-                    <Trans i18nKey="keyBenefits" defaults="Key Benefits" />
-                  </SubHeading>
-                  <KeyBenefits>
-                    <KeyBenefitsItem
-                      icon={<PaletteIcon />}
-                      title={
-                        <Trans
-                          i18nKey="customBranding"
-                          defaults="Custom Branding"
-                        />
-                      }
-                      description={
-                        <Trans
-                          i18nKey="customBrandingDescription"
-                          defaults="Show your logo and brand colors to your participants"
-                        />
-                      }
-                    />
-                    <KeyBenefitsItem
-                      icon={<CalendarCheckIcon />}
-                      title={
-                        <Trans
-                          i18nKey="featureNameSchedule"
-                          defaults="Schedule Poll"
-                        />
-                      }
-                      description={
-                        <Trans
-                          i18nKey="schedulePollDescription"
-                          defaults="Lock in the final meeting time and notify participants"
-                        />
-                      }
-                    />
-                    <KeyBenefitsItem
-                      icon={<CopyIcon />}
-                      title={
-                        <Trans
-                          i18nKey="featureNameDuplicate"
-                          defaults="Duplicate Poll"
-                        />
-                      }
-                      description={
-                        <Trans
-                          i18nKey="duplicatePollDescription"
-                          defaults="Quickly create similar polls from existing ones"
-                        />
-                      }
-                    />
-                    <KeyBenefitsItem
-                      icon={<SettingsIcon />}
-                      title={
-                        <Trans
-                          i18nKey="featureNameAdvancedSettings"
-                          defaults="Advanced Settings"
-                        />
-                      }
-                      description={
-                        <Trans
-                          i18nKey="advancedSettingsDescription"
-                          defaults="Customize poll behavior and participant permissions"
-                        />
-                      }
-                    />
-                    <KeyBenefitsItem
-                      icon={<ClockIcon />}
-                      title={
-                        <Trans
-                          i18nKey="featureNameExtendedPollLifetime"
-                          defaults="Extended Poll Lifetime"
-                        />
-                      }
-                      description={
-                        <Trans
-                          i18nKey="extendedPollLifetimeDescription"
-                          defaults="Keep polls indefinitely"
-                        />
-                      }
-                    />
-                    <KeyBenefitsItem
-                      icon={<UserPlusIcon />}
-                      title={
-                        <Trans
-                          i18nKey="teamCollaboration"
-                          defaults="Team collaboration"
-                        />
-                      }
-                      description={
-                        <Trans
-                          i18nKey="teamCollaborationDescription"
-                          defaults="Invite team members with centralized billing"
-                        />
-                      }
-                    />
-                    <KeyBenefitsItem
-                      icon={<LifeBuoyIcon />}
-                      title={
-                        <Trans
-                          i18nKey="prioritySupport"
-                          defaults="Priority support"
-                        />
-                      }
-                      description={
-                        <Trans
-                          i18nKey="prioritySupportDescription"
-                          defaults="Get faster response times and dedicated assistance"
-                        />
-                      }
-                    />
-                  </KeyBenefits>
-                </div>
-              </TabsContent>
-            </div>
+          {/* Right Side - Plan Benefits */}
+          <div className="hidden overflow-y-auto bg-gray-100 px-6 py-6 md:block dark:bg-gray-900">
+            <TabsContent value="hobby" className="space-y-6">
+              <DialogHeader>
+                <DialogTitle>{PLAN_NAMES.HOBBY}</DialogTitle>
+                <DialogDescription>
+                  <Trans
+                    i18nKey="planHobbyDescription"
+                    defaults="For casual users"
+                  />
+                </DialogDescription>
+              </DialogHeader>
+              <div className="space-y-3">
+                <SubHeading>
+                  <Trans i18nKey="keyBenefits" defaults="Key Benefits" />
+                </SubHeading>
+                <KeyBenefits>
+                  <KeyBenefitsItem
+                    icon={<CalendarSearchIcon />}
+                    title={
+                      <Trans i18nKey="basicPolls" defaults="Basic polls" />
+                    }
+                    description={
+                      <Trans
+                        i18nKey="basicPollsDescription"
+                        defaults="Create simple scheduling polls"
+                      />
+                    }
+                  />
+                  <KeyBenefitsItem
+                    icon={<TimerResetIcon />}
+                    title={
+                      <Trans
+                        i18nKey="limitedPollLifetime"
+                        defaults="Limited Poll Lifetime"
+                      />
+                    }
+                    description={
+                      <Trans
+                        i18nKey="limitedPollLifetimeDescription"
+                        defaults="Inactive polls are automatically deleted"
+                      />
+                    }
+                  />
+                </KeyBenefits>
+              </div>
+            </TabsContent>
+            <TabsContent value="pro" className="space-y-6">
+              <DialogHeader>
+                <DialogTitle>{PLAN_NAMES.PRO}</DialogTitle>
+                <DialogDescription>
+                  <Trans
+                    i18nKey="planProDescription"
+                    defaults="For professionals and power users"
+                  />
+                </DialogDescription>
+              </DialogHeader>
+              <div className="space-y-3">
+                <SubHeading>
+                  <Trans i18nKey="keyBenefits" defaults="Key Benefits" />
+                </SubHeading>
+                <KeyBenefits>
+                  <KeyBenefitsItem
+                    icon={<PaletteIcon />}
+                    title={
+                      <Trans
+                        i18nKey="customBranding"
+                        defaults="Custom Branding"
+                      />
+                    }
+                    description={
+                      <Trans
+                        i18nKey="customBrandingDescription"
+                        defaults="Show your logo and brand colors to your participants"
+                      />
+                    }
+                  />
+                  <KeyBenefitsItem
+                    icon={<CalendarCheckIcon />}
+                    title={
+                      <Trans
+                        i18nKey="featureNameSchedule"
+                        defaults="Schedule Poll"
+                      />
+                    }
+                    description={
+                      <Trans
+                        i18nKey="schedulePollDescription"
+                        defaults="Lock in the final meeting time and notify participants"
+                      />
+                    }
+                  />
+                  <KeyBenefitsItem
+                    icon={<CopyIcon />}
+                    title={
+                      <Trans
+                        i18nKey="featureNameDuplicate"
+                        defaults="Duplicate Poll"
+                      />
+                    }
+                    description={
+                      <Trans
+                        i18nKey="duplicatePollDescription"
+                        defaults="Quickly create similar polls from existing ones"
+                      />
+                    }
+                  />
+                  <KeyBenefitsItem
+                    icon={<SettingsIcon />}
+                    title={
+                      <Trans
+                        i18nKey="featureNameAdvancedSettings"
+                        defaults="Advanced Settings"
+                      />
+                    }
+                    description={
+                      <Trans
+                        i18nKey="advancedSettingsDescription"
+                        defaults="Customize poll behavior and participant permissions"
+                      />
+                    }
+                  />
+                  <KeyBenefitsItem
+                    icon={<ClockIcon />}
+                    title={
+                      <Trans
+                        i18nKey="featureNameExtendedPollLifetime"
+                        defaults="Extended Poll Lifetime"
+                      />
+                    }
+                    description={
+                      <Trans
+                        i18nKey="extendedPollLifetimeDescription"
+                        defaults="Keep polls indefinitely"
+                      />
+                    }
+                  />
+                  <KeyBenefitsItem
+                    icon={<UserPlusIcon />}
+                    title={
+                      <Trans
+                        i18nKey="teamCollaboration"
+                        defaults="Team collaboration"
+                      />
+                    }
+                    description={
+                      <Trans
+                        i18nKey="teamCollaborationDescription"
+                        defaults="Invite team members with centralized billing"
+                      />
+                    }
+                  />
+                  <KeyBenefitsItem
+                    icon={<LifeBuoyIcon />}
+                    title={
+                      <Trans
+                        i18nKey="prioritySupport"
+                        defaults="Priority support"
+                      />
+                    }
+                    description={
+                      <Trans
+                        i18nKey="prioritySupportDescription"
+                        defaults="Get faster response times and dedicated assistance"
+                      />
+                    }
+                  />
+                </KeyBenefits>
+              </div>
+            </TabsContent>
           </div>
         </Tabs>
       </DialogContent>

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -25,7 +25,6 @@
     "@radix-ui/react-portal": "^1.1.6",
     "@radix-ui/react-select": "^2.2.2",
     "@radix-ui/react-slot": "^1.1.2",
-    "@radix-ui/react-tabs": "^1.0.4",
     "@radix-ui/react-tooltip": "^1.1.8",
     "@rallly/languages": "workspace:*",
     "@rallly/tailwind-config": "workspace:*",

--- a/packages/ui/src/page-tabs.tsx
+++ b/packages/ui/src/page-tabs.tsx
@@ -1,56 +1,52 @@
 "use client";
 
-import * as TabsPrimitive from "@radix-ui/react-tabs";
-import * as React from "react";
+import { Tabs as TabsPrimitive } from "@base-ui/react/tabs";
 
 import { cn } from "./lib/utils";
 
-const Tabs = TabsPrimitive.Root;
+function Tabs(props: TabsPrimitive.Root.Props) {
+  return <TabsPrimitive.Root data-slot="page-tabs" {...props} />;
+}
 
-const TabsList = React.forwardRef<
-  React.ElementRef<typeof TabsPrimitive.List>,
-  React.ComponentPropsWithoutRef<typeof TabsPrimitive.List>
->(({ className, ...props }, ref) => (
-  <TabsPrimitive.List
-    ref={ref}
-    className={cn(
-      "-mb-px flex space-x-4 border-gray-200 border-b border-b-border",
-      className,
-    )}
-    {...props}
-  />
-));
-TabsList.displayName = TabsPrimitive.List.displayName;
+function TabsList({ className, ...props }: TabsPrimitive.List.Props) {
+  return (
+    <TabsPrimitive.List
+      data-slot="page-tabs-list"
+      activateOnFocus
+      className={cn(
+        "-mb-px flex space-x-4 border-gray-200 border-b border-b-border",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
 
-const TabsTrigger = React.forwardRef<
-  React.ComponentRef<typeof TabsPrimitive.Trigger>,
-  React.ComponentPropsWithoutRef<typeof TabsPrimitive.Trigger>
->(({ className, ...props }, ref) => (
-  <TabsPrimitive.Trigger
-    ref={ref}
-    className={cn(
-      "inline-flex h-9 items-center whitespace-nowrap rounded-none border-b-2 px-1 pt-1 pb-1 font-medium text-sm ring-offset-background transition-colors focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50",
-      "data-[state=active]:border-foreground data-[state=inactive]:border-transparent data-[state=active]:text-foreground data-[state=inactive]:text-muted-foreground data-[state=inactive]:hover:border-accent-border data-[state=inactive]:hover:text-accent-foreground",
-      className,
-    )}
-    {...props}
-  />
-));
-TabsTrigger.displayName = TabsPrimitive.Trigger.displayName;
+function TabsTrigger({ className, ...props }: TabsPrimitive.Tab.Props) {
+  return (
+    <TabsPrimitive.Tab
+      data-slot="page-tabs-trigger"
+      className={cn(
+        "inline-flex h-9 items-center whitespace-nowrap rounded-none border-b-2 px-1 pt-1 pb-1 font-medium text-sm ring-offset-background transition-colors focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50",
+        "not-data-active:border-transparent not-data-active:text-muted-foreground not-data-active:hover:border-accent-border not-data-active:hover:text-accent-foreground data-active:border-foreground data-active:text-foreground",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
 
-const TabsContent = React.forwardRef<
-  React.ElementRef<typeof TabsPrimitive.Content>,
-  React.ComponentPropsWithoutRef<typeof TabsPrimitive.Content>
->(({ className, ...props }, ref) => (
-  <TabsPrimitive.Content
-    ref={ref}
-    className={cn(
-      "mt-4 ring-offset-background focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 lg:mt-6",
-      className,
-    )}
-    {...props}
-  />
-));
-TabsContent.displayName = TabsPrimitive.Content.displayName;
+function TabsContent({ className, ...props }: TabsPrimitive.Panel.Props) {
+  return (
+    <TabsPrimitive.Panel
+      data-slot="page-tabs-content"
+      className={cn(
+        "mt-4 ring-offset-background focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 lg:mt-6",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
 
 export { Tabs, TabsContent, TabsList, TabsTrigger };

--- a/packages/ui/src/tabs.tsx
+++ b/packages/ui/src/tabs.tsx
@@ -1,55 +1,51 @@
 "use client";
 
-import * as TabsPrimitive from "@radix-ui/react-tabs";
-import * as React from "react";
+import { Tabs as TabsPrimitive } from "@base-ui/react/tabs";
 
 import { cn } from "./lib/utils";
 
-const Tabs = TabsPrimitive.Root;
+function Tabs(props: TabsPrimitive.Root.Props) {
+  return <TabsPrimitive.Root data-slot="tabs" {...props} />;
+}
 
-const TabsList = React.forwardRef<
-  React.ElementRef<typeof TabsPrimitive.List>,
-  React.ComponentPropsWithoutRef<typeof TabsPrimitive.List>
->(({ className, ...props }, ref) => (
-  <TabsPrimitive.List
-    ref={ref}
-    className={cn(
-      "inline-flex h-8 items-center justify-center rounded-lg border border-input bg-muted text-input-foreground dark:bg-gray-900",
-      className,
-    )}
-    {...props}
-  />
-));
-TabsList.displayName = TabsPrimitive.List.displayName;
+function TabsList({ className, ...props }: TabsPrimitive.List.Props) {
+  return (
+    <TabsPrimitive.List
+      data-slot="tabs-list"
+      activateOnFocus
+      className={cn(
+        "inline-flex h-8 items-center justify-center rounded-lg border border-input bg-muted text-input-foreground dark:bg-gray-900",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
 
-const TabsTrigger = React.forwardRef<
-  React.ElementRef<typeof TabsPrimitive.Trigger>,
-  React.ComponentPropsWithoutRef<typeof TabsPrimitive.Trigger>
->(({ className, ...props }, ref) => (
-  <TabsPrimitive.Trigger
-    ref={ref}
-    className={cn(
-      "inline-flex h-full items-center justify-center whitespace-nowrap rounded-lg px-3 font-normal text-muted-foreground text-sm ring-offset-background focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:bg-white data-[state=active]:text-foreground data-[state=active]:ring-1 data-[state=active]:ring-gray-200 dark:data-[state=active]:bg-gray-800 dark:data-[state=active]:ring-gray-700",
-      className,
-    )}
-    {...props}
-  />
-));
-TabsTrigger.displayName = TabsPrimitive.Trigger.displayName;
+function TabsTrigger({ className, ...props }: TabsPrimitive.Tab.Props) {
+  return (
+    <TabsPrimitive.Tab
+      data-slot="tabs-trigger"
+      className={cn(
+        "inline-flex h-full items-center justify-center whitespace-nowrap rounded-lg px-3 font-normal text-muted-foreground text-sm ring-offset-background focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-active:bg-white data-active:text-foreground data-active:ring-1 data-active:ring-gray-200 dark:data-active:bg-gray-800 dark:data-active:ring-gray-700",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
 
-const TabsContent = React.forwardRef<
-  React.ElementRef<typeof TabsPrimitive.Content>,
-  React.ComponentPropsWithoutRef<typeof TabsPrimitive.Content>
->(({ className, ...props }, ref) => (
-  <TabsPrimitive.Content
-    ref={ref}
-    className={cn(
-      "ring-offset-background focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
-      className,
-    )}
-    {...props}
-  />
-));
-TabsContent.displayName = TabsPrimitive.Content.displayName;
+function TabsContent({ className, ...props }: TabsPrimitive.Panel.Props) {
+  return (
+    <TabsPrimitive.Panel
+      data-slot="tabs-content"
+      className={cn(
+        "ring-offset-background focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
 
 export { Tabs, TabsContent, TabsList, TabsTrigger };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -782,9 +782,6 @@ importers:
       '@radix-ui/react-slot':
         specifier: ^1.1.2
         version: 1.2.4(@types/react@19.2.13)(react@19.2.6)
-      '@radix-ui/react-tabs':
-        specifier: ^1.0.4
-        version: 1.1.13(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@radix-ui/react-tooltip':
         specifier: ^1.1.8
         version: 1.2.8(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
@@ -3801,19 +3798,6 @@ packages:
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
     peerDependenciesMeta:
       '@types/react':
-        optional: true
-
-  '@radix-ui/react-tabs@1.1.13':
-    resolution: {integrity: sha512-7xdcatg7/U+7+Udyoj2zodtI9H/IIopqo+YOIcZOq1nJwXWBZ9p8xiu5llXlekDbZkca79a/fozEYQXIA4sW6A==}
-    peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-      '@types/react-dom':
         optional: true
 
   '@radix-ui/react-toggle@1.1.10':
@@ -15138,22 +15122,6 @@ snapshots:
       react: 19.2.6
     optionalDependencies:
       '@types/react': 19.2.13
-
-  '@radix-ui/react-tabs@1.1.13(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
-    dependencies:
-      '@radix-ui/primitive': 1.1.3
-      '@radix-ui/react-context': 1.1.2(@types/react@19.2.13)(react@19.2.6)
-      '@radix-ui/react-direction': 1.1.1(@types/react@19.2.13)(react@19.2.6)
-      '@radix-ui/react-id': 1.1.1(@types/react@19.2.13)(react@19.2.6)
-      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@radix-ui/react-roving-focus': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.13)(react@19.2.6)
-      react: 19.2.6
-      react-dom: 19.2.6(react@19.2.6)
-    optionalDependencies:
-      '@types/react': 19.2.13
-      '@types/react-dom': 19.2.3(@types/react@19.2.13)
 
   '@radix-ui/react-toggle@1.1.10(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
     dependencies:


### PR DESCRIPTION
Resolves RAL-1301

Fresh PR replacing #2587, which was closed after a conflict-resolution attempt bloated its diff with unrelated changes.

## Changes

- `packages/ui/src/tabs.tsx` and `packages/ui/src/page-tabs.tsx` (two wrappers over the same primitive) now wrap `@base-ui/react/tabs` instead of `@radix-ui/react-tabs`. Exported `Tabs`/`TabsList`/`TabsTrigger`/`TabsContent` names are unchanged.
- Part mapping: `Trigger` → `Tab`, `Content` → `Panel`. Active state selectors `data-[state=active]` → `data-active`; page-tabs' inactive selectors `data-[state=inactive]:*` → `not-data-active:*` (Base UI puts no attribute on inactive tabs; this version of Base UI uses `data-active`, not `data-selected`).
- `TabsList` sets `activateOnFocus` in both wrappers. Base UI defaults it to `false` (arrow keys move focus without switching tabs), while Radix defaulted to automatic activation. Without this, keyboard tab switching silently regresses — confirmed against the running app before and after.
- `pay-wall-dialog.tsx` used `asChild` on the Tabs root (which Base UI doesn't have) purely to merge the root onto a grid `<div>`. Since `Tabs.Root` renders a `<div>` itself, the grid classes now live directly on `Tabs` and the redundant wrapper div is gone — same DOM as before.
- `@radix-ui/react-tabs` removed from `packages/ui/package.json`.

## Behavior notes

- `Tab` renders a native `<button>` like Radix, so the existing `disabled:` styling variants are untouched.
- Inactive panels stay unmounted by default in both libraries (`keepMounted` ↔ `forceMount`), so no rendering change for the tabbed views (polls/events/users) or the pay-wall.
- `onValueChange` gains a second `eventDetails` argument; all consumers pass single-argument handlers, so no call sites change.

## Verification

Driven end-to-end against the local dev app (Playwright):

- `/polls` (page-tabs): active underline styling correct, clicking tabs updates selection and URL (`?status=closed`), arrow keys activate tabs (after the `activateOnFocus` fix; before it, arrows only moved focus)
- `/new` (tabs): Month/Week view toggle switches active pill styling and panel content
- Pay-wall dialog (hobby space → Upgrade): two-column grid renders identically without `asChild`, plan radio switches the benefits panel
- `tsc --noEmit` clean in `packages/ui`, `apps/web`, `apps/landing`; Biome clean; lockfile updated (−33 lines)
- `grep -rn "@radix-ui/react-tabs" packages apps` returns nothing; no app code styles tabs via `data-[state=active]`
- Consumers audited: poll-options-form, pay-wall-dialog, polls/events/users tabbed views, landing pricing-table

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated the plan selection experience with a clearer tabbed layout for comparing Hobby and Pro benefits.
  * Improved keyboard navigation by activating tabs when focused.
  * Preserved annual billing options, pricing details, and upgrade/current-plan actions for Pro plans.

* **Bug Fixes**
  * Improved synchronization of selected plan options and displayed plan benefits in the billing dialog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->