### PR TITLE
✨ Stitch guest server-side PostHog events to the client's anonymous id

### DIFF
--- a/apps/web/src/app/api/trpc/[trpc]/route.ts
+++ b/apps/web/src/app/api/trpc/[trpc]/route.ts
@@ -6,7 +6,7 @@ import { ipAddress } from "@vercel/functions";
 import type { NextRequest } from "next/server";
 import { getSession } from "@/lib/auth";
 import { getLocaleFromRequest } from "@/lib/locale/server";
-import { withPostHog } from "@/lib/posthog";
+import { getClientAnonymousDistinctId, withPostHog } from "@/lib/posthog";
 import type { TRPCContext } from "@/trpc/context";
 import { appRouter } from "@/trpc/routers";
 
@@ -49,6 +49,7 @@ const handler = async (req: NextRequest) => {
           locale,
           identifier,
           event,
+          anonymousDistinctId: getClientAnonymousDistinctId(req),
         } satisfies TRPCContext;
       },
       onError: ({ error }) => {

--- a/apps/web/src/lib/posthog.ts
+++ b/apps/web/src/lib/posthog.ts
@@ -1,4 +1,8 @@
 import { PostHog } from "@rallly/posthog/server";
+import {
+  getPostHogCookieName,
+  parsePostHogCookieDistinctId,
+} from "@rallly/posthog/utils";
 import type { NextRequest } from "next/server";
 import { after } from "next/server";
 import { env } from "@/env";
@@ -27,23 +31,51 @@ export function posthog() {
  * events (no person profile — they are transient and rarely convert);
  * identified users get person processing as usual. Group analytics is
  * unaffected either way.
+ *
+ * When a guest's client-side anonymous distinct_id is known (read from the
+ * posthog-js persistence cookie via getClientAnonymousDistinctId), guest
+ * events adopt it so server events stitch to the same journey as the guest's
+ * pageviews. Without it (ad blocker, GPC opt-out, cookie not yet written) we
+ * fall back to the guest user id — the event is still captured, just
+ * unstitched. Registered users always capture under their user id.
  */
 export function track(
-  user: { id: string; isGuest: boolean },
+  user: { id: string; isGuest: boolean; anonymousDistinctId?: string },
   event: {
     event: string;
     properties?: Record<string, unknown>;
     groups?: Record<string, string>;
   },
 ) {
+  const distinctId =
+    user.isGuest && user.anonymousDistinctId
+      ? user.anonymousDistinctId
+      : user.id;
+
   posthog()?.capture({
     ...event,
-    distinctId: user.id,
+    distinctId,
     properties: {
       ...event.properties,
       $process_person_profile: !user.isGuest,
     },
   });
+}
+
+/**
+ * Read the client's anonymous distinct_id from the posthog-js persistence
+ * cookie (persistence: "cookie"). Absent or malformed cookies yield undefined.
+ */
+export function getClientAnonymousDistinctId(req: NextRequest) {
+  if (!env.NEXT_PUBLIC_POSTHOG_API_KEY) {
+    return undefined;
+  }
+
+  const cookie = req.cookies.get(
+    getPostHogCookieName(env.NEXT_PUBLIC_POSTHOG_API_KEY),
+  );
+
+  return parsePostHogCookieDistinctId(cookie?.value) ?? undefined;
 }
 
 /**

--- a/apps/web/src/trpc/context.ts
+++ b/apps/web/src/trpc/context.ts
@@ -6,4 +6,10 @@ export type TRPCContext = {
   locale?: string;
   identifier?: string;
   event?: WideEvent;
+  /**
+   * The client's PostHog anonymous distinct_id, read from the posthog-js
+   * persistence cookie. Used to stitch guest server-side captures to the
+   * client's event stream. Absent when the cookie is missing or malformed.
+   */
+  anonymousDistinctId?: string;
 };

