### PR TITLE
♻️ Route server analytics through a guest-aware track() facade

### DIFF
--- a/apps/web/biome.json
+++ b/apps/web/biome.json
@@ -13,7 +13,11 @@
                 "paths": {
                   "dayjs": "Use the formatters in `@/lib/datetime` for display. dayjs is only allowed in files on the migration allowlist (see overrides in biome.json).",
                   "@/lib/dayjs": "Use the formatters in `@/lib/datetime` for display. dayjs is only allowed in files on the migration allowlist (see overrides in biome.json).",
-                  "@rallly/database": "Database access is confined to the DAL: only features/**/data.ts and features/**/mutations.ts may import @rallly/database. Existing violations are on the migration allowlist (see overrides in apps/web/biome.json)."
+                  "@rallly/database": "Database access is confined to the DAL: only features/**/data.ts and features/**/mutations.ts may import @rallly/database. Existing violations are on the migration allowlist (see overrides in apps/web/biome.json).",
+                  "@/lib/posthog": {
+                    "message": "User-attributed analytics events must go through track() from @/lib/posthog so guest person-profile handling cannot be forgotten at capture sites. The raw client is reserved for non-capture APIs (feature flags, identity merge) in allowlisted files (see overrides in apps/web/biome.json).",
+                    "importNames": ["posthog"]
+                  }
                 },
                 "patterns": [
                   {
@@ -42,7 +46,11 @@
                 "paths": {
                   "dayjs": "Use the formatters in `@/lib/datetime` for display. dayjs is only allowed in files on the migration allowlist (see overrides in biome.json).",
                   "@/lib/dayjs": "Use the formatters in `@/lib/datetime` for display. dayjs is only allowed in files on the migration allowlist (see overrides in biome.json).",
-                  "@rallly/database": "Database access is confined to the DAL: only features/**/data.ts and features/**/mutations.ts may import @rallly/database. Existing violations are on the migration allowlist (see overrides in apps/web/biome.json)."
+                  "@rallly/database": "Database access is confined to the DAL: only features/**/data.ts and features/**/mutations.ts may import @rallly/database. Existing violations are on the migration allowlist (see overrides in apps/web/biome.json).",
+                  "@/lib/posthog": {
+                    "message": "User-attributed analytics events must go through track() from @/lib/posthog so guest person-profile handling cannot be forgotten at capture sites. The raw client is reserved for non-capture APIs (feature flags, identity merge) in allowlisted files (see overrides in apps/web/biome.json).",
+                    "importNames": ["posthog"]
+                  }
                 },
                 "patterns": [
                   {
@@ -75,7 +83,11 @@
                 "paths": {
                   "dayjs": "Use the formatters in `@/lib/datetime` for display. dayjs is only allowed in files on the migration allowlist (see overrides in biome.json).",
                   "@/lib/dayjs": "Use the formatters in `@/lib/datetime` for display. dayjs is only allowed in files on the migration allowlist (see overrides in biome.json).",
-                  "@rallly/database": "Database access is confined to the DAL: only features/**/data.ts and features/**/mutations.ts may import @rallly/database. Existing violations are on the migration allowlist (see overrides in apps/web/biome.json)."
+                  "@rallly/database": "Database access is confined to the DAL: only features/**/data.ts and features/**/mutations.ts may import @rallly/database. Existing violations are on the migration allowlist (see overrides in apps/web/biome.json).",
+                  "@/lib/posthog": {
+                    "message": "User-attributed analytics events must go through track() from @/lib/posthog so guest person-profile handling cannot be forgotten at capture sites. The raw client is reserved for non-capture APIs (feature flags, identity merge) in allowlisted files (see overrides in apps/web/biome.json).",
+                    "importNames": ["posthog"]
+                  }
                 },
                 "patterns": [
                   {
@@ -108,7 +120,11 @@
                 "paths": {
                   "dayjs": "Use the formatters in `@/lib/datetime` for display. dayjs is only allowed in files on the migration allowlist (see overrides in biome.json).",
                   "@/lib/dayjs": "Use the formatters in `@/lib/datetime` for display. dayjs is only allowed in files on the migration allowlist (see overrides in biome.json).",
-                  "@rallly/database": "Database access is confined to the DAL: only features/**/data.ts and features/**/mutations.ts may import @rallly/database. Existing violations are on the migration allowlist (see overrides in apps/web/biome.json)."
+                  "@rallly/database": "Database access is confined to the DAL: only features/**/data.ts and features/**/mutations.ts may import @rallly/database. Existing violations are on the migration allowlist (see overrides in apps/web/biome.json).",
+                  "@/lib/posthog": {
+                    "message": "User-attributed analytics events must go through track() from @/lib/posthog so guest person-profile handling cannot be forgotten at capture sites. The raw client is reserved for non-capture APIs (feature flags, identity merge) in allowlisted files (see overrides in apps/web/biome.json).",
+                    "importNames": ["posthog"]
+                  }
                 },
                 "patterns": [
                   {
@@ -137,7 +153,11 @@
                 "paths": {
                   "dayjs": "Use the formatters in `@/lib/datetime` for display. dayjs is only allowed in files on the migration allowlist (see overrides in biome.json).",
                   "@/lib/dayjs": "Use the formatters in `@/lib/datetime` for display. dayjs is only allowed in files on the migration allowlist (see overrides in biome.json).",
-                  "@rallly/database": "Database access is confined to the DAL: only features/**/data.ts and features/**/mutations.ts may import @rallly/database. Existing violations are on the migration allowlist (see overrides in apps/web/biome.json)."
+                  "@rallly/database": "Database access is confined to the DAL: only features/**/data.ts and features/**/mutations.ts may import @rallly/database. Existing violations are on the migration allowlist (see overrides in apps/web/biome.json).",
+                  "@/lib/posthog": {
+                    "message": "User-attributed analytics events must go through track() from @/lib/posthog so guest person-profile handling cannot be forgotten at capture sites. The raw client is reserved for non-capture APIs (feature flags, identity merge) in allowlisted files (see overrides in apps/web/biome.json).",
+                    "importNames": ["posthog"]
+                  }
                 },
                 "patterns": [
                   {
@@ -174,7 +194,11 @@
               "options": {
                 "paths": {
                   "dayjs": "Use the formatters in `@/lib/datetime` for display. dayjs is only allowed in files on the migration allowlist (see overrides in biome.json).",
-                  "@/lib/dayjs": "Use the formatters in `@/lib/datetime` for display. dayjs is only allowed in files on the migration allowlist (see overrides in biome.json)."
+                  "@/lib/dayjs": "Use the formatters in `@/lib/datetime` for display. dayjs is only allowed in files on the migration allowlist (see overrides in biome.json).",
+                  "@/lib/posthog": {
+                    "message": "User-attributed analytics events must go through track() from @/lib/posthog so guest person-profile handling cannot be forgotten at capture sites. The raw client is reserved for non-capture APIs (feature flags, identity merge) in allowlisted files (see overrides in apps/web/biome.json).",
+                    "importNames": ["posthog"]
+                  }
                 },
                 "patterns": [
                   {
@@ -214,7 +238,11 @@
               "options": {
                 "paths": {
                   "dayjs": "Use the formatters in `@/lib/datetime` for display. dayjs is only allowed in files on the migration allowlist (see overrides in biome.json).",
-                  "@/lib/dayjs": "Use the formatters in `@/lib/datetime` for display. dayjs is only allowed in files on the migration allowlist (see overrides in biome.json)."
+                  "@/lib/dayjs": "Use the formatters in `@/lib/datetime` for display. dayjs is only allowed in files on the migration allowlist (see overrides in biome.json).",
+                  "@/lib/posthog": {
+                    "message": "User-attributed analytics events must go through track() from @/lib/posthog so guest person-profile handling cannot be forgotten at capture sites. The raw client is reserved for non-capture APIs (feature flags, identity merge) in allowlisted files (see overrides in apps/web/biome.json).",
+                    "importNames": ["posthog"]
+                  }
                 },
                 "patterns": [
                   {
@@ -270,7 +298,11 @@
               "options": {
                 "paths": {
                   "dayjs": "Use the formatters in `@/lib/datetime` for display. dayjs is only allowed in files on the migration allowlist (see overrides in biome.json).",
-                  "@/lib/dayjs": "Use the formatters in `@/lib/datetime` for display. dayjs is only allowed in files on the migration allowlist (see overrides in biome.json)."
+                  "@/lib/dayjs": "Use the formatters in `@/lib/datetime` for display. dayjs is only allowed in files on the migration allowlist (see overrides in biome.json).",
+                  "@/lib/posthog": {
+                    "message": "User-attributed analytics events must go through track() from @/lib/posthog so guest person-profile handling cannot be forgotten at capture sites. The raw client is reserved for non-capture APIs (feature flags, identity merge) in allowlisted files (see overrides in apps/web/biome.json).",
+                    "importNames": ["posthog"]
+                  }
                 },
                 "patterns": [
                   {
@@ -298,7 +330,11 @@
               "options": {
                 "paths": {
                   "dayjs": "Use the formatters in `@/lib/datetime` for display. dayjs is only allowed in files on the migration allowlist (see overrides in biome.json).",
-                  "@/lib/dayjs": "Use the formatters in `@/lib/datetime` for display. dayjs is only allowed in files on the migration allowlist (see overrides in biome.json)."
+                  "@/lib/dayjs": "Use the formatters in `@/lib/datetime` for display. dayjs is only allowed in files on the migration allowlist (see overrides in biome.json).",
+                  "@/lib/posthog": {
+                    "message": "User-attributed analytics events must go through track() from @/lib/posthog so guest person-profile handling cannot be forgotten at capture sites. The raw client is reserved for non-capture APIs (feature flags, identity merge) in allowlisted files (see overrides in apps/web/biome.json).",
+                    "importNames": ["posthog"]
+                  }
                 },
                 "patterns": [
                   {
@@ -334,7 +370,11 @@
               "options": {
                 "paths": {
                   "dayjs": "Use the formatters in `@/lib/datetime` for display. dayjs is only allowed in files on the migration allowlist (see overrides in biome.json).",
-                  "@/lib/dayjs": "Use the formatters in `@/lib/datetime` for display. dayjs is only allowed in files on the migration allowlist (see overrides in biome.json)."
+                  "@/lib/dayjs": "Use the formatters in `@/lib/datetime` for display. dayjs is only allowed in files on the migration allowlist (see overrides in biome.json).",
+                  "@/lib/posthog": {
+                    "message": "User-attributed analytics events must go through track() from @/lib/posthog so guest person-profile handling cannot be forgotten at capture sites. The raw client is reserved for non-capture APIs (feature flags, identity merge) in allowlisted files (see overrides in apps/web/biome.json).",
+                    "importNames": ["posthog"]
+                  }
                 },
                 "patterns": [
                   {
@@ -368,8 +408,44 @@
               "options": {
                 "paths": {
                   "dayjs": "Use the formatters in `@/lib/datetime` for display. dayjs is only allowed in files on the migration allowlist (see overrides in biome.json).",
-                  "@/lib/dayjs": "Use the formatters in `@/lib/datetime` for display. dayjs is only allowed in files on the migration allowlist (see overrides in biome.json)."
+                  "@/lib/dayjs": "Use the formatters in `@/lib/datetime` for display. dayjs is only allowed in files on the migration allowlist (see overrides in biome.json).",
+                  "@/lib/posthog": {
+                    "message": "User-attributed analytics events must go through track() from @/lib/posthog so guest person-profile handling cannot be forgotten at capture sites. The raw client is reserved for non-capture APIs (feature flags, identity merge) in allowlisted files (see overrides in apps/web/biome.json).",
+                    "importNames": ["posthog"]
+                  }
                 }
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "includes": [
+        "src/features/auth/mutations.ts",
+        "src/features/billing/webhook/mutations.ts",
+        "src/features/api-keys/data.ts"
+      ],
+      "linter": {
+        "rules": {
+          "style": {
+            "noRestrictedImports": {
+              "level": "error",
+              "options": {
+                "paths": {
+                  "dayjs": "Use the formatters in `@/lib/datetime` for display. dayjs is only allowed in files on the migration allowlist (see overrides in biome.json).",
+                  "@/lib/dayjs": "Use the formatters in `@/lib/datetime` for display. dayjs is only allowed in files on the migration allowlist (see overrides in biome.json)."
+                },
+                "patterns": [
+                  {
+                    "group": ["@/app", "@/app/**"],
+                    "message": "Only files inside app/ may import from app/. Routes are thin adapters; shared code belongs in features/, components/, or lib/. Existing violations are on the migration allowlist (see overrides in apps/web/biome.json)."
+                  },
+                  {
+                    "group": ["@/utils", "@/utils/**"],
+                    "message": "src/utils is dissolved. Generic helpers live in @/lib/utils, infrastructure in @/lib, domain code in the owning feature."
+                  }
+                ]
               }
             }
           }

--- a/apps/web/src/features/api-keys/actions.ts
+++ b/apps/web/src/features/api-keys/actions.ts
@@ -7,7 +7,7 @@ import {
   revokeApiKeySchema,
 } from "@/features/api-keys/schema";
 import { AppError } from "@/lib/errors/app-error";
-import { posthog } from "@/lib/posthog";
+import { track } from "@/lib/posthog";
 import { authActionClient } from "@/lib/safe-action/server";
 
 // The UI never offers these actions to users without API access, so a
@@ -50,8 +50,7 @@ export const createApiKeyAction = authActionClient
     });
 
     if (result.ok) {
-      posthog()?.capture({
-        distinctId: ctx.user.id,
+      track(ctx.user, {
         event: "developer:api_key_create",
         groups: {
           space: space.id,
@@ -70,8 +69,7 @@ export const revokeApiKeyAction = authActionClient
 
     await revokeApiKey({ spaceId: space.id, id: parsedInput.id });
 
-    posthog()?.capture({
-      distinctId: ctx.user.id,
+    track(ctx.user, {
       event: "developer:api_key_revoke",
       groups: {
         space: space.id,

--- a/apps/web/src/features/feedback/mutations.ts
+++ b/apps/web/src/features/feedback/mutations.ts
@@ -1,7 +1,7 @@
 import "server-only";
 
 import { sendRawEmail } from "@rallly/emails";
-import { posthog } from "@/lib/posthog";
+import { track } from "@/lib/posthog";
 
 export async function submitFeedback({
   userId,
@@ -21,8 +21,6 @@ export async function submitFeedback({
     text: `User: ${userName} (${userEmail})\n\n${content}`,
   });
 
-  posthog()?.capture({
-    event: "feedback_send",
-    distinctId: userId,
-  });
+  // Feedback is only reachable through authActionClient, which rejects guests.
+  track({ id: userId, isGuest: false }, { event: "feedback_send" });
 }

--- a/apps/web/src/features/space/actions.ts
+++ b/apps/web/src/features/space/actions.ts
@@ -4,7 +4,7 @@ import { prisma } from "@rallly/database";
 import * as z from "zod";
 import { setActiveSpace } from "@/features/user/mutations";
 import { AppError } from "@/lib/errors/app-error";
-import { posthog } from "@/lib/posthog";
+import { track } from "@/lib/posthog";
 import { authActionClient } from "@/lib/safe-action/server";
 
 export const setActiveSpaceAction = authActionClient
@@ -32,8 +32,7 @@ export const setActiveSpaceAction = authActionClient
       spaceId: parsedInput.spaceId,
     });
 
-    posthog()?.capture({
-      distinctId: ctx.user.id,
+    track(ctx.user, {
       event: "space_set_active",
       properties: {
         space_id: parsedInput.spaceId,

--- a/apps/web/src/lib/auth.ts
+++ b/apps/web/src/lib/auth.ts
@@ -37,7 +37,7 @@ import {
   LOCALE_COOKIE_NAME,
   LOCALE_COOKIE_OPTIONS,
 } from "@/lib/locale/constants";
-import { posthog } from "@/lib/posthog";
+import { identifyGroup, track } from "@/lib/posthog";
 import { getValueByPath } from "@/lib/utils/get-value-by-path";
 
 const kv = redis;
@@ -126,10 +126,8 @@ export const authLib = betterAuth({
       });
     },
     onPasswordReset: async ({ user }) => {
-      posthog()?.capture({
-        distinctId: user.id,
-        event: "password_reset",
-      });
+      // Guests have no credentials, so this is always an identified user.
+      track({ id: user.id, isGuest: false }, { event: "password_reset" });
     },
   },
   emailVerification: {
@@ -403,14 +401,17 @@ export const authLib = betterAuth({
           }
 
           if (path === "/email-otp/request-email-change") {
-            posthog()?.capture({
-              event: "account_email_change_request",
-              distinctId: session.user.id,
-              properties: {
-                fromEmail: session.user.email,
-                toEmail: newEmail,
+            // Email changes are only available to registered users.
+            track(
+              { id: session.user.id, isGuest: false },
+              {
+                event: "account_email_change_request",
+                properties: {
+                  fromEmail: session.user.email,
+                  toEmail: newEmail,
+                },
               },
-            });
+            );
             return;
           }
 
@@ -432,15 +433,17 @@ export const authLib = betterAuth({
             }
           }
 
-          posthog()?.capture({
-            event: "account_email_change_complete",
-            distinctId: session.user.id,
-            properties: {
-              $set: {
-                email: newEmail,
+          track(
+            { id: session.user.id, isGuest: false },
+            {
+              event: "account_email_change_complete",
+              properties: {
+                $set: {
+                  email: newEmail,
+                },
               },
             },
-          });
+          );
         } catch (error) {
           logger.error({ error }, "Failed to run email change side effects");
         }
@@ -468,7 +471,7 @@ export const authLib = betterAuth({
               ownerId: user.id,
             });
 
-            posthog()?.groupIdentify({
+            identifyGroup({
               groupType: "space",
               groupKey: space.id,
               properties: {
@@ -480,20 +483,22 @@ export const authLib = betterAuth({
             });
           }
 
-          posthog()?.capture({
-            distinctId: user.id,
-            event: "register",
-            properties: {
-              method: user.lastLoginMethod,
-              $set: {
-                name: user.name,
-                email: user.email,
-                tier: "hobby",
-                timeZone: user.timeZone ?? undefined,
-                locale: user.locale ?? undefined,
+          track(
+            { id: user.id, isGuest: false },
+            {
+              event: "register",
+              properties: {
+                method: user.lastLoginMethod,
+                $set: {
+                  name: user.name,
+                  email: user.email,
+                  tier: "hobby",
+                  timeZone: user.timeZone ?? undefined,
+                  locale: user.locale ?? undefined,
+                },
               },
             },
-          });
+          );
         },
       },
     },
@@ -511,11 +516,13 @@ export const authLib = betterAuth({
 
             // Anonymous users shouldn't trigger login events or create person profiles.
             if (user && !user.isAnonymous) {
-              posthog()?.capture({
-                distinctId: session.userId,
-                event: "login",
-                properties: { method: user.lastLoginMethod },
-              });
+              track(
+                { id: session.userId, isGuest: false },
+                {
+                  event: "login",
+                  properties: { method: user.lastLoginMethod },
+                },
+              );
             }
           });
         },

--- a/apps/web/src/lib/posthog.ts
+++ b/apps/web/src/lib/posthog.ts
@@ -17,6 +17,47 @@ export function posthog() {
   return instance;
 }
 
+/**
+ * Capture a product event attributed to the acting user.
+ *
+ * This is the only sanctioned way to capture user-attributed events on the
+ * server — importing the raw `posthog` client is lint-restricted (see
+ * noRestrictedImports in apps/web/biome.json) so the guest decision cannot
+ * be forgotten at individual capture sites. Guests are captured as anonymous
+ * events (no person profile — they are transient and rarely convert);
+ * identified users get person processing as usual. Group analytics is
+ * unaffected either way.
+ */
+export function track(
+  user: { id: string; isGuest: boolean },
+  event: {
+    event: string;
+    properties?: Record<string, unknown>;
+    groups?: Record<string, string>;
+  },
+) {
+  posthog()?.capture({
+    ...event,
+    distinctId: user.id,
+    properties: {
+      ...event.properties,
+      $process_person_profile: !user.isGuest,
+    },
+  });
+}
+
+/**
+ * Update properties on a group (e.g. poll, space). Groups are independent
+ * of person profiles, so no guest handling is involved.
+ */
+export function identifyGroup(group: {
+  groupType: string;
+  groupKey: string;
+  properties?: Record<string, unknown>;
+}) {
+  posthog()?.groupIdentify(group);
+}
+
 export function withPostHog(
   handler: (req: NextRequest) => Promise<Response>,
 ): (req: NextRequest) => Promise<Response> {

--- a/apps/web/src/trpc/routers/polls.ts
+++ b/apps/web/src/trpc/routers/polls.ts
@@ -19,7 +19,7 @@ import { MAX_POLL_DESCRIPTION_LENGTH } from "@/features/poll/schema";
 import { formatEventDateTime } from "@/features/scheduled-event/utils";
 import { getActiveSpaceForUser } from "@/features/space/data";
 import { dayjs } from "@/lib/dayjs";
-import { posthog } from "@/lib/posthog";
+import { identifyGroup, track } from "@/lib/posthog";
 import { createIcsEvent } from "@/lib/utils/ics";
 import {
   createRateLimitMiddleware,
@@ -158,16 +158,12 @@ export const polls = router({
       });
 
       if (moderation.verdict !== "safe") {
-        posthog()?.capture({
-          distinctId: ctx.user.id,
+        track(ctx.user, {
           event: "flagged_content",
           properties: {
             action: "create_poll",
             verdict: moderation.verdict,
             reason: moderation.reason,
-            // Guests are transient and rarely convert, so don't create a
-            // PostHog person profile for them.
-            $process_person_profile: !ctx.user.isGuest,
           },
         });
       }
@@ -265,7 +261,7 @@ export const polls = router({
         }
       }
 
-      posthog()?.groupIdentify({
+      identifyGroup({
         groupType: "poll",
         groupKey: poll.id,
         properties: {
@@ -282,9 +278,8 @@ export const polls = router({
         },
       });
 
-      posthog()?.capture({
+      track(ctx.user, {
         event: "poll_create",
-        distinctId: ctx.user.id,
         properties: {
           title: poll.title,
           optionCount: poll.options.length,
@@ -296,9 +291,6 @@ export const polls = router({
           hideScores: poll.hideScores,
           requireParticipantEmail: poll.requireParticipantEmail,
           isGuest: ctx.user.isGuest,
-          // Guests are transient and rarely convert, so don't create a
-          // PostHog person profile for them (keeps them as anonymous events).
-          $process_person_profile: !ctx.user.isGuest,
         },
         groups: {
           poll: poll.id,
@@ -357,16 +349,12 @@ export const polls = router({
       });
 
       if (moderation.verdict !== "safe") {
-        posthog()?.capture({
-          distinctId: ctx.user.id,
+        track(ctx.user, {
           event: "flagged_content",
           properties: {
             action: "update_poll",
             verdict: moderation.verdict,
             reason: moderation.reason,
-            // Guests are transient and rarely convert, so don't create a
-            // PostHog person profile for them.
-            $process_person_profile: !ctx.user.isGuest,
           },
         });
       }
@@ -512,17 +500,13 @@ export const polls = router({
         input.requireParticipantEmail !== undefined;
 
       if (hasDetailsUpdate) {
-        posthog()?.capture({
+        track(ctx.user, {
           event: "poll_update_details",
-          distinctId: ctx.user.id,
           properties: {
             title: updatedPoll.title,
             has_location: !!updatedPoll.location,
             has_description: !!updatedPoll.description,
             is_guest: ctx.user.isGuest,
-            // Guests are transient and rarely convert, so don't create a
-            // PostHog person profile for them (keeps them as anonymous events).
-            $process_person_profile: !ctx.user.isGuest,
           },
           groups: {
             poll: pollId,
@@ -531,14 +515,10 @@ export const polls = router({
       }
 
       if (hasOptionsUpdate) {
-        posthog()?.capture({
+        track(ctx.user, {
           event: "poll_update_options",
-          distinctId: ctx.user.id,
           properties: {
             option_count: updatedPoll._count.options,
-            // Guests are transient and rarely convert, so don't create a
-            // PostHog person profile for them (keeps them as anonymous events).
-            $process_person_profile: !ctx.user.isGuest,
           },
           groups: {
             poll: pollId,
@@ -547,17 +527,13 @@ export const polls = router({
       }
 
       if (hasSettingsUpdate) {
-        posthog()?.capture({
+        track(ctx.user, {
           event: "poll_update_settings",
-          distinctId: ctx.user.id,
           properties: {
             disable_comments: !!updatedPoll.disableComments,
             hide_participants: !!updatedPoll.hideParticipants,
             hide_scores: !!updatedPoll.hideScores,
             require_participant_email: !!updatedPoll.requireParticipantEmail,
-            // Guests are transient and rarely convert, so don't create a
-            // PostHog person profile for them (keeps them as anonymous events).
-            $process_person_profile: !ctx.user.isGuest,
           },
           groups: {
             poll: pollId,
@@ -590,14 +566,8 @@ export const polls = router({
       });
 
       // Track poll deletion analytics
-      posthog()?.capture({
+      track(ctx.user, {
         event: "poll_delete",
-        distinctId: ctx.user.id,
-        properties: {
-          // Guests are transient and rarely convert, so don't create a
-          // PostHog person profile for them (keeps them as anonymous events).
-          $process_person_profile: !ctx.user.isGuest,
-        },
         groups: {
           poll: pollId,
         },
@@ -624,7 +594,7 @@ export const polls = router({
         data: { muted: input.muted },
       });
 
-      posthog()?.groupIdentify({
+      identifyGroup({
         groupType: "poll",
         groupKey: input.pollId,
         properties: {
@@ -1103,9 +1073,8 @@ export const polls = router({
           );
         }
 
-        posthog()?.capture({
+        track(ctx.user, {
           event: "poll_schedule",
-          distinctId: ctx.user.id,
           properties: {
             attendee_count: attendees.length,
             days_since_created: dayjs().diff(poll.createdAt, "day"),
@@ -1153,9 +1122,8 @@ export const polls = router({
         }
       });
 
-      posthog()?.capture({
+      track(ctx.user, {
         event: "poll_reopen",
-        distinctId: ctx.user.id,
         groups: {
           poll: input.pollId,
         },
@@ -1188,14 +1156,8 @@ export const polls = router({
         },
       });
 
-      posthog()?.capture({
+      track(ctx.user, {
         event: "poll_close",
-        distinctId: ctx.user.id,
-        properties: {
-          // Guests are transient and rarely convert, so don't create a
-          // PostHog person profile for them (keeps them as anonymous events).
-          $process_person_profile: !ctx.user.isGuest,
-        },
         groups: {
           poll: input.pollId,
         },

--- a/apps/web/src/trpc/routers/polls/comments.ts
+++ b/apps/web/src/trpc/routers/polls/comments.ts
@@ -8,7 +8,7 @@ import * as z from "zod";
 import { getInstanceBranding } from "@/emails/branding";
 import { getNotificationRecipient } from "@/features/notifications/data";
 import { hasPollAdminAccess } from "@/features/poll/data";
-import { posthog } from "@/lib/posthog";
+import { track } from "@/lib/posthog";
 import {
   createRateLimitMiddleware,
   publicProcedure,
@@ -166,14 +166,10 @@ export const comments = router({
       }
 
       // Track comment addition analytics
-      posthog()?.capture({
-        distinctId: ctx.user.id,
+      track(ctx.user, {
         event: "poll_comment_add",
         properties: {
           is_guest: ctx.user.isGuest,
-          // Guests are transient and rarely convert, so don't create a
-          // PostHog person profile for them (keeps them as anonymous events).
-          $process_person_profile: !ctx.user.isGuest,
         },
         groups: {
           poll: pollId,
@@ -220,14 +216,8 @@ export const comments = router({
       });
 
       // Track comment deletion analytics
-      posthog()?.capture({
-        distinctId: actor.id,
+      track(actor, {
         event: "poll_comment_delete",
-        properties: {
-          // Guests are transient and rarely convert, so don't create a
-          // PostHog person profile for them (keeps them as anonymous events).
-          $process_person_profile: !actor.isGuest,
-        },
         groups: {
           poll: comment.pollId,
         },

--- a/apps/web/src/trpc/routers/polls/participants.ts
+++ b/apps/web/src/trpc/routers/polls/participants.ts
@@ -10,7 +10,7 @@ import * as z from "zod";
 import { getInstanceBranding, getSpaceBranding } from "@/emails/branding";
 import { getNotificationRecipient } from "@/features/notifications/data";
 import { hasPollAdminAccess } from "@/features/poll/data";
-import { posthog } from "@/lib/posthog";
+import { track } from "@/lib/posthog";
 import { getGravatarUrl } from "@/lib/utils/gravatar";
 import {
   createRateLimitMiddleware,
@@ -210,14 +210,10 @@ export const participants = router({
         },
       });
 
-      posthog()?.capture({
-        distinctId: actor.id,
+      track(actor, {
         event: "poll_response_delete",
         properties: {
           participant_id: participant.id,
-          // Guests are transient and rarely convert, so don't create a
-          // PostHog person profile for them (keeps them as anonymous events).
-          $process_person_profile: !actor.isGuest,
         },
         groups: {
           poll: participant.pollId,
@@ -351,16 +347,12 @@ export const participants = router({
           }),
         );
 
-        posthog()?.capture({
-          distinctId: ctx.user.id,
+        track(ctx.user, {
           event: "poll_response_submit",
           properties: {
             participant_id: participant.id,
             has_email: !!email,
             total_responses: totalResponses,
-            // Guests are transient and rarely convert, so don't create a
-            // PostHog person profile for them (keeps them as anonymous events).
-            $process_person_profile: !ctx.user.isGuest,
           },
           groups: {
             poll: pollId,
@@ -474,14 +466,8 @@ export const participants = router({
         });
       });
 
-      posthog()?.capture({
-        distinctId: actor.id,
+      track(actor, {
         event: "poll_response_update",
-        properties: {
-          // Guests are transient and rarely convert, so don't create a
-          // PostHog person profile for them (keeps them as anonymous events).
-          $process_person_profile: !actor.isGuest,
-        },
         groups: {
           poll: pollId,
         },

--- a/apps/web/src/trpc/routers/spaces.ts
+++ b/apps/web/src/trpc/routers/spaces.ts
@@ -24,7 +24,7 @@ import {
   toDBRole,
 } from "@/features/space/utils";
 import { setActiveSpace } from "@/features/user/mutations";
-import { posthog } from "@/lib/posthog";
+import { identifyGroup, track } from "@/lib/posthog";
 import {
   deleteImageFromS3,
   getImageUploadUrl,
@@ -164,7 +164,7 @@ export const spaces = router({
         ownerId: ctx.user.id,
       });
 
-      posthog()?.groupIdentify({
+      identifyGroup({
         groupType: "space",
         groupKey: space.id,
         properties: {
@@ -175,8 +175,7 @@ export const spaces = router({
         },
       });
 
-      posthog()?.capture({
-        distinctId: ctx.user.id,
+      track(ctx.user, {
         event: "space_create",
         properties: {
           space_name: space.name,
@@ -218,8 +217,7 @@ export const spaces = router({
       where: { id: ctx.space.id },
     });
 
-    posthog()?.capture({
-      distinctId: ctx.user.id,
+    track(ctx.user, {
       event: "space_delete",
       properties: {
         space_id: ctx.space.id,
@@ -264,8 +262,7 @@ export const spaces = router({
         },
       });
 
-      posthog()?.capture({
-        distinctId: ctx.user.id,
+      track(ctx.user, {
         event: "space_update",
         properties: {
           space_name: input.name,
@@ -303,8 +300,7 @@ export const spaces = router({
         data: { showBranding: input.showBranding },
       });
 
-      posthog()?.capture({
-        distinctId: ctx.user.id,
+      track(ctx.user, {
         event: "space_update_show_branding",
         properties: {
           showBranding: input.showBranding,
@@ -432,8 +428,7 @@ export const spaces = router({
         };
       }
 
-      posthog()?.capture({
-        distinctId: ctx.user.id,
+      track(ctx.user, {
         event: "space_member_invite",
         properties: {
           role: input.role,
@@ -506,8 +501,7 @@ export const spaces = router({
         logger.warn({ error }, "Failed to update user's active space");
       }
 
-      posthog()?.capture({
-        distinctId: ctx.user.id,
+      track(ctx.user, {
         event: "space_member_join",
         properties: {
           member_count: memberCount,
@@ -550,8 +544,7 @@ export const spaces = router({
         where: { spaceId: member.spaceId },
       });
 
-      posthog()?.capture({
-        distinctId: ctx.user.id,
+      track(ctx.user, {
         event: "space_member_remove",
         properties: {
           member_count: memberCount,
@@ -684,8 +677,7 @@ export const spaces = router({
       where: { spaceId: ctx.space.id },
     });
 
-    posthog()?.capture({
-      distinctId: ctx.user.id,
+    track(ctx.user, {
       event: "space_member_leave",
       properties: {
         member_count: memberCount,
@@ -763,8 +755,7 @@ export const spaces = router({
         where: { spaceId: input.spaceId },
       });
 
-      posthog()?.capture({
-        distinctId: ctx.user.id,
+      track(ctx.user, {
         event: "space_member_leave",
         properties: {
           member_count: memberCount,

--- a/apps/web/src/trpc/routers/user.ts
+++ b/apps/web/src/trpc/routers/user.ts
@@ -6,7 +6,7 @@ import { defaultNotificationPreferences } from "@/features/notifications/constan
 import { getNotificationPreferences } from "@/features/notifications/data";
 import { activityEventTypes } from "@/features/notifications/schema";
 import { defineAbilityFor } from "@/features/user/ability";
-import { posthog } from "@/lib/posthog";
+import { track } from "@/lib/posthog";
 import { privateProcedure, publicProcedure, router } from "../trpc";
 
 export const user = router({
@@ -94,9 +94,8 @@ export const user = router({
         },
       });
 
-      posthog()?.capture({
+      track(ctx.user, {
         event: "notification_preference_update",
-        distinctId: ctx.user.id,
         properties: {
           eventType: input.eventType,
           enabled: input.enabled,


### PR DESCRIPTION
## Description

Follow-up to #2676, which fixed guest person-profile creation by inlining `$process_person_profile: !isGuest` at each capture site. That works, but it's a *convention* — every future `capture()` call is a chance to forget the guest check, and the failure mode is silent (person counts quietly inflate again). This PR replaces the convention with structure, so the guest decision is made once and cannot be forgotten at individual capture sites.

### What changed

- **`track(user, event)`** in `lib/posthog.ts` is now the only sanctioned way to capture user-attributed events on the server. It takes the acting user (`{ id, isGuest }`), stamps `distinctId`, and decides person-profile processing centrally: guests are captured as anonymous events (no person profile), identified users as identified events. The inline `$process_person_profile` flags and their repeated comments are gone.
- **`identifyGroup()`** passthrough for `groupIdentify` — group analytics is independent of person profiles, so no guest handling is involved.
- **Lint enforcement**: `noRestrictedImports` in `apps/web/biome.json` now bans importing the raw `posthog` client, using the same enforcement idiom the repo already uses for the DAL (`@rallly/database`) and dayjs. A raw `posthog` import anywhere outside the allowlist is a lint **error**; `track`, `identifyGroup`, and `withPostHog` remain freely importable.
- **Allowlist** (raw client permitted, non-capture APIs only):
  - `features/api-keys/data.ts` — feature-flag check (`isFeatureEnabled`)
  - `features/auth/mutations.ts` — the `$merge_dangerously` identity operation
  - `features/billing/webhook/mutations.ts` — Stripe webhook system context (captures paying users with `$set` person properties; one event is keyed by email, not user id)

### Converted capture sites

All user-attributed captures now go through `track()`: poll routers (`polls.ts`, `participants.ts`, `comments.ts`), `spaces.ts` (9 events), `user.ts`, `api-keys/actions.ts`, `space/actions.ts`, `feedback/mutations.ts`, and `lib/auth.ts`. The auth flows pass `isGuest: false` explicitly — each is provably unreachable by guests (register/login are already guarded on `isAnonymous`; guests have no credentials or real email). Feedback is only reachable through `authActionClient`, which rejects guests.

### Verification

- `tsc --noEmit`: 0 errors
- Biome full-app check: clean (one pre-existing warning on `main`, untouched)
- **Negative test**: adding a raw `posthog` import to a converted file produces the expected `noRestrictedImports` error naming `track()` as the sanctioned path; reverting clears it
- Unit tests: 248/248 pass

## Checklist

Please check off all the following items with an "x" in the boxes before requesting a review.

- [x] I have performed a self-review of my code
- [x] My code follows the code style of this project
- [x] I have commented my code, particularly in hard-to-understand areas

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015BMMEbDVXJ2QvawiP9gTQH

---
_Generated by [Claude Code](https://claude.ai/code/session_015BMMEbDVXJ2QvawiP9gTQH)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Analytics**
  * Improved reliability and consistency of event tracking across account, space, poll, feedback, API key, and notification workflows.
  * Enhanced group analytics for spaces and polls.
  * Ensured guest and authenticated activity is attributed correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->