### PR TITLE
💄 Match PageTitle height to default button

### DIFF
--- a/apps/web/src/components/page-layout.tsx
+++ b/apps/web/src/components/page-layout.tsx
@@ -27,7 +27,7 @@ export function PageTitle({
   return (
     <h1
       className={cn(
-        "flex items-center gap-3 truncate font-semibold text-foreground text-lg tracking-tight",
+        "flex h-9 items-center gap-3 truncate font-semibold text-foreground text-lg tracking-tight",
         className,
       )}
     >


### PR DESCRIPTION
## Description

`PageHeader` lays out its children with `items-start`, so `PageTitle` was only as tall as its own line box — 28px, from `text-lg` — while the default-size buttons rendered next to it in `PageHeaderActions` are 36px (`h-9` in `buttonVariants`). The result was that page titles and their adjacent action buttons did not line up.

This gives `PageTitle` `h-9` so its height matches the default button size and the two align.

Note for reviewers: `h-9` is hardcoded to mirror the `default` size in `packages/ui/src/button-variants.ts`. If that size ever changes, this needs to change with it — there is no shared token linking them today.

## Checklist

- [x] I have performed a self-review of my code
- [x] My code follows the code style of this project
- [ ] I have commented my code, particularly in hard-to-understand areas

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Adjusted page title spacing for more consistent visual alignment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->