### PR TITLE
🔧 Disable Vercel deployments for Crowdin l10n branches

### DIFF
--- a/apps/landing/vercel.json
+++ b/apps/landing/vercel.json
@@ -1,6 +1,11 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "buildCommand": "cd ../.. && pnpm build:landing",
+  "git": {
+    "deploymentEnabled": {
+      "l10n_*": false
+    }
+  },
   "rewrites": [
     {
       "source": "/poll/:path*",

--- a/apps/web/vercel.json
+++ b/apps/web/vercel.json
@@ -1,6 +1,11 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "buildCommand": "cd ../.. && pnpm build:web && pnpm db:deploy",
+  "git": {
+    "deploymentEnabled": {
+      "l10n_*": false
+    }
+  },
   "crons": [
     {
       "path": "/api/house-keeping/auto-close-polls",


### PR DESCRIPTION
## Problem

Every Crowdin sync floods the Vercel account with deployments (see #2630). Crowdin's GitHub integration pushes one commit per language file to `l10n_main` (~15 per sync), and Vercel builds every push — for both the web and landing projects.

The `[ci skip]` flag Crowdin appends to its commit messages only skips GitHub Actions; Vercel does not honor it, and Crowdin has no option to squash its commits.

## Fix

Add `git.deploymentEnabled: { "l10n_*": false }` to both `vercel.json` files. Vercel creates no deployments at all for pushes to `l10n_*` branches — no builds and no dashboard entries (unlike the Ignored Build Step, which still creates skipped deployment records).

## Notes

- Crowdin PRs will no longer get preview deployments or Vercel status checks. Vercel checks are not required on branch protection, so merging is unaffected.
- Takes effect once merged to `main` — Vercel reads `vercel.json` from the commit being deployed, so the currently open Crowdin PR keeps deploying until then.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment settings to prevent automatic deployments from locale-related branches.
  * Applied the deployment control consistently across the landing page and web applications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->