### PR TITLE
🐛 Use a shared distinct id for group identify events

### DIFF
--- a/apps/web/src/features/billing/webhook/mutations.ts
+++ b/apps/web/src/features/billing/webhook/mutations.ts
@@ -21,7 +21,7 @@ import {
 } from "@/features/billing/webhook/utils";
 import { licenseManager } from "@/features/licensing/mutations";
 import { licenseCheckoutMetadataSchema } from "@/features/licensing/schema";
-import { posthog } from "@/lib/posthog";
+import { identifyGroup, posthog } from "@/lib/posthog";
 
 async function getExpandedSubscription(subscriptionId: string) {
   return stripe.subscriptions.retrieve(subscriptionId, {
@@ -281,7 +281,7 @@ async function onCustomerSubscriptionCreated(event: Stripe.Event) {
     return syncSpaceTier(tx, spaceId);
   });
 
-  posthog()?.groupIdentify({
+  identifyGroup({
     groupType: "space",
     groupKey: spaceId,
     properties: {
@@ -368,7 +368,7 @@ async function onCustomerSubscriptionDeleted(event: Stripe.Event) {
     return syncSpaceTier(tx, spaceId);
   });
 
-  posthog()?.groupIdentify({
+  identifyGroup({
     groupType: "space",
     groupKey: spaceId,
     properties: {
@@ -461,7 +461,7 @@ async function onCustomerSubscriptionUpdated(event: Stripe.Event) {
     return syncSpaceTier(tx, spaceId);
   });
 
-  posthog()?.groupIdentify({
+  identifyGroup({
     groupType: "space",
     groupKey: spaceId,
     properties: {

--- a/apps/web/src/lib/posthog.ts
+++ b/apps/web/src/lib/posthog.ts
@@ -78,16 +78,27 @@ export function getClientAnonymousDistinctId(req: NextRequest) {
   return parsePostHogCookieDistinctId(cookie?.value) ?? undefined;
 }
 
+// Without an explicit distinctId, groupIdentify defaults to
+// $<groupType>_<groupKey>, creating a dummy person profile per group
+// (PostHog/posthog#7921). A single shared id caps the junk at one person.
+// Sending the event personless is not an option — ingestion only applies
+// $group_set when person processing is enabled.
+const GROUP_IDENTIFY_DISTINCT_ID = "server_group_identify";
+
 /**
- * Update properties on a group (e.g. poll, space). Groups are independent
- * of person profiles, so no guest handling is involved.
+ * Update properties on a group (e.g. poll, space). Group identify events are
+ * not attributed to the acting user — actor attribution belongs on the
+ * accompanying track() event.
  */
 export function identifyGroup(group: {
   groupType: string;
   groupKey: string;
   properties?: Record<string, unknown>;
 }) {
-  posthog()?.groupIdentify(group);
+  posthog()?.groupIdentify({
+    ...group,
+    distinctId: GROUP_IDENTIFY_DISTINCT_ID,
+  });
 }
 
 export function withPostHog(

--- a/packages/posthog/src/scripts/backfill-space-group-properties.ts
+++ b/packages/posthog/src/scripts/backfill-space-group-properties.ts
@@ -34,9 +34,10 @@ const API_HOST = process.env.NEXT_PUBLIC_POSTHOG_API_HOST;
 const PAGE_SIZE = 500;
 const SAMPLE_SIZE = 10;
 // Without an explicit distinctId, groupIdentify defaults to $space_<groupKey>,
-// which creates a dummy person profile PER GROUP (PostHog/posthog#7921). A
-// single shared id caps the junk at one person for the whole run.
-const BACKFILL_DISTINCT_ID = "space_group_properties_backfill";
+// which creates a dummy person profile PER GROUP (PostHog/posthog#7921). Shares
+// the id used by identifyGroup in apps/web so all group identifies collapse
+// into a single dummy person.
+const BACKFILL_DISTINCT_ID = "server_group_identify";
 // Matches DEFAULT_SEAT_LIMIT in apps/web — spaces without an active
 // subscription have a single seat
 const DEFAULT_SEAT_COUNT = 1;


### PR DESCRIPTION
## Problem

`groupIdentify` calls (polls, spaces, billing webhook) don't pass a `distinctId`, so posthog-node defaults to `$<groupType>_<groupKey>` — creating a dummy person profile for **every group we identify** ([PostHog/posthog#7921](https://github.com/PostHog/posthog/issues/7921)).

## Options considered

1. **Pass the acting user's id** — doesn't cover guests: polls are created by guests, and identifying with a guest id (person processing on) would create guest person profiles, undoing #2676. The billing webhook has a real user, but a split policy isn't worth it since group properties don't record who set them — actor attribution already lives on the accompanying `track()` events.
2. **Send the event personless (`$process_person_profile: false`)** — verified against PostHog's ingestion pipeline ([process-groups-step.ts](https://github.com/PostHog/posthog/blob/master/nodejs/src/ingestion/common/steps/event-processing/process-groups-step.ts)): the `$group_set` upsert only runs when `processPerson` is true, so a personless `$groupidentify` silently drops the group property update. Dead end.
3. **Shared constant distinct id** — caps the junk at exactly one person total. ✅

## Changes

- `identifyGroup` in `lib/posthog.ts` now always sends `distinctId: "server_group_identify"`
- The billing webhook's three direct `groupIdentify` calls route through `identifyGroup`
- The backfill script reuses the same id so all group identifies collapse into a single dummy person (it hasn't run yet, so no orphaned id is left behind)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved subscription lifecycle tracking for more consistent group identification.
  * Consolidated group activity under a fixed tracking identity, reducing duplicate placeholder profiles.
  * Updated historical group-property backfill behavior to align with the improved tracking approach.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->