### PR TITLE
🐛 Respect the user's week start preference in the week calendar (RAL-1341)

### DIFF
--- a/apps/web/src/features/poll/components/forms/poll-options-form/dayjs-localizer.test.ts
+++ b/apps/web/src/features/poll/components/forms/poll-options-form/dayjs-localizer.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+import { dayjs } from "@/lib/dayjs";
+import dayjsLocalizer from "./dayjs-localizer";
+
+// The DateLocalizer typings omit the week unit react-big-calendar passes at
+// runtime, so widen to the shape under test.
+const createLocalizer = (weekStart?: number) =>
+  dayjsLocalizer(dayjs, { weekStart }) as unknown as {
+    startOfWeek: () => number;
+    startOf: (date: Date, unit: string) => Date;
+    endOf: (date: Date, unit: string) => Date;
+    eq: (a: Date, b: Date, unit: string) => boolean;
+  };
+
+// 2026-07-14 is a Tuesday
+const tuesday = new Date(2026, 6, 14, 12, 0, 0);
+
+describe("dayjsLocalizer weekStart", () => {
+  it("defaults to the dayjs locale week start when no weekStart is given", () => {
+    const localizer = createLocalizer();
+    expect(localizer.startOfWeek()).toBe(0);
+    expect(localizer.startOf(tuesday, "week")).toEqual(
+      new Date(2026, 6, 12, 0, 0, 0),
+    );
+  });
+
+  it("starts the week on Monday when weekStart is 1", () => {
+    const localizer = createLocalizer(1);
+    expect(localizer.startOfWeek()).toBe(1);
+    expect(localizer.startOf(tuesday, "week")).toEqual(
+      new Date(2026, 6, 13, 0, 0, 0),
+    );
+    expect(localizer.endOf(tuesday, "week")).toEqual(
+      new Date(2026, 6, 19, 23, 59, 59, 999),
+    );
+  });
+
+  it("starts the week on Saturday when weekStart is 6", () => {
+    const localizer = createLocalizer(6);
+    expect(localizer.startOf(tuesday, "week")).toEqual(
+      new Date(2026, 6, 11, 0, 0, 0),
+    );
+    expect(localizer.endOf(tuesday, "week")).toEqual(
+      new Date(2026, 6, 17, 23, 59, 59, 999),
+    );
+  });
+
+  it("keeps a date already on the week start day in place", () => {
+    const localizer = createLocalizer(1);
+    const monday = new Date(2026, 6, 13, 8, 30, 0);
+    expect(localizer.startOf(monday, "week")).toEqual(
+      new Date(2026, 6, 13, 0, 0, 0),
+    );
+  });
+
+  it("compares dates by the configured week boundary", () => {
+    const localizer = createLocalizer(1);
+    const sunday = new Date(2026, 6, 12);
+    const monday = new Date(2026, 6, 13);
+    // With Monday as week start, Sunday belongs to the previous week
+    expect(localizer.eq(sunday, monday, "week")).toBe(false);
+    expect(localizer.eq(monday, tuesday, "week")).toBe(true);
+  });
+});

--- a/apps/web/src/features/poll/components/forms/poll-options-form/dayjs-localizer.ts
+++ b/apps/web/src/features/poll/components/forms/poll-options-form/dayjs-localizer.ts
@@ -54,12 +54,30 @@ function fixUnit(unit) {
   return datePart;
 }
 
