### PR TITLE
🐛 Skip lastUsedAt write for non-Pro API keys (RAL-1336)

### DIFF
--- a/apps/web/src/app/api/private/[...route]/route.test.ts
+++ b/apps/web/src/app/api/private/[...route]/route.test.ts
@@ -211,6 +211,31 @@ describe("Private API - /polls", () => {
       expect(json.error.code).toBe("SPACE_NOT_PRO");
     });
 
+    it("should not schedule a lastUsedAt write when the space is not pro", async () => {
+      const hobbyApiKey = {
+        ...mockApiKey,
+        hashedKey: hashApiKey(testApiKey),
+        lastUsedAt: null,
+        space: { ...mockApiKey.space, tier: "hobby" },
+      };
+      vi.mocked(prisma.spaceApiKey.findMany).mockResolvedValue([hobbyApiKey]);
+
+      const res = await app.request("/api/private/polls", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${testApiKey}`,
+        },
+        body: JSON.stringify({
+          title: "Test Poll",
+          dates: ["2025-01-15"],
+        }),
+      });
+
+      expect(res.status).toBe(403);
+      expect(after).not.toHaveBeenCalled();
+    });
+
     it("should return 200 with a valid key when the space is pro", async () => {
       const res = await app.request("/api/private/polls", {
         method: "POST",

--- a/apps/web/src/app/api/private/utils/api-key.ts
+++ b/apps/web/src/app/api/private/utils/api-key.ts
@@ -79,10 +79,12 @@ const verifyKey = bearerAuth({
       return false;
     }
 
+    const effectiveTier = isSelfHosted ? ("pro" as const) : spaceTier;
+
     c.set("apiAuth", {
       spaceId,
       spaceOwnerId,
-      spaceTier: isSelfHosted ? ("pro" as const) : spaceTier,
+      spaceTier: effectiveTier,
       apiKeyId,
     });
 
@@ -97,7 +99,10 @@ const verifyKey = bearerAuth({
       !lastUsedAt ||
       now.getTime() - lastUsedAt.getTime() > LAST_USED_AT_WRITE_INTERVAL_MS;
 
-    if (rehashedKey || isLastUsedAtStale) {
+    // Skip the write for non-Pro spaces: requireProSpace rejects them with
+    // 403, so bumping lastUsedAt would misreport a blocked key as active and
+    // waste a DB write on rejected traffic. Self-hosted is always Pro here.
+    if (effectiveTier === "pro" && (rehashedKey || isLastUsedAtStale)) {
       after(() =>
         prisma.spaceApiKey.update({
           where: { id: apiKeyId },


### PR DESCRIPTION
## Problem

In `verifyToken` (inside `verifyKey`/`bearerAuth`), the throttled `lastUsedAt` update and lazy scrypt→sha256 hash re-migration were scheduled via `after()` **before** the `requireProSpace` middleware runs. Requests from a downgraded (hobby-tier) space are rejected with 403 `SPACE_NOT_PRO`, yet the key's `lastUsedAt` still got bumped.

Two issues:
- `lastUsedAt` misleadingly implied the key was actively used when every request was being rejected.
- Blocked traffic still cost a DB write.

## Fix

Gate the `lastUsedAt`/rehash write on the effective tier being `"pro"`. The effective tier is computed once (`isSelfHosted ? "pro" : spaceTier`) and reused for both the `apiAuth` context and the write gate.

Self-hosted is always forced to `"pro"`, so its `lastUsedAt` write behavior is unchanged.

## Testing

- `pnpm --filter @rallly/web type-check` — clean
- `route.test.ts` — 49 tests pass, including a new test asserting no `lastUsedAt` write is scheduled for a hobby-tier space (403).

Fixes RAL-1336.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected API access enforcement for non-Pro spaces, returning a `403` response when Pro-only endpoints are accessed.
  * Prevented usage metadata updates for unauthorized non-Pro API keys.
  * Preserved API key activity updates for eligible Pro and self-hosted deployments.
  * Added regression coverage to verify the corrected behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->