### PR TITLE
🐛 Fix pre-existing issues in invite-dialog and vote-summary-progress-bar

### DIFF
--- a/apps/web/src/features/poll/components/invite-dialog.tsx
+++ b/apps/web/src/features/poll/components/invite-dialog.tsx
@@ -7,6 +7,7 @@ import {
   DialogHeader,
   DialogTitle,
   DialogTrigger,
+  useDialog,
 } from "@rallly/ui/dialog";
 
 import { ArrowUpRightIcon, Share2Icon } from "lucide-react";
@@ -41,7 +42,7 @@ export function CopyInviteLinkButton() {
       }}
     >
       {didCopy ? (
-        <Trans i18nKey="copied" />
+        <Trans i18nKey="copied" defaults="Copied" />
       ) : (
         <span className="min-w-0 truncate">{inviteLinkWithoutProtocol}</span>
       )}
@@ -50,11 +51,11 @@ export function CopyInviteLinkButton() {
 }
 
 export const InviteDialog = () => {
-  const [isOpen, setIsOpen] = React.useState(false);
+  const dialog = useDialog();
   const poll = usePoll();
 
   return (
-    <Dialog open={isOpen} onOpenChange={setIsOpen}>
+    <Dialog {...dialog.dialogProps}>
       <DialogTrigger render={<Button variant="primary" />}>
         <Share2Icon data-icon="inline-start" />
         <span className="sr-only sm:not-sr-only">

--- a/apps/web/src/features/poll/components/vote-summary-progress-bar.tsx
+++ b/apps/web/src/features/poll/components/vote-summary-progress-bar.tsx
@@ -26,6 +26,9 @@ export const VoteSummaryProgressBar = (props: {
   ifNeedBe: string[];
   no: string[];
 }) => {
+  const toWidth = (count: number) =>
+    props.total > 0 ? `${(count / props.total) * 100}%` : "0%";
+
   return (
     <div className="flex h-1.5 grow overflow-hidden rounded-sm bg-muted">
       <Tooltip>
@@ -34,7 +37,7 @@ export const VoteSummaryProgressBar = (props: {
             <div
               className="h-full bg-green-500 opacity-75 hover:opacity-100"
               style={{
-                width: `${(props.yes.length / props.total) * 100}%`,
+                width: toWidth(props.yes.length),
               }}
             />
           }
@@ -49,7 +52,7 @@ export const VoteSummaryProgressBar = (props: {
             <div
               className="h-full bg-amber-400 opacity-75 hover:opacity-100"
               style={{
-                width: `${(props.ifNeedBe.length / props.total) * 100}%`,
+                width: toWidth(props.ifNeedBe.length),
               }}
             />
           }
@@ -64,7 +67,7 @@ export const VoteSummaryProgressBar = (props: {
             <div
               className="h-full bg-transparent opacity-75 hover:opacity-100"
               style={{
-                width: `${(props.no.length / props.total) * 100}%`,
+                width: toWidth(props.no.length),
               }}
             />
           }


### PR DESCRIPTION
Fixes three pre-existing issues flagged by CodeRabbit during the RAL-1291 migration review (deferred from that move-only PR):

1. **vote-summary-progress-bar.tsx** — segment widths were computed as `(count / total) * 100`%, rendering `NaN%` when a poll has no participants. Widths now resolve to `0%` when total is 0.
2. **invite-dialog.tsx** — `<Trans i18nKey="copied" />` was missing the `defaults` prop required by our i18n convention.
3. **invite-dialog.tsx** — dialog open state now uses the `useDialog` hook from `@rallly/ui/dialog` instead of local `React.useState`, which also restores focus to the trigger on dismiss.

Fixes RAL-1322

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved invite dialog behavior when opening and closing.
  * Added a fallback “Copied” message for improved translation support.
  * Prevented vote summary progress bars from displaying invalid widths when there are no votes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->