### PR TITLE
♻️ Convert feedback submission from tRPC mutation to server action

### DIFF
--- a/apps/web/public/locales/en/app.json
+++ b/apps/web/public/locales/en/app.json
@@ -297,6 +297,7 @@
   "featureNameExtendedPollLifetime": "Extended Poll Lifetime",
   "featureNameSchedule": "Schedule Poll",
   "feedback": "Feedback",
+  "feedbackDialogEnterFeedback": "Enter your feedback",
   "fileTooLarge": "File too large",
   "fileTooLargeDescription": "Please upload a file smaller than 2MB.",
   "forgotPassword": "Forgot Password?",

--- a/apps/web/src/features/feedback/actions.ts
+++ b/apps/web/src/features/feedback/actions.ts
@@ -1,0 +1,21 @@
+"use server";
+
+import {
+  authActionClient,
+  createRateLimitMiddleware,
+} from "@/lib/safe-action/server";
+import { submitFeedback } from "./mutations";
+import { feedbackSchema } from "./schema";
+
+export const submitFeedbackAction = authActionClient
+  .metadata({ actionName: "submit_feedback" })
+  .use(createRateLimitMiddleware(5, "1 h"))
+  .inputSchema(feedbackSchema)
+  .action(async ({ ctx, parsedInput }) => {
+    await submitFeedback({
+      userId: ctx.user.id,
+      userName: ctx.user.name,
+      userEmail: ctx.user.email,
+      content: parsedInput.content,
+    });
+  });

--- a/apps/web/src/features/feedback/components/feedback-dialog.tsx
+++ b/apps/web/src/features/feedback/components/feedback-dialog.tsx
@@ -16,24 +16,25 @@ import { CheckCircle2Icon } from "lucide-react";
 import { useForm } from "react-hook-form";
 
 import { Trans } from "@/i18n/client";
