### PR TITLE
✨ Add wide event logging to private API requests (RAL-1264)

### DIFF
--- a/apps/web/src/app/api/private/[...route]/route.ts
+++ b/apps/web/src/app/api/private/[...route]/route.ts
@@ -31,6 +31,7 @@ import {
   generateTimeSlots,
   parseStartTime,
 } from "../utils/time-slots";
+import { wideEvent } from "../utils/wide-event";
 
 type Env = {
   Variables: {
@@ -44,6 +45,8 @@ type Env = {
 };
 
 const app = new Hono<Env>().basePath("/api/private");
+
+app.use("*", wideEvent);
 
 app.use("*", async (c, next) => {
   if (isMaintenanceModeEnabled()) {

--- a/apps/web/src/app/api/private/utils/wide-event.test.ts
+++ b/apps/web/src/app/api/private/utils/wide-event.test.ts
@@ -1,0 +1,124 @@
+import { Hono } from "hono";
+import { bearerAuth } from "hono/bearer-auth";
+import { rateLimiter } from "hono-rate-limiter";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const info = vi.fn();
+const warn = vi.fn();
+const error = vi.fn();
+
+vi.mock("@rallly/logger", () => ({
+  logger: {
+    info: (event: unknown) => info(event),
+    warn: (event: unknown) => warn(event),
+    error: (event: unknown) => error(event),
+  },
+  createWideEvent: (event: Record<string, unknown>) => ({
+    timestamp: "2026-01-01T00:00:00.000Z",
+    ...event,
+  }),
+}));
+
+import { wideEvent } from "./wide-event";
+
+type TestEnv = {
+  Variables: {
+    apiAuth?: { spaceId: string; apiKeyId: string };
+  };
+};
+
+const buildApp = () => {
+  const app = new Hono<TestEnv>();
+  app.use("*", wideEvent);
+
+  app.get(
+    "/ok",
+    async (c, next) => {
+      c.set("apiAuth", { spaceId: "space-1", apiKeyId: "key-1" });
+      await next();
+    },
+    rateLimiter({
+      windowMs: 60_000,
+      limit: 5,
+      keyGenerator: () => "space-1",
+    }),
+    (c) => c.json({ ok: true }),
+  );
+
+  app.get(
+    "/unauthorized",
+    bearerAuth({ verifyToken: async () => false }),
+    (c) => c.json({ ok: true }),
+  );
+
+  app.get("/boom", () => {
+    throw new Error("kaboom");
+  });
+
+  return app;
+};
+
+describe("wideEvent middleware", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("emits a single info event with request, auth and rate-limit context on success", async () => {
+    const res = await buildApp().request("/ok");
+
+    expect(res.status).toBe(200);
+    expect(info).toHaveBeenCalledTimes(1);
+    expect(warn).not.toHaveBeenCalled();
+    expect(error).not.toHaveBeenCalled();
+
+    const event = info.mock.calls[0][0];
+    expect(event).toMatchObject({
+      service: "private-api",
+      method: "GET",
+      path: "/ok",
+      statusCode: 200,
+      spaceId: "space-1",
+      apiKeyId: "key-1",
+      rateLimiter: "private-api",
+      rateLimiterConsumedPoints: 1,
+      rateLimiterRemainingPoints: 4,
+    });
+    expect(typeof event.durationMs).toBe("number");
+  });
+
+  it("warns and captures a 401 without auth context", async () => {
+    const res = await buildApp().request("/unauthorized");
+
+    expect(res.status).toBe(401);
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(info).not.toHaveBeenCalled();
+
+    const event = warn.mock.calls[0][0];
+    expect(event).toMatchObject({ statusCode: 401, path: "/unauthorized" });
+    expect(event.spaceId).toBeUndefined();
+    expect(event.apiKeyId).toBeUndefined();
+    expect(event.rateLimiter).toBeUndefined();
+  });
+
+  it("logs an error event with error details on an unhandled throw", async () => {
+    const res = await buildApp().request("/boom");
+
+    expect(res.status).toBe(500);
+    expect(error).toHaveBeenCalledTimes(1);
+
+    const event = error.mock.calls[0][0];
+    expect(event).toMatchObject({
+      statusCode: 500,
+      errorType: "Error",
+      errorMessage: "kaboom",
+    });
+  });
+
+  it("propagates the request id from x-vercel-id", async () => {
+    await buildApp().request("/ok", {
+      headers: { "x-vercel-id": "req-123" },
+    });
+
+    expect(info.mock.calls[0][0].requestId).toBe("req-123");
+  });
+});

--- a/apps/web/src/app/api/private/utils/wide-event.ts
+++ b/apps/web/src/app/api/private/utils/wide-event.ts
@@ -1,0 +1,73 @@
+import { createWideEvent, logger } from "@rallly/logger";
+import { createMiddleware } from "hono/factory";
+import type { RateLimitInfo } from "hono-rate-limiter";
+
+type WideEventEnv = {
+  Variables: {
+    apiAuth?: {
+      spaceId: string;
+      apiKeyId: string;
+    };
+    rateLimit?: RateLimitInfo;
+  };
+};
+
+/**
+ * Emits a single wide event per request, following the "one event per request"
+ * pattern in `packages/logger/src/wide-event.ts`. Registered first so it wraps
+ * every outcome, including maintenance (503), auth (401/403), and rate limit
+ * (429) short-circuits from downstream middleware.
+ */
+export const wideEvent = createMiddleware<WideEventEnv>(async (c, next) => {
+  const startTime = Date.now();
+  const event = createWideEvent({
+    service: "private-api",
+    requestId:
+      c.req.header("x-vercel-id") ?? c.req.header("x-request-id") ?? undefined,
+    method: c.req.method,
+    path: c.req.path,
+    ip: c.req.header("x-vercel-forwarded-for") ?? undefined,
+    ja4Digest: c.req.header("x-vercel-ja4-digest") ?? undefined,
+  });
+
+  try {
+    await next();
+
+    // `c.res.status` is authoritative: Hono's error handler has already
+    // resolved thrown HTTPExceptions (e.g. the 401 from bearer auth) into the
+    // correct status. `c.error` is still set for those, so enrich error fields
+    // from it but never let it override the resolved status.
+    event.statusCode = c.res.status;
+
+    if (c.error) {
+      event.errorType = c.error.name;
+      event.errorMessage = c.error.message;
+    }
+  } finally {
+    // `apiAuth` and `rateLimit` are populated by downstream middleware, so they
+    // are only available once `next()` has run — and stay absent when the
+    // request is rejected before they run (401 unauthenticated, 403 non-pro).
+    const apiAuth = c.get("apiAuth");
+    if (apiAuth) {
+      event.spaceId = apiAuth.spaceId;
+      event.apiKeyId = apiAuth.apiKeyId;
+    }
+
+    const rateLimit = c.get("rateLimit");
+    if (rateLimit) {
+      event.rateLimiter = "private-api";
+      event.rateLimiterConsumedPoints = rateLimit.used;
+      event.rateLimiterRemainingPoints = rateLimit.remaining;
+    }
+
+    event.durationMs = Date.now() - startTime;
+
+    if (event.statusCode && event.statusCode >= 500) {
+      logger.error(event);
+    } else if (event.statusCode && event.statusCode >= 400) {
+      logger.warn(event);
+    } else {
+      logger.info(event);
+    }
+  }
+});


### PR DESCRIPTION
## Summary

The private API previously recorded nothing beyond `spaceApiKey.lastUsedAt`. This adds one wide event per request so we can watch adoption and abuse after launch (and it's the dataset we'd need if we ever revisit metering).

A Hono middleware (`wideEvent`) is registered as the first `app.use("*")`, ahead of the maintenance, auth and rate-limit middleware, so it wraps every outcome — successes, 401 unauthenticated, 403 non-pro, 429 rate-limited, 503 maintenance, and unhandled 500s.

### Fields emitted
- `requestId`, `service` (`"private-api"`), `method`, `path`, `statusCode`, `durationMs`, `ip`, `ja4Digest`
- `spaceId`, `apiKeyId` — from `apiAuth`, present once auth succeeds (absent on 401)
- `rateLimiter`, `rateLimiterConsumedPoints`, `rateLimiterRemainingPoints` — the previously-declared-but-never-populated fields, read from the `hono-rate-limiter` context once that middleware has run (absent on 401/403, which short-circuit before it)
- `errorType` / `errorMessage` on failures

Log level follows the existing tRPC handler convention: `error` for ≥500, `warn` for ≥400, `info` otherwise.

### Implementation note
`c.res.status` is treated as authoritative for the status code. Hono's error handler resolves thrown `HTTPException`s (e.g. bearer-auth's 401) into the correct response but leaves `c.error` set, so `c.error` is used only to enrich error fields — never to override the resolved status. An earlier draft that keyed off `c.error` mislabelled every 401 as a 500; the test suite catches this.

## Testing
- New `wide-event.test.ts` exercises the middleware directly (success with auth + rate-limit context, 401 without auth context, unhandled throw → 500, requestId propagation)
- Existing 66 route tests still pass; the events they emit were spot-checked to confirm correct fields and status codes per outcome
- `type-check` and `biome check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added comprehensive request monitoring for private API endpoints, including response status, duration, request identifiers, client details, authentication, and rate-limit information.
  * Added severity-based logging for successful requests, warnings, and errors.
* **Bug Fixes**
  * Improved error request reporting while preserving the correct HTTP response status.
* **Tests**
  * Added coverage for successful, unauthorized, failed, and request-tracking scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->