### PR TITLE
⚡️ Disable prefetching on invite page links

### DIFF
--- a/apps/web/src/app/[locale]/invite/[urlId]/invite-page.tsx
+++ b/apps/web/src/app/[locale]/invite/[urlId]/invite-page.tsx
@@ -34,6 +34,7 @@ const GoToApp = () => {
             <Link
               className="inline-flex items-center gap-2 hover:underline"
               href={`/poll/${poll.id}`}
+              prefetch={false}
             >
               <Trans i18nKey="manage" defaults="Manage" />
               <ArrowUpRightIcon className="size-4" />

--- a/apps/web/src/features/poll/components/create-poll.tsx
+++ b/apps/web/src/features/poll/components/create-poll.tsx
@@ -230,6 +230,7 @@ export const CreatePoll: React.FunctionComponent = () => {
 
             <Link
               href={`/invite/${createdPollId}`}
+              prefetch={false}
               className={buttonVariants()}
               onClick={() => {
                 posthog?.capture("poll_creation:view_button_click");

--- a/apps/web/src/features/poll/components/invite-dialog.tsx
+++ b/apps/web/src/features/poll/components/invite-dialog.tsx
@@ -86,6 +86,7 @@ export const InviteDialog = () => {
               <Link
                 target="_blank"
                 href={`/invite/${poll.id}`}
+                prefetch={false}
                 className={buttonVariants()}
               >
                 <ArrowUpRightIcon className="size-4" />


### PR DESCRIPTION
## What changed

Added `prefetch={false}` to the three internal `next/link` instances involved with the `/invite/[urlId]` page:

- `invite-page.tsx` — the creator-only **Manage** link to `/poll/[id]` (the only internal link rendered on the invite page with default prefetching)
- `create-poll.tsx` — the **View poll** link to `/invite/[id]` in the post-creation dialog
- `invite-dialog.tsx` — the open-in-new-tab link to `/invite/[id]`

## Why

Viewport prefetches on these links trigger invite page RSC renders we don't want. Audited the full component tree reachable from the invite route plus every link elsewhere in the app targeting `/invite/...`; everything else was already safe:

- `PollFooter` attribution already sets `prefetch={false}`
- `TruncatedLinkify` links are external URLs, which Next never prefetches (`coercePrefetchableUrl` returns null for cross-origin hrefs)
- No `router.prefetch()` or `<link rel="prefetch">` in the tree

## Reviewer note

`target="_blank"` does **not** suppress prefetching — verified against the Next 16.2.6 source, only `prefetch={false}` or a cross-origin href does. The invite dialog link was prefetching into a cache that a new-tab navigation never uses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved navigation reliability by preventing automatic preloading on invite and poll links.
  * Reduced unnecessary network requests when opening poll invitations or returning to the app.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->