--- a/apps/web/src/trpc/routers/polls.ts
+++ b/apps/web/src/trpc/routers/polls.ts
@@ -158,14 +158,17 @@ export const polls = router({
       });
 
       if (moderation.verdict !== "safe") {
-        track(ctx.user, {
-          event: "flagged_content",
-          properties: {
-            action: "create_poll",
-            verdict: moderation.verdict,
-            reason: moderation.reason,
+        track(
+          { ...ctx.user, anonymousDistinctId: ctx.anonymousDistinctId },
+          {
+            event: "flagged_content",
+            properties: {
+              action: "create_poll",
+              verdict: moderation.verdict,
+              reason: moderation.reason,
+            },
           },
-        });
+        );
       }
 
       if (moderation.verdict === "flagged") {
@@ -278,25 +281,28 @@ export const polls = router({
         },
       });
 
-      track(ctx.user, {
-        event: "poll_create",
-        properties: {
-          title: poll.title,
-          optionCount: poll.options.length,
-          hasLocation: !!location,
-          hasDescription: !!description,
-          timezone: input.timeZone,
-          disableComments: poll.disableComments,
-          hideParticipants: poll.hideParticipants,
-          hideScores: poll.hideScores,
-          requireParticipantEmail: poll.requireParticipantEmail,
-          isGuest: ctx.user.isGuest,
+      track(
+        { ...ctx.user, anonymousDistinctId: ctx.anonymousDistinctId },
+        {
+          event: "poll_create",
+          properties: {
+            title: poll.title,
+            optionCount: poll.options.length,
+            hasLocation: !!location,
+            hasDescription: !!description,
+            timezone: input.timeZone,
+            disableComments: poll.disableComments,
+            hideParticipants: poll.hideParticipants,
+            hideScores: poll.hideScores,
+            requireParticipantEmail: poll.requireParticipantEmail,
+            isGuest: ctx.user.isGuest,
+          },
+          groups: {
+            poll: poll.id,
+            ...(poll.spaceId ? { space: poll.spaceId } : {}),
+          },
         },
-        groups: {
-          poll: poll.id,
-          ...(poll.spaceId ? { space: poll.spaceId } : {}),
-        },
-      });
+      );
 
       return { ok: true as const, data: { id: poll.id } };
     }),
