### PR TITLE
♻️ Style svgs in DropdownMenuItem and remove DropdownMenuItemIconLabel

### DIFF
--- a/apps/web/src/app/[locale]/(space)/settings/api-keys/components/revoke-api-key-button.tsx
+++ b/apps/web/src/app/[locale]/(space)/settings/api-keys/components/revoke-api-key-button.tsx
@@ -63,9 +63,9 @@ export function RevokeApiKeyButton({
             onClick={() => {
               revokeDialog.trigger();
             }}
-            className="text-destructive"
+            variant="destructive"
           >
-            <BanIcon className="size-4" />
+            <BanIcon />
             <Trans i18nKey="revoke" defaults="Revoke" />
           </DropdownMenuItem>
         </DropdownMenuContent>

--- a/apps/web/src/app/[locale]/(space)/settings/members/components/invite-dropdown-menu.tsx
+++ b/apps/web/src/app/[locale]/(space)/settings/members/components/invite-dropdown-menu.tsx
@@ -63,9 +63,9 @@ export function InviteDropdownMenu({ invite }: { invite: SpaceMemberInvite }) {
               cancelInviteDialog.trigger();
             }}
             disabled={!canCancelInvite}
-            className="text-destructive"
+            variant="destructive"
           >
-            <XIcon className="size-4" />
+            <XIcon />
             <Trans i18nKey="cancelInvite" defaults="Cancel invite" />
           </DropdownMenuItem>
         </DropdownMenuContent>

--- a/apps/web/src/app/[locale]/(space)/settings/members/components/member-dropdown-menu.tsx
+++ b/apps/web/src/app/[locale]/(space)/settings/members/components/member-dropdown-menu.tsx
@@ -107,9 +107,9 @@ export function MemberDropdownMenu({ member }: { member: MemberDTO }) {
               removeMemberDialog.trigger();
             }}
             disabled={!canDeleteMember}
-            className="text-destructive"
+            variant="destructive"
           >
-            <XIcon className="size-4" />
+            <XIcon />
             <Trans i18nKey="removeMember" defaults="Remove member" />
           </DropdownMenuItem>
         </DropdownMenuContent>

--- a/apps/web/src/app/[locale]/control-panel/users/user-row.tsx
+++ b/apps/web/src/app/[locale]/control-panel/users/user-row.tsx
@@ -145,24 +145,24 @@ export function UserRow({
                 </DropdownMenuItem>
               ) : (
                 <DropdownMenuItem
-                  className="text-destructive"
+                  variant="destructive"
                   onClick={() => {
                     banDialog.trigger();
                   }}
                   disabled={!canBan}
                 >
-                  <BanIcon className="size-4" />
+                  <BanIcon />
                   <Trans i18nKey="banUser" defaults="Ban user" />
                 </DropdownMenuItem>
               )}
               <DropdownMenuItem
-                className="text-destructive"
+                variant="destructive"
                 onClick={async () => {
                   deleteDialog.trigger();
                 }}
                 disabled={!canDelete}
               >
-                <TrashIcon className="size-4" />
+                <TrashIcon />
                 <Trans i18nKey="delete" defaults="Delete" />
               </DropdownMenuItem>
             </DropdownMenuContent>

--- a/apps/web/src/features/poll/components/discussion.tsx
+++ b/apps/web/src/features/poll/components/discussion.tsx
@@ -222,7 +222,7 @@ function DiscussionInner() {
                             </DropdownMenuTrigger>
                             <DropdownMenuContent align="start">
                               <DropdownMenuItem
-                                className="text-destructive"
+                                variant="destructive"
                                 onClick={() => {
                                   deleteComment.mutate({
                                     commentId: comment.id,
@@ -230,7 +230,7 @@ function DiscussionInner() {
                                   });
                                 }}
                               >
-                                <TrashIcon className="size-4" />
+                                <TrashIcon />
                                 <Trans i18nKey="delete" />
                               </DropdownMenuItem>
                             </DropdownMenuContent>

--- a/apps/web/src/features/poll/components/manage-poll.tsx
+++ b/apps/web/src/features/poll/components/manage-poll.tsx
@@ -5,11 +5,9 @@ import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
-  DropdownMenuItemIconLabel,
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@rallly/ui/dropdown-menu";
-import { Icon } from "@rallly/ui/icon";
 import {
   CalendarCheck2Icon,
   ChevronDownIcon,
@@ -80,9 +78,7 @@ function OpenCloseToggle() {
           );
         }}
       >
-        <Icon>
-          <PlayIcon />
-        </Icon>
+        <PlayIcon />
         <Trans i18nKey="reopenPoll" defaults="Reopen" />
       </DropdownMenuItem>
     );
