### PR TITLE
📈 Track custom branding as a space group property

### DIFF
--- a/apps/web/src/features/billing/webhook/mutations.ts
+++ b/apps/web/src/features/billing/webhook/mutations.ts
@@ -285,7 +285,7 @@ async function onCustomerSubscriptionCreated(event: Stripe.Event) {
     groupType: "space",
     groupKey: spaceId,
     properties: {
-      seatCount: quantity,
+      seat_count: quantity,
       tier,
     },
   });
@@ -465,7 +465,7 @@ async function onCustomerSubscriptionUpdated(event: Stripe.Event) {
     groupType: "space",
     groupKey: spaceId,
     properties: {
-      seatCount: quantity,
+      seat_count: quantity,
       tier,
     },
   });

--- a/apps/web/src/lib/auth.ts
+++ b/apps/web/src/lib/auth.ts
@@ -476,8 +476,8 @@ export const authLib = betterAuth({
               groupKey: space.id,
               properties: {
                 name: space.name,
-                memberCount: 1,
-                seatCount: 1,
+                member_count: 1,
+                seat_count: 1,
                 tier: "hobby",
               },
             });

--- a/apps/web/src/trpc/routers/spaces.ts
+++ b/apps/web/src/trpc/routers/spaces.ts
@@ -304,7 +304,7 @@ export const spaces = router({
         groupType: "space",
         groupKey: ctx.space.id,
         properties: {
-          custom_branding_enabled: input.showBranding,
+          custom_branding: input.showBranding,
         },
       });
 

--- a/apps/web/src/trpc/routers/spaces.ts
+++ b/apps/web/src/trpc/routers/spaces.ts
@@ -169,8 +169,8 @@ export const spaces = router({
         groupKey: space.id,
         properties: {
           name: space.name,
-          memberCount: 1,
-          seatCount: 1,
+          member_count: 1,
+          seat_count: 1,
           tier: "hobby",
         },
       });

--- a/apps/web/src/trpc/routers/spaces.ts
+++ b/apps/web/src/trpc/routers/spaces.ts
@@ -300,6 +300,14 @@ export const spaces = router({
         data: { showBranding: input.showBranding },
       });
 
+      identifyGroup({
+        groupType: "space",
+        groupKey: ctx.space.id,
+        properties: {
+          custom_branding_enabled: input.showBranding,
+        },
+      });
+
       track(ctx.user, {
         event: "space_update_show_branding",
         properties: {


### PR DESCRIPTION
## Description

Tracks whether a space has custom branding enabled as a PostHog group property, and standardizes space group properties on snake_case.

- `spaces.updateShowBranding` now calls `identifyGroup` after the DB write, setting `custom_branding` on the `space` group so spaces can be filtered/broken down by branding status in PostHog.
- Renames the remaining camelCase space group properties to snake_case (`memberCount` → `member_count`, `seatCount` → `seat_count`) at all five write sites (space create, sign-up default space, Stripe webhooks). The `poll` group already used snake_case, so this unifies the scheme.

**Reviewer notes:**

- Existing spaces won't have the new property names until the backfill runs — tracked in RAL-1365. Old keys (`seatCount`, `memberCount`, and the short-lived `custom_branding_enabled`) linger on existing groups until then; dashboard cleanup in PostHog Data Management happens after the backfill.
- The remaining `seatCount`/`memberCount` identifiers in the codebase are i18n keys and dashboard stats, not analytics properties, and are intentionally unchanged.

## Checklist

- [x] I have performed a self-review of my code
- [x] My code follows the code style of this project
- [x] I have commented my code, particularly in hard-to-understand areas

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Analytics**
  * Standardized subscription, membership, and seat metric property names to consistent snake_case keys (e.g., `seat_count`, `member_count`) across subscription and space/account flows.
  * Enhanced branding analytics by identifying the space’s `custom_branding` value when branding settings change (alongside the existing branding update tracking).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->