### PR TITLE
🐛 Preserve poll time zone when re-adding options after clearing all (#1218)

### DIFF
--- a/apps/web/src/features/poll/components/forms/poll-options-form/month-calendar/month-calendar.tsx
+++ b/apps/web/src/features/poll/components/forms/poll-options-form/month-calendar/month-calendar.tsx
@@ -279,7 +279,8 @@ const MonthCalendar: React.FunctionComponent<DateTimePickerProps> = ({
 
                             if (
                               options.length === 0 &&
-                              newOption.type === "timeSlot"
+                              newOption.type === "timeSlot" &&
+                              !form.getValues("timeZone")
                             ) {
                               form.setValue("timeZone", getBrowserTimeZone());
                             }


### PR DESCRIPTION
Fixes #1218.

## Problem

On the **Edit options** page, deleting *all* options and then clicking a day to add a new time slot silently changes the poll's time zone to the viewer's browser time zone. Deleting only *some* options preserves it — the bug only triggers when the option list is emptied first.

## Root cause

In `month-calendar.tsx`, the day-click handler set the browser time zone unconditionally whenever a time slot was added to an empty option list:

```js
if (options.length === 0 && newOption.type === "timeSlot") {
  form.setValue("timeZone", getBrowserTimeZone());
}
```

The form's `timeZone` value survives the deletion (nothing resets it on empty), so this overwrote the poll's real time zone. The equivalent path in `handleDurationChange` already guards with `!form.getValues("timeZone")`; this one didn't.

## Fix

Add the same guard so the browser time zone is only used when no time zone is set, leaving an existing poll's time zone intact.

## Notes

- The original 2024 fix (#1221) was reverted (#1227); this addresses the same report at its current location after the datetime/localization rework.
- The "time zone was uneditable" half of the original report was already fixed by #2436 (`disableTimeZoneChange = hasVotes`). This PR covers the remaining silent-overwrite half.
- `tsc --noEmit` and `biome check` pass on the changed file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved an existing time zone when adding new time slots.
  * Automatically set the time zone only when creating a time slot and no time zone is already selected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->