### PR TITLE
✨ Adopt the user's saved locale on sign-in

### DIFF
--- a/apps/web/src/app/[locale]/(space)/settings/preferences/components/language-preference.tsx
+++ b/apps/web/src/app/[locale]/(space)/settings/preferences/components/language-preference.tsx
@@ -38,6 +38,11 @@ export const LanguagePreference = ({
     resolver: zodResolver(formSchema),
   });
 
+  // The saved preference can differ from the locale the app is rendered in
+  // (e.g. the cookie was reset on this device). Saving must be possible in
+  // that state even though the field matches its default.
+  const selectedLanguage = form.watch("language");
+
   return (
     <Form {...form}>
       <form
@@ -70,7 +75,7 @@ export const LanguagePreference = ({
         />
         <div className="mt-6 flex flex-wrap gap-2">
           <Button
-            disabled={!form.formState.isDirty}
+            disabled={!form.formState.isDirty && selectedLanguage === locale}
             loading={form.formState.isSubmitting}
             type="submit"
           >

--- a/apps/web/src/app/[locale]/(space)/settings/preferences/components/language-preference.tsx
+++ b/apps/web/src/app/[locale]/(space)/settings/preferences/components/language-preference.tsx
@@ -31,17 +31,18 @@ export const LanguagePreference = ({
 }) => {
   const { locale } = useLocale();
   const updateLocalization = useSafeAction(updateLocalizationAction);
-  const form = useForm({
-    defaultValues: {
-      language: defaultValue ?? locale,
-    },
-    resolver: zodResolver(formSchema),
-  });
 
   // The saved preference can differ from the locale the app is rendered in
   // (e.g. the cookie was reset on this device). Saving must be possible in
   // that state even though the field matches its default.
-  const selectedLanguage = form.watch("language");
+  const savedLanguage = defaultValue ?? locale;
+
+  const form = useForm({
+    defaultValues: {
+      language: savedLanguage,
+    },
+    resolver: zodResolver(formSchema),
+  });
 
   return (
     <Form {...form}>
@@ -75,7 +76,7 @@ export const LanguagePreference = ({
         />
         <div className="mt-6 flex flex-wrap gap-2">
           <Button
-            disabled={!form.formState.isDirty && selectedLanguage === locale}
+            disabled={!form.formState.isDirty && savedLanguage === locale}
             loading={form.formState.isSubmitting}
             type="submit"
           >

--- a/apps/web/src/lib/auth.ts
+++ b/apps/web/src/lib/auth.ts
@@ -33,7 +33,7 @@ import { getTranslation } from "@/i18n/server";
 import { getLocale } from "@/i18n/server/get-locale";
 import { hostOnlyCookieCleanup } from "@/lib/auth-plugins/host-only-cookie-cleanup";
 import { redis } from "@/lib/kv";
-import { setLocaleCookie } from "@/lib/locale/cookie";
+import { deleteLocaleCookie, setLocaleCookie } from "@/lib/locale/cookie";
 import { posthog } from "@/lib/posthog";
 import { getValueByPath } from "@/lib/utils/get-value-by-path";
 
@@ -334,6 +334,27 @@ export const authLib = betterAuth({
       }
     }),
     after: createAuthMiddleware(async (ctx) => {
+      if (ctx.path === "/sign-out") {
+        const returned = ctx.context.returned as
+          | { success?: boolean }
+          | undefined;
+
+        // The locale cookie projects the signed-out user's preference;
+        // revert to accept-language for whoever uses this device next.
+        // Best-effort: a failure must not break sign-out.
+        if (returned?.success === true) {
+          try {
+            await deleteLocaleCookie();
+          } catch (error) {
+            logger.error(
+              { error },
+              "Failed to delete locale cookie on sign-out",
+            );
+          }
+        }
+        return;
+      }
+
       if (
         ctx.path !== "/email-otp/request-email-change" &&
         ctx.path !== "/email-otp/change-email"

--- a/apps/web/src/lib/auth.ts
+++ b/apps/web/src/lib/auth.ts
@@ -33,6 +33,7 @@ import { getTranslation } from "@/i18n/server";
 import { getLocale } from "@/i18n/server/get-locale";
 import { hostOnlyCookieCleanup } from "@/lib/auth-plugins/host-only-cookie-cleanup";
 import { redis } from "@/lib/kv";
+import { setLocaleCookie } from "@/lib/locale/cookie";
 import { posthog } from "@/lib/posthog";
 import { getValueByPath } from "@/lib/utils/get-value-by-path";
 
@@ -458,7 +459,20 @@ export const authLib = betterAuth({
     },
     session: {
       create: {
-        after: async (session) => {
+        after: async (session, ctx) => {
+          // Adopt the user's saved language on this device. Must happen
+          // before the response is sent (not in `after`), and only in a
+          // request context where cookies can be written.
+          if (ctx) {
+            const user = await prisma.user.findUnique({
+              where: { id: session.userId },
+              select: { locale: true },
+            });
+            if (user?.locale) {
+              await setLocaleCookie(user.locale);
+            }
+          }
+
           after(async () => {
             const user = await prisma.user
               .update({

--- a/apps/web/src/lib/auth.ts
+++ b/apps/web/src/lib/auth.ts
@@ -462,14 +462,23 @@ export const authLib = betterAuth({
         after: async (session, ctx) => {
           // Adopt the user's saved language on this device. Must happen
           // before the response is sent (not in `after`), and only in a
-          // request context where cookies can be written.
+          // request context where cookies can be written. Best-effort:
+          // a failure here must not break a sign-in whose session is
+          // already persisted.
           if (ctx) {
-            const user = await prisma.user.findUnique({
-              where: { id: session.userId },
-              select: { locale: true },
-            });
-            if (user?.locale) {
-              await setLocaleCookie(user.locale);
+            try {
+              const user = await prisma.user.findUnique({
+                where: { id: session.userId },
+                select: { locale: true },
+              });
+              if (user?.locale) {
+                await setLocaleCookie(user.locale);
+              }
+            } catch (error) {
+              logger.error(
+                { error, userId: session.userId },
+                "Failed to set locale cookie on sign-in",
+              );
             }
           }
 

--- a/apps/web/src/lib/locale/cookie.ts
+++ b/apps/web/src/lib/locale/cookie.ts
@@ -16,3 +16,13 @@ export async function setLocaleCookie(locale: string) {
   const cookieStore = await cookies();
   cookieStore.set(LOCALE_COOKIE_NAME, locale, LOCALE_COOKIE_OPTIONS);
 }
+
+export async function deleteLocaleCookie() {
+  const cookieStore = await cookies();
+  // Expire via set() with the same attributes — a deletion only takes
+  // effect when path and domain match the original cookie.
+  cookieStore.set(LOCALE_COOKIE_NAME, "", {
+    ...LOCALE_COOKIE_OPTIONS,
+    maxAge: 0,
+  });
+}


### PR DESCRIPTION
## Description

Follow-up to #2664 and #2666. The locale cookie now follows the session lifecycle, plus a recovery path for users affected by the old sync bug:

### 1. Adopt the user's saved locale on sign-in

With the client-side locale sync removed, nothing reconciled a device's locale cookie with the user's saved preference. This sets the locale cookie from the user's DB locale whenever a session is created (`databaseHooks.session.create.after`), which every sign-in method passes through: email OTP, Google, Microsoft, OIDC, and guest sessions.

This covers the realistic cross-device story: change your language on one device, and any other device picks it up the next time you sign in. Sign-in is the one moment where DB-wins is unambiguous (a new session has no competing device-local intent) and where the read and the cookie write happen in a single server pass, so the race that plagued `LocaleSync` cannot occur. Already-open sessions on other devices remain a known, low-stakes gap that self-heals at their next sign-in.

- The cookie is written before the response goes out, deliberately outside the deferred `after()` block that handles `lastSeenAt` and analytics.
- Best-effort (try/catch + log) and guarded on `ctx`, so it can never break a sign-in.

### 2. Reset the locale cookie on sign-out

The cookie's only non-default source is now the account preference, so it's a projection of the session. When the session ends, the cookie is deleted (`hooks.after` on `/sign-out`, only on success, best-effort) and the proxy re-seeds it from `accept-language` on the next request. This also fixes the shared-device case where the next person would inherit the previous user's language.

### 3. Allow saving a language preference that differs from the active locale

Users affected by the old sync bug have their saved language in the DB but a reset (English) cookie on the device. On the preferences page the select already shows their saved language, so the form is never dirty and Save was unreachable. Save is now enabled whenever the saved language differs from the locale the app is rendered in, letting affected users self-serve immediately instead of waiting for their next sign-in.

### Verification

Driven against the dev app with Playwright (mailpit OTP login):

- **Sign-in adoption** (DB locale `de`): fresh browser context with no locale cookie → after login, cookie is `de` and the app renders in German immediately. Context seeded with a conflicting `rallly_locale=es` cookie (login page renders Spanish) → after login, cookie flips to `de` and the app renders in German.
- **Sign-out reset** (DB `de`, browser `accept-language: fr`): after login the cookie is `de`; after sign-out the cookie is deleted; the next page load re-seeds it to `fr` and the login page renders in French.
- **Save button** (DB `de`, cookie forced to `en` post-login to simulate an affected user): page renders in English with "Deutsch" selected and Save enabled; clicking Save switches the app to German; once consistent, Save is disabled again.

## Checklist

- [x] I have performed a self-review of my code
- [x] My code follows the code style of this project
- [x] I have commented my code, particularly in hard-to-understand areas

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Automatically apply the user’s saved locale during session creation by setting the locale cookie before the response is sent.
  * On successful sign-out, best-effort clear the locale cookie so the next session starts with the correct locale.
* **UX Improvements**
  * Refined the language preference “Save” button behavior to enable saving when the derived saved language differs from the currently rendered locale, and disable only when there’s no effective change.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->