### PR TITLE
🐛 Fix language preference resetting after save

### DIFF
--- a/apps/web/src/app/[locale]/(space)/settings/preferences/components/language-preference.tsx
+++ b/apps/web/src/app/[locale]/(space)/settings/preferences/components/language-preference.tsx
@@ -15,9 +15,10 @@ import Link from "next/link";
 import { useForm } from "react-hook-form";
 import * as z from "zod";
 import { LanguageSelect } from "@/components/language-selector";
+import { updateLocalizationAction } from "@/features/user/actions";
 import { Trans } from "@/i18n/client";
 import { useLocale } from "@/lib/locale/client";
-import { trpc } from "@/trpc/client";
+import { useSafeAction } from "@/lib/safe-action/client";
 
 const formSchema = z.object({
   language: z.string(),
@@ -28,12 +29,8 @@ export const LanguagePreference = ({
 }: {
   defaultValue?: string;
 }) => {
-  const { locale, changeLocale } = useLocale();
-  const updateLocale = trpc.user.updateLocale.useMutation({
-    onSuccess: (_data, variables) => {
-      changeLocale(variables.locale);
-    },
-  });
+  const { locale } = useLocale();
+  const updateLocalization = useSafeAction(updateLocalizationAction);
   const form = useForm({
     defaultValues: {
       language: defaultValue ?? locale,
@@ -45,7 +42,12 @@ export const LanguagePreference = ({
     <Form {...form}>
       <form
         onSubmit={form.handleSubmit(async (data) => {
-          await updateLocale.mutateAsync({ locale: data.language });
+          const result = await updateLocalization.executeAsync({
+            locale: data.language,
+          });
+          if (!result?.serverError && !result?.validationErrors) {
+            form.reset({ language: data.language });
+          }
         })}
       >
         <FormField

--- a/apps/web/src/features/user/actions.ts
+++ b/apps/web/src/features/user/actions.ts
@@ -1,12 +1,14 @@
 "use server";
 import { subject } from "@casl/ability";
 import { prisma } from "@rallly/database";
+import { supportedLngs } from "@rallly/languages";
 import { headers } from "next/headers";
 import * as z from "zod";
 import { banUser, unbanUser, updateUserRole } from "@/features/user/mutations";
 import authLib from "@/lib/auth";
 import { timeFormatSchema, weekStartSchema } from "@/lib/datetime/schema";
 import { AppError } from "@/lib/errors/app-error";
+import { setLocaleCookie } from "@/lib/locale/cookie";
 import {
   adminActionClient,
   authActionClient,
@@ -43,6 +45,10 @@ export const updateLocalizationAction = authActionClient
   .metadata({ actionName: "update_localization" })
   .inputSchema(
     z.object({
+      locale: z
+        .string()
+        .refine((value) => supportedLngs.includes(value))
+        .optional(),
       timeZone: timezoneSchema.optional(),
       timeFormat: timeFormatSchema.optional(),
       weekStart: weekStartSchema.optional(),
@@ -51,12 +57,17 @@ export const updateLocalizationAction = authActionClient
   .action(async ({ parsedInput }) => {
     await authLib.api.updateUser({
       body: {
+        locale: parsedInput.locale,
         timeZone: parsedInput.timeZone,
         timeFormat: parsedInput.timeFormat,
         weekStart: parsedInput.weekStart,
       },
       headers: await headers(),
     });
+
+    if (parsedInput.locale) {
+      await setLocaleCookie(parsedInput.locale);
+    }
   });
 
 export const getAvatarUploadUrlAction = authActionClient

--- a/apps/web/src/lib/locale/client.tsx
+++ b/apps/web/src/lib/locale/client.tsx
@@ -4,7 +4,10 @@ import Cookies from "js-cookie";
 import { useParams, useRouter } from "next/navigation";
 import React from "react";
 import { useTranslation } from "@/i18n/client";
-import { LOCALE_COOKIE_NAME } from "@/lib/locale/constants";
+import {
+  LOCALE_COOKIE_NAME,
+  LOCALE_COOKIE_OPTIONS,
+} from "@/lib/locale/constants";
 
 export function LocaleSync({ userLocale }: { userLocale?: string }) {
   const { locale } = useLocale();
@@ -35,10 +38,7 @@ export function LocaleSync({ userLocale }: { userLocale?: string }) {
 }
 
 export function setLocaleCookie(locale: string) {
-  Cookies.set(LOCALE_COOKIE_NAME, locale, {
-    path: "/",
-    domain: process.env.NEXT_PUBLIC_COOKIE_DOMAIN,
-  });
+  Cookies.set(LOCALE_COOKIE_NAME, locale, LOCALE_COOKIE_OPTIONS);
 }
 
 export function useLocale() {

--- a/apps/web/src/lib/locale/client.tsx
+++ b/apps/web/src/lib/locale/client.tsx
@@ -37,19 +37,14 @@ export function LocaleSync({ userLocale }: { userLocale?: string }) {
   return null;
 }
 
-export function setLocaleCookie(locale: string) {
+function setLocaleCookie(locale: string) {
   Cookies.set(LOCALE_COOKIE_NAME, locale, LOCALE_COOKIE_OPTIONS);
 }
 
 export function useLocale() {
   const { locale } = useParams();
-  const router = useRouter();
 
   return {
     locale: locale as string,
-    changeLocale: (locale: string) => {
-      setLocaleCookie(locale);
-      router.refresh();
-    },
   };
 }

--- a/apps/web/src/lib/locale/constants.ts
+++ b/apps/web/src/lib/locale/constants.ts
@@ -1,1 +1,8 @@
 export const LOCALE_COOKIE_NAME = "rallly_locale";
+
+// Read via process.env: this module is imported from the proxy (edge) and
+// client bundles, where `@/env` is unavailable.
+export const LOCALE_COOKIE_OPTIONS = {
+  path: "/",
+  domain: process.env.NEXT_PUBLIC_COOKIE_DOMAIN,
+};

--- a/apps/web/src/lib/locale/cookie.ts
+++ b/apps/web/src/lib/locale/cookie.ts
@@ -1,0 +1,18 @@
+import "server-only";
+import { supportedLngs } from "@rallly/languages";
+import { cookies } from "next/headers";
+import {
+  LOCALE_COOKIE_NAME,
+  LOCALE_COOKIE_OPTIONS,
+} from "@/lib/locale/constants";
+
+export async function getLocaleCookie() {
+  const cookieStore = await cookies();
+  const locale = cookieStore.get(LOCALE_COOKIE_NAME)?.value;
+  return locale && supportedLngs.includes(locale) ? locale : undefined;
+}
+
+export async function setLocaleCookie(locale: string) {
+  const cookieStore = await cookies();
+  cookieStore.set(LOCALE_COOKIE_NAME, locale, LOCALE_COOKIE_OPTIONS);
+}

--- a/apps/web/src/trpc/routers/user.ts
+++ b/apps/web/src/trpc/routers/user.ts
@@ -110,14 +110,6 @@ export const user = router({
         },
       });
     }),
-  updateLocale: privateProcedure
-    .input(z.object({ locale: z.string() }))
-    .mutation(async ({ input, ctx }) => {
-      await prisma.user.update({
-        where: { id: ctx.user.id },
-        data: { locale: input.locale },
-      });
-    }),
   submitFeedback: privateProcedure
     .use(createRateLimitMiddleware("submit_feedback", 5, "1 h"))
     .input(feedbackSchema)


### PR DESCRIPTION
## Description

Fixes [RAL-1362](https://linear.app/rallly/issue/RAL-1362/changing-language-preference-shows-refresh-toast-and-resets-to-english): saving a new language in Settings → Preferences immediately showed the "Your language preferences changed / Refresh" toast and reverted the app to English, even though the new locale was written to the database.

### Root cause

The language form called the tRPC mutation `user.updateLocale`, which wrote `locale` with a raw Prisma update. With Better Auth `secondaryStorage`, the user object is frozen inside the Redis session snapshot, so `getSession()` kept returning the old locale. After `router.refresh()`, the space layout's `getMe` (which returns the session user) still said `en` while the cookie said the new locale. `LocaleSync` treated the mismatch as a preference change made elsewhere, overwrote the cookie back to `en`, and fired the toast.

### Changes

- `updateLocalizationAction` now accepts `locale` (validated against `supportedLngs`), writes it through Better Auth's `updateUser` endpoint (which refreshes the session snapshot and cookie cache), and sets the locale cookie server-side.
- New `lib/locale/cookie.ts` (`server-only`) with `getLocaleCookie`/`setLocaleCookie` built on `next/headers`. Kept separate from `lib/locale/server.ts`, which is bundled into the edge proxy where `next/headers` is unusable.
- `LOCALE_COOKIE_OPTIONS` shared via `lib/locale/constants.ts` so the client and server cookie setters cannot drift.
- The language preference form just calls the action; `useSafeAction`'s automatic `router.refresh()` picks up the new cookie through the proxy rewrite. No more `changeLocale` call.
- Deleted the broken `updateLocale` tRPC mutation (this form was its only caller; writes belong in server actions).

### Verification

Driven end to end against the dev app (mailpit OTP login, Playwright): reproduced the bug on the base commit first, then confirmed with the fix that English → Deutsch sticks across a hard reload with no toast (polled every 250ms for transient flashes), the reverse switch works through the German UI, and replaying the action with an unsupported locale `xx` is rejected.

## Checklist

- [x] I have performed a self-review of my code
- [x] My code follows the code style of this project
- [x] I have commented my code, particularly in hard-to-understand areas

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved language preference updates with validated language selection.
- **Bug Fixes**
  - Invalid language values are rejected.
  - The selected language is now shown in the form only after a successful update.
  - Locale cookie handling is consistent across the application, improving reliability.
- **Chores**
  - Updated the underlying language update flow to use a safer server-side action instead of a private endpoint.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->