### PR TITLE
🔧 Fix invalid shadcn components.json in packages/ui

### DIFF
--- a/packages/ui/components.json
+++ b/packages/ui/components.json
@@ -1,11 +1,19 @@
 {
   "$schema": "https://ui.shadcn.com/schema.json",
-  "style": "default",
+  "style": "base-vega",
   "rsc": true,
   "tsx": true,
+  "tailwind": {
+    "config": "",
+    "css": "../tailwind-config/shared-styles.css",
+    "baseColor": "gray",
+    "cssVariables": true
+  },
   "aliases": {
     "components": "@rallly/ui",
-    "ui": "src",
-    "utils": "@rallly/ui"
-  }
+    "ui": "@rallly/ui",
+    "utils": "@rallly/ui",
+    "hooks": "@rallly/ui/hooks"
+  },
+  "iconLibrary": "lucide"
 }


### PR DESCRIPTION
## Problem

`npx shadcn@latest info -c packages/ui` failed with **"Invalid configuration found in packages/ui/components.json"**, breaking the shadcn CLI for the ui workspace.

## Cause

The config predated the current schema (https://ui.shadcn.com/schema.json):

- The required `tailwind` object (`css`, `baseColor`, `cssVariables`) was missing entirely
- `"style": "default"` is the legacy Radix-era style
- `"ui": "src"` was not a resolvable import alias

## Fix

- Add the `tailwind` block: empty `config` (Tailwind v4, no config file), `css` pointing at `packages/tailwind-config/shared-styles.css` where the design tokens live, `baseColor: gray`
- Switch style to `base-vega` so `shadcn add` pulls Base UI component variants, matching the ongoing Radix → Base UI migration
- Fix aliases to resolve through the package's `exports` map (`components`/`ui`/`utils` → `@rallly/ui`, `hooks` → `@rallly/ui/hooks`); dropped `lib` since `@rallly/ui/lib` can't resolve through `"./*": "./src/*.tsx"`
- Declare `iconLibrary: lucide`

## Verification

`npx shadcn@latest info -c packages/ui` now succeeds: Tailwind v4 detected, all aliases resolve to real paths, base registry is `base` (Base UI), and it correctly detects the 30 installed components.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the UI styling preset to Base Vega.
  * Added Tailwind CSS configuration with CSS variable support.
  * Added Lucide as the icon library.
  * Updated UI and hooks import aliases for improved configuration consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->