### PR TITLE
♻️ Move isInjectedExtensionException into posthog utils

### DIFF
--- a/packages/posthog/src/client.ts
+++ b/packages/posthog/src/client.ts
@@ -1,43 +1,12 @@
 "use client";
-import type { CaptureResult } from "posthog-js";
 import posthog from "posthog-js";
 
 export { useFeatureFlagEnabled } from "posthog-js/react";
 
-import { isGlobalPrivacyControlEnabled } from "./utils";
-
-/**
- * Stack-frame function names that only ever appear in password-manager browser
- * extension content scripts (1Password/Dashlane-style form scanners), never in
- * our own code. Such extensions scan the page for login forms, misread our
- * invite voting form (`voting-form.tsx`) as a login form, and throw a
- * `DOMException: InvalidAccessError` from inside their own `MutationObserver`
- * callback. PostHog's exception autocapture then attributes the error to our
- * page URL, so this third-party noise ends up in error tracking.
- *
- * Matching any of these frames lets us drop the whole noise class — including
- * future variants such as other `logLogin*Detected` probes — before it is sent.
- */
-const EXTENSION_NOISE_FRAME_PATTERN =
-  /^(dispatchToBridge|logLogin\w*Detected)$/;
-
-function isInjectedExtensionException(event: CaptureResult) {
-  const exceptionList = event.properties?.$exception_list as
-    | Array<{ stacktrace?: { frames?: Array<{ function?: string }> } }>
-    | undefined;
-
-  if (!Array.isArray(exceptionList)) {
-    return false;
-  }
-
-  return exceptionList.some((exception) =>
-    exception?.stacktrace?.frames?.some(
-      (frame) =>
-        typeof frame?.function === "string" &&
-        EXTENSION_NOISE_FRAME_PATTERN.test(frame.function),
-    ),
-  );
-}
+import {
+  isGlobalPrivacyControlEnabled,
+  isInjectedExtensionException,
+} from "./utils";
 
 if (typeof window !== "undefined" && process.env.NEXT_PUBLIC_POSTHOG_API_KEY) {
   posthog.init(process.env.NEXT_PUBLIC_POSTHOG_API_KEY, {

--- a/packages/posthog/src/utils.ts
+++ b/packages/posthog/src/utils.ts
@@ -1,3 +1,5 @@
+import type { CaptureResult } from "posthog-js";
+
 type NavigatorWithGlobalPrivacyControl = Navigator & {
   globalPrivacyControl?: boolean;
 };
@@ -7,5 +9,38 @@ export function isGlobalPrivacyControlEnabled() {
     typeof navigator !== "undefined" &&
     (navigator as NavigatorWithGlobalPrivacyControl).globalPrivacyControl ===
       true
+  );
+}
+
+/**
+ * Stack-frame function names that only ever appear in password-manager browser
+ * extension content scripts (1Password/Dashlane-style form scanners), never in
+ * our own code. Such extensions scan the page for login forms, misread our
+ * invite voting form (`voting-form.tsx`) as a login form, and throw a
+ * `DOMException: InvalidAccessError` from inside their own `MutationObserver`
+ * callback. PostHog's exception autocapture then attributes the error to our
+ * page URL, so this third-party noise ends up in error tracking.
+ *
+ * Matching any of these frames lets us drop the whole noise class — including
+ * future variants such as other `logLogin*Detected` probes — before it is sent.
+ */
+const EXTENSION_NOISE_FRAME_PATTERN =
+  /^(dispatchToBridge|logLogin\w*Detected)$/;
+
+export function isInjectedExtensionException(event: CaptureResult) {
+  const exceptionList = event.properties?.$exception_list as
+    | Array<{ stacktrace?: { frames?: Array<{ function?: string }> } }>
+    | undefined;
+
+  if (!Array.isArray(exceptionList)) {
+    return false;
+  }
+
+  return exceptionList.some((exception) =>
+    exception?.stacktrace?.frames?.some(
+      (frame) =>
+        typeof frame?.function === "string" &&
+        EXTENSION_NOISE_FRAME_PATTERN.test(frame.function),
+    ),
   );
 }


### PR DESCRIPTION
Moves `isInjectedExtensionException` (and its `EXTENSION_NOISE_FRAME_PATTERN`) from `packages/posthog/src/client.ts` into `packages/posthog/src/utils.ts`, exported alongside `isGlobalPrivacyControlEnabled`. No behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved filtering of exception reports caused by injected password-manager browser extensions.
  - Reduces noisy error events while preserving legitimate exception reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->