### PR TITLE
✅ Set up unit testing in @rallly/ui and move markdown-description test (RAL-1332)

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -8,6 +8,7 @@
     "check": "biome check .",
     "check:fix": "biome check . --write",
     "ui:add": "npx shadcn-ui@latest add",
+    "test:unit": "vitest run",
     "type-check": "tsc --noEmit"
   },
   "exports": {
@@ -42,8 +43,12 @@
   },
   "devDependencies": {
     "@rallly/tsconfig": "workspace:*",
+    "@testing-library/react": "^16.3.0",
     "@types/react": "19.2.13",
     "@types/react-dom": "19.2.3",
-    "unified": "^11.0.5"
+    "@vitejs/plugin-react": "^5.0.0",
+    "jsdom": "^26.1.0",
+    "unified": "^11.0.5",
+    "vitest": "^4.0.16"
   }
 }

--- a/packages/ui/src/markdown-description.test.tsx
+++ b/packages/ui/src/markdown-description.test.tsx
@@ -1,6 +1,6 @@
-import { MarkdownDescription } from "@rallly/ui/markdown-description";
 import { render } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
+import { MarkdownDescription } from "./markdown-description";
 
 function renderMarkdown(content: string) {
   const { container } = render(<MarkdownDescription content={content} />);

--- a/packages/ui/vitest.config.mts
+++ b/packages/ui/vitest.config.mts
@@ -1,0 +1,10 @@
+import react from "@vitejs/plugin-react";
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  plugins: [react()],
+  test: {
+    environment: "jsdom",
+    include: ["src/**/*.test.{ts,tsx}"],
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -825,15 +825,27 @@ importers:
       '@rallly/tsconfig':
         specifier: workspace:*
         version: link:../tsconfig
+      '@testing-library/react':
+        specifier: ^16.3.0
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@types/react':
         specifier: 19.2.13
         version: 19.2.13
       '@types/react-dom':
         specifier: 19.2.3
         version: 19.2.3(@types/react@19.2.13)
+      '@vitejs/plugin-react':
+        specifier: ^5.0.0
+        version: 5.1.3(vite@7.3.1(@types/node@24.10.11)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))
+      jsdom:
+        specifier: ^26.1.0
+        version: 26.1.0
       unified:
         specifier: ^11.0.5
         version: 11.0.5
+      vitest:
+        specifier: ^4.0.16
+        version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@24.10.11)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0)
 
   packages/utils:
     dependencies:


### PR DESCRIPTION
## Summary

Adds a minimal Vitest harness to `packages/ui` so component tests can live next to the components they cover, and moves the `MarkdownDescription` XSS/sanitization test out of `apps/web` to sit beside its component.

- `packages/ui/vitest.config.mts` — jsdom + `@vitejs/plugin-react`, mirroring `apps/web/vitest.config.mts`
- devDeps: `vitest`, `jsdom`, `@vitejs/plugin-react`, `@testing-library/react`
- `test:unit` script in `packages/ui/package.json` so `turbo test:unit` (root `pnpm test:unit`) picks the package up in CI
- Moved `markdown-description.test.tsx` → `packages/ui/src/`, next to `markdown-description.tsx` (import switched to relative)

No `setupFiles` / `@testing-library/jest-dom` — the test uses only `render` and plain vitest matchers.

## Sequencing

PR #2648 (which last modified this test file) is confirmed merged at the tip of `main`; this branch is based on it, so no stale version was moved.

## Testing

- `pnpm --filter @rallly/ui test:unit` → 9 passed
- root `pnpm test:unit` → 18 files, 230 tests passed (turbo now runs `@rallly/ui#test:unit`)
- `pnpm --filter @rallly/ui check` → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added unit test support for the UI package using Vitest.
  * Configured tests to run in a browser-like environment with React support.
  * Updated a markdown description test to use the local component module.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->