### PR TITLE
🔧 Make dev server domain configurable via DEV_DOMAIN

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -89,6 +89,14 @@ The following instructions are for running the project locally for development.
    pnpm dev
    ```
 
+   By default the app is served at `https://web.rallly.test`. To run it at a different domain (e.g. to run multiple dev servers from separate worktrees at the same time), set `DEV_DOMAIN` to the full domain you want:
+
+   ```bash
+   DEV_DOMAIN=web-myfeature.rallly.test pnpm dev
+   ```
+
+   This registers the domain with portless, allows it as a dev origin in Next.js, and overrides `NEXT_PUBLIC_BASE_URL` so links, assets, and auth callbacks point at the right host. Note that `DEV_DOMAIN` must be set in your shell — setting it in `.env` has no effect because the dev script reads it before Next.js loads env files.
+
 ## Translations 🌐
 
 To contribute translations, please check out our [guide for translators](https://support.rallly.co/contribute/translations) which contains all the information you need to get started.

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -12,7 +12,7 @@ const withBundleAnalyzer = createBundleAnalyzer({
 });
 
 const nextConfig: NextConfig = {
-  allowedDevOrigins: ["web.rallly.test"],
+  allowedDevOrigins: [process.env.DEV_DOMAIN ?? "web.rallly.test"],
   experimental: {
     staleTimes: {
       dynamic: 60,

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "private": true,
   "scripts": {
-    "dev": "portless web.rallly next dev",
+    "dev": "domain=${DEV_DOMAIN:-web.rallly.test}; env ${DEV_DOMAIN:+NEXT_PUBLIC_BASE_URL=https://$DEV_DOMAIN} portless ${domain%.test} next dev",
     "build": "next build",
     "build:test": "NODE_ENV=test next build",
     "analyze": "cross-env ANALYZE=true next build",

--- a/turbo.json
+++ b/turbo.json
@@ -39,7 +39,8 @@
     "dev": {
       "dependsOn": ["^db:generate"],
       "cache": false,
-      "persistent": true
+      "persistent": true,
+      "passThroughEnv": ["DEV_DOMAIN"]
     },
     "start": {
       "cache": false,


### PR DESCRIPTION
## What

Adds a `DEV_DOMAIN` env var to run the web dev server at a domain other than the default `web.rallly.test`, so multiple worktrees can each run their own dev server side by side:

```bash
DEV_DOMAIN=web-myfeature.rallly.test pnpm dev
```

## How

- **`apps/web/package.json`** — the dev script derives the portless app name by stripping the `.test` TLD from `DEV_DOMAIN` (default `web.rallly.test` keeps behavior identical). When the var is set, it also overrides `NEXT_PUBLIC_BASE_URL` in the process env — real env vars take precedence over `.env` in Next, so assets (`assetPrefix`), absolute links, and auth callbacks all point at the actual serving domain without editing `.env`.
- **`apps/web/next.config.ts`** — `allowedDevOrigins` reads `DEV_DOMAIN`, falling back to `web.rallly.test`.
- **`turbo.json`** — `DEV_DOMAIN` added to the dev task's `passThroughEnv`; turbo 2.x strict env mode otherwise strips it before the script's shell expansion runs.
- **`CONTRIBUTING.md`** — documents the variable, including that it must be set in the shell (not `.env`, which loads too late for the dev script).

## Verification

- Shell expansion tested against a stub portless: unset → `portless web.rallly next dev` with no `NEXT_PUBLIC_BASE_URL` override (identical to current behavior); set → TLD-stripped name plus matching base URL.
- `turbo run dev --dry=json` confirms strict env mode with `DEV_DOMAIN` in the passthrough list.
- Portless spawns the child with `...process.env`, so the var and the base URL override reach `next.config.ts` and the app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)