### PR TITLE
💄 Add padding to poll header option columns

### DIFF
--- a/apps/web/src/features/poll/components/desktop-poll/poll-header.tsx
+++ b/apps/web/src/features/poll/components/desktop-poll/poll-header.tsx
@@ -148,7 +148,7 @@ const PollHeader = () => {
               key={option.optionId}
               scope="col"
               style={{ minWidth: 80, top: scoreRowTop }}
-              className="sticky z-20 border-b border-l bg-background pb-2.5 align-top"
+              className="sticky z-20 border-b border-l bg-background px-2 pb-2.5 align-top"
             >
               <div className="flex flex-col items-center gap-3">
                 {option.type === "timeSlot" ? (
@@ -158,7 +158,7 @@ const PollHeader = () => {
                     duration={option.duration}
                   />
                 ) : (
-                  <p className="font-normal text-muted-foreground text-xs">
+                  <p className="whitespace-nowrap font-normal text-muted-foreground text-xs">
                     <Trans i18nKey="allDay" defaults="All-Day" />
                   </p>
                 )}


### PR DESCRIPTION
## Summary
Long option labels in some locales (e.g. Italian "Tutto il giorno" for All-Day) barely fit inside the poll header columns, touching the column borders.

- Add horizontal padding (`px-2`) to the option `<th>` cells, which previously only had bottom padding
- Add `whitespace-nowrap` to the all-day label so long translations force the column to grow (the table is `table-auto`) instead of wrapping or getting crushed to the 80px min width

🤖 Generated with [Claude Code](https://claude.com/claude-code)