### PR TITLE
✨ Add SMTP_DEBUG option for verbose SMTP logging

### DIFF
--- a/apps/docs/self-hosting/configuration.mdx
+++ b/apps/docs/self-hosting/configuration.mdx
@@ -74,6 +74,14 @@ An SMTP server is required to send magic-link sign-in emails and notifications.
   <Note>Available from v4.8.0 and later.</Note>
 </ParamField>
 
+<ParamField path="SMTP_DEBUG" default="false">
+  Set to `true` to log the full SMTP conversation. Useful for troubleshooting email delivery issues.
+
+  <Warning>Debug output includes the authentication exchange, where credentials are only base64 encoded. Enable this only while troubleshooting and redact your logs before sharing them.</Warning>
+
+  <Note>Available from v4.12.0 and later.</Note>
+</ParamField>
+
 ## Auth
 
 <ParamField path="EMAIL_LOGIN_ENABLED" default="true">

--- a/apps/web/src/env.ts
+++ b/apps/web/src/env.ts
@@ -45,6 +45,7 @@ export const env = createEnv({
     SMTP_SECURE: z.enum(["true", "false"]).optional(),
     SMTP_PORT: z.string().optional(),
     SMTP_REJECT_UNAUTHORIZED: z.enum(["true", "false"]).optional(),
+    SMTP_DEBUG: z.enum(["true", "false"]).optional(),
     /** @deprecated Use SMTP_REJECT_UNAUTHORIZED instead */
     SMTP_TLS_ENABLED: z.enum(["true", "false"]).optional(),
     /**
@@ -237,6 +238,7 @@ export const env = createEnv({
     SMTP_SECURE: process.env.SMTP_SECURE,
     SMTP_PORT: process.env.SMTP_PORT,
     SMTP_REJECT_UNAUTHORIZED: process.env.SMTP_REJECT_UNAUTHORIZED,
+    SMTP_DEBUG: process.env.SMTP_DEBUG,
     SMTP_TLS_ENABLED: process.env.SMTP_TLS_ENABLED,
     ALLOWED_EMAILS: process.env.ALLOWED_EMAILS,
     EMAIL_LOGIN_ENABLED: process.env.EMAIL_LOGIN_ENABLED,

--- a/packages/emails/src/transport.ts
+++ b/packages/emails/src/transport.ts
@@ -1,9 +1,27 @@
 import * as aws from "@aws-sdk/client-ses";
 import { defaultProvider } from "@aws-sdk/credential-provider-node";
+import { logger } from "@rallly/logger";
 import type { Transporter } from "nodemailer";
 import { createTransport } from "nodemailer";
+import type { Logger as NodemailerLogger } from "nodemailer/lib/shared";
 
 type EmailProvider = "ses" | "smtp";
+
+// Adapts pino to nodemailer's bunyan-style logger interface. Pino exposes
+// `level` as a property while nodemailer's type expects a method (it never
+// calls it).
+function createSmtpDebugLogger(): NodemailerLogger {
+  const smtpLogger = logger.child({ name: "smtp" }, { level: "trace" });
+  return {
+    level: () => {},
+    trace: smtpLogger.trace.bind(smtpLogger),
+    debug: smtpLogger.debug.bind(smtpLogger),
+    info: smtpLogger.info.bind(smtpLogger),
+    warn: smtpLogger.warn.bind(smtpLogger),
+    error: smtpLogger.error.bind(smtpLogger),
+    fatal: smtpLogger.fatal.bind(smtpLogger),
+  };
+}
 
 export type SupportedEmailProviders = EmailProvider;
 
@@ -40,6 +58,11 @@ function createTransportForProvider(provider: EmailProvider): Transporter {
       const rejectUnauthorized =
         process.env.SMTP_REJECT_UNAUTHORIZED !== "false";
 
+      // Logs the full SMTP conversation including the auth exchange, where
+      // credentials are only base64 encoded. Never enable outside of
+      // troubleshooting.
+      const debug = process.env.SMTP_DEBUG === "true";
+
       // Warn about security change if no explicit setting
       if (
         process.env.SMTP_REJECT_UNAUTHORIZED === undefined &&
@@ -64,6 +87,8 @@ function createTransportForProvider(provider: EmailProvider): Transporter {
           rejectUnauthorized,
           servername: process.env.SMTP_TLS_SERVERNAME,
         },
+        debug,
+        logger: debug ? createSmtpDebugLogger() : undefined,
       });
     }
   }


### PR DESCRIPTION
Fixes #1952

## What

Adds an opt-in `SMTP_DEBUG` environment variable. When set to `true`, the full SMTP conversation (connection, handshake, protocol exchange) is logged through the shared pino logger, giving self-hosters actionable output when diagnosing email delivery issues.

## How

- `packages/emails/src/transport.ts`: passes nodemailer's `debug`/`logger` options when `SMTP_DEBUG=true`. A small adapter maps pino to nodemailer's bunyan style logger interface (pino exposes `level` as a property while nodemailer's type expects a method). The child logger runs at trace level so transcript lines are emitted regardless of the global `LOG_LEVEL`.
- `apps/web/src/env.ts`: declares the new variable alongside the other SMTP flags.
- `apps/docs/self-hosting/configuration.mdx`: documents the variable, marked as available from v4.12.0, with a warning that debug output includes the auth exchange (credentials are only base64 encoded), so it should only be enabled while troubleshooting.

Off by default. No behavior change unless the flag is set.

## Verification

Sent mail through the transport against local mailpit:
- `SMTP_DEBUG=true`: full SMTP transcript emitted as structured JSON under `name: "smtp"` (DNS resolution, EHLO exchange, handshake, message send)
- unset: no transcript output, mail sends as before

`pnpm --filter @rallly/emails type-check` and `pnpm --filter @rallly/web type-check` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional SMTP conversation debug logging to assist with diagnosing email delivery issues.
  * Enabled via the `SMTP_DEBUG` environment setting.
* **Bug Fixes**
  * Improved compatibility between application logging and email transport diagnostics.
* **Documentation**
  * Documented the new `SMTP_DEBUG` option (default: `false`) in the self-hosting email (SMTP) configuration guide.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->