### PR TITLE
🐛 Parse only autolinks from GFM, not the full extension set

### DIFF
--- a/apps/web/src/features/poll/components/markdown-description.test.tsx
+++ b/apps/web/src/features/poll/components/markdown-description.test.tsx
@@ -66,6 +66,22 @@ describe("MarkdownDescription", () => {
       expect(anchor?.getAttribute("href") ?? "").not.toContain("javascript:");
     });
 
+    it("does not parse GFM structures the schema cannot preserve", () => {
+      // Tables must not vanish into empty output — without table parsing the
+      // source survives as plain text.
+      const table = renderMarkdown("| a | b |\n|---|---|\n| 1 | 2 |");
+      expect(table.querySelector("table")).toBeNull();
+      expect(table.textContent).toContain("| a | b |");
+
+      // Footnotes must not leave dangling in-page anchors. (Without footnote
+      // parsing, [^1] falls back to a plain CommonMark reference link.)
+      const footnote = renderMarkdown("text[^1]\n\n[^1]: note");
+      expect(footnote.querySelector('a[href^="#"]')).toBeNull();
+
+      // Strikethrough stays literal rather than silently losing its markup.
+      expect(renderMarkdown("~~gone~~").textContent).toContain("~~gone~~");
+    });
+
     it("strips disallowed tags but keeps their text", () => {
       const container = renderMarkdown("# heading\n\n> quote\n\n`code`");
       expect(container.querySelector("h1")).toBeNull();

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -27,6 +27,8 @@
     "cmdk": "^1.1.1",
     "input-otp": "^1.4.2",
     "lucide-react": "^0.479.0",
+    "mdast-util-gfm-autolink-literal": "^2.0.1",
+    "micromark-extension-gfm-autolink-literal": "^2.1.0",
     "next-themes": "^0.4.6",
     "react": "19.2.6",
     "react-aria-components": "^1.16.0",
@@ -35,13 +37,13 @@
     "react-markdown": "^10.1.0",
     "rehype-sanitize": "^6.0.0",
     "remark-breaks": "^4.0.0",
-    "remark-gfm": "^4.0.1",
     "sonner": "^2.0.6",
     "tailwind-merge": "^1.12.0"
   },
   "devDependencies": {
     "@rallly/tsconfig": "workspace:*",
     "@types/react": "19.2.13",
-    "@types/react-dom": "19.2.3"
+    "@types/react-dom": "19.2.3",
+    "unified": "^11.0.5"
   }
 }

--- a/packages/ui/src/markdown-description.tsx
+++ b/packages/ui/src/markdown-description.tsx
@@ -1,9 +1,29 @@
+import { gfmAutolinkLiteralFromMarkdown } from "mdast-util-gfm-autolink-literal";
+import { gfmAutolinkLiteral } from "micromark-extension-gfm-autolink-literal";
 import Markdown from "react-markdown";
 import type { Options as SanitizeSchema } from "rehype-sanitize";
 import rehypeSanitize from "rehype-sanitize";
 import remarkBreaks from "remark-breaks";
-import remarkGfm from "remark-gfm";
+import type { Plugin } from "unified";
 import { cn } from "./lib/utils";
+
+// Autolink bare URLs only — the one GFM behavior we want. Using the full
+// remark-gfm would also parse tables, strikethrough, task lists and footnotes,
+// which the sanitize schema below can't preserve: tables collapse to empty
+// output and footnotes leave dangling anchors. So we wire up just the autolink
+// extension instead.
+const remarkAutolinkLiteral: Plugin = function () {
+  // These data fields are declared by remark-parse's type augmentation, which
+  // we don't depend on directly — hence the local shape.
+  const data = this.data() as {
+    micromarkExtensions?: unknown[];
+    fromMarkdownExtensions?: unknown[];
+  };
+  data.micromarkExtensions ??= [];
+  data.micromarkExtensions.push(gfmAutolinkLiteral());
+  data.fromMarkdownExtensions ??= [];
+  data.fromMarkdownExtensions.push(gfmAutolinkLiteralFromMarkdown());
+};
 
 // Locked-down allowlist: only the formatting the editor can produce.
 // Deliberately built from scratch rather than extending rehype-sanitize's
@@ -37,7 +57,7 @@ export function MarkdownDescription({
       )}
     >
       <Markdown
-        remarkPlugins={[remarkGfm, remarkBreaks]}
+        remarkPlugins={[remarkAutolinkLiteral, remarkBreaks]}
         rehypePlugins={[[rehypeSanitize, schema]]}
         components={{
           a: ({ href, children }) => (

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -785,6 +785,12 @@ importers:
       lucide-react:
         specifier: ^0.479.0
         version: 0.479.0(react@19.2.6)
+      mdast-util-gfm-autolink-literal:
+        specifier: ^2.0.1
+        version: 2.0.1
+      micromark-extension-gfm-autolink-literal:
+        specifier: ^2.1.0
+        version: 2.1.0
       next-themes:
         specifier: ^0.4.6
         version: 0.4.6(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
@@ -809,9 +815,6 @@ importers:
       remark-breaks:
         specifier: ^4.0.0
         version: 4.0.0
-      remark-gfm:
-        specifier: ^4.0.1
-        version: 4.0.1
       sonner:
         specifier: ^2.0.6
         version: 2.0.7(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
@@ -828,6 +831,9 @@ importers:
       '@types/react-dom':
         specifier: 19.2.3
         version: 19.2.3(@types/react@19.2.13)
+      unified:
+        specifier: ^11.0.5
+        version: 11.0.5
 
   packages/utils:
     dependencies:


### PR DESCRIPTION
Follow-up to #2644, addressing a review finding that arrived after the merge (the fix commit was pushed to the branch post-merge and never landed).

## Problem

`remark-gfm` parses the *full* GFM extension set — tables, strikethrough, task lists, footnotes — but the sanitize allowlist in `MarkdownDescription` only preserves `p, strong, em, a, ul, ol, li, br`. Verified degradation:

- **Tables** collapsed to an empty div — the content vanished entirely
- **Footnotes** emitted a dangling `#user-content-fn-1` anchor pointing at a sanitizer-stripped section
- **Strikethrough / task lists** silently lost their markup

The only GFM behavior the renderer actually wants is **bare-URL autolinking** (parity with the old `TruncatedLinkify`, pinned by an existing test).

## Fix

`remark-gfm` has no per-feature toggles, so it's replaced with a small inline remark plugin that registers only the autolink-literal extension:

- `remark-gfm` removed; `micromark-extension-gfm-autolink-literal` + `mdast-util-gfm-autolink-literal` promoted from transitive to direct deps (same maintainer — they're remark-gfm's own internals, 31M+ weekly downloads each)
- Unsupported GFM syntax now stays as literal text instead of vanishing or breaking

## Validation

- New regression test: table source survives as text (no `<table>`, no empty output), no dangling in-page anchors from footnotes, strikethrough stays literal
- All 9 unit tests pass, including the pre-existing autolink and XSS suites
- `type-check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Markdown security by preventing unsupported formatting—such as tables, footnotes, and strikethrough text—from being rendered as HTML.
  * Preserved automatic linking for bare URLs while maintaining existing line-break and link behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->