### PR TITLE
💄 Move settings back button to the sidebar footer

### DIFF
--- a/apps/web/src/app/[locale]/(space)/settings/layout.tsx
+++ b/apps/web/src/app/[locale]/(space)/settings/layout.tsx
@@ -1,4 +1,3 @@
-import { buttonVariants } from "@rallly/ui";
 import { Icon } from "@rallly/ui/icon";
 import {
   Sidebar,
@@ -10,6 +9,7 @@ import {
   SidebarHeader,
   SidebarInset,
   SidebarMenu,
+  SidebarMenuButton,
   SidebarMenuItem,
   SidebarProvider,
   SidebarSeparator,
@@ -44,18 +44,10 @@ export default async function Layout({
             <SidebarGroup>
               <SidebarGroupContent>
                 <SidebarMenu>
-                  <SidebarMenuItem className="flex items-center gap-3">
-                    <Link
-                      href="/"
-                      className={buttonVariants({
-                        variant: "ghost",
-                        size: "icon",
-                      })}
-                    >
-                      <Icon>
-                        <ArrowLeftIcon />
-                      </Icon>
-                    </Link>
+                  <SidebarMenuItem className="flex h-9 items-center gap-2 px-2">
+                    <Icon>
+                      <SettingsIcon />
+                    </Icon>
                     <span className="font-medium text-sm">
                       <Trans i18nKey="settings" defaults="Settings" />
                     </span>
@@ -85,6 +77,19 @@ export default async function Layout({
             <DeveloperSidebarMenu />
           </SidebarContent>
           <SidebarFooter>
+            <SidebarGroup>
+              <SidebarGroupContent>
+                <SidebarMenu>
+                  <SidebarMenuItem>
+                    <SidebarMenuButton render={<Link href="/" />}>
+                      <ArrowLeftIcon />
+                      <Trans i18nKey="back" defaults="Back" />
+                    </SidebarMenuButton>
+                  </SidebarMenuItem>
+                </SidebarMenu>
+              </SidebarGroupContent>
+            </SidebarGroup>
+            <SidebarSeparator className="my-1" />
             <NavUser />
           </SidebarFooter>
         </Sidebar>


### PR DESCRIPTION
## Summary

Moves the back button in the settings layout from the sidebar header to the sidebar footer, placing it in exactly the same position as the Settings menu item in the dashboard sidebar footer. This lets you toggle between the dashboard and settings without moving the mouse.

- Footer now mirrors the dashboard footer structure: a "Back" menu item (`SidebarMenuButton` + `Link` to `/`) directly above the separator and `NavUser`, so the two items align pixel for pixel.
- Header keeps the "Settings" title, now with the settings icon instead of the icon back button, matching the mobile header treatment.
- Reuses the existing `back` i18n key.

## Test plan

- [x] Verified in the browser: footer items in both layouts sit at the identical position above the user menu, and clicking "Back" navigates to `/`.
- [x] Biome and `tsc` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Improvements**
  * Updated the settings sidebar header with a dedicated settings indicator.
  * Moved the “Back” navigation link to the sidebar footer for clearer navigation.
  * Refined the sidebar separator styling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->