### PR TITLE
🐛 Fix admin-setup redirect loop and authorize admin access against the database

### DIFF
--- a/apps/web/src/app/[locale]/admin-setup/actions.ts
+++ b/apps/web/src/app/[locale]/admin-setup/actions.ts
@@ -1,8 +1,10 @@
 "use server";
 
 import { prisma } from "@rallly/database";
+import { headers } from "next/headers";
 import { redirect } from "next/navigation";
 import { isInitialAdmin } from "@/features/setup/utils";
+import { authLib } from "@/lib/auth";
 import { AppError } from "@/lib/errors/app-error";
 import { authActionClient } from "@/lib/safe-action/server";
 
@@ -22,6 +24,16 @@ export const makeMeAdminAction = authActionClient
       },
       data: {
         role: "admin",
+      },
+    });
+
+    // The session cookie cache still holds the old role, which would send
+    // /control-panel straight back here. Re-issue it from the database
+    // before redirecting.
+    await authLib.api.getSession({
+      headers: await headers(),
+      query: {
+        disableCookieCache: true,
       },
     });
 

--- a/apps/web/src/app/[locale]/admin-setup/page.tsx
+++ b/apps/web/src/app/[locale]/admin-setup/page.tsx
@@ -11,14 +11,25 @@ import {
   EmptyStateTitle,
 } from "@/components/empty-state";
 import { isInitialAdmin } from "@/features/setup/utils";
+import { getCurrentUser } from "@/features/user/data";
 import { Trans } from "@/i18n/client";
 import { getTranslation } from "@/i18n/server";
-import { createPrivateSSRHelper } from "@/trpc/server/create-ssr-helper";
+import { buildSafeRedirectUrl } from "@/lib/utils/redirect";
 import { MakeMeAdminButton } from "./make-me-admin-button";
 
 export default async function AdminSetupPage() {
-  const helpers = await createPrivateSSRHelper();
-  const user = await helpers.user.getAuthed.fetch();
+  // Read the role from the database — the session cookie cache can hold
+  // a stale role.
+  const user = await getCurrentUser();
+
+  if (!user) {
+    redirect(
+      buildSafeRedirectUrl({
+        destination: "/login",
+        returnUrl: "/admin-setup",
+      }),
+    );
+  }
 
   if (user.role === "admin") {
     redirect("/control-panel");

--- a/apps/web/src/trpc/server/create-ssr-helper.ts
+++ b/apps/web/src/trpc/server/create-ssr-helper.ts
@@ -3,6 +3,7 @@ import { notFound, redirect } from "next/navigation";
 import { cache } from "react";
 import superjson from "superjson";
 import { isInitialAdmin } from "@/features/setup/utils";
+import { getCurrentUser } from "@/features/user/data";
 import { getSession } from "@/lib/auth";
 import { InvalidSessionError } from "@/lib/errors/invalid-session-error";
 import { getPathname } from "@/lib/pathname";
@@ -65,19 +66,18 @@ export const createPrivateSSRHelper = cache(async () => {
  * is not an admin.
  */
 export const createAdminSSRHelper = cache(async () => {
-  const user = (await getSession())?.user;
+  // Admin access must be authorized against the database — the session
+  // cookie cache can hold a stale role. getCurrentUser also rejects
+  // banned users and returns null for guests.
+  const user = await getCurrentUser();
 
-  if (!user || user.isGuest) {
+  if (!user) {
     redirect(
       buildSafeRedirectUrl({
         destination: "/login",
         returnUrl: await getPathname(),
       }),
     );
-  }
-
-  if (user.banned) {
-    throw new InvalidSessionError();
   }
 
   if (user.role !== "admin") {

--- a/apps/web/src/trpc/trpc.ts
+++ b/apps/web/src/trpc/trpc.ts
@@ -134,7 +134,14 @@ export const privateProcedure = publicProcedure.use(async ({ ctx, next }) => {
 });
 
 export const adminProcedure = privateProcedure.use(async ({ ctx, next }) => {
-  if (ctx.user.role !== "admin") {
+  // ctx.user comes from the session cookie cache, which can hold a stale
+  // role — admin access must be authorized against the database.
+  const user = await prisma.user.findUnique({
+    where: { id: ctx.user.id },
+    select: { role: true },
+  });
+
+  if (user?.role !== "admin") {
     throw new TRPCError({
       code: "FORBIDDEN",
       message: "Admin access required",

--- a/apps/web/tests/admin-setup.spec.ts
+++ b/apps/web/tests/admin-setup.spec.ts
@@ -114,6 +114,14 @@ test.describe("Admin Setup Page Access", () => {
       await page.waitForURL("/control-panel", { timeout: 5000 });
     }).toPass();
 
+    // The URL check above can pass on the transient redirect even when a
+    // stale session cookie bounces us back to /admin-setup, so assert the
+    // control panel actually rendered.
+    await expect(
+      page.getByRole("heading", { name: "Home", level: 1 }),
+    ).toBeVisible();
+    await expect(page).toHaveURL("/control-panel");
+
     const user = await prisma.user.findUnique({
       where: { email: INITIAL_ADMIN_TEST_EMAIL },
     });


### PR DESCRIPTION
## Description

Fixes the redirect loop on `/admin-setup` in production: clicking "Make me an admin" updated the role directly in the database, but Better-Auth's session cookie cache (5-minute `maxAge`) still held `role: "user"`, so `/control-panel` bounced the user straight back to `/admin-setup` until the cookie expired.

Two changes:

1. **Refresh the session cookie after promotion** — `makeMeAdminAction` now calls `auth.api.getSession({ query: { disableCookieCache: true } })` after updating the role, re-issuing the cookie from the database before redirecting. This keeps the client-side session (e.g. the control panel menu item) consistent immediately.

2. **Authorize admin access against the database, never the cookie** — the session's role claim can be stale for up to the cookie cache's `maxAge`, so the admin gates no longer trust it:
   - `adminProcedure` (tRPC) now fetches the role from the database
   - `createAdminSSRHelper` now uses `getCurrentUser()` (DB-backed, also handles banned/guest users)
   - the `/admin-setup` page reads the role via `getCurrentUser()`
   - `adminActionClient` already checked the database via `getCurrentUser()` — unchanged

The integration test is also hardened: it previously only waited for the `/control-panel` URL — which the transient redirect satisfies even when the loop occurs — and asserted the role in the database, which was always correct. It now asserts the control panel actually renders and the URL stays on `/control-panel`. Verified locally that the hardened test fails on the old action code (reproducing the loop) and that the admin-setup and control-panel suites pass with these changes.

## Checklist

Please check off all the following items with an "x" in the boxes before requesting a review.

- [x] I have performed a self-review of my code
- [x] My code follows the code style of this project
- [x] I have commented my code, particularly in hard-to-understand areas

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0172b7m13iWBM98N2o3My8RS

---
_Generated by [Claude Code](https://claude.ai/code/session_0172b7m13iWBM98N2o3My8RS)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved the initial admin setup flow to reliably recognize newly granted administrator access.
  - Ensured users are redirected to the control panel with an up-to-date session after becoming an administrator.
  - Strengthened administrator access checks by verifying the current role before allowing access.
  - Improved handling of unauthenticated or restricted users, including safe redirection to login or appropriate access pages.
- **Tests**
  - Added verification that the control panel fully loads after completing admin setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->