### PR TITLE
📝 Remove stale components/poll reference from CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,7 +86,7 @@ pnpm sherif               # Check package dependencies
   - `utils/` - Shared utilities
 
 ### Key Features & Structure
-- **Polls**: Core scheduling functionality in `apps/web/src/features/poll/` (legacy UI still in `components/poll/`)
+- **Polls**: Core scheduling functionality in `apps/web/src/features/poll/`
 - **Spaces**: Workspace/team organization in `apps/web/src/features/space/`
 - **Authentication**: Better-Auth config in `apps/web/src/lib/auth.ts`, domain logic in `apps/web/src/features/auth/`
 - **tRPC API**: Routers in `apps/web/src/trpc/routers/`


### PR DESCRIPTION
## Description

Removes the stale "(legacy UI still in `components/poll/`)" note from the Key Features & Structure section of CLAUDE.md. `apps/web/src/components/poll/` no longer exists — the legacy poll UI was migrated into `features/poll/` in #2622. A repo-wide search confirmed this was the only remaining reference to `components/poll` in markdown docs.

## Checklist

- [x] I have performed a self-review of my code
- [x] My code follows the code style of this project
- [x] I have commented my code, particularly in hard-to-understand areas

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the architecture documentation to reflect the current Polls feature location.
  * Removed the outdated reference to the legacy Poll UI path.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->