### PR TITLE
✨ Render poll/event descriptions as sanitized Markdown

### DIFF
--- a/apps/web/src/app/[locale]/e/[id]/page.tsx
+++ b/apps/web/src/app/[locale]/e/[id]/page.tsx
@@ -1,5 +1,6 @@
 import { buttonVariants } from "@rallly/ui";
 import { AvatarGroup, AvatarGroupCount } from "@rallly/ui/avatar";
+import { MarkdownDescription } from "@rallly/ui/markdown-description";
 import { absoluteUrl } from "@rallly/utils/absolute-url";
 import { MapPinIcon } from "lucide-react";
 import type { Metadata } from "next";
@@ -13,7 +14,6 @@ import { OptimizedAvatarImage } from "@/components/optimized-avatar-image";
 import { SessionRefresher } from "@/components/session-refresher";
 import { BrandStyle } from "@/features/branding/components/brand-style";
 import { formatLocationText } from "@/features/location/utils";
-import TruncatedLinkify from "@/features/poll/components/truncated-linkify";
 import {
   EventCalendarCard,
   EventDate,
@@ -223,9 +223,7 @@ export default async function EventPage({
                 <EventSectionTitle>
                   {t("eventPageAbout", { defaultValue: "About" })}
                 </EventSectionTitle>
-                <p className="whitespace-pre-wrap text-pretty text-foreground text-sm leading-relaxed">
-                  <TruncatedLinkify>{event.description}</TruncatedLinkify>
-                </p>
+                <MarkdownDescription content={event.description} />
               </EventSection>
             ) : null}
             {visibleAttendees.length > 0 ? (

--- a/apps/web/src/features/poll/components/event-card.tsx
+++ b/apps/web/src/features/poll/components/event-card.tsx
@@ -63,9 +63,7 @@ export function EventCard() {
         ) : null}
         <div>
           <EventMetaTitle>{poll.title}</EventMetaTitle>
-          <EventMetaDescription className="mt-2">
-            {poll.description}
-          </EventMetaDescription>
+          <EventMetaDescription className="mt-2" content={poll.description} />
         </div>
         <EventMetaList className="mt-4">
           {poll.user ? (

--- a/apps/web/src/features/poll/components/event-meta.tsx
+++ b/apps/web/src/features/poll/components/event-meta.tsx
@@ -1,6 +1,6 @@
 import { cn } from "@rallly/ui";
+import { MarkdownDescription } from "@rallly/ui/markdown-description";
 import { OptimizedAvatarImage } from "@/components/optimized-avatar-image";
-import TruncatedLinkify from "@/features/poll/components/truncated-linkify";
 
 export function EventMetaTitle({
   className,
@@ -18,20 +18,19 @@ export function EventMetaTitle({
 
 export function EventMetaDescription({
   className,
-  children,
+  content,
 }: {
   className?: string;
-  children: React.ReactNode;
+  content?: string | null;
 }) {
+  if (!content) {
+    return null;
+  }
   return (
-    <p
-      className={cn(
-        className,
-        "min-w-0 whitespace-pre-wrap text-pretty text-foreground text-sm leading-relaxed opacity-90",
-      )}
-    >
-      <TruncatedLinkify>{children}</TruncatedLinkify>
-    </p>
+    <MarkdownDescription
+      content={content}
+      className={cn(className, "min-w-0 opacity-90")}
+    />
   );
 }
 

--- a/apps/web/src/features/poll/components/markdown-description.test.tsx
+++ b/apps/web/src/features/poll/components/markdown-description.test.tsx
@@ -1,0 +1,79 @@
+import { MarkdownDescription } from "@rallly/ui/markdown-description";
+import { render } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+function renderMarkdown(content: string) {
+  const { container } = render(<MarkdownDescription content={content} />);
+  return container;
+}
+
+describe("MarkdownDescription", () => {
+  describe("allowed formatting", () => {
+    it("renders bold, italic and lists", () => {
+      const html = renderMarkdown(
+        "**bold** and *italic*\n\n- one\n- two\n\n1. first\n2. second",
+      ).innerHTML;
+      expect(html).toContain("<strong>bold</strong>");
+      expect(html).toContain("<em>italic</em>");
+      expect(html).toContain("<ul>");
+      expect(html).toContain("<ol>");
+      expect(html.match(/<li>/g)).toHaveLength(4);
+    });
+
+    it("renders markdown links with safe rel/target", () => {
+      const container = renderMarkdown("[example](https://example.com)");
+      const anchor = container.querySelector("a");
+      expect(anchor).not.toBeNull();
+      expect(anchor?.getAttribute("href")).toBe("https://example.com");
+      expect(anchor?.getAttribute("target")).toBe("_blank");
+      expect(anchor?.getAttribute("rel")).toBe("noopener noreferrer");
+    });
+
+    it("autolinks bare URLs", () => {
+      const anchor = renderMarkdown(
+        "see https://example.com for more",
+      ).querySelector("a");
+      expect(anchor?.getAttribute("href")).toBe("https://example.com");
+    });
+
+    it("preserves single line breaks", () => {
+      expect(renderMarkdown("line one\nline two").innerHTML).toContain("<br>");
+    });
+  });
+
+  describe("XSS defense", () => {
+    it("never emits an executable script element", () => {
+      const container = renderMarkdown(
+        "hello <script>alert('xss')</script> world",
+      );
+      // The payload may survive as inert text, but must never become a real
+      // <script> node that the browser would execute.
+      expect(container.querySelector("script")).toBeNull();
+      expect(container.innerHTML).not.toContain("<script");
+    });
+
+    it("strips inline event handlers and raw html", () => {
+      const container = renderMarkdown('<img src=x onerror="alert(1)">');
+      expect(container.querySelector("img")).toBeNull();
+      expect(container.innerHTML).not.toContain("onerror");
+    });
+
+    it("strips javascript: protocol links", () => {
+      const anchor = renderMarkdown(
+        "[click](javascript:alert(1))",
+      ).querySelector("a");
+      // Either the anchor is dropped or its href is neutralised — never javascript:.
+      expect(anchor?.getAttribute("href") ?? "").not.toContain("javascript:");
+    });
+
+    it("strips disallowed tags but keeps their text", () => {
+      const container = renderMarkdown("# heading\n\n> quote\n\n`code`");
+      expect(container.querySelector("h1")).toBeNull();
+      expect(container.querySelector("blockquote")).toBeNull();
+      expect(container.querySelector("code")).toBeNull();
+      expect(container.textContent).toContain("heading");
+      expect(container.textContent).toContain("quote");
+      expect(container.textContent).toContain("code");
+    });
+  });
+});

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -32,6 +32,10 @@
     "react-aria-components": "^1.16.0",
     "react-dom": "19.2.6",
     "react-hook-form": "^7.68.0",
+    "react-markdown": "^10.1.0",
+    "rehype-sanitize": "^6.0.0",
+    "remark-breaks": "^4.0.0",
+    "remark-gfm": "^4.0.1",
     "sonner": "^2.0.6",
     "tailwind-merge": "^1.12.0"
   },

--- a/packages/ui/src/markdown-description.tsx
+++ b/packages/ui/src/markdown-description.tsx
@@ -1,0 +1,54 @@
+import Markdown from "react-markdown";
+import type { Options as SanitizeSchema } from "rehype-sanitize";
+import rehypeSanitize from "rehype-sanitize";
+import remarkBreaks from "remark-breaks";
+import remarkGfm from "remark-gfm";
+import { cn } from "./lib/utils";
+
+// Locked-down allowlist: only the formatting the editor can produce.
+// Deliberately built from scratch rather than extending rehype-sanitize's
+// defaultSchema so nothing (task lists, footnotes, images, headings, raw
+// classNames) is inherited. This is the primary XSS defense for descriptions,
+// which accept arbitrary Markdown when POSTed directly.
+const schema: SanitizeSchema = {
+  tagNames: ["p", "strong", "em", "a", "ul", "ol", "li", "br"],
+  attributes: {
+    a: ["href"],
+  },
+  protocols: {
+    href: ["http", "https", "mailto"],
+  },
+  clobberPrefix: "md-",
+  strip: ["script"],
+};
+
+export function MarkdownDescription({
+  content,
+  className,
+}: {
+  content: string;
+  className?: string;
+}) {
+  return (
+    <div
+      className={cn(
+        "space-y-2 text-pretty text-foreground text-sm leading-relaxed [&_a]:text-link [&_ol]:list-decimal [&_ol]:pl-5 [&_ul]:list-disc [&_ul]:pl-5",
+        className,
+      )}
+    >
+      <Markdown
+        remarkPlugins={[remarkGfm, remarkBreaks]}
+        rehypePlugins={[[rehypeSanitize, schema]]}
+        components={{
+          a: ({ href, children }) => (
+            <a href={href} target="_blank" rel="noopener noreferrer">
+              {children}
+            </a>
+          ),
+        }}
+      >
+        {content}
+      </Markdown>
+    </div>
+  );
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -94,7 +94,7 @@ importers:
         version: 8.1.0(typescript@6.0.3)
       '@vercel/analytics':
         specifier: ^1.5.0
-        version: 1.6.1(next@16.2.6(@opentelemetry/api@1.9.0)(@playwright/test@1.58.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)
+        version: 1.6.1(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)
       dayjs:
         specifier: ^1.11.13
         version: 1.11.19
@@ -133,7 +133,7 @@ importers:
         version: 6.0.0(@types/react@19.2.13)(react@19.2.6)
       next-seo:
         specifier: ^6.1.0
-        version: 6.8.0(next@16.2.6(@opentelemetry/api@1.9.0)(@playwright/test@1.58.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        version: 6.8.0(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       pg:
         specifier: ^8.17.1
         version: 8.18.0
@@ -800,6 +800,18 @@ importers:
       react-hook-form:
         specifier: ^7.68.0
         version: 7.71.1(react@19.2.6)
+      react-markdown:
+        specifier: ^10.1.0
+        version: 10.1.0(@types/react@19.2.13)(react@19.2.6)
+      rehype-sanitize:
+        specifier: ^6.0.0
+        version: 6.0.0
+      remark-breaks:
+        specifier: ^4.0.0
+        version: 4.0.0
+      remark-gfm:
+        specifier: ^4.0.1
+        version: 4.0.1
       sonner:
         specifier: ^2.0.6
         version: 2.0.7(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
@@ -5847,6 +5859,7 @@ packages:
 
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
+    deprecated: Potential CWE-502 - Update to 1.3.1 or higher
 
   '@upstash/core-analytics@0.0.9':
     resolution: {integrity: sha512-9NXXxZ5y1/A/zqKLlVT7NsAWSggJfOjB0hG6Ffx29b4jbzHOiQVWB55h5+j2clT9Ib+mNPXn0iB5zN3aWLkICw==}
@@ -7739,6 +7752,9 @@ packages:
   hast-util-phrasing@3.0.1:
     resolution: {integrity: sha512-6h60VfI3uBQUxHqTyMymMZnEbNl1XmEGtOxxKYL7stY2o601COo62AWAYBQR9lZbYXYSBoxag8UpPRXK+9fqSQ==}
 
+  hast-util-sanitize@5.0.2:
+    resolution: {integrity: sha512-3yTWghByc50aGS7JlGhk61SPenfE/p1oaFeNwkOOyrscaOkMGrcW9+Cy/QAIOBpZxP1yqDIzFMR0+Np0i0+usg==}
+
   hast-util-to-estree@3.1.3:
     resolution: {integrity: sha512-48+B/rJWAp0jamNbAAf9M7Uf//UVqAoMmgXhBdxTDJLGKY+LRnZ99qcG+Qjl5HfMpYNzS5v4EAwVEF34LeAj7w==}
 
@@ -7814,6 +7830,9 @@ packages:
   html-to-text@9.0.5:
     resolution: {integrity: sha512-qY60FjREgVZL03vJU6IfMV4GDjGBIoOyvuFdpBDIX9yTlDw0TjxVBQp+P8NvpdIXNJvfWBTNul7fsAQJq2FNpg==}
     engines: {node: '>=14'}
+
+  html-url-attributes@3.0.1:
+    resolution: {integrity: sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ==}
 
   html-void-elements@3.0.0:
     resolution: {integrity: sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==}
@@ -8617,6 +8636,9 @@ packages:
 
   mdast-util-mdxjs-esm@2.0.1:
     resolution: {integrity: sha512-EcmOpxsZ96CvlP03NghtH1EsLtr0n9Tm4lPUJUBccV9RwUOneqSycg19n5HGzCf+10LozMRSObtVr3ee1WoHtg==}
+
+  mdast-util-newline-to-break@2.0.0:
+    resolution: {integrity: sha512-MbgeFca0hLYIEx/2zGsszCSEJJ1JSCdiY5xQxRcLDDGa8EPvlLPupJ4DSajbMPAnC0je8jfb9TiUATnxxrHUog==}
 
   mdast-util-phrasing@4.1.0:
     resolution: {integrity: sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w==}
@@ -9703,6 +9725,12 @@ packages:
   react-lifecycles-compat@3.0.4:
     resolution: {integrity: sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==}
 
+  react-markdown@10.1.0:
+    resolution: {integrity: sha512-qKxVopLT/TyA6BX3Ue5NwabOsAzm0Q7kAPwq6L+wWDwisYs7R8vZ0nRXqq6rkueboxpkjvLGU9fWifiX/ZZFxQ==}
+    peerDependencies:
+      '@types/react': '>=18'
+      react: '>=18'
+
   react-overlays@5.2.1:
     resolution: {integrity: sha512-GLLSOLWr21CqtJn8geSwQfoJufdt3mfdsnIiQswouuQ2MMPns+ihZklxvsTDKD3cR2tF8ELbi5xUsvqVhR6WvA==}
     peerDependencies:
@@ -9858,8 +9886,14 @@ packages:
   rehype-recma@1.0.0:
     resolution: {integrity: sha512-lqA4rGUf1JmacCNWWZx0Wv1dHqMwxzsDWYMTowuplHF3xH0N/MmrZ/G3BDZnzAkRmxDadujCjaKM2hqYdCBOGw==}
 
+  rehype-sanitize@6.0.0:
+    resolution: {integrity: sha512-CsnhKNsyI8Tub6L4sm5ZFsme4puGfc6pYylvXo1AeqaGbjOYyzNv3qZPwvs0oMJ39eryyeOdmxwUIo94IpEhqg==}
+
   rehype-stringify@10.0.1:
     resolution: {integrity: sha512-k9ecfXHmIPuFVI61B9DeLPN0qFHfawM6RsuX48hoqlaKSF61RskNjSm1lI8PhBEM0MRdLxVVm4WmTqJQccH9mA==}
+
+  remark-breaks@4.0.0:
+    resolution: {integrity: sha512-IjEjJOkH4FuJvHZVIW0QCDWxcG96kCq7An/KVH2NfJe6rKZU2AsHeB3OEjPNRxi4QC34Xdx7I2KGYn6IpT7gxQ==}
 
   remark-frontmatter@5.0.0:
     resolution: {integrity: sha512-XTFYvNASMe5iPN0719nPrdItC9aU0ssC4v14mH1BCi1u0n1gAocqcujWUrByftZTbLhRtiKRyjYTSIOcr69UVQ==}
@@ -17553,7 +17587,7 @@ snapshots:
     dependencies:
       uncrypto: 0.1.3
 
-  '@vercel/analytics@1.6.1(next@16.2.6(@opentelemetry/api@1.9.0)(@playwright/test@1.58.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)':
+  '@vercel/analytics@1.6.1(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)':
     optionalDependencies:
       next: 16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react: 19.2.6
@@ -19641,6 +19675,12 @@ snapshots:
       hast-util-is-body-ok-link: 3.0.1
       hast-util-is-element: 3.0.0
 
+  hast-util-sanitize@5.0.2:
+    dependencies:
+      '@types/hast': 3.0.4
+      '@ungap/structured-clone': 1.3.0
+      unist-util-position: 5.0.0
+
   hast-util-to-estree@3.1.3:
     dependencies:
       '@types/estree': 1.0.8
@@ -19789,6 +19829,8 @@ snapshots:
       dom-serializer: 2.0.0
       htmlparser2: 8.0.2
       selderee: 0.11.0
+
+  html-url-attributes@3.0.1: {}
 
   html-void-elements@3.0.0: {}
 
@@ -20756,6 +20798,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  mdast-util-newline-to-break@2.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-find-and-replace: 3.0.2
+
   mdast-util-phrasing@4.1.0:
     dependencies:
       '@types/mdast': 4.0.4
@@ -21313,7 +21360,7 @@ snapshots:
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
 
-  next-seo@6.8.0(next@16.2.6(@opentelemetry/api@1.9.0)(@playwright/test@1.58.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
+  next-seo@6.8.0(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
     dependencies:
       next: 16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react: 19.2.6
@@ -22150,6 +22197,24 @@ snapshots:
 
   react-lifecycles-compat@3.0.4: {}
 
+  react-markdown@10.1.0(@types/react@19.2.13)(react@19.2.6):
+    dependencies:
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      '@types/react': 19.2.13
+      devlop: 1.1.0
+      hast-util-to-jsx-runtime: 2.3.6
+      html-url-attributes: 3.0.1
+      mdast-util-to-hast: 13.2.1
+      react: 19.2.6
+      remark-parse: 11.0.0
+      remark-rehype: 11.1.2
+      unified: 11.0.5
+      unist-util-visit: 5.1.0
+      vfile: 6.0.3
+    transitivePeerDependencies:
+      - supports-color
+
   react-overlays@5.2.1(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
     dependencies:
       '@babel/runtime': 7.28.6
@@ -22388,10 +22453,21 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  rehype-sanitize@6.0.0:
+    dependencies:
+      '@types/hast': 3.0.4
+      hast-util-sanitize: 5.0.2
+
   rehype-stringify@10.0.1:
     dependencies:
       '@types/hast': 3.0.4
       hast-util-to-html: 9.0.4
+      unified: 11.0.5
+
+  remark-breaks@4.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-newline-to-break: 2.0.0
       unified: 11.0.5
 
   remark-frontmatter@5.0.0:
@@ -22406,7 +22482,7 @@ snapshots:
   remark-gfm@4.0.0:
     dependencies:
       '@types/mdast': 4.0.4
-      mdast-util-gfm: 3.0.0
+      mdast-util-gfm: 3.1.0
       micromark-extension-gfm: 3.0.0
       remark-parse: 11.0.0
       remark-stringify: 11.0.0


### PR DESCRIPTION
Phase 1 of [RAL-1222](https://linear.app/rallly/issue/RAL-1222) — the **rendering / display side**. Editor + length validation follow in [RAL-1331](https://linear.app/rallly/issue/RAL-1331).

## What this does

Poll and event descriptions were rendered as plain text (`whitespace-pre-wrap` + `TruncatedLinkify`). This adds a shared `<MarkdownDescription>` renderer in `@rallly/ui` and swaps it into both description call sites.

Backwards compatible — existing plain text is valid Markdown, `remark-breaks` preserves the single-newline fidelity `whitespace-pre-wrap` gave, and `remark-gfm` keeps bare-URL autolinking. **No data migration.**

## Security (the point of shipping this together)

The renderer is the primary XSS defense. The old plain-text path was safe by construction; a Markdown renderer is not. The sanitize schema is a **from-scratch allowlist** (not an extension of `defaultSchema`, so nothing like task-list inputs / footnotes / raw classNames is inherited):

- tags: `p, strong, em, a, ul, ol, li, br` only
- `a[href]` restricted to `http` / `https` / `mailto`
- links forced to `target="_blank"` + `rel="noopener noreferrer"`

This lands in the same PR as rendering by design — it cannot be split into a later phase without shipping an XSS hole in between.

## Changes

- `packages/ui/src/markdown-description.tsx` — new shared renderer (isomorphic; works in both the client poll card and the RSC event page)
- `event-meta.tsx` — `EventMetaDescription` now takes a `content` string prop and renders through the new component (with a null guard)
- `event-card.tsx` + `e/[id]/page.tsx` — swapped to the new renderer; dropped the now-unused `TruncatedLinkify` import on the event page (still used for `poll.location`, left intact)
- deps (`react-markdown`, `remark-gfm`, `remark-breaks`, `rehype-sanitize`) added to `@rallly/ui`, not the web app

## Tests

`markdown-description.test.tsx` renders the real component through jsdom and asserts:
- ✅ bold / italic / bullet + numbered lists render
- ✅ markdown links get safe `rel`/`target`; bare URLs autolink; single line breaks preserved
- ✅ `<script>` never becomes an executable node; inline `onerror` / raw `<img>` stripped; `javascript:` links neutralized; disallowed tags (headings, blockquote, code) stripped while their text survives

`pnpm --filter @rallly/web type-check` and the unit suite pass.

## Notes / accepted tradeoffs

- Existing descriptions containing Markdown special chars (`*`, `_`, leading `-`) may render with unintended formatting — **accepted** (low incidence), per the issue.
- `TruncatedLinkify` truncated long bare URLs for display; Markdown autolink does not. Minor, non-blocking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Event descriptions now support Markdown formatting, including lists, emphasis, links, and preserved line breaks.
  * Bare URLs are automatically converted into clickable links.
  * External links open safely in a new tab.

* **Bug Fixes**
  * Potentially unsafe HTML, scripts, event handlers, and dangerous links are blocked from rendered descriptions.
  * Empty event descriptions are no longer displayed as blank blocks.

* **Tests**
  * Added coverage for Markdown rendering, link behavior, and security protections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->