### PR TITLE
🐛 Authorize admin mutations against the database, not the session snapshot

### DIFF
--- a/apps/web/src/app/[locale]/admin-setup/actions.ts
+++ b/apps/web/src/app/[locale]/admin-setup/actions.ts
@@ -1,9 +1,9 @@
 "use server";
 
-import { prisma } from "@rallly/database";
 import { headers } from "next/headers";
 import { redirect } from "next/navigation";
 import { isInitialAdmin } from "@/features/setup/utils";
+import { updateUserRole } from "@/features/user/mutations";
 import { authLib } from "@/lib/auth";
 import { AppError } from "@/lib/errors/app-error";
 import { authActionClient } from "@/lib/safe-action/server";
@@ -18,14 +18,7 @@ export const makeMeAdminAction = authActionClient
       });
     }
 
-    await prisma.user.update({
-      where: {
-        id: ctx.user.id,
-      },
-      data: {
-        role: "admin",
-      },
-    });
+    await updateUserRole({ userId: ctx.user.id, role: "admin" });
 
     // The session cookie cache still holds the old role, which would send
     // /control-panel straight back here. Re-issue it from the database

--- a/apps/web/src/features/moderation/mutations.ts
+++ b/apps/web/src/features/moderation/mutations.ts
@@ -6,7 +6,7 @@ import { createLogger } from "@rallly/logger";
 import { generateText } from "ai";
 import { after } from "next/server";
 import { env } from "@/env";
-import { banUserAsSystem } from "@/features/user/mutations";
+import { banUser } from "@/features/user/mutations";
 import type { ModerationResult, ModerationVerdict } from "./types";
 import { containsSuspiciousPatterns } from "./utils";
 
