### PR TITLE
⚡️ Run control panel user search queries in parallel

### DIFF
--- a/apps/web/src/app/[locale]/control-panel/users/page.tsx
+++ b/apps/web/src/app/[locale]/control-panel/users/page.tsx
@@ -65,26 +65,27 @@ async function loadData({
     where.role = role;
   }
 
-  const allUsers = await prisma.user.findMany({
-    select: {
-      id: true,
-      name: true,
-      email: true,
-      image: true,
-      role: true,
-      banned: true,
-    },
-    take: pageSize,
-    skip: (page - 1) * pageSize,
-    where,
-    orderBy: {
-      createdAt: "desc",
-    },
-  });
-
-  const totalUsers = await prisma.user.count({
-    where,
-  });
+  const [allUsers, totalUsers] = await Promise.all([
+    prisma.user.findMany({
+      select: {
+        id: true,
+        name: true,
+        email: true,
+        image: true,
+        role: true,
+        banned: true,
+      },
+      take: pageSize,
+      skip: (page - 1) * pageSize,
+      where,
+      orderBy: {
+        createdAt: "desc",
+      },
+    }),
+    prisma.user.count({
+      where,
+    }),
+  ]);
 
   const ability = defineAbilityFor({ role: user.role, id: user.id });
 


### PR DESCRIPTION
The users list query and the count query in the control panel share the same predicate but ran sequentially — two full round trips back to back on every load, search, and post-action refresh of the users page. Running them in parallel halves that latency for free.

This is step one of addressing the slow users page. Whether the `ILIKE '%q%'` search additionally needs pg_trgm indexes depends on prod timings — decision deferred until we have an `EXPLAIN ANALYZE` from prod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved user list loading speed by retrieving user records and total counts concurrently.
  * Preserved existing pagination, filtering, sorting, and displayed user information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->