@@ -349,14 +355,17 @@ export const polls = router({
       });
 
       if (moderation.verdict !== "safe") {
-        track(ctx.user, {
-          event: "flagged_content",
-          properties: {
-            action: "update_poll",
-            verdict: moderation.verdict,
-            reason: moderation.reason,
+        track(
+          { ...ctx.user, anonymousDistinctId: ctx.anonymousDistinctId },
+          {
+            event: "flagged_content",
+            properties: {
+              action: "update_poll",
+              verdict: moderation.verdict,
+              reason: moderation.reason,
+            },
           },
-        });
+        );
       }
 
       if (moderation.verdict === "flagged") {
@@ -500,45 +509,54 @@ export const polls = router({
         input.requireParticipantEmail !== undefined;
 
       if (hasDetailsUpdate) {
-        track(ctx.user, {
-          event: "poll_update_details",
-          properties: {
-            title: updatedPoll.title,
-            has_location: !!updatedPoll.location,
-            has_description: !!updatedPoll.description,
-            is_guest: ctx.user.isGuest,
+        track(
+          { ...ctx.user, anonymousDistinctId: ctx.anonymousDistinctId },
+          {
+            event: "poll_update_details",
+            properties: {
+              title: updatedPoll.title,
+              has_location: !!updatedPoll.location,
+              has_description: !!updatedPoll.description,
+              is_guest: ctx.user.isGuest,
+            },
+            groups: {
+              poll: pollId,
+            },
           },
-          groups: {
-            poll: pollId,
-          },
-        });
+        );
       }
 
       if (hasOptionsUpdate) {
-        track(ctx.user, {
-          event: "poll_update_options",
-          properties: {
-            option_count: updatedPoll._count.options,
+        track(
+          { ...ctx.user, anonymousDistinctId: ctx.anonymousDistinctId },
+          {
+            event: "poll_update_options",
+            properties: {
+              option_count: updatedPoll._count.options,
+            },
+            groups: {
+              poll: pollId,
+            },
           },
-          groups: {
-            poll: pollId,
-          },
-        });
+        );
       }
 
       if (hasSettingsUpdate) {
-        track(ctx.user, {
-          event: "poll_update_settings",
-          properties: {
-            disable_comments: !!updatedPoll.disableComments,
-            hide_participants: !!updatedPoll.hideParticipants,
-            hide_scores: !!updatedPoll.hideScores,
-            require_participant_email: !!updatedPoll.requireParticipantEmail,
+        track(
+          { ...ctx.user, anonymousDistinctId: ctx.anonymousDistinctId },
+          {
+            event: "poll_update_settings",
+            properties: {
+              disable_comments: !!updatedPoll.disableComments,
+              hide_participants: !!updatedPoll.hideParticipants,
+              hide_scores: !!updatedPoll.hideScores,
+              require_participant_email: !!updatedPoll.requireParticipantEmail,
+            },
+            groups: {
+              poll: pollId,
+            },
           },
-          groups: {
-            poll: pollId,
-          },
-        });
+        );
       }
 
       return { ok: true as const };
@@ -566,12 +584,15 @@ export const polls = router({
       });
 
       // Track poll deletion analytics
-      track(ctx.user, {
-        event: "poll_delete",
-        groups: {
-          poll: pollId,
+      track(
+        { ...ctx.user, anonymousDistinctId: ctx.anonymousDistinctId },
+        {
+          event: "poll_delete",
+          groups: {
+            poll: pollId,
+          },
         },
-      });
+      );
     }),
   // END LEGACY ROUTES
   toggleMuted: privateProcedure
@@ -1073,17 +1094,20 @@ export const polls = router({
           );
         }
 
-        track(ctx.user, {
-          event: "poll_schedule",
-          properties: {
-            attendee_count: attendees.length,
-            days_since_created: dayjs().diff(poll.createdAt, "day"),
-            participant_count: poll.participants.length,
+        track(
+          { ...ctx.user, anonymousDistinctId: ctx.anonymousDistinctId },
+          {
+            event: "poll_schedule",
+            properties: {
+              attendee_count: attendees.length,
+              days_since_created: dayjs().diff(poll.createdAt, "day"),
+              participant_count: poll.participants.length,
+            },
+            groups: {
+              poll: poll.id,
+            },
           },
-          groups: {
-            poll: poll.id,
-          },
-        });
+        );
       }
     }),
   reopen: privateProcedure
@@ -1122,12 +1146,15 @@ export const polls = router({
         }
       });
 
-      track(ctx.user, {
-        event: "poll_reopen",
-        groups: {
-          poll: input.pollId,
+      track(
+        { ...ctx.user, anonymousDistinctId: ctx.anonymousDistinctId },
+        {
+          event: "poll_reopen",
+          groups: {
+            poll: input.pollId,
+          },
         },
-      });
+      );
     }),
   close: possiblyPublicProcedure
     .input(
@@ -1156,12 +1183,15 @@ export const polls = router({
         },
       });
 
-      track(ctx.user, {
-        event: "poll_close",
-        groups: {
-          poll: input.pollId,
+      track(
+        { ...ctx.user, anonymousDistinctId: ctx.anonymousDistinctId },
+        {
+          event: "poll_close",
+          groups: {
+            poll: input.pollId,
+          },
         },
-      });
+      );
     }),
   duplicate: proProcedure
     .input(

--- a/apps/web/src/trpc/routers/polls/comments.ts
+++ b/apps/web/src/trpc/routers/polls/comments.ts
@@ -166,15 +166,18 @@ export const comments = router({
       }
 
       // Track comment addition analytics
-      track(ctx.user, {
-        event: "poll_comment_add",
-        properties: {
-          is_guest: ctx.user.isGuest,
+      track(
+        { ...ctx.user, anonymousDistinctId: ctx.anonymousDistinctId },
+        {
+          event: "poll_comment_add",
+          properties: {
+            is_guest: ctx.user.isGuest,
+          },
+          groups: {
+            poll: pollId,
+          },
         },
-        groups: {
-          poll: pollId,
-        },
-      });
+      );
 
       return newComment;
     }),
@@ -216,11 +219,14 @@ export const comments = router({
       });
 
       // Track comment deletion analytics
-      track(actor, {
-        event: "poll_comment_delete",
-        groups: {
-          poll: comment.pollId,
+      track(
+        { ...actor, anonymousDistinctId: ctx.anonymousDistinctId },
+        {
+          event: "poll_comment_delete",
+          groups: {
+            poll: comment.pollId,
+          },
         },
-      });
+      );
     }),
 });

--- a/apps/web/src/trpc/routers/polls/participants.ts
+++ b/apps/web/src/trpc/routers/polls/participants.ts
@@ -210,15 +210,18 @@ export const participants = router({
         },
       });
 
