### PR TITLE
🏷️ Declare @types/react in @rallly/emails

### DIFF
--- a/packages/emails/package.json
+++ b/packages/emails/package.json
@@ -32,6 +32,8 @@
     "@rallly/tsconfig": "workspace:*",
     "@react-email/ui": "^6.6.3",
     "@types/nodemailer": "^6.4.14",
+    "@types/react": "19.2.13",
+    "@types/react-dom": "19.2.3",
     "i18next-cli": "^1.58.1",
     "react-email": "^6.6.3"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -94,7 +94,7 @@ importers:
         version: 8.1.0(typescript@6.0.3)
       '@vercel/analytics':
         specifier: ^1.5.0
-        version: 1.6.1(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)
+        version: 1.6.1(next@16.2.6(@opentelemetry/api@1.9.0)(@playwright/test@1.58.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)
       dayjs:
         specifier: ^1.11.13
         version: 1.11.19
@@ -133,7 +133,7 @@ importers:
         version: 6.0.0(@types/react@19.2.13)(react@19.2.6)
       next-seo:
         specifier: ^6.1.0
-        version: 6.8.0(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        version: 6.8.0(next@16.2.6(@opentelemetry/api@1.9.0)(@playwright/test@1.58.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       pg:
         specifier: ^8.17.1
         version: 8.18.0
@@ -624,6 +624,12 @@ importers:
       '@types/nodemailer':
         specifier: ^6.4.14
         version: 6.4.22
+      '@types/react':
+        specifier: 19.2.13
+        version: 19.2.13
+      '@types/react-dom':
+        specifier: 19.2.3
+        version: 19.2.3(@types/react@19.2.13)
       i18next-cli:
         specifier: ^1.58.1
         version: 1.58.1(@types/node@24.10.11)(i18next@26.3.0(typescript@6.0.3))(react-dom@19.2.6(react@19.2.6))(typescript@6.0.3)
@@ -17755,7 +17761,7 @@ snapshots:
     dependencies:
       uncrypto: 0.1.3
 
-  '@vercel/analytics@1.6.1(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)':
+  '@vercel/analytics@1.6.1(next@16.2.6(@opentelemetry/api@1.9.0)(@playwright/test@1.58.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)':
     optionalDependencies:
       next: 16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react: 19.2.6
@@ -21515,7 +21521,7 @@ snapshots:
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
 
-  next-seo@6.8.0(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
+  next-seo@6.8.0(next@16.2.6(@opentelemetry/api@1.9.0)(@playwright/test@1.58.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
     dependencies:
       next: 16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react: 19.2.6


### PR DESCRIPTION
## Summary
`packages/emails` uses JSX in every template but never declared `@types/react` or `@types/react-dom`. Type-checking only worked because tsc found the React typings through pnpm's hidden hoisted fallback (`node_modules/.pnpm/node_modules`) — the same fragile mechanism the `@hookform/resolvers` packageExtension comment in `pnpm-workspace.yaml` warns about.

Found while evaluating pnpm's `enableGlobalVirtualStore` (which removes that fallback and surfaced 34 `JSX.IntrinsicElements` errors in this package). The global virtual store itself is not being adopted — ~75 dependencies in `apps/web` alone (react-aria, react-hook-form, @tanstack/react-query, @sentry/react, next) have `.d.ts` files that import React types without declaring `@types/react`, which breaks or silently degrades type-checking under that layout. This PR keeps only the fix that is correct regardless of layout.

## Changes
- Add `@types/react` and `@types/react-dom` as devDependencies of `@rallly/emails`, pinned to the same versions used by `apps/web` and `packages/ui`.

## Test plan
- `pnpm type-check` passes across the workspace (fresh, no incremental cache)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved development support for React and ReactDOM TypeScript projects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->