@@ -132,7 +132,7 @@ export async function moderateContent({
   if (containsBannedDomain(textToModerate)) {
     logger.warn({ userId }, "Banned domain detected, banning user");
     after(() =>
-      banUserAsSystem({
+      banUser({
         userId,
         reason: "Automatic ban: banned domain detected in content",
       }),

--- a/apps/web/src/features/user/actions.ts
+++ b/apps/web/src/features/user/actions.ts
@@ -8,6 +8,7 @@ import {
   unbanUser,
   updateUserImage,
   updateUserName,
+  updateUserRole,
 } from "@/features/user/mutations";
 import authLib from "@/lib/auth";
 import { timeFormatSchema, weekStartSchema } from "@/lib/datetime/schema";
@@ -152,14 +153,7 @@ export const changeRoleAction = adminActionClient
       });
     }
 
-    await prisma.user.update({
-      where: {
-        id: targetUser.id,
-      },
-      data: {
-        role,
-      },
-    });
+    await updateUserRole({ userId: targetUser.id, role });
   });
 
 export const banUserAction = adminActionClient

--- a/apps/web/src/features/user/mutations.ts
+++ b/apps/web/src/features/user/mutations.ts
@@ -79,11 +79,36 @@ export async function updateUserImage({
   revalidateTag(userProfileTag(userId), "max");
 }
 
+// Role changes must go through Better-Auth's internal adapter so the user
+// snapshot cached in each session (secondary storage) gets refreshed — a bare
+// Prisma write leaves every active session on the old role, and Better-Auth's
+// own permission checks (e.g. banUser) read the session, not the database.
+// The admin plugin's setRole endpoint is not used because it authorizes
+// against the caller's possibly stale session — authorization is the caller's
+// responsibility.
+export async function updateUserRole({
+  userId,
+  role,
+}: {
+  userId: string;
+  role: "user" | "admin";
+}) {
+  const { internalAdapter } = await authLib.$context;
+
+  await internalAdapter.updateUser(userId, {
+    role,
+    updatedAt: new Date(),
+  });
+}
+
 // Bans must go through Better-Auth rather than Prisma so the user's sessions
 // are actually revoked — with secondary storage enabled, sessions live in
 // Redis, not the Session table, and only Better-Auth's own APIs delete those
 // keys. A bare `banned: true` write leaves the user logged in until their
-// session expires.
+// session expires. The admin plugin's banUser endpoint is deliberately not
+// used: it authorizes against the caller's session snapshot rather than the
+// database, and the moderation auto-ban runs without an admin session at all.
+// Authorization is the caller's responsibility.
 
 export async function banUser({
   userId,
@@ -92,44 +117,11 @@ export async function banUser({
   userId: string;
   reason?: string;
 }) {
-  await authLib.api.banUser({
-    body: { userId, banReason: reason },
-    headers: await headers(),
-  });
-
-  await prisma.user.update({
-    where: { id: userId },
-    data: { bannedAt: new Date() },
-  });
-}
-
-export async function unbanUser({ userId }: { userId: string }) {
-  await authLib.api.unbanUser({
-    body: { userId },
-    headers: await headers(),
-  });
-
-  await prisma.user.update({
-    where: { id: userId },
-    data: { bannedAt: null },
-  });
-}
-
-// For bans issued without an admin session (e.g. the moderation auto-ban).
-// Mirrors what authLib.api.banUser does internally, minus the permission
-// checks — authorization is the caller's responsibility.
-export async function banUserAsSystem({
-  userId,
-  reason,
-}: {
-  userId: string;
-  reason: string;
-}) {
   const { internalAdapter } = await authLib.$context;
 
   await internalAdapter.updateUser(userId, {
     banned: true,
-    banReason: reason,
+    banReason: reason ?? null,
     updatedAt: new Date(),
   });
 
@@ -138,6 +130,22 @@ export async function banUserAsSystem({
   await prisma.user.update({
     where: { id: userId },
     data: { bannedAt: new Date() },
+  });
+}
+
+export async function unbanUser({ userId }: { userId: string }) {
+  const { internalAdapter } = await authLib.$context;
+
+  await internalAdapter.updateUser(userId, {
+    banned: false,
+    banReason: null,
+    banExpires: null,
+    updatedAt: new Date(),
+  });
+
+  await prisma.user.update({
+    where: { id: userId },
+    data: { bannedAt: null },
   });
 }
 

--- a/apps/web/src/lib/safe-action/server.ts
+++ b/apps/web/src/lib/safe-action/server.ts
@@ -1,6 +1,7 @@
 import "server-only";
 
 import * as Sentry from "@sentry/nextjs";
+import { APIError } from "better-auth/api";
 import { createMiddleware, createSafeActionClient } from "next-safe-action";
 import * as z from "zod";
 import { defineAbilityFor } from "@/features/user/ability";
@@ -77,6 +78,19 @@ export const actionClient = createSafeActionClient({
 
     if (error instanceof AppError) {
       return error.code;
+    }
+
+    if (error instanceof APIError) {
+      switch (error.status) {
+        case "UNAUTHORIZED":
+        case "FORBIDDEN":
+        case "NOT_FOUND":
+        case "PAYMENT_REQUIRED":
+        case "PAYLOAD_TOO_LARGE":
+        case "TOO_MANY_REQUESTS":
+        case "SERVICE_UNAVAILABLE":
+          return error.status;
+      }
     }
 
     return "INTERNAL_SERVER_ERROR" as const;


### PR DESCRIPTION
## Problem

Banning a user in prod failed with `APIError: You are not allowed to ban users` even though the caller is an admin.

With `secondaryStorage` enabled, better-auth serializes `{ session, user }` into Redis at session creation. `findSession` returns that snapshot without touching the database, and the daily session refresh carries the old user object forward. Since admin roles were granted with raw Prisma writes (`makeMeAdminAction`, `changeRoleAction`), better-auth never refreshed the snapshots — the database said `admin` while every active session still said `user`. Rallly's own checks pass (they authorize against the database since #2632), but `authLib.api.banUser` runs better-auth's internal check against the stale session role and throws.

The error was also invisible: `handleServerError` captured it in Sentry and collapsed it to a generic `INTERNAL_SERVER_ERROR` toast.

## Changes

- **Role changes go through `internalAdapter.updateUser`** (new `updateUserRole` mutation) so `refreshUserSessions` rewrites the Redis snapshots. This also makes the `disableCookieCache` re-issue in admin-setup actually effective with secondary storage.
- **Ban/unban go through `internalAdapter`** instead of the admin plugin endpoints, which authorize against the session snapshot. Authorization stays where it already is: CASL against the database (including the self-ban guard). `banUserAsSystem` is merged into `banUser` — one code path for admin bans and the moderation auto-ban.
- **Better-auth `APIError` codes surface through safe-action** so future failures toast the real error code instead of a generic internal server error. Sentry capture is kept.

## Verification

Drove the dev app end-to-end (Redis secondary storage active): logged in as the seeded control panel admin, banned `dev@rallly.co` via the UI (dialog closed, DB shows `banned=t`, reason, `bannedAt`), then unbanned (flags cleared). Type check and Biome pass.

## Note for prod

Existing stale sessions are not retroactively fixed — re-login once after deploy so your session snapshot picks up the admin role.

Supersedes #2637, which was accidentally branched off a WIP base.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Admin role changes now follow a consistent authorization flow and refresh access promptly.
  * Banned-domain moderation enforcement continues to flag content and restrict affected accounts.
  * Account bans now revoke active sessions, while unbanning properly restores account access.
* **Bug Fixes**
  * Improved handling of authentication and service errors so users receive more accurate status messages, including permission, rate-limit, and availability errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->