-      track(actor, {
-        event: "poll_response_delete",
-        properties: {
-          participant_id: participant.id,
+      track(
+        { ...actor, anonymousDistinctId: ctx.anonymousDistinctId },
+        {
+          event: "poll_response_delete",
+          properties: {
+            participant_id: participant.id,
+          },
+          groups: {
+            poll: participant.pollId,
+          },
         },
-        groups: {
-          poll: participant.pollId,
-        },
-      });
+      );
     }),
   add: publicProcedure
     .use(createRateLimitMiddleware("add_participant", 10, "1 h"))
@@ -347,17 +350,20 @@ export const participants = router({
           }),
         );
 
-        track(ctx.user, {
-          event: "poll_response_submit",
-          properties: {
-            participant_id: participant.id,
-            has_email: !!email,
-            total_responses: totalResponses,
+        track(
+          { ...ctx.user, anonymousDistinctId: ctx.anonymousDistinctId },
+          {
+            event: "poll_response_submit",
+            properties: {
+              participant_id: participant.id,
+              has_email: !!email,
+              total_responses: totalResponses,
+            },
+            groups: {
+              poll: pollId,
+            },
           },
-          groups: {
-            poll: pollId,
-          },
-        });
+        );
 
         return createParticipantFullDTO(participant);
       },
@@ -466,12 +472,15 @@ export const participants = router({
         });
       });
 
-      track(actor, {
-        event: "poll_response_update",
-        groups: {
-          poll: pollId,
+      track(
+        { ...actor, anonymousDistinctId: ctx.anonymousDistinctId },
+        {
+          event: "poll_response_update",
+          groups: {
+            poll: pollId,
+          },
         },
-      });
+      );
 
       return createParticipantFullDTO(participant);
     }),

--- a/packages/posthog/package.json
+++ b/packages/posthog/package.json
@@ -8,6 +8,7 @@
     "./utils": "./src/utils.ts"
   },
   "scripts": {
+    "test:unit": "vitest run",
     "type-check": "tsc --noEmit"
   },
   "dependencies": {
@@ -20,6 +21,7 @@
     "@rallly/tsconfig": "workspace:*",
     "@types/js-cookie": "^3.0.1",
     "@types/node": "^24.1.0",
-    "@types/react": "19.2.13"
+    "@types/react": "19.2.13",
+    "vitest": "^4.0.16"
   }
 }

--- a/packages/posthog/src/utils.test.ts
+++ b/packages/posthog/src/utils.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+import { getPostHogCookieName, parsePostHogCookieDistinctId } from "./utils";
+
+describe("getPostHogCookieName", () => {
+  it("builds the posthog-js persistence cookie name", () => {
+    expect(getPostHogCookieName("phc_abc123")).toBe("ph_phc_abc123_posthog");
+  });
+});
+
+describe("parsePostHogCookieDistinctId", () => {
+  it("parses a URL-encoded JSON cookie value", () => {
+    const value = encodeURIComponent(
+      JSON.stringify({ distinct_id: "0198c0de-anon", $sesid: [123, "abc"] }),
+    );
+    expect(parsePostHogCookieDistinctId(value)).toBe("0198c0de-anon");
+  });
+
+  it("parses an already-decoded JSON cookie value", () => {
+    const value = JSON.stringify({ distinct_id: "anon-id" });
+    expect(parsePostHogCookieDistinctId(value)).toBe("anon-id");
+  });
+
+  it("parses a decoded value containing a literal percent sign", () => {
+    const value = JSON.stringify({
+      distinct_id: "anon-id",
+      $initial_referrer: "https://example.com/?q=100%",
+    });
+    expect(parsePostHogCookieDistinctId(value)).toBe("anon-id");
+  });
+
+  it("returns null for undefined", () => {
+    expect(parsePostHogCookieDistinctId(undefined)).toBeNull();
+  });
+
+  it("returns null for an empty string", () => {
+    expect(parsePostHogCookieDistinctId("")).toBeNull();
+  });
+
+  it("returns null for malformed JSON", () => {
+    expect(parsePostHogCookieDistinctId("not-json")).toBeNull();
+    expect(parsePostHogCookieDistinctId("%7Bbroken")).toBeNull();
+  });
+
+  it("returns null for JSON without a distinct_id", () => {
+    expect(
+      parsePostHogCookieDistinctId(JSON.stringify({ $sesid: [1, "a"] })),
+    ).toBeNull();
+  });
+
+  it("returns null for a non-string distinct_id", () => {
+    expect(
+      parsePostHogCookieDistinctId(JSON.stringify({ distinct_id: 42 })),
+    ).toBeNull();
+  });
+
+  it("returns null for an empty distinct_id", () => {
+    expect(
+      parsePostHogCookieDistinctId(JSON.stringify({ distinct_id: "" })),
+    ).toBeNull();
+  });
+
+  it("returns null for non-object JSON", () => {
+    expect(parsePostHogCookieDistinctId('"a string"')).toBeNull();
+    expect(parsePostHogCookieDistinctId("null")).toBeNull();
+  });
+});

