### PR TITLE
🐛 Fix API keys with underscores in prefix being rejected

### DIFF
--- a/apps/web/src/features/api-keys/utils.test.ts
+++ b/apps/web/src/features/api-keys/utils.test.ts
@@ -95,8 +95,13 @@ describe("isLegacyApiKeyHash", () => {
 
 describe("extractApiKeyPrefix", () => {
   it("should extract prefix from valid API key", () => {
-    const apiKey = "sk_abc123_def456";
-    expect(extractApiKeyPrefix(apiKey)).toBe("abc123");
+    const apiKey = "sk_abc12345_def456ghi789jkl012mno345pqr678";
+    expect(extractApiKeyPrefix(apiKey)).toBe("abc12345");
+  });
+
+  it("should extract prefix containing underscores", () => {
+    const apiKey = "sk_a_b-c_d5_def456ghi789jkl012mno345pqr678";
+    expect(extractApiKeyPrefix(apiKey)).toBe("a_b-c_d5");
   });
 
   it("should handle malformed keys with fallback", () => {
@@ -104,9 +109,11 @@ describe("extractApiKeyPrefix", () => {
     expect(extractApiKeyPrefix(malformed)).toBe(malformed.slice(0, 12));
   });
 
-  it("should handle keys with extra underscores", () => {
-    const apiKey = "sk_prefix_secret_extra";
-    expect(extractApiKeyPrefix(apiKey)).toBe("prefix");
+  it("should extract the stored prefix from generated keys", async () => {
+    for (let i = 0; i < 50; i++) {
+      const result = await createApiKey();
+      expect(extractApiKeyPrefix(result.apiKey)).toBe(result.prefix);
+    }
   });
 });
 

--- a/apps/web/src/features/api-keys/utils.ts
+++ b/apps/web/src/features/api-keys/utils.ts
@@ -29,6 +29,10 @@ export const hashApiKey = (rawKey: string): string => {
   return `sha256$${salt}$${hash}`;
 };
 
+const API_KEY_SCHEME = "sk_";
+// randomToken(6) → 8 base64url characters
+const API_KEY_PREFIX_LENGTH = 8;
+
 /**
  * Create an API key with the format: sk_{prefix}_{secret}
  * @returns Object containing the full API key and components for storage
@@ -40,7 +44,7 @@ export const createApiKey = async (): Promise<{
 }> => {
   const prefix = randomToken(6);
   const secret = randomToken(24);
-  const apiKey = `sk_${prefix}_${secret}`;
+  const apiKey = `${API_KEY_SCHEME}${prefix}_${secret}`;
 
   return {
     apiKey,
@@ -50,14 +54,19 @@ export const createApiKey = async (): Promise<{
 };
 
 /**
- * Extract the prefix from a raw API key
+ * Extract the prefix from a raw API key.
+ *
+ * The prefix and secret are base64url, whose alphabet includes `_`, so the
+ * key cannot be split on underscores — the prefix is extracted by position.
  * @param rawKey Raw API key in format sk_{prefix}_{secret}
  * @returns The prefix portion
  */
 export const extractApiKeyPrefix = (rawKey: string): string => {
-  const parts = rawKey.split("_").filter(Boolean);
-  if (parts.length >= 3 && parts[1]) {
-    return parts[1];
+  if (rawKey.startsWith(API_KEY_SCHEME)) {
+    return rawKey.slice(
+      API_KEY_SCHEME.length,
+      API_KEY_SCHEME.length + API_KEY_PREFIX_LENGTH,
+    );
   }
   // Fallback for malformed keys
   return rawKey.slice(0, 12);


### PR DESCRIPTION
## Summary

Fixes [RAL-1317](https://linear.app/rallly/issue/RAL-1317/api-keys-with-an-underscore-in-the-prefix-are-silently-rejected): `createApiKey` generates the prefix with `randomToken(6)`, which is base64url — an alphabet that includes `_`. Since the key format is `sk_{prefix}_{secret}`, `extractApiKeyPrefix`'s split-on-underscore returned only the fragment before the first underscore inside the prefix. The truncated prefix then failed the length check in the auth middleware's `timingSafeEqual` comparison, so ~12% of issued keys (1 − (63/64)⁸) never worked, returning 401 from the moment they were created.

## Changes

- `extractApiKeyPrefix` now extracts the prefix positionally (8 chars after `sk_`) instead of splitting on underscores. This also repairs already-issued broken keys without rotation — the stored prefix was always the full 8 characters; only extraction was wrong.
- Added regression tests: a literal prefix containing underscores, and an invariant test asserting `extractApiKeyPrefix(apiKey) === prefix` across 50 generated keys (~99.8% chance of covering an underscore prefix per run).

Legacy `rly_`-format keys don't need handling: the `api_keys` table was dropped (not migrated) in `20260107155716_remove_user_api_keys`, so all live keys use the `sk_` format with a fixed 8-char prefix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved API key prefix extraction for keys containing underscores or dashes.
  * Standardized API key formatting to ensure generated prefixes are extracted consistently.
  * Added validation across multiple generated API keys to improve reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->