@@ -106,9 +102,7 @@ function OpenCloseToggle() {
           );
         }}
       >
-        <Icon>
-          <CircleStopIcon />
-        </Icon>
+        <CircleStopIcon />
         <Trans i18nKey="closePoll" defaults="Close" />
       </DropdownMenuItem>
     );
@@ -141,23 +135,20 @@ const ManagePoll: React.FunctionComponent<{
           <DropdownMenuItem
             render={<Link href={`/poll/${poll.id}/edit-details`} />}
           >
-            <DropdownMenuItemIconLabel icon={PencilIcon}>
-              <Trans i18nKey="editDetails" />
-            </DropdownMenuItemIconLabel>
+            <PencilIcon />
+            <Trans i18nKey="editDetails" />
           </DropdownMenuItem>
           <DropdownMenuItem
             render={<Link href={`/poll/${poll.id}/edit-options`} />}
           >
-            <DropdownMenuItemIconLabel icon={TableIcon}>
-              <Trans i18nKey="editOptions" />
-            </DropdownMenuItemIconLabel>
+            <TableIcon />
+            <Trans i18nKey="editOptions" />
           </DropdownMenuItem>
           <DropdownMenuItem
             render={<Link href={`/poll/${poll.id}/edit-settings`} />}
           >
-            <DropdownMenuItemIconLabel icon={Settings2Icon}>
-              <Trans i18nKey="editSettings" defaults="Edit settings" />
-            </DropdownMenuItemIconLabel>
+            <Settings2Icon />
+            <Trans i18nKey="editSettings" defaults="Edit settings" />
           </DropdownMenuItem>
           <DropdownMenuSeparator />
           {poll.status === "scheduled" || poll.status === "canceled" ? null : (
@@ -177,9 +168,7 @@ const ManagePoll: React.FunctionComponent<{
                   }
                 }}
               >
-                <Icon>
-                  <CalendarCheck2Icon />
-                </Icon>
+                <CalendarCheck2Icon />
                 <Trans i18nKey="schedulePoll" defaults="Schedule" />
                 {isFree ? <ProBadge /> : null}
               </DropdownMenuItem>
@@ -188,9 +177,8 @@ const ManagePoll: React.FunctionComponent<{
           )}
           <DropdownMenuSeparator />
           <DropdownMenuItem onClick={exportToCsv}>
-            <DropdownMenuItemIconLabel icon={DownloadIcon}>
-              <Trans i18nKey="exportToCsv" />
-            </DropdownMenuItemIconLabel>
+            <DownloadIcon />
+            <Trans i18nKey="exportToCsv" />
           </DropdownMenuItem>
           <DropdownMenuItem
             onClick={() => {
@@ -206,10 +194,9 @@ const ManagePoll: React.FunctionComponent<{
               }
             }}
           >
-            <DropdownMenuItemIconLabel icon={CopyIcon}>
-              <Trans i18nKey="duplicate" defaults="Duplicate" />
-              {isFree ? <ProBadge /> : null}
-            </DropdownMenuItemIconLabel>
+            <CopyIcon />
+            <Trans i18nKey="duplicate" defaults="Duplicate" />
+            {isFree ? <ProBadge /> : null}
           </DropdownMenuItem>
           <DropdownMenuSeparator />
           <DropdownMenuItem
@@ -218,7 +205,7 @@ const ManagePoll: React.FunctionComponent<{
               setShowDeletePollDialog(true);
             }}
           >
-            <TrashIcon className="size-4 opacity-75" />
+            <TrashIcon />
             <Trans i18nKey="delete" />
           </DropdownMenuItem>
         </DropdownMenuContent>

--- a/apps/web/src/features/poll/components/participant-dropdown.tsx
+++ b/apps/web/src/features/poll/components/participant-dropdown.tsx
@@ -12,7 +12,6 @@ import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
-  DropdownMenuItemIconLabel,
   DropdownMenuLabel,
   DropdownMenuSeparator,
   DropdownMenuTrigger,