--- a/packages/posthog/src/utils.ts
+++ b/packages/posthog/src/utils.ts
@@ -1,5 +1,47 @@
 import type { CaptureResult } from "posthog-js";
 
+export function getPostHogCookieName(apiKey: string) {
+  return `ph_${apiKey}_posthog`;
+}
+
+/**
+ * Extract the client's distinct_id from the posthog-js persistence cookie
+ * (`persistence: "cookie"` in client.ts). The raw cookie value is URL-encoded
+ * JSON, but some runtimes hand it over already decoded — handle both. Returns
+ * null for a missing or malformed value.
+ */
+export function parsePostHogCookieDistinctId(
+  cookieValue: string | undefined,
+): string | null {
+  if (!cookieValue) {
+    return null;
+  }
+
+  let json = cookieValue;
+  try {
+    json = decodeURIComponent(cookieValue);
+  } catch {
+    // Not URL-encoded — parse as-is
+  }
+
+  try {
+    const parsed: unknown = JSON.parse(json);
+    if (
+      typeof parsed === "object" &&
+      parsed !== null &&
+      "distinct_id" in parsed
+    ) {
+      const distinctId = (parsed as { distinct_id: unknown }).distinct_id;
+      if (typeof distinctId === "string" && distinctId.length > 0) {
+        return distinctId;
+      }
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
 type NavigatorWithGlobalPrivacyControl = Navigator & {
   globalPrivacyControl?: boolean;
 };

--- a/packages/posthog/vitest.config.mts
+++ b/packages/posthog/vitest.config.mts
@@ -1,0 +1,9 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    globals: true,
+    include: ["**/*.test.ts"],
+    exclude: ["**/node_modules/**", "**/*.spec.ts"],
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -690,6 +690,9 @@ importers:
       '@types/react':
         specifier: 19.2.13
         version: 19.2.13
+      vitest:
+        specifier: ^4.0.16
+        version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@24.10.11)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0)
 
   packages/screenshots:
     dependencies:


### PR DESCRIPTION
## Problem

A guest's PostHog journey is split across two distinct_ids that are never linked: client-side pageviews/pageleaves under the device-generated anonymous distinct_id, and server-side product events (`poll_create`, votes, comments) under the Rallly guest user id. Guest funnels like page view → vote can't be analyzed.

Fixes [RAL-1366](https://linear.app/rallly/issue/RAL-1366/stitch-guest-server-side-posthog-events-to-the-clients-anonymous-id)

## Approach

Server-side capture stays (complete, immune to ad blockers). For guest captures, the server adopts the client's anonymous distinct_id:

- `@rallly/posthog/utils` gains `getPostHogCookieName()` and `parsePostHogCookieDistinctId()` — the posthog-js persistence cookie (`persistence: "cookie"`) holds URL-encoded JSON with a `distinct_id` field; parsing is defensive (missing/malformed → null) and covered by unit tests.
- The tRPC route handler reads the cookie once via `getClientAnonymousDistinctId(req)` and puts it on the tRPC context as `anonymousDistinctId`.
- `track()` accepts an optional `anonymousDistinctId` on the actor: guests capture under it when present, falling back to the guest user id when absent (ad blocker, GPC opt-out, cookie not yet written) — no events are lost either way. `$process_person_profile: false` is kept for guests.
- Registered users are unchanged (`distinctId: user.id`, identified).
- The `$merge_dangerously` call in `features/auth/mutations.ts` stays for fallback/historical events.

Touched capture sites are the guest-reachable polls tRPC routers (same set as #2676).

## Verification

- `pnpm test:unit` — 11 new tests for the cookie parser, all suites pass
- `pnpm type-check`, `pnpm check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved analytics continuity for guest users across browser and server-side events.
  - Guest activity, including poll actions, comments, and participant interactions, is now associated more reliably with the same anonymous session.

- **Tests**
  - Added automated coverage for reading and validating analytics cookies, including malformed and encoded values.
  - Added unit test tooling and configuration for the analytics package.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->