-export default function (dayjs) {
+export default function (dayjs, { weekStart } = {}) {
   const locale = (m, c) => (c ? m.locale(c) : m);
+
+  function firstOfWeek() {
+    if (weekStart !== undefined) {
+      return weekStart;
+    }
+    const data = dayjs.localeData();
+    return data ? data.firstDayOfWeek() : 0;
+  }
+
+  // dayjs' own startOf("week") uses the global locale's week start, so week
+  // boundaries are computed manually from the configured weekStart.
+  function startOfWeek(date) {
+    const day = dayjs(date).startOf("day");
+    return day.subtract((day.day() - firstOfWeek() + 7) % 7, "day");
+  }
 
   /*** BEGIN localized date arithmetic methods with dayjs ***/
   function defineComparators(a, b, unit) {
     const datePart = fixUnit(unit);
+    if (datePart === "week") {
+      return [startOfWeek(a), startOfWeek(b), "day"];
+    }
     const dtA = datePart ? dayjs(a).startOf(datePart) : dayjs(a);
     const dtB = datePart ? dayjs(b).startOf(datePart) : dayjs(b);
     return [dtA, dtB, datePart];
@@ -68,6 +86,9 @@ export default function (dayjs) {
   // biome-ignore lint/style/useDefaultParameterLast: Fix this later
   function startOf(date = null, unit) {
     const datePart = fixUnit(unit);
+    if (datePart === "week") {
+      return startOfWeek(date).toDate();
+    }
     if (datePart) {
       return dayjs(date).startOf(datePart).toDate();
     }
@@ -77,6 +98,9 @@ export default function (dayjs) {
   // biome-ignore lint/style/useDefaultParameterLast: Fix this later
   function endOf(date = null, unit) {
     const datePart = fixUnit(unit);
+    if (datePart === "week") {
+      return startOfWeek(date).add(6, "day").endOf("day").toDate();
+    }
     if (datePart) {
       return dayjs(date).endOf(datePart).toDate();
     }
@@ -184,17 +208,12 @@ export default function (dayjs) {
     return dt.minutes();
   }
 
-  function firstOfWeek() {
-    const data = dayjs.localeData();
-    return data ? data.firstDayOfWeek() : 0;
-  }
-
   function firstVisibleDay(date) {
-    return dayjs(date).startOf("month").startOf("week").toDate();
+    return startOfWeek(dayjs(date).startOf("month")).toDate();
   }
 
   function lastVisibleDay(date) {
-    return dayjs(date).endOf("month").endOf("week").toDate();
+    return endOf(dayjs(date).endOf("month").toDate(), "week");
   }
 
   function visibleDays(date) {

--- a/apps/web/src/features/poll/components/forms/poll-options-form/week-calendar.tsx
+++ b/apps/web/src/features/poll/components/forms/poll-options-form/week-calendar.tsx
@@ -2,7 +2,7 @@ import "react-big-calendar/lib/css/react-big-calendar.css";
 import "./rbc-overrides.css";
 
 import { XIcon } from "lucide-react";
-import type React from "react";
+import React from "react";
 import type { CalendarProps } from "react-big-calendar";
 import { Calendar } from "react-big-calendar";
 import { createBreakpoint } from "react-use";
@@ -18,8 +18,6 @@ import DateNavigationToolbar from "./date-navigation-toolbar";
 import dayjsLocalizer from "./dayjs-localizer";
 import type { DateTimeOption, DateTimePickerProps } from "./types";
 import { formatDateWithoutTz } from "./utils";
-
-const localizer = dayjsLocalizer(dayjs);
 
 const useDevice = createBreakpoint({ desktop: 720, mobile: 360 });
 
@@ -37,8 +35,13 @@ const WeekCalendar: React.FunctionComponent<DateTimePickerProps> = ({
   duration = 60,
   onChangeDuration,
 }) => {
-  const { locale, timeFormat } = useDateTimeConfig();
+  const { locale, timeFormat, weekStart } = useDateTimeConfig();
   const { formatDuration } = useDateTime();
+
+  const localizer = React.useMemo(
+    () => dayjsLocalizer(dayjs, { weekStart }),
+    [weekStart],
+  );
 
   // The form works in naive local times; format in the system zone.
   const formatTime = (time: Date) =>


### PR DESCRIPTION
## Summary

The week view calendar on the poll creation page always started the week on Sunday, ignoring the week start preference from Settings → Preferences.

The react-big-calendar localizer in `dayjs-localizer.ts` resolved the first day of the week from the global dayjs locale (always `en` → Sunday, since we never set a dayjs locale) and its `startOf`/`endOf` implementations ignored the week start react-big-calendar passes when computing the week range. The `weekStart` value was already available via `useDateTimeConfig()` in `WeekCalendar` but never reached the localizer.

## Changes

- `dayjsLocalizer` now accepts a `weekStart` option (0–6) and computes week boundaries from it directly instead of relying on the dayjs locale: `firstOfWeek`, `startOf`/`endOf` for the week unit, week granularity comparisons, and the month view visible day range all honor it. Falls back to the dayjs locale when no `weekStart` is given.
- `WeekCalendar` builds the localizer from the `weekStart` in `useDateTimeConfig()`, so both the stored user preference and the locale default flow through.
- Added unit tests covering default, Monday, and Saturday week starts, boundary days, and week equality comparisons.

## Verification

- `vitest`: 5/5 tests pass; `tsc --noEmit` and Biome clean.
- Verified in the browser on `/new`: default locale renders the week view Sun–Sat; with a Monday start config (German locale default) the week view renders Mo 13 → So 19 and the range label follows ("13.–19. Juli").

Fixes [RAL-1341](https://linear.app/rallly/issue/RAL-1341/week-calendar-doesnt-respect-the-users-preferred-week-start-day)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Calendar week calculations now support configurable week-start days.
  * Calendar boundaries and visible dates update automatically when the configured week start changes.

* **Bug Fixes**
  * Improved week comparisons and date ranges for non-default week starts, including Monday and Saturday configurations.

* **Tests**
  * Added coverage for week-start behavior, boundary dates, and week comparisons.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->