### PR TITLE
♻️ Migrate Tooltip to Base UI

### DIFF
--- a/apps/web/src/app/[locale]/(space)/settings/calendars/components/calendar-connection-list.tsx
+++ b/apps/web/src/app/[locale]/(space)/settings/calendars/components/calendar-connection-list.tsx
@@ -67,37 +67,39 @@ export function CalendarConnectionList() {
             </div>
             <div className="flex items-center gap-2">
               <Tooltip>
-                <TooltipTrigger asChild>
-                  <Button
-                    aria-label={t("syncCalendar", {
-                      defaultValue: "Sync calendar",
-                    })}
-                    loading={syncCalendar.isPending}
-                    variant="ghost"
-                    size="icon"
-                    onClick={() => {
-                      toast.promise(
-                        syncCalendar.mutateAsync({ id: calendar.id }),
-                        {
-                          loading: t("syncCalendarLoading", {
-                            defaultValue: "Syncing calendar…",
-                          }),
-                          success: t("syncCalendarSuccess", {
-                            defaultValue: "Calendar synced",
-                          }),
-                          error: t("syncCalendarError", {
-                            defaultValue:
-                              "There was an issue syncing your calendar",
-                          }),
-                        },
-                      );
-                    }}
-                  >
-                    <Icon>
-                      <RefreshCcwIcon />
-                    </Icon>
-                  </Button>
-                </TooltipTrigger>
+                <TooltipTrigger
+                  render={
+                    <Button
+                      aria-label={t("syncCalendar", {
+                        defaultValue: "Sync calendar",
+                      })}
+                      loading={syncCalendar.isPending}
+                      variant="ghost"
+                      size="icon"
+                      onClick={() => {
+                        toast.promise(
+                          syncCalendar.mutateAsync({ id: calendar.id }),
+                          {
+                            loading: t("syncCalendarLoading", {
+                              defaultValue: "Syncing calendar…",
+                            }),
+                            success: t("syncCalendarSuccess", {
+                              defaultValue: "Calendar synced",
+                            }),
+                            error: t("syncCalendarError", {
+                              defaultValue:
+                                "There was an issue syncing your calendar",
+                            }),
+                          },
+                        );
+                      }}
+                    >
+                      <Icon>
+                        <RefreshCcwIcon />
+                      </Icon>
+                    </Button>
+                  }
+                />
                 <TooltipContent>
                   <Trans i18nKey="syncCalendar" defaults="Sync calendar" />
                 </TooltipContent>

--- a/apps/web/src/components/copy-link-button.tsx
+++ b/apps/web/src/components/copy-link-button.tsx
@@ -21,23 +21,25 @@ export function CopyLinkButton({
   const { t } = useTranslation();
   return (
     <Tooltip open={didCopy ? true : undefined}>
-      <TooltipTrigger asChild>
-        <Button
-          aria-label={t("copyLink", { defaultValue: "Copy link" })}
-          className={className}
-          variant="ghost"
-          size="icon"
-          onClick={() => {
-            copy(href);
-            setDidCopy(true);
-            setTimeout(() => setDidCopy(false), 1000);
-          }}
-        >
-          <Icon>
-            <CopyIcon />
-          </Icon>
-        </Button>
-      </TooltipTrigger>
+      <TooltipTrigger
+        render={
+          <Button
+            aria-label={t("copyLink", { defaultValue: "Copy link" })}
+            className={className}
+            variant="ghost"
+            size="icon"
+            onClick={() => {
+              copy(href);
+              setDidCopy(true);
+              setTimeout(() => setDidCopy(false), 1000);
+            }}
+          >
+            <Icon>
+              <CopyIcon />
+            </Icon>
+          </Button>
+        }
+      />
       <TooltipContent>
         {didCopy ? (
           <div className="flex items-center gap-2">

--- a/apps/web/src/components/poll/desktop-poll.tsx
+++ b/apps/web/src/components/poll/desktop-poll.tsx
@@ -94,46 +94,52 @@ function TableControls({
         {showScrollControls ? (
           <>
             <Tooltip>
-              <TooltipTrigger asChild>
-                <Button
-                  aria-label={t("scrollLeft", { defaultValue: "Scroll Left" })}
-                  variant="ghost"
-                  size="icon"
-                  disabled={!canScrollPrev}
-                  onClick={onGoToPreviousPage}
-                >
-                  <Icon>
-                    <ArrowLeftIcon />
-                  </Icon>
-                </Button>
-              </TooltipTrigger>
+              <TooltipTrigger
+                render={
+                  <Button
+                    aria-label={t("scrollLeft", {
+                      defaultValue: "Scroll Left",
+                    })}
+                    variant="ghost"
+                    size="icon"
+                    disabled={!canScrollPrev}
+                    onClick={onGoToPreviousPage}
+                  >
+                    <Icon>
+                      <ArrowLeftIcon />
+                    </Icon>
+                  </Button>
+                }
+              />
               <TooltipContent>
                 <Trans i18nKey="scrollLeft" defaults="Scroll Left" />
               </TooltipContent>
             </Tooltip>
             <Tooltip>
-              <TooltipTrigger asChild>
-                <Button
-                  aria-label={t("scrollRight", {
-                    defaultValue: "Scroll Right",
-                  })}
-                  className="relative"
-                  variant="ghost"
-                  size="icon"
-                  disabled={!canScrollNext}
-                  onClick={onGoToNextPage}
-                >
-                  <Icon>
-                    <ArrowRightIcon />
-                  </Icon>
-                  {showScrollIndicator ? (
-                    <span className="absolute -top-0.5 -right-0.5 flex size-2">
-                      <span className="absolute top-0 right-0 inline-flex h-full w-full animate-ping rounded-full bg-rose-400 opacity-75" />
-                      <span className="relative inline-flex size-2 rounded-full bg-rose-500" />
-                    </span>
-                  ) : null}
-                </Button>
-              </TooltipTrigger>
+              <TooltipTrigger
+                render={
+                  <Button
+                    aria-label={t("scrollRight", {
+                      defaultValue: "Scroll Right",
+                    })}
+                    className="relative"
+                    variant="ghost"
+                    size="icon"
+                    disabled={!canScrollNext}
+                    onClick={onGoToNextPage}
+                  >
+                    <Icon>
+                      <ArrowRightIcon />
+                    </Icon>
+                    {showScrollIndicator ? (
+                      <span className="absolute -top-0.5 -right-0.5 flex size-2">
+                        <span className="absolute top-0 right-0 inline-flex h-full w-full animate-ping rounded-full bg-rose-400 opacity-75" />
+                        <span className="relative inline-flex size-2 rounded-full bg-rose-500" />
+                      </span>
+                    ) : null}
+                  </Button>
+                }
+              />
               <TooltipContent>
                 <Trans i18nKey="scrollRight" defaults="Scroll Right" />
               </TooltipContent>
@@ -142,36 +148,41 @@ function TableControls({
         ) : null}
         {expanded ? (
           <Tooltip>
-            <TooltipTrigger asChild>
-              <Button
-                aria-label={t("shrink", { defaultValue: "Shrink" })}
-                variant="ghost"
-                size="icon"
-                onClick={onCollapse}
-              >
-                <Icon>
-                  <ShrinkIcon />
-                </Icon>
-              </Button>
-            </TooltipTrigger>
+            <TooltipTrigger
+              render={
+                <Button
+                  aria-label={t("shrink", { defaultValue: "Shrink" })}
+                  variant="ghost"
+                  size="icon"
+                  onClick={onCollapse}
+                >
+                  <Icon>
+                    <ShrinkIcon />
+                  </Icon>
+                </Button>
+              }
+            />
             <TooltipContent>
               <Trans i18nKey="shrink" defaults="Shrink" />
             </TooltipContent>
           </Tooltip>
         ) : (
-          <Tooltip delayDuration={0}>
-            <TooltipTrigger asChild>
-              <Button
-                aria-label={t("expand", { defaultValue: "Expand" })}
-                variant="ghost"
-                size="icon"
-                onClick={onExpand}
-              >
-                <Icon>
-                  <ExpandIcon />
-                </Icon>
-              </Button>
-            </TooltipTrigger>
+          <Tooltip>
+            <TooltipTrigger
+              delay={0}
+              render={
+                <Button
+                  aria-label={t("expand", { defaultValue: "Expand" })}
+                  variant="ghost"
+                  size="icon"
+                  onClick={onExpand}
+                >
+                  <Icon>
+                    <ExpandIcon />
+                  </Icon>
+                </Button>
+              }
+            />
             <TooltipContent>
               <Trans i18nKey="expand" defaults="Expand" />
             </TooltipContent>

--- a/apps/web/src/components/poll/desktop-poll/participant-row-form.tsx
+++ b/apps/web/src/components/poll/desktop-poll/participant-row-form.tsx
@@ -1,11 +1,6 @@
 import { cn } from "@rallly/ui";
 import { Button } from "@rallly/ui/button";
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipPortal,
-  TooltipTrigger,
-} from "@rallly/ui/tooltip";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@rallly/ui/tooltip";
 import { UndoIcon } from "lucide-react";
 import * as React from "react";
 import { Controller } from "react-hook-form";
@@ -77,23 +72,23 @@ const ParticipantRowForm = ({
           {!isNew ? (
             <div className="flex items-center gap-1">
               <Tooltip>
-                <TooltipTrigger asChild>
-                  <Button
-                    aria-label={t("cancel", { defaultValue: "Cancel" })}
-                    variant="ghost"
-                    onClick={() => {
-                      form.cancel();
-                    }}
-                    size="icon-sm"
-                  >
-                    <UndoIcon />
-                  </Button>
-                </TooltipTrigger>
-                <TooltipPortal>
-                  <TooltipContent>
-                    <Trans i18nKey="cancel" />
-                  </TooltipContent>
-                </TooltipPortal>
+                <TooltipTrigger
+                  render={
+                    <Button
+                      aria-label={t("cancel", { defaultValue: "Cancel" })}
+                      variant="ghost"
+                      onClick={() => {
+                        form.cancel();
+                      }}
+                      size="icon-sm"
+                    >
+                      <UndoIcon />
+                    </Button>
+                  }
+                />
+                <TooltipContent>
+                  <Trans i18nKey="cancel" />
+                </TooltipContent>
               </Tooltip>
               <Button
                 variant="primary"

--- a/apps/web/src/components/poll/desktop-poll/poll-header.tsx
+++ b/apps/web/src/components/poll/desktop-poll/poll-header.tsx
@@ -1,10 +1,5 @@
 import { cn } from "@rallly/ui";
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipPortal,
-  TooltipTrigger,
-} from "@rallly/ui/tooltip";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@rallly/ui/tooltip";
 import { ClockIcon } from "lucide-react";
 import type * as React from "react";
 import { ConnectedScoreSummary } from "@/components/poll/score-summary";
@@ -25,16 +20,14 @@ const TimeRange: React.FunctionComponent<{
       )}
     >
       <span data-testid="option-start-time">{start}</span>
-      <Tooltip delayDuration={0}>
-        <TooltipTrigger className="flex items-center gap-x-1">
+      <Tooltip>
+        <TooltipTrigger delay={0} className="flex items-center gap-x-1">
           <ClockIcon className="size-3" />
           {duration}
         </TooltipTrigger>
-        <TooltipPortal>
-          <TooltipContent className="text-xs">
-            {start} - {end}
-          </TooltipContent>
-        </TooltipPortal>
+        <TooltipContent className="text-xs">
+          {start} - {end}
+        </TooltipContent>
       </Tooltip>
     </div>
   );

--- a/apps/web/src/components/poll/notification-toggle.tsx
+++ b/apps/web/src/components/poll/notification-toggle.tsx
@@ -1,12 +1,7 @@
 "use client";
 
 import { Button } from "@rallly/ui/button";
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipPortal,
-  TooltipTrigger,
-} from "@rallly/ui/tooltip";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@rallly/ui/tooltip";
 import { BellIcon, BellOffIcon } from "lucide-react";
 
 import { useUser } from "@/components/user-provider";
@@ -37,43 +32,45 @@ export function NotificationToggle() {
 
   return (
     <Tooltip>
-      <TooltipTrigger asChild>
-        <Button
-          variant="ghost"
-          aria-pressed={poll.muted}
-          aria-label={
-            poll.muted
-              ? t("unmuteNotifications", {
-                  defaultValue: "Unmute notifications",
-                })
-              : t("muteNotifications", { defaultValue: "Mute notifications" })
-          }
-          onClick={() => {
-            toggleMuted.mutate({ pollId: poll.id, muted: !poll.muted });
-          }}
-        >
-          {poll.muted ? <BellOffIcon /> : <BellIcon />}
-          <span className="sr-only">
-            {poll.muted
-              ? t("unmuteNotifications", {
-                  defaultValue: "Unmute notifications",
-                })
-              : t("muteNotifications", { defaultValue: "Mute notifications" })}
-          </span>
-        </Button>
-      </TooltipTrigger>
-      <TooltipPortal>
-        <TooltipContent>
-          {poll.muted ? (
-            <Trans
-              i18nKey="unmuteNotifications"
-              defaults="Unmute notifications"
-            />
-          ) : (
-            <Trans i18nKey="muteNotifications" defaults="Mute notifications" />
-          )}
-        </TooltipContent>
-      </TooltipPortal>
+      <TooltipTrigger
+        render={
+          <Button
+            variant="ghost"
+            aria-pressed={poll.muted}
+            aria-label={
+              poll.muted
+                ? t("unmuteNotifications", {
+                    defaultValue: "Unmute notifications",
+                  })
+                : t("muteNotifications", { defaultValue: "Mute notifications" })
+            }
+            onClick={() => {
+              toggleMuted.mutate({ pollId: poll.id, muted: !poll.muted });
+            }}
+          >
+            {poll.muted ? <BellOffIcon /> : <BellIcon />}
+            <span className="sr-only">
+              {poll.muted
+                ? t("unmuteNotifications", {
+                    defaultValue: "Unmute notifications",
+                  })
+                : t("muteNotifications", {
+                    defaultValue: "Mute notifications",
+                  })}
+            </span>
+          </Button>
+        }
+      />
+      <TooltipContent>
+        {poll.muted ? (
+          <Trans
+            i18nKey="unmuteNotifications"
+            defaults="Unmute notifications"
+          />
+        ) : (
+          <Trans i18nKey="muteNotifications" defaults="Mute notifications" />
+        )}
+      </TooltipContent>
     </Tooltip>
   );
 }

--- a/apps/web/src/components/poll/truncated-linkify.tsx
+++ b/apps/web/src/components/poll/truncated-linkify.tsx
@@ -27,16 +27,18 @@ export const truncateLink = (href: string, text: string, key: number) => {
     finalText += "…";
     return (
       <Tooltip>
-        <TooltipTrigger asChild>
-          <Link
-            className="text-link"
-            target="_blank"
-            href={href}
-            rel="nofollow noreferrer noopener"
-          >
-            {finalText}
-          </Link>
-        </TooltipTrigger>
+        <TooltipTrigger
+          render={
+            <Link
+              className="text-link"
+              target="_blank"
+              href={href}
+              rel="nofollow noreferrer noopener"
+            >
+              {finalText}
+            </Link>
+          }
+        />
         <TooltipContent className="max-w-md break-all text-xs">
           {href}
         </TooltipContent>

--- a/apps/web/src/components/vote-summary-progress-bar.tsx
+++ b/apps/web/src/components/vote-summary-progress-bar.tsx
@@ -29,40 +29,46 @@ export const VoteSummaryProgressBar = (props: {
   return (
     <div className="flex h-1.5 grow overflow-hidden rounded-sm bg-muted">
       <Tooltip>
-        <TooltipTrigger asChild>
-          <div
-            className="h-full bg-green-500 opacity-75 hover:opacity-100"
-            style={{
-              width: `${(props.yes.length / props.total) * 100}%`,
-            }}
-          />
-        </TooltipTrigger>
+        <TooltipTrigger
+          render={
+            <div
+              className="h-full bg-green-500 opacity-75 hover:opacity-100"
+              style={{
+                width: `${(props.yes.length / props.total) * 100}%`,
+              }}
+            />
+          }
+        />
         <TooltipContent side="bottom">
           <ListNames participantIds={props.yes} />
         </TooltipContent>
       </Tooltip>
       <Tooltip>
-        <TooltipTrigger asChild>
-          <div
-            className="h-full bg-amber-400 opacity-75 hover:opacity-100"
-            style={{
-              width: `${(props.ifNeedBe.length / props.total) * 100}%`,
-            }}
-          />
-        </TooltipTrigger>
+        <TooltipTrigger
+          render={
+            <div
+              className="h-full bg-amber-400 opacity-75 hover:opacity-100"
+              style={{
+                width: `${(props.ifNeedBe.length / props.total) * 100}%`,
+              }}
+            />
+          }
+        />
         <TooltipContent side="bottom">
           <ListNames participantIds={props.ifNeedBe} />
         </TooltipContent>
       </Tooltip>
       <Tooltip>
-        <TooltipTrigger asChild>
-          <div
-            className="h-full bg-transparent opacity-75 hover:opacity-100"
-            style={{
-              width: `${(props.no.length / props.total) * 100}%`,
-            }}
-          />
-        </TooltipTrigger>
+        <TooltipTrigger
+          render={
+            <div
+              className="h-full bg-transparent opacity-75 hover:opacity-100"
+              style={{
+                width: `${(props.no.length / props.total) * 100}%`,
+              }}
+            />
+          }
+        />
         <TooltipContent side="bottom">
           <ListNames participantIds={props.no} />
         </TooltipContent>

--- a/apps/web/src/features/licensing/components/refresh-license-button.tsx
+++ b/apps/web/src/features/licensing/components/refresh-license-button.tsx
@@ -13,20 +13,22 @@ export function RefreshLicenseButton() {
 
   return (
     <Tooltip>
-      <TooltipTrigger asChild>
-        <Button
-          variant="ghost"
-          loading={refreshInstanceLicense.isExecuting}
-          onClick={async () => await refreshInstanceLicense.executeAsync()}
-        >
-          <Icon>
-            <RefreshCwIcon />
-          </Icon>
-          <span className="sr-only">
-            <Trans i18nKey="refreshLicense" defaults="Refresh License" />
-          </span>
-        </Button>
-      </TooltipTrigger>
+      <TooltipTrigger
+        render={
+          <Button
+            variant="ghost"
+            loading={refreshInstanceLicense.isExecuting}
+            onClick={async () => await refreshInstanceLicense.executeAsync()}
+          >
+            <Icon>
+              <RefreshCwIcon />
+            </Icon>
+            <span className="sr-only">
+              <Trans i18nKey="refreshLicense" defaults="Refresh License" />
+            </span>
+          </Button>
+        }
+      />
       <TooltipContent>
         <Trans i18nKey="refreshLicense" defaults="Refresh License" />
       </TooltipContent>

--- a/apps/web/src/features/licensing/components/remove-license-button.tsx
+++ b/apps/web/src/features/licensing/components/remove-license-button.tsx
@@ -27,16 +27,20 @@ export function RemoveLicenseButton() {
   return (
     <Dialog {...dialog.dialogProps}>
       <Tooltip>
-        <TooltipTrigger asChild>
-          <DialogTrigger
-            render={<Button variant="ghost" onClick={() => dialog.trigger()} />}
-          >
-            <XIcon data-icon="inline-start" />
-            <span className="sr-only">
-              <Trans i18nKey="removeLicense" defaults="Remove License" />
-            </span>
-          </DialogTrigger>
-        </TooltipTrigger>
+        <TooltipTrigger
+          render={
+            <DialogTrigger
+              render={
+                <Button variant="ghost" onClick={() => dialog.trigger()} />
+              }
+            >
+              <XIcon data-icon="inline-start" />
+              <span className="sr-only">
+                <Trans i18nKey="removeLicense" defaults="Remove License" />
+              </span>
+            </DialogTrigger>
+          }
+        />
         <TooltipContent>
           <Trans i18nKey="removeLicense" defaults="Remove License" />
         </TooltipContent>

--- a/apps/web/src/features/poll/components/poll-status-icon.tsx
+++ b/apps/web/src/features/poll/components/poll-status-icon.tsx
@@ -56,9 +56,11 @@ export function PollStatusIcon({
     return (
       <TooltipProvider>
         <Tooltip>
-          <TooltipTrigger asChild>
-            <span className={cn("inline-flex", className)}>{icon}</span>
-          </TooltipTrigger>
+          <TooltipTrigger
+            render={
+              <span className={cn("inline-flex", className)}>{icon}</span>
+            }
+          />
           <TooltipContent>
             <p>{label}</p>
           </TooltipContent>

--- a/apps/web/src/features/poll/components/polls-infinite-list.tsx
+++ b/apps/web/src/features/poll/components/polls-infinite-list.tsx
@@ -80,15 +80,17 @@ function PollListItem({
         <div className="hidden items-center justify-end gap-4 sm:flex">
           {participants.length > 0 ? (
             <Tooltip>
-              <TooltipTrigger asChild>
-                <span className="cursor-help text-muted-foreground text-sm">
-                  <Trans
-                    i18nKey="participantCount"
-                    defaults="{count, plural, =0 {No participants} =1 {1 participant} other {# participants}}"
-                    values={{ count: participants.length }}
-                  />
-                </span>
-              </TooltipTrigger>
+              <TooltipTrigger
+                render={
+                  <span className="cursor-help text-muted-foreground text-sm">
+                    <Trans
+                      i18nKey="participantCount"
+                      defaults="{count, plural, =0 {No participants} =1 {1 participant} other {# participants}}"
+                      values={{ count: participants.length }}
+                    />
+                  </span>
+                }
+              />
               <TooltipContent>
                 <ul>
                   {participants.slice(0, 10).map((participant) => (

--- a/apps/web/src/features/scheduled-event/components/scheduled-event-list.tsx
+++ b/apps/web/src/features/scheduled-event/components/scheduled-event-list.tsx
@@ -82,15 +82,17 @@ export function ScheduledEventListItem({
               <div className="text-muted-foreground text-sm">
                 {invites.length > 0 ? (
                   <Tooltip>
-                    <TooltipTrigger asChild>
-                      <span className="cursor-help">
-                        <Trans
-                          i18nKey="attendeeCount"
-                          defaults="{count, plural, =0 {No attendees} one {1 attendee} other {# attendees}}"
-                          values={{ count: invites.length }}
-                        />
-                      </span>
-                    </TooltipTrigger>
+                    <TooltipTrigger
+                      render={
+                        <span className="cursor-help">
+                          <Trans
+                            i18nKey="attendeeCount"
+                            defaults="{count, plural, =0 {No attendees} one {1 attendee} other {# attendees}}"
+                            values={{ count: invites.length }}
+                          />
+                        </span>
+                      }
+                    />
                     <TooltipContent>
                       <ul>
                         {invites.slice(0, 10).map((invite) => (

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -24,7 +24,6 @@
     "@radix-ui/react-popover": "^1.0.5",
     "@radix-ui/react-portal": "^1.1.6",
     "@radix-ui/react-slot": "^1.1.2",
-    "@radix-ui/react-tooltip": "^1.1.8",
     "@rallly/languages": "workspace:*",
     "@rallly/tailwind-config": "workspace:*",
     "@react-aria/color": "^3.1.5",

--- a/packages/ui/src/sidebar.tsx
+++ b/packages/ui/src/sidebar.tsx
@@ -123,7 +123,7 @@ const SidebarProvider = React.forwardRef<
 
     return (
       <SidebarContext.Provider value={contextValue}>
-        <TooltipProvider delayDuration={0}>
+        <TooltipProvider delay={0}>
           <div
             style={
               {
@@ -577,7 +577,7 @@ const SidebarMenuButton = React.forwardRef<
 
     return (
       <Tooltip>
-        <TooltipTrigger asChild>{button}</TooltipTrigger>
+        <TooltipTrigger render={button} />
         <TooltipContent
           side="right"
           align="center"

--- a/packages/ui/src/tooltip.tsx
+++ b/packages/ui/src/tooltip.tsx
@@ -1,41 +1,56 @@
 "use client";
 
-import * as TooltipPrimitive from "@radix-ui/react-tooltip";
-import * as React from "react";
+import { Tooltip as TooltipPrimitive } from "@base-ui/react/tooltip";
 
 import { cn } from "./lib/utils";
 
-const TooltipProvider = TooltipPrimitive.Provider;
+function TooltipProvider({ ...props }: TooltipPrimitive.Provider.Props) {
+  return <TooltipPrimitive.Provider data-slot="tooltip-provider" {...props} />;
+}
 
-const Tooltip = TooltipPrimitive.Root;
+function Tooltip({ ...props }: TooltipPrimitive.Root.Props) {
+  return <TooltipPrimitive.Root data-slot="tooltip" {...props} />;
+}
 
-const TooltipTrigger = TooltipPrimitive.Trigger;
+function TooltipTrigger({ ...props }: TooltipPrimitive.Trigger.Props) {
+  return <TooltipPrimitive.Trigger data-slot="tooltip-trigger" {...props} />;
+}
 
-const TooltipPortal = TooltipPrimitive.Portal;
+function TooltipContent({
+  className,
+  side = "bottom",
+  sideOffset = 4,
+  align,
+  alignOffset,
+  children,
+  ...props
+}: TooltipPrimitive.Popup.Props &
+  Pick<
+    TooltipPrimitive.Positioner.Props,
+    "side" | "sideOffset" | "align" | "alignOffset"
+  >) {
+  return (
+    <TooltipPrimitive.Portal>
+      <TooltipPrimitive.Positioner
+        side={side}
+        sideOffset={sideOffset}
+        align={align}
+        alignOffset={alignOffset}
+        className="isolate z-50"
+      >
+        <TooltipPrimitive.Popup
+          data-slot="tooltip-content"
+          className={cn(
+            "z-50 overflow-hidden rounded-md bg-gray-800 px-2 py-1.5 text-gray-50 text-sm shadow-2xs",
+            className,
+          )}
+          {...props}
+        >
+          {children}
+        </TooltipPrimitive.Popup>
+      </TooltipPrimitive.Positioner>
+    </TooltipPrimitive.Portal>
+  );
+}
 
-const TooltipContent = React.forwardRef<
-  React.ElementRef<typeof TooltipPrimitive.Content>,
-  React.ComponentPropsWithoutRef<typeof TooltipPrimitive.Content>
->(({ className, sideOffset = 4, side = "bottom", ...props }, ref) => (
-  <TooltipPrimitive.Content
-    ref={ref}
-    sideOffset={sideOffset}
-    side={side}
-    className={cn(
-      "z-50 overflow-hidden rounded-md bg-gray-800 px-2 py-1.5 text-gray-50 text-sm shadow-2xs",
-      className,
-    )}
-    {...props}
-  >
-    {props.children}
-  </TooltipPrimitive.Content>
-));
-TooltipContent.displayName = TooltipPrimitive.Content.displayName;
-
-export {
-  Tooltip,
-  TooltipContent,
-  TooltipPortal,
-  TooltipProvider,
-  TooltipTrigger,
-};
+export { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -94,7 +94,7 @@ importers:
         version: 8.1.0(typescript@6.0.3)
       '@vercel/analytics':
         specifier: ^1.5.0
-        version: 1.6.1(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)
+        version: 1.6.1(next@16.2.6(@opentelemetry/api@1.9.0)(@playwright/test@1.58.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)
       dayjs:
         specifier: ^1.11.13
         version: 1.11.19
@@ -133,7 +133,7 @@ importers:
         version: 6.0.0(@types/react@19.2.13)(react@19.2.6)
       next-seo:
         specifier: ^6.1.0
-        version: 6.8.0(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        version: 6.8.0(next@16.2.6(@opentelemetry/api@1.9.0)(@playwright/test@1.58.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       pg:
         specifier: ^8.17.1
         version: 8.18.0
@@ -776,9 +776,6 @@ importers:
       '@radix-ui/react-slot':
         specifier: ^1.1.2
         version: 1.2.4(@types/react@19.2.13)(react@19.2.6)
-      '@radix-ui/react-tooltip':
-        specifier: ^1.1.8
-        version: 1.2.8(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@rallly/languages':
         specifier: workspace:*
         version: link:../languages
@@ -3791,19 +3788,6 @@ packages:
       '@types/react-dom':
         optional: true
 
-  '@radix-ui/react-tooltip@1.2.8':
-    resolution: {integrity: sha512-tY7sVt1yL9ozIxvmbtN5qtmH2krXcBCfjEiCgKGLqunJHvgvZG2Pcl2oQ3kbcZARb1BGEHdkLzcYGO8ynVlieg==}
-    peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-      '@types/react-dom':
-        optional: true
-
   '@radix-ui/react-use-callback-ref@1.1.1':
     resolution: {integrity: sha512-FkBMwD+qbGQeMu1cOHnuGB6x4yzPjho8ap5WtbEJ26umhgqVXbhekKUQO+hZEL1vU92a3wHwdp0HAcqAUF5iDg==}
     peerDependencies:
@@ -3883,19 +3867,6 @@ packages:
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
     peerDependenciesMeta:
       '@types/react':
-        optional: true
-
-  '@radix-ui/react-visually-hidden@1.2.3':
-    resolution: {integrity: sha512-pzJq12tEaaIhqjbzpCuv/OypJY/BPavOofm+dbab+MHLajy277+1lLm6JFcGgF5eskJ6mquGirhXY2GD/8u8Ug==}
-    peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-      '@types/react-dom':
         optional: true
 
   '@radix-ui/rect@1.1.1':
@@ -15081,26 +15052,6 @@ snapshots:
       '@types/react': 19.2.13
       '@types/react-dom': 19.2.3(@types/react@19.2.13)
 
-  '@radix-ui/react-tooltip@1.2.8(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
-    dependencies:
-      '@radix-ui/primitive': 1.1.3
-      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.13)(react@19.2.6)
-      '@radix-ui/react-context': 1.1.2(@types/react@19.2.13)(react@19.2.6)
-      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@radix-ui/react-id': 1.1.1(@types/react@19.2.13)(react@19.2.6)
-      '@radix-ui/react-popper': 1.2.8(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@radix-ui/react-portal': 1.1.9(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@radix-ui/react-slot': 1.2.3(@types/react@19.2.13)(react@19.2.6)
-      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.13)(react@19.2.6)
-      '@radix-ui/react-visually-hidden': 1.2.3(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      react: 19.2.6
-      react-dom: 19.2.6(react@19.2.6)
-    optionalDependencies:
-      '@types/react': 19.2.13
-      '@types/react-dom': 19.2.3(@types/react@19.2.13)
-
   '@radix-ui/react-use-callback-ref@1.1.1(@types/react@19.2.13)(react@19.2.6)':
     dependencies:
       react: 19.2.6
@@ -15161,15 +15112,6 @@ snapshots:
       react: 19.2.6
     optionalDependencies:
       '@types/react': 19.2.13
-
-  '@radix-ui/react-visually-hidden@1.2.3(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
-    dependencies:
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      react: 19.2.6
-      react-dom: 19.2.6(react@19.2.6)
-    optionalDependencies:
-      '@types/react': 19.2.13
-      '@types/react-dom': 19.2.3(@types/react@19.2.13)
 
   '@radix-ui/rect@1.1.1': {}
 
@@ -17892,7 +17834,7 @@ snapshots:
     dependencies:
       uncrypto: 0.1.3
 
-  '@vercel/analytics@1.6.1(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)':
+  '@vercel/analytics@1.6.1(next@16.2.6(@opentelemetry/api@1.9.0)(@playwright/test@1.58.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)':
     optionalDependencies:
       next: 16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react: 19.2.6
@@ -21652,7 +21594,7 @@ snapshots:
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
 
-  next-seo@6.8.0(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
+  next-seo@6.8.0(next@16.2.6(@opentelemetry/api@1.9.0)(@playwright/test@1.58.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
     dependencies:
       next: 16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react: 19.2.6


### PR DESCRIPTION
Closes RAL-1302. Redo of #2588 on top of the Dialog (#2612) and Select (#2610) migrations, following the same wrapper conventions.

## Changes

- `packages/ui/src/tooltip.tsx` rewritten on `@base-ui/react/tooltip`: `TooltipContent` renders `Portal > Positioner > Popup`, with `side` / `sideOffset` / `align` / `alignOffset` forwarded to the Positioner. Previous defaults preserved (`side="bottom"`, `sideOffset={4}`) along with the existing popup classes.
- `TooltipPortal` export removed — Content portals itself. The three consumers that wrapped Content in it are unwrapped.
- All `TooltipTrigger asChild` call sites move to `render` (14 files), including the nested `TooltipTrigger > DialogTrigger` composition in `remove-license-button.tsx`.
- `delayDuration` is gone in Base UI: sidebar's `TooltipProvider delayDuration={0}` becomes `delay={0}`; the two `<Tooltip delayDuration={0}>` roots (desktop-poll, poll-header) move the delay to the Trigger's `delay` prop.
- `@radix-ui/react-tooltip` removed from `@rallly/ui` dependencies.

## Behavior notes

- Default open delay changes from Radix's 700ms to Base UI's 600ms (the app-level provider sets no delay).
- The instant-open window after closing a tooltip (Radix `skipDelayDuration`, 300ms) becomes Base UI's `timeout` default of 400ms.

## Verification

- `tsc --noEmit` clean in `packages/ui` and `apps/web`; Biome clean.
- Logged-in Playwright smoke test against the dev server: polls-list participant tooltip, copy-link tooltip, invite-page duration tooltip (`delay={0}` path), and notification-toggle tooltip all render with correct content and bottom placement, no console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tooltip rendering and positioning across calendar, poll, licensing, scheduling, voting, and navigation interfaces.
  * Preserved existing actions and accessibility labels for copy, sync, notification, licensing, and poll controls.
  * Standardized tooltip behavior, including immediate display for select controls and clearer contextual guidance.
  * Maintained tooltip content for attendee counts, participant lists, links, statuses, and time ranges.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->