### PR TITLE
🚸 Reject banned users before sending a login verification code

### DIFF
--- a/apps/web/src/app/[locale]/(auth)/login/components/login-email-form.tsx
+++ b/apps/web/src/app/[locale]/(auth)/login/components/login-email-form.tsx
@@ -74,6 +74,14 @@ export function LoginWithEmailForm() {
                     }),
                   });
                   break;
+                case "BANNED_USER":
+                  form.setError("identifier", {
+                    message: t("authErrorsUserBanned", {
+                      defaultValue:
+                        "This account has been banned. Please contact support if you believe this is an error.",
+                    }),
+                  });
+                  break;
                 default:
                   form.setError("password", {
                     message: res.error.message,

--- a/apps/web/src/app/[locale]/(auth)/login/components/login-email-form.tsx
+++ b/apps/web/src/app/[locale]/(auth)/login/components/login-email-form.tsx
@@ -111,6 +111,14 @@ export function LoginWithEmailForm() {
                     message: t("authErrorsEmailBlocked"),
                   });
                   break;
+                case "BANNED_USER":
+                  form.setError("identifier", {
+                    message: t("authErrorsUserBanned", {
+                      defaultValue:
+                        "This account has been banned. Please contact support if you believe this is an error.",
+                    }),
+                  });
+                  break;
                 default:
                   form.setError("identifier", {
                     message: res.error.message,

--- a/apps/web/src/lib/auth.ts
+++ b/apps/web/src/lib/auth.ts
@@ -311,6 +311,25 @@ export const authLib = betterAuth({
             });
           }
         }
+
+        // Reject banned users before a verification code goes out — the
+        // admin plugin only enforces bans at session creation, which is
+        // after the OTP email has already been sent. Keyed off `email`
+        // only: the change-email endpoints submit `newEmail` and already
+        // require a session, which a banned user cannot hold.
+        const accountEmail = ctx.body?.email as string | undefined;
+        if (accountEmail) {
+          const user = await prisma.user.findUnique({
+            where: { email: accountEmail.toLowerCase() },
+            select: { banned: true },
+          });
+          if (user?.banned) {
+            throw new APIError("FORBIDDEN", {
+              code: "BANNED_USER",
+              message: "You have been banned from this application",
+            });
+          }
+        }
       }
     }),
     after: createAuthMiddleware(async (ctx) => {

--- a/apps/web/src/lib/auth.ts
+++ b/apps/web/src/lib/auth.ts
@@ -320,7 +320,7 @@ export const authLib = betterAuth({
         const accountEmail = ctx.body?.email as string | undefined;
         if (accountEmail) {
           const user = await prisma.user.findUnique({
-            where: { email: accountEmail.toLowerCase() },
+            where: { email: accountEmail },
             select: { banned: true },
           });
           if (user?.banned) {


### PR DESCRIPTION
## Problem

A banned user requesting a login code still received a real OTP email and only learned they were banned after fetching the code and entering it. Ban enforcement lives in better-auth's admin plugin, which only guards session creation — the OTP send endpoint has no ban check.

## Change

- Check `banned` in the existing `hooks.before` middleware in `auth.ts`, alongside the blocked-domain and temporary-email checks, and throw `FORBIDDEN` with better-auth's own `BANNED_USER` code so the send step and the verify step fail identically. Keyed off `ctx.body.email` only — the change-email endpoints submit `newEmail` and already require a session, which a banned user cannot hold.
- Handle `BANNED_USER` in the login form's error switch, reusing the existing `authErrorsUserBanned` translation (already used by the `?error=Banned` redirect path).

Trade-off, considered and accepted: this reveals ban status to anyone who knows the email address at the pre-auth step (previously you had to prove inbox access first). The same step already reveals blocked-domain status, and ban status for a scheduling app has no meaningful attacker value.

## Verification

Ran the app from this branch against the shared dev stack and drove the login form with Playwright:

- Banned user: inline "This account has been banned..." error on the email field, stays on /login, **0 emails** in mailpit
- Normal user: OTP email delivered as before

Type check, Biome, and `i18n:scan` (no new keys needed) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented banned accounts from receiving email verification or one-time passcode messages.
  * Added clearer form-level messaging when a banned account attempts password sign-in or email-OTP sign-in.
  * Improved banned-account error handling so users see the correct “banned” notification instead of a generic error.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->