### PR TITLE
♻️ Move buy-license checkout logic behind features/licensing

### DIFF
--- a/apps/web/src/app/api/stripe/buy-license/route.ts
+++ b/apps/web/src/app/api/stripe/buy-license/route.ts
@@ -1,111 +1,18 @@
-import { stripe } from "@rallly/billing";
-import type { LicenseType } from "@rallly/database";
-import { createLogger } from "@rallly/logger";
 import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
-import * as z from "zod";
-import type { LicenseCheckoutMetadata } from "@/features/licensing/schema";
-
-const logger = createLogger("api/stripe/buy-license");
-
-const productSchema = z.enum(["plus", "organization"]);
-
-type Product = z.infer<typeof productSchema>;
-
-const mapProductToLicenseType: Record<
-  Product,
-  { lookupKey: string; type: LicenseType; seats: number }
-> = {
-  plus: { lookupKey: "plus", type: "PLUS", seats: 5 },
-  organization: {
-    lookupKey: "early-organization",
-    type: "ORGANIZATION",
-    seats: 50,
-  },
-};
+import { createLicenseCheckoutSession } from "@/features/licensing/mutations";
+import { licenseCheckoutProductSchema } from "@/features/licensing/schema";
 
 export async function GET(request: NextRequest) {
-  const product = productSchema.parse(
+  const product = licenseCheckoutProductSchema.parse(
     request.nextUrl.searchParams.get("product"),
   );
 
-  const { lookupKey } = mapProductToLicenseType[product];
+  const result = await createLicenseCheckoutSession({ product });
 
-  const prices = await stripe.prices.list({
-    lookup_keys: [lookupKey],
-  });
-
-  if (!prices.data || prices.data.length === 0) {
-    logger.error({ product }, "No price found for lookup_key");
-    return NextResponse.json(
-      { error: "Pricing information not found for this product." },
-      { status: 500 },
-    ); // Or 404 if you prefer
-  }
-  if (prices.data.length > 1) {
-    logger.warn(
-      { product },
-      "Multiple prices found for lookup_key, using the first one",
-    );
+  if ("url" in result) {
+    return NextResponse.redirect(result.url, 303);
   }
 
-  const price = prices.data[0];
-
-  if (!price.id) {
-    logger.error({ product }, "Price object is missing an ID");
-    return NextResponse.json(
-      { error: "Price configuration error." },
-      { status: 500 },
-    );
-  }
-
-  const { type, seats } = mapProductToLicenseType[product];
-
-  try {
-    const session = await stripe.checkout.sessions.create({
-      line_items: [
-        {
-          price: price.id,
-          quantity: 1,
-        },
-      ],
-      mode: "payment",
-      success_url: "https://rallly.co/licensing/thank-you",
-      allow_promotion_codes: true,
-      billing_address_collection: "required",
-      tax_id_collection: {
-        enabled: true,
-      },
-      automatic_tax: {
-        enabled: true,
-      },
-      invoice_creation: {
-        enabled: true,
-      },
-      metadata: {
-        licenseType: type,
-        version: 4,
-        seats,
-      } satisfies LicenseCheckoutMetadata,
-    });
-
-    if (session.url) {
-      return NextResponse.redirect(session.url, 303);
-    }
-
-    return NextResponse.json(
-      { error: "Something went wrong" },
-      { status: 500 },
-    );
-  } catch (error) {
-    logger.error({ error }, "Stripe API error");
-    let errorMessage =
-      "An unexpected error occurred with our payment processor.";
-
-    if (error instanceof stripe.errors.StripeError) {
-      errorMessage = error.message;
-    }
-
-    return NextResponse.json({ error: errorMessage }, { status: 500 });
-  }
+  return NextResponse.json({ error: result.error }, { status: 500 });
 }

--- a/apps/web/src/features/licensing/mutations.ts
+++ b/apps/web/src/features/licensing/mutations.ts
@@ -1,10 +1,14 @@
 import "server-only";
 
+import { stripe } from "@rallly/billing";
 import { prisma } from "@rallly/database";
 import { createLogger } from "@rallly/logger";
 import { env } from "@/env";
 import type {
   CreateLicenseInput,
+  LicenseCheckoutMetadata,
+  LicenseCheckoutProduct,
+  LicenseType,
   ValidateLicenseInputKeySchema,
 } from "@/features/licensing/schema";
 import {
@@ -118,6 +122,94 @@ export async function createLicense({
     : await prisma.license.create({ data });
 
   return { key: license.licenseKey };
+}
+
+const licenseCheckoutProducts: Record<
+  LicenseCheckoutProduct,
+  { lookupKey: string; type: LicenseType; seats: number }
+> = {
+  plus: { lookupKey: "plus", type: "PLUS", seats: 5 },
+  organization: {
+    lookupKey: "early-organization",
+    type: "ORGANIZATION",
+    seats: 50,
+  },
+};
+
+export async function createLicenseCheckoutSession({
+  product,
+}: {
+  product: LicenseCheckoutProduct;
+}): Promise<{ url: string } | { error: string }> {
+  const { lookupKey, type, seats } = licenseCheckoutProducts[product];
+
+  const prices = await stripe.prices.list({
+    lookup_keys: [lookupKey],
+  });
+
+  if (!prices.data || prices.data.length === 0) {
+    logger.error({ product }, "No price found for lookup_key");
+    return { error: "Pricing information not found for this product." };
+  }
+
+  if (prices.data.length > 1) {
+    logger.warn(
+      { product },
+      "Multiple prices found for lookup_key, using the first one",
+    );
+  }
+
+  const price = prices.data[0];
+
+  if (!price.id) {
+    logger.error({ product }, "Price object is missing an ID");
+    return { error: "Price configuration error." };
+  }
+
+  try {
+    const session = await stripe.checkout.sessions.create({
+      line_items: [
+        {
+          price: price.id,
+          quantity: 1,
+        },
+      ],
+      mode: "payment",
+      success_url: "https://rallly.co/licensing/thank-you",
+      allow_promotion_codes: true,
+      billing_address_collection: "required",
+      tax_id_collection: {
+        enabled: true,
+      },
+      automatic_tax: {
+        enabled: true,
+      },
+      invoice_creation: {
+        enabled: true,
+      },
+      metadata: {
+        licenseType: type,
+        version: 4,
+        seats,
+      } satisfies LicenseCheckoutMetadata,
+    });
+
+    if (!session.url) {
+      return { error: "Something went wrong" };
+    }
+
+    return { url: session.url };
+  } catch (error) {
+    logger.error({ error }, "Stripe API error");
+
+    if (error instanceof stripe.errors.StripeError) {
+      return { error: error.message };
+    }
+
+    return {
+      error: "An unexpected error occurred with our payment processor.",
+    };
+  }
 }
 
 export async function validateLicenseKey({

--- a/apps/web/src/features/licensing/schema.ts
+++ b/apps/web/src/features/licensing/schema.ts
@@ -79,6 +79,12 @@ export type ValidateLicenseKeyResponse = z.infer<
   typeof validateLicenseKeyResponseSchema
 >;
 
+export const licenseCheckoutProductSchema = z.enum(["plus", "organization"]);
+
+export type LicenseCheckoutProduct = z.infer<
+  typeof licenseCheckoutProductSchema
+>;
+
 export const licenseCheckoutMetadataSchema = z.object({
   licenseType: licenseTypeSchema,
   version: z.coerce.number(),


### PR DESCRIPTION
Resolves RAL-1312 (flagged during RAL-1290).

`app/api/stripe/buy-license/route.ts` contained the license checkout business logic (product → license type/seats mapping, price lookup, Stripe checkout session creation). Same treatment as the webhook in RAL-1290:

- `createLicenseCheckoutSession` now lives in `features/licensing/mutations.ts`, returning a `{ url } | { error }` result (matching the discriminated-return style of `validateLicenseKey` in the same file, and keeping the route's error response bodies byte-identical — `AppError` would have prefixed the messages with the error code)
- `licenseCheckoutProductSchema` (`plus` / `organization`) added to `features/licensing/schema.ts`
- The route is now a thin adapter: parse query param, call the mutation, redirect or return the error JSON

Behavior-preserving; no live Stripe verification (dev test key is expired).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for purchasing Plus and Organization licenses through Stripe Checkout.
  * Added validation for supported license products before checkout begins.

* **Bug Fixes**
  * Improved checkout error handling for missing, invalid, or ambiguous pricing configurations.
  * Enhanced handling of Stripe and unexpected checkout failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->