### PR TITLE
🐛 Don't create PostHog person profiles for guest users

### DIFF
--- a/apps/web/src/trpc/routers/polls.ts
+++ b/apps/web/src/trpc/routers/polls.ts
@@ -165,6 +165,9 @@ export const polls = router({
             action: "create_poll",
             verdict: moderation.verdict,
             reason: moderation.reason,
+            // Guests are transient and rarely convert, so don't create a
+            // PostHog person profile for them.
+            $process_person_profile: !ctx.user.isGuest,
           },
         });
       }
@@ -293,6 +296,9 @@ export const polls = router({
           hideScores: poll.hideScores,
           requireParticipantEmail: poll.requireParticipantEmail,
           isGuest: ctx.user.isGuest,
+          // Guests are transient and rarely convert, so don't create a
+          // PostHog person profile for them (keeps them as anonymous events).
+          $process_person_profile: !ctx.user.isGuest,
         },
         groups: {
           poll: poll.id,
@@ -358,6 +364,9 @@ export const polls = router({
             action: "update_poll",
             verdict: moderation.verdict,
             reason: moderation.reason,
+            // Guests are transient and rarely convert, so don't create a
+            // PostHog person profile for them.
+            $process_person_profile: !ctx.user.isGuest,
           },
         });
       }
@@ -511,6 +520,9 @@ export const polls = router({
             has_location: !!updatedPoll.location,
             has_description: !!updatedPoll.description,
             is_guest: ctx.user.isGuest,
+            // Guests are transient and rarely convert, so don't create a
+            // PostHog person profile for them (keeps them as anonymous events).
+            $process_person_profile: !ctx.user.isGuest,
           },
           groups: {
             poll: pollId,
@@ -524,6 +536,9 @@ export const polls = router({
           distinctId: ctx.user.id,
           properties: {
             option_count: updatedPoll._count.options,
+            // Guests are transient and rarely convert, so don't create a
+            // PostHog person profile for them (keeps them as anonymous events).
+            $process_person_profile: !ctx.user.isGuest,
           },
           groups: {
             poll: pollId,
@@ -540,6 +555,9 @@ export const polls = router({
             hide_participants: !!updatedPoll.hideParticipants,
             hide_scores: !!updatedPoll.hideScores,
             require_participant_email: !!updatedPoll.requireParticipantEmail,
+            // Guests are transient and rarely convert, so don't create a
+            // PostHog person profile for them (keeps them as anonymous events).
+            $process_person_profile: !ctx.user.isGuest,
           },
           groups: {
             poll: pollId,
@@ -575,6 +593,11 @@ export const polls = router({
       posthog()?.capture({
         event: "poll_delete",
         distinctId: ctx.user.id,
+        properties: {
+          // Guests are transient and rarely convert, so don't create a
+          // PostHog person profile for them (keeps them as anonymous events).
+          $process_person_profile: !ctx.user.isGuest,
+        },
         groups: {
           poll: pollId,
         },
@@ -1168,6 +1191,11 @@ export const polls = router({
       posthog()?.capture({
         event: "poll_close",
         distinctId: ctx.user.id,
+        properties: {
+          // Guests are transient and rarely convert, so don't create a
+          // PostHog person profile for them (keeps them as anonymous events).
+          $process_person_profile: !ctx.user.isGuest,
+        },
         groups: {
           poll: input.pollId,
         },

--- a/apps/web/src/trpc/routers/polls/comments.ts
+++ b/apps/web/src/trpc/routers/polls/comments.ts
@@ -15,7 +15,7 @@ import {
   requireUserMiddleware,
   router,
 } from "../../trpc";
-import { resolveUserId } from "./utils";
+import { resolveActor } from "./utils";
 
 const logger = createLogger("comments");
 
@@ -171,6 +171,9 @@ export const comments = router({
         event: "poll_comment_add",
         properties: {
           is_guest: ctx.user.isGuest,
+          // Guests are transient and rarely convert, so don't create a
+          // PostHog person profile for them (keeps them as anonymous events).
+          $process_person_profile: !ctx.user.isGuest,
         },
         groups: {
           poll: pollId,
@@ -187,7 +190,7 @@ export const comments = router({
       }),
     )
     .mutation(async ({ input: { commentId, token }, ctx }) => {
-      const userId = await resolveUserId(token, ctx.user);
+      const actor = await resolveActor(token, ctx.user);
 
       const comment = await prisma.comment.findUnique({
         where: { id: commentId },
@@ -201,9 +204,9 @@ export const comments = router({
         });
       }
 
-      const isAuthor = comment.userId === userId;
+      const isAuthor = comment.userId === actor.id;
 
-      if (!isAuthor && !(await hasPollAdminAccess(comment.pollId, userId))) {
+      if (!isAuthor && !(await hasPollAdminAccess(comment.pollId, actor.id))) {
         throw new TRPCError({
           code: "FORBIDDEN",
           message: "You are not allowed to delete this comment",
@@ -217,14 +220,17 @@ export const comments = router({
       });
 
       // Track comment deletion analytics
-      if (comment) {
-        posthog()?.capture({
-          distinctId: userId,
-          event: "poll_comment_delete",
-          groups: {
-            poll: comment.pollId,
-          },
-        });
-      }
+      posthog()?.capture({
+        distinctId: actor.id,
+        event: "poll_comment_delete",
+        properties: {
+          // Guests are transient and rarely convert, so don't create a
+          // PostHog person profile for them (keeps them as anonymous events).
+          $process_person_profile: !actor.isGuest,
+        },
+        groups: {
+          poll: comment.pollId,
+        },
+      });
     }),
 });

--- a/apps/web/src/trpc/routers/polls/participants.ts
+++ b/apps/web/src/trpc/routers/polls/participants.ts
@@ -20,7 +20,7 @@ import {
 } from "../../trpc";
 import {
   createParticipantEditToken,
-  resolveUserId,
+  resolveActor,
   tryResolveUserId,
 } from "./utils";
 
@@ -196,9 +196,9 @@ export const participants = router({
       }),
     )
     .mutation(async ({ input: { participantId, token }, ctx }) => {
-      const userId = await resolveUserId(token, ctx.user);
+      const actor = await resolveActor(token, ctx.user);
 
-      const participant = await canModifyParticipant(participantId, userId);
+      const participant = await canModifyParticipant(participantId, actor.id);
 
       await prisma.participant.update({
         where: {
@@ -211,10 +211,13 @@ export const participants = router({
       });
 
       posthog()?.capture({
-        distinctId: userId,
+        distinctId: actor.id,
         event: "poll_response_delete",
         properties: {
           participant_id: participant.id,
+          // Guests are transient and rarely convert, so don't create a
+          // PostHog person profile for them (keeps them as anonymous events).
+          $process_person_profile: !actor.isGuest,
         },
         groups: {
           poll: participant.pollId,
@@ -355,6 +358,9 @@ export const participants = router({
             participant_id: participant.id,
             has_email: !!email,
             total_responses: totalResponses,
+            // Guests are transient and rarely convert, so don't create a
+            // PostHog person profile for them (keeps them as anonymous events).
+            $process_person_profile: !ctx.user.isGuest,
           },
           groups: {
             poll: pollId,
@@ -373,7 +379,7 @@ export const participants = router({
       }),
     )
     .mutation(async ({ input: { participantId, newName, token }, ctx }) => {
-      const userId = await resolveUserId(token, ctx.user);
+      const { id: userId } = await resolveActor(token, ctx.user);
 
       await canModifyParticipant(participantId, userId);
 
@@ -402,11 +408,11 @@ export const participants = router({
       }),
     )
     .mutation(async ({ input: { participantId, votes, token }, ctx }) => {
-      const userId = await resolveUserId(token, ctx.user);
+      const actor = await resolveActor(token, ctx.user);
 
       const existingParticipant = await canModifyParticipant(
         participantId,
-        userId,
+        actor.id,
       );
 
       const pollId = existingParticipant.pollId;
@@ -469,8 +475,13 @@ export const participants = router({
       });
 
       posthog()?.capture({
-        distinctId: userId,
+        distinctId: actor.id,
         event: "poll_response_update",
+        properties: {
+          // Guests are transient and rarely convert, so don't create a
+          // PostHog person profile for them (keeps them as anonymous events).
+          $process_person_profile: !actor.isGuest,
+        },
         groups: {
           poll: pollId,
         },

--- a/apps/web/src/trpc/routers/polls/utils.ts
+++ b/apps/web/src/trpc/routers/polls/utils.ts
@@ -23,24 +23,48 @@ export async function createParticipantEditToken(
   );
 }
 
-export async function resolveUserId(
-  token: string | undefined,
-  ctxUser: { id: string } | undefined,
-): Promise<string> {
-  const userId = await tryResolveUserId(token, ctxUser);
-  if (!userId) {
-    throw new TRPCError({
-      code: "UNAUTHORIZED",
-      message: "This method requires a user or valid token",
-    });
-  }
-  return userId;
-}
-
 export async function tryResolveUserId(
   token: string | undefined,
   ctxUser: { id: string } | undefined,
 ): Promise<string | null> {
   const userIdFromToken = await getUserIdFromToken(token);
   return userIdFromToken ?? ctxUser?.id ?? null;
+}
+
+type Actor = { id: string; isGuest: boolean };
+
+/**
+ * Resolve the acting user along with whether they should be treated as a guest
+ * for analytics (person-processing) purposes.
+ *
+ * Participant/comment edit tokens are only ever issued to guest participants,
+ * so a token-resolved actor is treated as a guest. A signed-in real user always
+ * acts through their session (`ctxUser`), never a token.
+ */
+export async function tryResolveActor(
+  token: string | undefined,
+  ctxUser: Actor | undefined,
+): Promise<Actor | null> {
+  const userIdFromToken = await getUserIdFromToken(token);
+  if (userIdFromToken) {
+    return { id: userIdFromToken, isGuest: true };
+  }
+  if (ctxUser) {
+    return { id: ctxUser.id, isGuest: ctxUser.isGuest };
+  }
+  return null;
+}
+
+export async function resolveActor(
+  token: string | undefined,
+  ctxUser: Actor | undefined,
+): Promise<Actor> {
+  const actor = await tryResolveActor(token, ctxUser);
+  if (!actor) {
+    throw new TRPCError({
+      code: "UNAUTHORIZED",
+      message: "This method requires a user or valid token",
+    });
+  }
+  return actor;
 }


### PR DESCRIPTION
## Description

Server-side product events attributed to a user (poll responses, participants, poll create/update, comments) were captured with `distinctId: <userId>` and no person-processing control. In PostHog's data model, any `capture()` with a `distinctId` and no `$process_person_profile: false` creates/updates a **person profile** for that id.

Because guests are backed by a real (anonymous) `User` row with a stable id, every guest who submitted a response, added a comment, or created a poll became an **identified PostHog person** — inflating person counts and person-processing cost, even though guests are almost never identified anywhere else and rarely convert to a real account.

This was inconsistent with existing intent in the codebase: the client `identify()` (`user-provider.tsx`) is gated on `!isGuest`, and the server `login` event (`auth.ts`) already skips anonymous users with the comment *"Anonymous users shouldn't trigger login events or create person profiles."* The product events simply never got the same treatment.

### What changed

- **Inlined `$process_person_profile: !isGuest`** on the guest-capable capture sites in the poll / participant / comment routers, so guest events are recorded as (cheaper) anonymous events with **no person profile**. Group analytics (`groups: { poll }`) is unaffected — group processing is independent of person processing.
- Real-user-only procedures (poll `reopen`, `schedule`) are left untouched — a guest can never reach them.
- **`resolveActor` / `tryResolveActor`** in `polls/utils.ts` resolve the acting user together with their guest status (replacing `resolveUserId` in the mutating paths), so edit-token flows — where the actor comes from a token rather than the session — know whether to suppress person processing. Participant/comment edit tokens are only ever issued to guest participants, so a token-resolved actor is treated as a guest.

### Trade-off / note

PostHog's model can't give you both "no guest person profiles" and "merge full guest history into the account on conversion" — anonymous events aren't retroactively backfilled to a person. Since the overwhelming majority of guests never convert, suppressing guest person profiles is the right default. The existing `$merge_dangerously` call on guest→account conversion (`features/auth/mutations.ts`) is left in place as it's harmless; a first-class signup event on the real user id would be the cleaner long-term conversion signal (follow-up).

## Checklist

Please check off all the following items with an "x" in the boxes before requesting a review.

- [x] I have performed a self-review of my code
- [x] My code follows the code style of this project
- [x] I have commented my code, particularly in hard-to-understand areas

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015BMMEbDVXJ2QvawiP9gTQH

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Guest participants can now perform supported poll, comment, and participant actions with more consistent identity handling.
  - Poll and comment activity analytics now distinguish guest activity without creating person profiles.

- **Bug Fixes**
  - Improved authorization and activity tracking when guests modify or delete comments and participants.
  - Preserved existing poll permissions and behavior for signed-in users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->