### PR TITLE
🔧 Pin turbopack.root so worktrees resolve their own lockfile

### DIFF
--- a/apps/landing/next.config.ts
+++ b/apps/landing/next.config.ts
@@ -1,3 +1,4 @@
+import path from "node:path";
 import createBundleAnalyzer from "@next/bundle-analyzer";
 import type { NextConfig } from "next";
 
@@ -42,6 +43,7 @@ const nextConfig: NextConfig = {
     ],
   },
   turbopack: {
+    root: path.join(__dirname, "../.."),
     rules: {
       "*.svg": {
         loaders: ["@svgr/webpack"],

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -3,6 +3,7 @@
 // https://nextjs.org/docs/api-reference/next.config.js/introduction
 // https://docs.sentry.io/platforms/javascript/guides/nextjs/
 
+import path from "node:path";
 import createBundleAnalyzer from "@next/bundle-analyzer";
 import { withSentryConfig } from "@sentry/nextjs";
 import type { NextConfig } from "next";
@@ -38,6 +39,7 @@ const nextConfig: NextConfig = {
     return config;
   },
   turbopack: {
+    root: path.join(__dirname, "../.."),
     rules: {
       "*.svg": {
         loaders: ["@svgr/webpack"],


### PR DESCRIPTION
## Description

Running the dev server from a git worktree under `.claude/worktrees/` printed:

```
We detected multiple lockfiles and selected the directory of /Users/lukevella/Documents/rallly/pnpm-workspace.yaml as the root directory.
```

Worktrees live inside the main checkout, so Turbopack's workspace root inference walks up past the worktree's `pnpm-lock.yaml`, finds the main checkout's lockfile above it, and selects the main repo as root. That means a worktree dev server resolves modules against the wrong checkout, not just a noisy warning.

Fix: set `turbopack.root` to `path.join(__dirname, "../..")` in `apps/web` and `apps/landing` next configs. Resolving relative to the config file means the main checkout and every worktree each point at their own monorepo root.

## Checklist

- [x] I have performed a self-review of my code
- [x] My code follows the code style of this project
- [x] I have commented my code, particularly in hard-to-understand areas

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved application build configuration to ensure more consistent development and build behavior across the landing and web applications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->