@@ -88,20 +87,18 @@ export const ParticipantDropdown = ({
           </DropdownMenuLabel>
           <DropdownMenuSeparator />
           <DropdownMenuItem onClick={onEdit}>
-            <DropdownMenuItemIconLabel icon={PencilIcon}>
-              <Trans i18nKey="editVotes" />
-            </DropdownMenuItemIconLabel>
+            <PencilIcon />
+            <Trans i18nKey="editVotes" />
           </DropdownMenuItem>
           <DropdownMenuItem onClick={() => setIsChangeNameModalVisible(true)}>
-            <DropdownMenuItemIconLabel icon={TagIcon}>
-              <Trans i18nKey="changeName" />
-            </DropdownMenuItemIconLabel>
+            <TagIcon />
+            <Trans i18nKey="changeName" />
           </DropdownMenuItem>
           <DropdownMenuItem
-            className="text-destructive"
+            variant="destructive"
             onClick={() => setIsDeleteParticipantModalVisible(true)}
           >
-            <TrashIcon className="size-4" />
+            <TrashIcon />
             <Trans i18nKey="delete" />
           </DropdownMenuItem>
         </DropdownMenuContent>

--- a/packages/ui/src/dropdown-menu.tsx
+++ b/packages/ui/src/dropdown-menu.tsx
@@ -52,12 +52,13 @@ function DropdownMenuContent({
 }
 
 const dropdownMenuItemVariants = cva(
-  "relative flex cursor-default select-none items-center gap-x-2.5 rounded-lg px-2 py-1.5 text-sm outline-hidden data-disabled:pointer-events-none data-highlighted:bg-popover-accent data-disabled:opacity-50 data-highlighted:ring-1 data-highlighted:ring-menu-item-outline data-highlighted:ring-inset",
+  "relative flex cursor-default select-none items-center gap-x-2.5 rounded-lg px-2 py-1.5 text-sm outline-hidden data-disabled:pointer-events-none data-highlighted:bg-popover-accent data-disabled:opacity-50 data-highlighted:ring-1 data-highlighted:ring-menu-item-outline data-highlighted:ring-inset [&_svg:not([class*='size-'])]:size-4 [&_svg]:pointer-events-none [&_svg]:shrink-0",
   {
     variants: {
       variant: {
-        default: "",
-        destructive: "text-destructive",
+        default: "[&_svg:not([class*='text-'])]:text-muted-foreground",
+        destructive:
+          "text-destructive [&_svg:not([class*='text-'])]:text-destructive",
       },
     },
     defaultVariants: {
@@ -193,26 +194,10 @@ function DropdownMenuSubContent({
   );
 }
 
-function DropdownMenuItemIconLabel({
-  icon: IconComponent,
-  children,
-}: {
-  icon: React.ComponentType<{ className?: string }>;
-  children: React.ReactNode;
-}) {
-  return (
-    <span className="flex items-center gap-2.5">
-      <IconComponent className="size-4 text-muted-foreground" />
-      {children}
-    </span>
-  );
-}
-
 export {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
-  DropdownMenuItemIconLabel,
   DropdownMenuLabel,
   DropdownMenuRadioGroup,
   DropdownMenuRadioItem,


### PR DESCRIPTION
## Summary

Removes the `DropdownMenuItemIconLabel` wrapper component. `DropdownMenuItem` now detects and styles svg children directly, following the shadcn pattern merged with our existing item styles:

- Base: `[&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4`
- `default` variant: icons get `text-muted-foreground`
- `destructive` variant: item and icons get `text-destructive`

The color rules are guarded with `:not([class*='text-'])` (unlike shadcn's unguarded `*:[svg]:text-destructive`) because `[&_svg]` compiles to a descendant selector that outweighs a plain utility class on the icon — the guard preserves explicit per-icon colors and keeps the `<Icon>` wrapper compatible. `DropdownMenuRadioItem` and `DropdownMenuSubTrigger` share the same cva, so they inherit the rules.

Menu items can now use bare lucide icons:

```tsx
<DropdownMenuItem>
  <PencilIcon />
  <Trans i18nKey="editDetails" />
</DropdownMenuItem>
```

## Consumer changes

- `manage-poll.tsx`, `participant-dropdown.tsx`: replaced `DropdownMenuItemIconLabel` and redundant `<Icon>` wrappers with bare icons
- Five files used `className="text-destructive"` on items with icons relying on color inheritance, which the new default variant would have turned gray — converted to `variant="destructive"`: `user-row.tsx`, `invite-dropdown-menu.tsx`, `member-dropdown-menu.tsx`, `revoke-api-key-button.tsx`, `discussion.tsx`

## Intentional visual changes

- Submenu chevron in `DropdownMenuSubTrigger` is now muted instead of foreground
- Manage poll delete icon drops `opacity-75` in favor of plain `text-destructive`, matching other destructive items

Audited remaining consumers: the connect calendar dropdown uses `next/image` (renders `<img>`, unaffected) and the add to calendar brand svgs use hardcoded fills rather than `currentColor`, so the color rule is inert on them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Standardized dropdown menu styling for destructive actions such as revoke, delete, remove, cancel, and ban.
  * Improved icon alignment and color handling across dropdown menus.
  * Updated poll and participant menus with a more consistent icon-and-label layout.
  * Applied clearer visual treatment to destructive menu actions throughout settings, user management, comments, and poll management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->