### PR TITLE
♻️ Migrate Dialog to Base UI

### DIFF
--- a/apps/web/src/app/[locale]/(optional-space)/poll/[urlId]/duplicate-dialog.tsx
+++ b/apps/web/src/app/[locale]/(optional-space)/poll/[urlId]/duplicate-dialog.tsx
@@ -51,10 +51,8 @@ export function DuplicateDialog({
           }}
         />
         <DialogFooter>
-          <DialogClose asChild>
-            <Button>
-              <Trans i18nKey="cancel" />
-            </Button>
+          <DialogClose render={<Button />}>
+            <Trans i18nKey="cancel" />
           </DialogClose>
           <Button
             type="submit"

--- a/apps/web/src/app/[locale]/(space)/settings/api-keys/components/revoke-api-key-button.tsx
+++ b/apps/web/src/app/[locale]/(space)/settings/api-keys/components/revoke-api-key-button.tsx
@@ -107,10 +107,8 @@ export function RevokeApiKeyButton({
             >
               <Trans i18nKey="revoke" defaults="Revoke" />
             </Button>
-            <DialogClose asChild>
-              <Button>
-                <Trans i18nKey="cancel" defaults="Cancel" />
-              </Button>
+            <DialogClose render={<Button />}>
+              <Trans i18nKey="cancel" defaults="Cancel" />
             </DialogClose>
           </DialogFooter>
         </DialogContent>

--- a/apps/web/src/app/[locale]/(space)/settings/billing/components/manage-seats-dialog.tsx
+++ b/apps/web/src/app/[locale]/(space)/settings/billing/components/manage-seats-dialog.tsx
@@ -174,10 +174,8 @@ export function ManageSeatsDialog({
           />
         </div>
         <DialogFooter>
-          <DialogClose asChild>
-            <Button>
-              <Trans i18nKey="cancel" defaults="Cancel" />
-            </Button>
+          <DialogClose render={<Button />}>
+            <Trans i18nKey="cancel" defaults="Cancel" />
           </DialogClose>
           <Button
             variant="primary"

--- a/apps/web/src/app/[locale]/(space)/settings/billing/page-client.tsx
+++ b/apps/web/src/app/[locale]/(space)/settings/billing/page-client.tsx
@@ -150,22 +150,21 @@ function BillingPageContent({ tier }: { tier: SpaceTier }) {
                       usedSeats={seats.used}
                       currentSeats={seats.total}
                     >
-                      <DialogTrigger asChild>
-                        <Button
-                          onClick={() => {
-                            posthog?.capture(
-                              "space_billing:manage_seats_button_click",
-                            );
-                          }}
-                        >
-                          <Icon>
-                            <ArmchairIcon />
-                          </Icon>
-                          <Trans
-                            i18nKey="manageSeats"
-                            defaults="Manage Seats"
+                      <DialogTrigger
+                        render={
+                          <Button
+                            onClick={() => {
+                              posthog?.capture(
+                                "space_billing:manage_seats_button_click",
+                              );
+                            }}
                           />
-                        </Button>
+                        }
+                      >
+                        <Icon>
+                          <ArmchairIcon />
+                        </Icon>
+                        <Trans i18nKey="manageSeats" defaults="Manage Seats" />
                       </DialogTrigger>
                     </ManageSeatsDialog>
                   </div>

--- a/apps/web/src/app/[locale]/(space)/settings/general/components/delete-space-button.tsx
+++ b/apps/web/src/app/[locale]/(space)/settings/general/components/delete-space-button.tsx
@@ -109,10 +109,8 @@ function DeleteSpaceDialog({
               />
             </div>
             <DialogFooter>
-              <DialogClose asChild>
-                <Button>
-                  <Trans i18nKey="cancel" defaults="Cancel" />
-                </Button>
+              <DialogClose render={<Button />}>
+                <Trans i18nKey="cancel" defaults="Cancel" />
               </DialogClose>
               <Button
                 type="submit"
@@ -139,10 +137,8 @@ interface DeleteSpaceButtonProps {
 export function DeleteSpaceButton({ spaceName }: DeleteSpaceButtonProps) {
   return (
     <DeleteSpaceDialog spaceName={spaceName}>
-      <DialogTrigger asChild>
-        <Button className="text-destructive">
-          <Trans i18nKey="deleteSpace" defaults="Delete Space" />
-        </Button>
+      <DialogTrigger render={<Button className="text-destructive" />}>
+        <Trans i18nKey="deleteSpace" defaults="Delete Space" />
       </DialogTrigger>
     </DeleteSpaceDialog>
   );

--- a/apps/web/src/app/[locale]/(space)/settings/general/components/leave-space-button.tsx
+++ b/apps/web/src/app/[locale]/(space)/settings/general/components/leave-space-button.tsx
@@ -120,10 +120,8 @@ function LeaveSpaceDialog({
             />
           </form>
           <DialogFooter>
-            <DialogClose asChild>
-              <Button>
-                <Trans i18nKey="cancel" defaults="Cancel" />
-              </Button>
+            <DialogClose render={<Button />}>
+              <Trans i18nKey="cancel" defaults="Cancel" />
             </DialogClose>
             <Button
               form={formName}
@@ -151,11 +149,9 @@ export function LeaveSpaceButton({
 }: LeaveSpaceButtonProps) {
   return (
     <LeaveSpaceDialog spaceName={spaceName} spaceId={spaceId}>
-      <DialogTrigger asChild>
-        <Button>
-          <LogOutIcon data-icon="inline-start" />
-          <Trans i18nKey="leaveSpace" defaults="Leave Space" />
-        </Button>
+      <DialogTrigger render={<Button />}>
+        <LogOutIcon data-icon="inline-start" />
+        <Trans i18nKey="leaveSpace" defaults="Leave Space" />
       </DialogTrigger>
     </LeaveSpaceDialog>
   );

--- a/apps/web/src/app/[locale]/(space)/settings/members/components/invite-dropdown-menu.tsx
+++ b/apps/web/src/app/[locale]/(space)/settings/members/components/invite-dropdown-menu.tsx
@@ -107,10 +107,8 @@ export function InviteDropdownMenu({ invite }: { invite: SpaceMemberInvite }) {
             >
               <Trans i18nKey="confirm" defaults="Confirm" />
             </Button>
-            <DialogClose asChild>
-              <Button>
-                <Trans i18nKey="cancel" defaults="Cancel" />
-              </Button>
+            <DialogClose render={<Button />}>
+              <Trans i18nKey="cancel" defaults="Cancel" />
             </DialogClose>
           </DialogFooter>
         </DialogContent>

--- a/apps/web/src/app/[locale]/(space)/settings/members/components/member-dropdown-menu.tsx
+++ b/apps/web/src/app/[locale]/(space)/settings/members/components/member-dropdown-menu.tsx
@@ -150,10 +150,8 @@ export function MemberDropdownMenu({ member }: { member: MemberDTO }) {
             >
               <Trans i18nKey="confirm" defaults="Confirm" />
             </Button>
-            <DialogClose asChild>
-              <Button>
-                <Trans i18nKey="cancel" defaults="Cancel" />
-              </Button>
+            <DialogClose render={<Button />}>
+              <Trans i18nKey="cancel" defaults="Cancel" />
             </DialogClose>
           </DialogFooter>
         </DialogContent>

--- a/apps/web/src/app/[locale]/(space)/settings/profile/delete-account-dialog.tsx
+++ b/apps/web/src/app/[locale]/(space)/settings/profile/delete-account-dialog.tsx
@@ -88,10 +88,8 @@ export function DeleteAccountDialog({ children, ...rest }: DialogProps & {}) {
               />
             </div>
             <DialogFooter>
-              <DialogClose asChild>
-                <Button>
-                  <Trans i18nKey="cancel" defaults="Cancel" />
-                </Button>
+              <DialogClose render={<Button />}>
+                <Trans i18nKey="cancel" defaults="Cancel" />
               </DialogClose>
               <Button
                 type="submit"

--- a/apps/web/src/app/[locale]/(space)/settings/profile/profile-page.tsx
+++ b/apps/web/src/app/[locale]/(space)/settings/profile/profile-page.tsx
@@ -76,10 +76,8 @@ export function ProfilePage() {
             </PageSectionHeader>
             <PageSectionContent>
               <DeleteAccountDialog>
-                <DialogTrigger asChild>
-                  <Button className="text-destructive">
-                    <Trans i18nKey="deleteAccount" defaults="Delete Account" />
-                  </Button>
+                <DialogTrigger render={<Button className="text-destructive" />}>
+                  <Trans i18nKey="deleteAccount" defaults="Delete Account" />
                 </DialogTrigger>
               </DeleteAccountDialog>
             </PageSectionContent>

--- a/apps/web/src/app/[locale]/(space)/settings/spaces/components/leave-space-dialog.tsx
+++ b/apps/web/src/app/[locale]/(space)/settings/spaces/components/leave-space-dialog.tsx
@@ -107,10 +107,8 @@ export function LeaveSpaceDialog({
               )}
             />
             <DialogFooter>
-              <DialogClose asChild>
-                <Button>
-                  <Trans i18nKey="cancel" defaults="Cancel" />
-                </Button>
+              <DialogClose render={<Button />}>
+                <Trans i18nKey="cancel" defaults="Cancel" />
               </DialogClose>
               <Button
                 type="submit"

--- a/apps/web/src/app/[locale]/control-panel/license/page.tsx
+++ b/apps/web/src/app/[locale]/control-panel/license/page.tsx
@@ -194,11 +194,9 @@ export default async function LicensePage() {
                 <Trans i18nKey="purchaseLicense" defaults="Purchase license" />
               </a>
               <Dialog>
-                <DialogTrigger asChild>
-                  <Button variant="primary">
-                    <PlusIcon data-icon="inline-start" />
-                    <Trans i18nKey="addLicenseKey" defaults="Add license key" />
-                  </Button>
+                <DialogTrigger render={<Button variant="primary" />}>
+                  <PlusIcon data-icon="inline-start" />
+                  <Trans i18nKey="addLicenseKey" defaults="Add license key" />
                 </DialogTrigger>
                 <DialogContent size="sm">
                   <DialogHeader>

--- a/apps/web/src/app/[locale]/control-panel/users/dialogs/delete-user-dialog.tsx
+++ b/apps/web/src/app/[locale]/control-panel/users/dialogs/delete-user-dialog.tsx
@@ -110,10 +110,8 @@ export function DeleteUserDialog({
               )}
             />
             <DialogFooter className="mt-6">
-              <DialogClose asChild>
-                <Button>
-                  <Trans i18nKey="cancel" defaults="Cancel" />
-                </Button>
+              <DialogClose render={<Button />}>
+                <Trans i18nKey="cancel" defaults="Cancel" />
               </DialogClose>
               <Button
                 variant="destructive"

--- a/apps/web/src/app/[locale]/e/[id]/components/registration-dialog.tsx
+++ b/apps/web/src/app/[locale]/e/[id]/components/registration-dialog.tsx
@@ -26,8 +26,8 @@ export function RegistrationDialog({
   return (
     <Dialog
       {...dialogProps}
-      onOpenChange={(open) => {
-        dialogProps.onOpenChange?.(open);
+      onOpenChange={(open, eventDetails) => {
+        dialogProps.onOpenChange?.(open, eventDetails);
         if (!open) {
           // Reflect the new registration (e.g. the going count) once the
           // dialog is dismissed, then reset for the next time it opens.

--- a/apps/web/src/components/clock.tsx
+++ b/apps/web/src/components/clock.tsx
@@ -63,10 +63,10 @@ const Clock = ({ className }: { className?: string }) => {
   );
 };
 
-const ClockPreferences = ({ children }: React.PropsWithChildren) => {
+const ClockPreferences = ({ children }: { children: React.ReactElement }) => {
   return (
     <Dialog modal={false}>
-      <DialogTrigger asChild>{children}</DialogTrigger>
+      <DialogTrigger render={children} />
       <DialogContent className="sm:max-w-sm">
         <DialogHeader>
           <DialogTitle>

--- a/apps/web/src/components/invite-dialog.tsx
+++ b/apps/web/src/components/invite-dialog.tsx
@@ -55,13 +55,11 @@ export const InviteDialog = () => {
 
   return (
     <Dialog open={isOpen} onOpenChange={setIsOpen}>
-      <DialogTrigger asChild={true}>
-        <Button variant="primary">
-          <Share2Icon data-icon="inline-start" />
-          <span className="sr-only sm:not-sr-only">
-            <Trans i18nKey="share" defaults="Share" />
-          </span>
-        </Button>
+      <DialogTrigger render={<Button variant="primary" />}>
+        <Share2Icon data-icon="inline-start" />
+        <span className="sr-only sm:not-sr-only">
+          <Trans i18nKey="share" defaults="Share" />
+        </span>
       </DialogTrigger>
       <DialogContent data-testid="invite-participant-dialog">
         <div className="flex">

--- a/apps/web/src/components/modal/modal.tsx
+++ b/apps/web/src/components/modal/modal.tsx
@@ -47,9 +47,7 @@ const Modal: React.FunctionComponent<ModalProps> = ({
         </DialogHeader>
         <p className="text-sm">{content}</p>
         <DialogFooter>
-          <DialogClose asChild>
-            <Button>{cancelText}</Button>
-          </DialogClose>
+          <DialogClose render={<Button />}>{cancelText}</DialogClose>
           <Button
             variant="primary"
             onClick={() => {

--- a/apps/web/src/components/poll/manage-poll/schedule-poll-dialog.tsx
+++ b/apps/web/src/components/poll/manage-poll/schedule-poll-dialog.tsx
@@ -244,10 +244,8 @@ export function SchedulePollDialog(props: DialogProps) {
           }}
         />
         <DialogFooter>
-          <DialogClose asChild>
-            <Button>
-              <Trans i18nKey="cancel" />
-            </Button>
+          <DialogClose render={<Button />}>
+            <Trans i18nKey="cancel" />
           </DialogClose>
           <Button
             loading={scheduleEvent.isPending}

--- a/apps/web/src/features/event-types/components/create-event-type-dialog.tsx
+++ b/apps/web/src/features/event-types/components/create-event-type-dialog.tsx
@@ -97,10 +97,12 @@ export function CreateEventTypeDialog({ open, onOpenChange }: DialogProps) {
               setShowDescription={setShowDescription}
             />
             <DialogFooter className="pt-2">
-              <DialogClose asChild>
-                <Button type="button" disabled={createEventType.isPending}>
-                  <Trans i18nKey="cancel" defaults="Cancel" />
-                </Button>
+              <DialogClose
+                render={
+                  <Button type="button" disabled={createEventType.isPending} />
+                }
+              >
+                <Trans i18nKey="cancel" defaults="Cancel" />
               </DialogClose>
               <Button
                 type="submit"

--- a/apps/web/src/features/event-types/components/delete-event-type-dialog.tsx
+++ b/apps/web/src/features/event-types/components/delete-event-type-dialog.tsx
@@ -65,10 +65,10 @@ export function DeleteEventTypeDialog({
           </DialogDescription>
         </DialogHeader>
         <DialogFooter>
-          <DialogClose asChild>
-            <Button type="button" disabled={softDelete.isPending}>
-              <Trans i18nKey="cancel" defaults="Cancel" />
-            </Button>
+          <DialogClose
+            render={<Button type="button" disabled={softDelete.isPending} />}
+          >
+            <Trans i18nKey="cancel" defaults="Cancel" />
           </DialogClose>
           <Button
             type="button"

--- a/apps/web/src/features/event-types/components/edit-event-type-dialog.tsx
+++ b/apps/web/src/features/event-types/components/edit-event-type-dialog.tsx
@@ -111,10 +111,12 @@ export function EditEventTypeDialog({
               setShowDescription={setShowDescription}
             />
             <DialogFooter className="pt-2">
-              <DialogClose asChild>
-                <Button type="button" disabled={updateEventType.isPending}>
-                  <Trans i18nKey="cancel" defaults="Cancel" />
-                </Button>
+              <DialogClose
+                render={
+                  <Button type="button" disabled={updateEventType.isPending} />
+                }
+              >
+                <Trans i18nKey="cancel" defaults="Cancel" />
               </DialogClose>
               <Button
                 type="submit"

--- a/apps/web/src/features/licensing/components/remove-license-button.tsx
+++ b/apps/web/src/features/licensing/components/remove-license-button.tsx
@@ -28,13 +28,13 @@ export function RemoveLicenseButton() {
     <Dialog {...dialog.dialogProps}>
       <Tooltip>
         <TooltipTrigger asChild>
-          <DialogTrigger asChild>
-            <Button variant="ghost" onClick={() => dialog.trigger()}>
-              <XIcon data-icon="inline-start" />
-              <span className="sr-only">
-                <Trans i18nKey="removeLicense" defaults="Remove License" />
-              </span>
-            </Button>
+          <DialogTrigger
+            render={<Button variant="ghost" onClick={() => dialog.trigger()} />}
+          >
+            <XIcon data-icon="inline-start" />
+            <span className="sr-only">
+              <Trans i18nKey="removeLicense" defaults="Remove License" />
+            </span>
           </DialogTrigger>
         </TooltipTrigger>
         <TooltipContent>
@@ -54,10 +54,8 @@ export function RemoveLicenseButton() {
           </DialogDescription>
         </DialogHeader>
         <DialogFooter>
-          <DialogClose asChild>
-            <Button>
-              <Trans i18nKey="cancel" defaults="Cancel" />
-            </Button>
+          <DialogClose render={<Button />}>
+            <Trans i18nKey="cancel" defaults="Cancel" />
           </DialogClose>
           <Button
             loading={isPending}

--- a/apps/web/src/features/poll/components/polls-infinite-list.tsx
+++ b/apps/web/src/features/poll/components/polls-infinite-list.tsx
@@ -206,10 +206,8 @@ function PollListItem({
             </DialogDescription>
           </DialogHeader>
           <DialogFooter>
-            <DialogClose asChild>
-              <Button>
-                <Trans i18nKey="cancel" />
-              </Button>
+            <DialogClose render={<Button />}>
+              <Trans i18nKey="cancel" />
             </DialogClose>
             <Button
               variant="destructive"

--- a/apps/web/src/features/scheduled-event/components/scheduled-event-list.tsx
+++ b/apps/web/src/features/scheduled-event/components/scheduled-event-list.tsx
@@ -193,10 +193,8 @@ export function ScheduledEventListItem({
             </DialogDescription>
           </DialogHeader>
           <DialogFooter>
-            <DialogClose asChild>
-              <Button variant="default">
-                <Trans i18nKey="cancel" defaults="Cancel" />
-              </Button>
+            <DialogClose render={<Button variant="default" />}>
+              <Trans i18nKey="cancel" defaults="Cancel" />
             </DialogClose>
             <Button
               variant="destructive"

--- a/packages/ui/src/command.tsx
+++ b/packages/ui/src/command.tsx
@@ -1,10 +1,10 @@
 "use client";
 
-import type { DialogProps } from "@radix-ui/react-dialog";
 import { Command as CommandPrimitive } from "cmdk";
 import { SearchIcon } from "lucide-react";
 import * as React from "react";
 
+import type { DialogProps } from "./dialog";
 import { Dialog, DialogContent } from "./dialog";
 import { usePlatform } from "./hooks/use-platform";
 import { Icon } from "./icon";

--- a/packages/ui/src/dialog.tsx
+++ b/packages/ui/src/dialog.tsx
@@ -1,47 +1,45 @@
 "use client";
 
-import * as DialogPrimitive from "@radix-ui/react-dialog";
+import { Dialog as DialogPrimitive } from "@base-ui/react/dialog";
 import type { VariantProps } from "class-variance-authority";
 import { cva } from "class-variance-authority";
 import { XIcon } from "lucide-react";
 import React from "react";
 import { cn } from "./lib/utils";
 
-function Dialog({
-  ...props
-}: React.ComponentProps<typeof DialogPrimitive.Root>) {
+function Dialog({ ...props }: DialogPrimitive.Root.Props) {
   return <DialogPrimitive.Root data-slot="dialog" {...props} />;
 }
 
-export type DialogProps = React.ComponentProps<typeof DialogPrimitive.Root>;
+export type DialogProps = Omit<
+  DialogPrimitive.Root.Props,
+  "children" | "onOpenChange"
+> & {
+  children?: React.ReactNode;
+  onOpenChange?: (open: boolean) => void;
+};
 
-function DialogTrigger({
-  ...props
-}: React.ComponentProps<typeof DialogPrimitive.Trigger>) {
+function DialogTrigger({ ...props }: DialogPrimitive.Trigger.Props) {
   return <DialogPrimitive.Trigger data-slot="dialog-trigger" {...props} />;
 }
 
-function DialogPortal({
-  ...props
-}: React.ComponentProps<typeof DialogPrimitive.Portal>) {
+function DialogPortal({ ...props }: DialogPrimitive.Portal.Props) {
   return <DialogPrimitive.Portal data-slot="dialog-portal" {...props} />;
 }
 
-function DialogClose({
-  ...props
-}: React.ComponentProps<typeof DialogPrimitive.Close>) {
+function DialogClose({ ...props }: DialogPrimitive.Close.Props) {
   return <DialogPrimitive.Close data-slot="dialog-close" {...props} />;
 }
 
 function DialogOverlay({
   className,
   ...props
-}: React.ComponentProps<typeof DialogPrimitive.Overlay>) {
+}: DialogPrimitive.Backdrop.Props) {
   return (
-    <DialogPrimitive.Overlay
+    <DialogPrimitive.Backdrop
       data-slot="dialog-overlay"
       className={cn(
-        "data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-gray-900/50 data-[state=closed]:animate-out data-[state=open]:animate-in",
+        "data-closed:fade-out-0 data-open:fade-in-0 fixed inset-0 z-50 bg-gray-900/50 data-closed:animate-out data-open:animate-in",
         className,
       )}
       {...props}
@@ -51,7 +49,7 @@ function DialogOverlay({
 
 const dialogVariants = cva(
   cn(
-    "data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-2xl border border-popover-border bg-popover p-4 shadow-lg outline-none duration-200 data-[state=closed]:animate-out data-[state=open]:animate-in",
+    "data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-2xl border border-popover-border bg-popover p-4 shadow-lg outline-none duration-200 data-closed:animate-out data-open:animate-in",
   ),
   {
     variants: {
@@ -77,26 +75,26 @@ function DialogContent({
   showCloseButton = true,
   size = "md",
   ...props
-}: React.ComponentProps<typeof DialogPrimitive.Content> &
+}: DialogPrimitive.Popup.Props &
   VariantProps<typeof dialogVariants> & {
     showCloseButton?: boolean;
   }) {
   return (
     <DialogPortal data-slot="dialog-portal">
       <DialogOverlay />
-      <DialogPrimitive.Content
+      <DialogPrimitive.Popup
         data-slot="dialog-content"
         className={cn(dialogVariants({ size }), className)}
         {...props}
       >
         {children}
         {showCloseButton && (
-          <DialogClose className="absolute top-4 right-4 rounded-xs opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-hidden focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground [&_svg:not([class*='size-'])]:size-4 [&_svg]:pointer-events-none [&_svg]:shrink-0">
+          <DialogClose className="absolute top-4 right-4 rounded-xs opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-hidden focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none [&_svg:not([class*='size-'])]:size-4 [&_svg]:pointer-events-none [&_svg]:shrink-0">
             <XIcon />
             <span className="sr-only">Close</span>
           </DialogClose>
         )}
-      </DialogPrimitive.Content>
+      </DialogPrimitive.Popup>
     </DialogPortal>
   );
 }
@@ -118,10 +116,7 @@ function DialogFooter({ className, ...props }: React.ComponentProps<"div">) {
   );
 }
 
-function DialogTitle({
-  className,
-  ...props
-}: React.ComponentProps<typeof DialogPrimitive.Title>) {
+function DialogTitle({ className, ...props }: DialogPrimitive.Title.Props) {
   return (
     <DialogPrimitive.Title
       data-slot="dialog-title"
@@ -137,7 +132,7 @@ function DialogTitle({
 function DialogDescription({
   className,
   ...props
-}: React.ComponentProps<typeof DialogPrimitive.Description>) {
+}: DialogPrimitive.Description.Props) {
   return (
     <DialogPrimitive.Description
       data-slot="dialog-description"


### PR DESCRIPTION
Resolves RAL-1303

Redo of #2589 (closed, stale) rebased onto current main (post Select migration and directory restructure).

## Changes

- `packages/ui/src/dialog.tsx` now wraps `@base-ui/react/dialog`: `Overlay` → `Backdrop`, `Content` → `Popup`; animation selectors `data-[state=open]`/`data-[state=closed]` → `data-open`/`data-closed`. All exported names unchanged. **The `useDialog` API (`trigger()`, `dismiss()`, `dialogProps`, `triggerProps`) is untouched.**
- All `DialogTrigger asChild` / `DialogClose asChild` sites across the app converted to the Base UI `render` prop (element props go in `render={<Button …/>}`, labels stay as children). `clock.tsx`'s trigger wrapped an opaque `children` prop, so it now passes it straight through (`render={children}`) with the prop narrowed to `React.ReactElement`.
- The exported `DialogProps` type keeps its pre-migration contract — `children?: React.ReactNode` and `onOpenChange?: (open: boolean) => void` — layered over Base UI's Root props, so the app components that re-declare `DialogProps` and call `onOpenChange(open)` themselves compile unchanged. `command.tsx`'s `DialogProps` type import moves from `@radix-ui/react-dialog` to `./dialog`.
- `registration-dialog.tsx` wraps `React.ComponentProps<typeof Dialog>` directly (not `DialogProps`), so its `onOpenChange` interceptor now forwards the `eventDetails` argument.
- Dropped two dead classes on the built-in close button (`data-[state=open]:bg-accent`/`text-muted-foreground` — Base UI puts no state attribute on Close).
- **Per RAL-1303, `@radix-ui/react-dialog` stays in `packages/ui/package.json`** — `sheet.tsx` still builds on it until RAL-1304 lands.

## Verification

- `tsc --noEmit` clean in `packages/ui` and `apps/web`; Biome clean; no `DialogTrigger asChild`/`DialogClose asChild` remain; only remaining `@radix-ui/react-dialog` importer is `sheet.tsx`.
- Driven end-to-end against the dev app (Playwright): delete-account dialog opens via `DialogTrigger render`, closes via Cancel (`DialogClose render`), built-in X, Escape, and backdrop click; command menu (`CommandDialog` + `useDialog`) opens on ⌘K, navigates and dismisses on select; poll Share/invite dialog opens and closes. No console/server warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated dialogs and modal controls across the application for more consistent opening, closing, and button behavior.
  * Standardized confirmation, cancellation, invitation, deletion, licensing, and settings dialogs while preserving existing labels, actions, and loading states.
  * Improved dialog interactions for registration flows, including more complete open/close event handling.

* **Bug Fixes**
  * Preserved localized button text and existing dialog functionality during the UI updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->