-import { isSelfHosted } from "@/lib/constants";
-import { trpc } from "@/trpc/client";
+import { useSafeAction } from "@/lib/safe-action/client";
+import { submitFeedbackAction } from "../actions";
+import { isFeedbackEnabled } from "../constants";
 import { feedbackSchema } from "../schema";
 
 export function FeedbackDialog(props: DialogProps) {
-  const submitFeedback = trpc.user.submitFeedback.useMutation();
+  const submitFeedback = useSafeAction(submitFeedbackAction);
   const form = useForm({
     resolver: zodResolver(feedbackSchema),
   });
 
-  if (isSelfHosted) {
+  if (!isFeedbackEnabled) {
     return null;
   }
 
   return (
     <Dialog {...props}>
       <DialogContent>
-        {!form.formState.isSubmitSuccessful ? (
+        {!submitFeedback.hasSucceeded ? (
           <>
             <DialogHeader>
               <DialogTitle>
@@ -49,9 +50,9 @@ export function FeedbackDialog(props: DialogProps) {
 
             <Form {...form}>
               <form
-                onSubmit={form.handleSubmit((data) =>
-                  submitFeedback.mutateAsync(data),
-                )}
+                onSubmit={form.handleSubmit(async (data) => {
+                  await submitFeedback.executeAsync(data);
+                })}
               >
                 <FormField
                   control={form.control}

--- a/apps/web/src/features/feedback/components/feedback-dialog.tsx
+++ b/apps/web/src/features/feedback/components/feedback-dialog.tsx
@@ -15,13 +15,14 @@ import { Textarea } from "@rallly/ui/textarea";
 import { CheckCircle2Icon } from "lucide-react";
 import { useForm } from "react-hook-form";
 
-import { Trans } from "@/i18n/client";
+import { Trans, useTranslation } from "@/i18n/client";
 import { useSafeAction } from "@/lib/safe-action/client";
 import { submitFeedbackAction } from "../actions";
 import { isFeedbackEnabled } from "../constants";
 import { feedbackSchema } from "../schema";
 
 export function FeedbackDialog(props: DialogProps) {
+  const { t } = useTranslation();
   const submitFeedback = useSafeAction(submitFeedbackAction);
   const form = useForm({
     resolver: zodResolver(feedbackSchema),
@@ -64,7 +65,9 @@ export function FeedbackDialog(props: DialogProps) {
                         className="w-full"
                         rows={5}
                         {...field}
-                        placeholder="Enter your feedback"
+                        placeholder={t("feedbackDialogEnterFeedback", {
+                          defaultValue: "Enter your feedback",
+                        })}
                       />
                       <FormMessage />
                     </FormItem>

--- a/apps/web/src/features/feedback/mutations.ts
+++ b/apps/web/src/features/feedback/mutations.ts
@@ -1,0 +1,28 @@
+import "server-only";
+
+import { sendRawEmail } from "@rallly/emails";
+import { posthog } from "@/lib/posthog";
+
+export async function submitFeedback({
+  userId,
+  userName,
+  userEmail,
+  content,
+}: {
+  userId: string;
+  userName: string;
+  userEmail: string;
+  content: string;
+}) {
+  await sendRawEmail({
+    to: "feedback@rallly.co",
+    replyTo: userEmail,
+    subject: "Feedback",
+    text: `User: ${userName} (${userEmail})\n\n${content}`,
+  });
+
+  posthog()?.capture({
+    event: "feedback_send",
+    distinctId: userId,
+  });
+}

--- a/apps/web/src/trpc/routers/user.ts
+++ b/apps/web/src/trpc/routers/user.ts
@@ -1,20 +1,13 @@
 import { subject } from "@casl/ability";
 import { prisma } from "@rallly/database";
-import { sendRawEmail } from "@rallly/emails";
 import { TRPCError } from "@trpc/server";
 import * as z from "zod";
-import { feedbackSchema } from "@/features/feedback/schema";
 import { defaultNotificationPreferences } from "@/features/notifications/constants";
 import { getNotificationPreferences } from "@/features/notifications/data";
 import { activityEventTypes } from "@/features/notifications/schema";
 import { defineAbilityFor } from "@/features/user/ability";
 import { posthog } from "@/lib/posthog";
-import {
-  createRateLimitMiddleware,
-  privateProcedure,
-  publicProcedure,
-  router,
-} from "../trpc";
+import { privateProcedure, publicProcedure, router } from "../trpc";
 
 export const user = router({
   getMe: publicProcedure.query(async ({ ctx }) => {
@@ -116,22 +109,6 @@ export const user = router({
       await prisma.user.update({
         where: { id: ctx.user.id },
         data: { locale: input.locale },
-      });
-    }),
-  submitFeedback: privateProcedure
-    .use(createRateLimitMiddleware("submit_feedback", 5, "1 h"))
-    .input(feedbackSchema)
-    .mutation(async ({ input, ctx }) => {
-      sendRawEmail({
-        to: "feedback@rallly.co",
-        replyTo: ctx.user.email ?? undefined,
-        subject: "Feedback",
-        text: `User: ${ctx.user.name} (${ctx.user.email})\n\n${input.content}`,
-      });
-
-      posthog()?.capture({
-        event: "feedback_send",
-        distinctId: ctx.user.id,
       });
     }),
 });


### PR DESCRIPTION
## Summary

Moves feedback submission off the frozen tRPC transport onto a server action, fully contained in `features/feedback/`:

- `features/feedback/mutations.ts` — `submitFeedback` sends the feedback email and captures the PostHog event; takes explicit params so it stays callable from system contexts
- `features/feedback/actions.ts` — `submitFeedbackAction` on `authActionClient` with the same 5/hour rate limit as before
- `feedback-dialog.tsx` — uses `useSafeAction`; success screen now keys off `hasSucceeded` so a server error (e.g. rate limit) keeps the form visible and shows the standard error toast. Also swaps the direct `isSelfHosted` check for the feature's own `isFeedbackEnabled` constant
- Removes `user.submitFeedback` from the tRPC router along with its now-unused imports

Behavior changes worth noting:
- `sendRawEmail` is now awaited (previously fire-and-forget), so delivery isn't at the mercy of the lambda being frozen after the response
- Errors now surface to the user via the global action error toast; previously a failed `mutateAsync` rejected silently

## Test plan
- `pnpm check` and `pnpm type-check` pass
- No remaining references to `trpc.user.submitFeedback`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an in-app feedback submission flow with server-side validation and rate limiting.
  * Feedback submissions are sent securely and recorded for analytics after success.
  * Feedback dialog visibility now follows the configured feedback setting.
* **Bug Fixes**
  * Improved feedback submission success handling and updated the UI response after sending.
  * Updated the feedback input placeholder to use the localized text.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->