### PR TITLE
🐛 Fix session cookies being dropped by locale cookie writes

### DIFF
--- a/apps/web/src/lib/auth.ts
+++ b/apps/web/src/lib/auth.ts
@@ -33,7 +33,10 @@ import { getTranslation } from "@/i18n/server";
 import { getLocale } from "@/i18n/server/get-locale";
 import { hostOnlyCookieCleanup } from "@/lib/auth-plugins/host-only-cookie-cleanup";
 import { redis } from "@/lib/kv";
-import { deleteLocaleCookie, setLocaleCookie } from "@/lib/locale/cookie";
+import {
+  LOCALE_COOKIE_NAME,
+  LOCALE_COOKIE_OPTIONS,
+} from "@/lib/locale/constants";
 import { posthog } from "@/lib/posthog";
 import { getValueByPath } from "@/lib/utils/get-value-by-path";
 
@@ -334,6 +337,14 @@ export const authLib = betterAuth({
       }
     }),
     after: createAuthMiddleware(async (ctx) => {
+      // Locale cookie writes go through better-auth's response
+      // (ctx.setCookie), never next/headers: mutating Next's cookie store
+      // makes Next rebuild this handler's Set-Cookie headers through a
+      // name-keyed map, which collapses the duplicate-name session cookies
+      // that crossSubDomainCookies + hostOnlyCookieCleanup produce and
+      // drops the real one. And it must happen in this hook rather than a
+      // database hook: create.after runs after the transaction, once the
+      // response cookies can no longer be changed.
       if (ctx.path === "/sign-out") {
         const returned = ctx.context.returned as
           | { success?: boolean }
@@ -341,18 +352,26 @@ export const authLib = betterAuth({
 
         // The locale cookie projects the signed-out user's preference;
         // revert to accept-language for whoever uses this device next.
-        // Best-effort: a failure must not break sign-out.
         if (returned?.success === true) {
-          try {
-            await deleteLocaleCookie();
-          } catch (error) {
-            logger.error(
-              { error },
-              "Failed to delete locale cookie on sign-out",
-            );
-          }
+          ctx.setCookie(LOCALE_COOKIE_NAME, "", {
+            ...LOCALE_COOKIE_OPTIONS,
+            maxAge: 0,
+          });
         }
         return;
+      }
+
+      // A new session in the response means the user just signed in:
+      // adopt their saved language on this device.
+      const newSessionUser = ctx.context.newSession?.user as
+        | { locale?: string | null }
+        | undefined;
+      if (newSessionUser?.locale) {
+        ctx.setCookie(
+          LOCALE_COOKIE_NAME,
+          newSessionUser.locale,
+          LOCALE_COOKIE_OPTIONS,
+        );
       }
 
       if (
@@ -480,29 +499,7 @@ export const authLib = betterAuth({
     },
     session: {
       create: {
-        after: async (session, ctx) => {
-          // Adopt the user's saved language on this device. Must happen
-          // before the response is sent (not in `after`), and only in a
-          // request context where cookies can be written. Best-effort:
-          // a failure here must not break a sign-in whose session is
-          // already persisted.
-          if (ctx) {
-            try {
-              const user = await prisma.user.findUnique({
-                where: { id: session.userId },
-                select: { locale: true },
-              });
-              if (user?.locale) {
-                await setLocaleCookie(user.locale);
-              }
-            } catch (error) {
-              logger.error(
-                { error, userId: session.userId },
-                "Failed to set locale cookie on sign-in",
-              );
-            }
-          }
-
+        after: async (session) => {
           after(async () => {
             const user = await prisma.user
               .update({

--- a/apps/web/src/lib/locale/cookie.ts
+++ b/apps/web/src/lib/locale/cookie.ts
@@ -12,17 +12,11 @@ export async function getLocaleCookie() {
   return locale && supportedLngs.includes(locale) ? locale : undefined;
 }
 
+// Server-action/RSC contexts only. Never call from better-auth hooks:
+// mutating Next's cookie store during a route-handler request makes Next
+// rebuild the handler's Set-Cookie headers through a name-keyed map,
+// dropping duplicate-name cookies (see the locale writes in lib/auth.ts).
 export async function setLocaleCookie(locale: string) {
   const cookieStore = await cookies();
   cookieStore.set(LOCALE_COOKIE_NAME, locale, LOCALE_COOKIE_OPTIONS);
-}
-
-export async function deleteLocaleCookie() {
-  const cookieStore = await cookies();
-  // Expire via set() with the same attributes — a deletion only takes
-  // effect when path and domain match the original cookie.
-  cookieStore.set(LOCALE_COOKIE_NAME, "", {
-    ...LOCALE_COOKIE_OPTIONS,
-    maxAge: 0,
-  });
 }


### PR DESCRIPTION
## Problem

#2667 broke session creation and sign-out in production. Entering a valid OTP silently refreshed the login page, sign-out left users signed in, and nothing was logged.

## Root cause

The locale cookie was written via `next/headers` `cookies().set()` from inside better-auth request handling. Once Next's mutable cookie store is dirty, Next rebuilds the route handler's `Set-Cookie` headers through `appendMutableCookies`, which round-trips every header through `ResponseCookies` — a map keyed by cookie **name**.

In production `NEXT_PUBLIC_COOKIE_DOMAIN` is set, so `crossSubDomainCookies` + `hostOnlyCookieCleanup` legitimately emit **two** `Set-Cookie` headers per session cookie name: the real domain-scoped cookie plus a host-only deletion. The name-keyed rebuild keeps only the last one — the deletion:

- **Sign-in**: the browser received only the empty deletion cookie → no session, no error.
- **Sign-out**: the domain-scoped deletion was replaced by the host-only one → the real session cookie survived.

CI passed because the cookie domain is unset there, so no duplicate names exist. Reproduced against Next 16.2.6's actual merge code with the exact header layout captured from prod.

## Fix

Write the locale cookie through better-auth's own response: `ctx.setCookie` in the `hooks.after` middleware, keyed off `ctx.context.newSession` for sign-in adoption. Next's cookie store is never touched, so the response headers pass through verbatim.

The database hook (where #2667 put it) can't do this: `session.create.after` is queued via `queueAfterTransactionHook` and runs after the endpoint finishes, when response cookies can no longer be changed — that's why the original change reached for `next/headers` in the first place.

## Verification

Ran the app locally with `NEXT_PUBLIC_COOKIE_DOMAIN=rallly.test` to recreate the prod cookie topology and drove the flows over HTTP:

- OTP sign-in (user with saved locale `de`): response carries the intact domain session cookies, `rallly_locale=de`, and the host-only cleanup deletions — all verbatim; `get-session` confirms the session works.
- Sign-out: domain-scoped session deletions intact, plus `rallly_locale` deletion with matching domain; token revoked afterwards.
- Probes: anonymous sign-in (no saved locale) sets no locale cookie and keeps its session; wrong-path sign-out without a session still clears the locale cookie harmlessly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved locale preference handling during sign-in, sign-out, and session creation.
  * Ensured locale settings are cleared only after successful sign-out.
  * Preserved saved locale preferences when establishing a new session.

* **Documentation**
  * Clarified when locale cookie utilities should be used.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->