### PR TITLE
🚚 Move discussion into features/poll

### DIFF
--- a/apps/web/biome.json
+++ b/apps/web/biome.json
@@ -121,7 +121,6 @@
     {
       "includes": [
         "src/components/add-to-calendar-button.tsx",
-        "src/components/discussion/discussion.tsx",
         "src/components/event-card.tsx",
         "src/components/forms/poll-settings.tsx",
         "src/components/layouts/poll-layout.tsx",

--- a/apps/web/src/app/[locale]/(optional-space)/poll/[urlId]/admin-page.tsx
+++ b/apps/web/src/app/[locale]/(optional-space)/poll/[urlId]/admin-page.tsx
@@ -1,9 +1,9 @@
 "use client";
-import Discussion from "@/components/discussion";
 import { EventCard } from "@/components/event-card";
 import { PollFooter } from "@/components/poll/poll-footer";
 import { ResponsiveResults } from "@/components/poll/responsive-results";
 import { VotingForm } from "@/components/poll/voting-form";
+import Discussion from "@/features/poll/components/discussion";
 import { GuestPollAlert } from "./guest-poll-alert";
 
 export function AdminPage() {

--- a/apps/web/src/app/[locale]/invite/[urlId]/invite-page.tsx
+++ b/apps/web/src/app/[locale]/invite/[urlId]/invite-page.tsx
@@ -2,12 +2,12 @@
 import { Alert, AlertDescription } from "@rallly/ui/alert";
 import { ArrowUpRightIcon, CrownIcon } from "lucide-react";
 import Link from "next/link";
-import Discussion from "@/components/discussion";
 import { EventCard } from "@/components/event-card";
 import { PollFooter } from "@/components/poll/poll-footer";
 import { ResponsiveResults } from "@/components/poll/responsive-results";
 import { VotingForm } from "@/components/poll/voting-form";
 import { usePoll } from "@/features/poll/client";
+import Discussion from "@/features/poll/components/discussion";
 import { Trans } from "@/i18n/client";
 import { trpc } from "@/trpc/client";
 

--- a/apps/web/src/components/discussion/index.ts
+++ b/apps/web/src/components/discussion/index.ts
@@ -1,1 +1,0 @@
-export { default } from "./discussion";

--- a/apps/web/src/features/poll/components/discussion.tsx
+++ b/apps/web/src/features/poll/components/discussion.tsx
@@ -25,13 +25,13 @@ import { OptimizedAvatarImage } from "@/components/optimized-avatar-image";
 import { Participant, ParticipantName } from "@/components/participant";
 import { useParticipants } from "@/components/participants-provider";
 import { useEditToken } from "@/components/poll/mutations";
+import TruncatedLinkify from "@/components/poll/truncated-linkify";
+import { useUser } from "@/components/user-provider";
 import { usePoll, useRole } from "@/features/poll/client";
 import { Trans, useTranslation } from "@/i18n/client";
 import { RelativeTime } from "@/lib/datetime/relative-time";
 import { requiredString } from "@/lib/utils/form-validation";
 import { trpc } from "@/trpc/client";
-import TruncatedLinkify from "../poll/truncated-linkify";
-import { useUser } from "../user-provider";
 
 interface CommentForm {
   authorName: string;


### PR DESCRIPTION
Part of RAL-1291 (migrate legacy poll domain UI from components/ into features/poll). Stacked on #2616 (shared biome.json allowlist edits); merge that first — GitHub will retarget this to main.

- Move `components/discussion/discussion.tsx` → `features/poll/components/discussion.tsx` (move only; two relative imports rewritten to `@/components/*` aliases)
- Drop the `index.ts` barrel (barrels are banned in features/); the two app-page importers now import the file directly
- Remove the freed entry from the `src/components/**` migration allowlist in `apps/web/biome.json`

Verified: `pnpm type-check`, `pnpm check`, `pnpm test:unit` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)