### PR TITLE
🐛 Exclude soft-deleted polls from access checks and notification recipients

### DIFF
--- a/apps/web/src/features/notifications/data.ts
+++ b/apps/web/src/features/notifications/data.ts
@@ -47,10 +47,15 @@ export async function getNotificationRecipient({
 }): Promise<NotificationRecipient | null> {
   const poll = await prisma.poll.findUnique({
     where: { id: pollId },
-    select: { userId: true, muted: true },
+    select: { userId: true, muted: true, deleted: true },
   });
 
-  if (!poll?.userId || poll.userId === excludeUserId || poll.muted) {
+  if (
+    !poll?.userId ||
+    poll.deleted ||
+    poll.userId === excludeUserId ||
+    poll.muted
+  ) {
     return null;
   }
 

--- a/apps/web/src/features/poll/data.ts
+++ b/apps/web/src/features/poll/data.ts
@@ -254,8 +254,14 @@ export async function canUserManagePoll(
   poll: {
     userId?: string | null;
     spaceId?: string | null;
+    deleted?: boolean;
   },
 ) {
+  if (poll.deleted) {
+    // A deleted poll cannot be managed by anyone
+    return false;
+  }
+
   if (poll.userId && poll.userId === user.id) {
     // user is owner
     return true;
@@ -284,6 +290,7 @@ export const hasPollAdminAccess = async (pollId: string, userId: string) => {
   const poll = await prisma.poll.findFirst({
     where: {
       id: pollId,
+      deleted: false,
       OR: [{ userId: userId }, { space: { members: { some: { userId } } } }],
     },
     select: {


### PR DESCRIPTION
## Description

Fixes Linear issue [RAL-1318](https://linear.app/rallly/issue/RAL-1318): three server helpers ignored the `deleted` flag on polls, so soft-deleted polls could still authorize admin operations and trigger notifications.

- **`hasPollAdminAccess`** (`apps/web/src/features/poll/data.ts`) — added `deleted: false` to the `findFirst` where clause. Admin operations (update, close, reopen, book, duplicate, mark-as-deleted, comment/participant deletion) no longer authorize against soft-deleted polls.
- **`canUserManagePoll`** (`apps/web/src/features/poll/data.ts`) — added an optional `deleted` field to the `poll` parameter and an early `return false` when set. Its only caller (`polls.get` in `apps/web/src/trpc/routers/polls.ts`) already selects `deleted` and throws `NOT_FOUND` before calling the helper, so this is defense-in-depth for future callers rather than a behavior change on that path.
- **`getNotificationRecipient`** (`apps/web/src/features/notifications/data.ts`) — added `deleted` to the poll select and returns `null` when the poll is soft-deleted, so comment/participant notifications (`polls/comments.ts`, `polls/participants.ts`) are no longer sent for deleted polls.

Deliberately untouched: the cleanup flows (`removeDeletedPolls`, `deleteInactivePolls` in `features/poll/mutations.ts`) query deleted polls directly and do not go through these helpers, so they keep operating on deleted polls as intended; there is no user-facing restore endpoint that relies on these helpers. Note that `polls.markAsDeleted` on an already-deleted poll now returns `FORBIDDEN` instead of redundantly re-marking it, consistent with treating deleted polls as nonexistent.

## Checklist

Please check off all the following items with an "x" in the boxes before requesting a review.

- [x] I have performed a self-review of my code
- [x] My code follows the code style of this project
- [x] I have commented my code, particularly in hard-to-understand areas

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Kxc7uutKSz3A8LCVgvfgzt

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kxc7uutKSz3A8LCVgvfgzt)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Deleted polls are no longer treated as manageable by administrators or poll owners.
  * Notifications are no longer sent for deleted polls.
  * Improved access control and notification behavior for deleted content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->