### PR TITLE
♻️ Replace user.getMe tRPC query with a server-fed UserProvider

### DIFF
--- a/apps/web/src/app/[locale]/(optional-space)/layout.tsx
+++ b/apps/web/src/app/[locale]/(optional-space)/layout.tsx
@@ -2,7 +2,9 @@ import { dehydrate, HydrationBoundary } from "@tanstack/react-query";
 import { SessionRefresher } from "@/components/session-refresher";
 import { PayWall } from "@/features/billing/components/pay-wall";
 import { isQuickCreateEnabled } from "@/features/quick-create/constants";
+import { UserProvider } from "@/features/user/components/user-provider";
 import { getLocale } from "@/i18n/server/get-locale";
+import { getSession } from "@/lib/auth";
 import { DeviceDateTimeProvider } from "@/lib/datetime/device";
 import { getDeviceDateTimeConfig } from "@/lib/datetime/server";
 import {
@@ -19,27 +21,33 @@ export default async function Layout({
     ? await createPublicSSRHelper()
     : await createPrivateSSRHelper();
 
-  const [locale, deviceDateTimeConfig, user] = await Promise.all([
+  const [locale, deviceDateTimeConfig, session] = await Promise.all([
     getLocale(),
     getDeviceDateTimeConfig(),
-    helpers.user.getMe.fetch(),
+    getSession(),
     helpers.billing.getTier.prefetch(),
   ]);
+
+  const user = session?.user;
 
   return (
     <HydrationBoundary state={dehydrate(helpers.queryClient)}>
       <SessionRefresher />
-      <DeviceDateTimeProvider
-        locale={locale}
-        timeZone={user?.timeZone ?? deviceDateTimeConfig.timeZone ?? undefined}
-        timeFormat={
-          user?.timeFormat ?? deviceDateTimeConfig.timeFormat ?? undefined
-        }
-        weekStart={user?.weekStart ?? undefined}
-      >
-        {children}
-        <PayWall />
-      </DeviceDateTimeProvider>
+      <UserProvider user={user ?? null}>
+        <DeviceDateTimeProvider
+          locale={locale}
+          timeZone={
+            user?.timeZone ?? deviceDateTimeConfig.timeZone ?? undefined
+          }
+          timeFormat={
+            user?.timeFormat ?? deviceDateTimeConfig.timeFormat ?? undefined
+          }
+          weekStart={user?.weekStart ?? undefined}
+        >
+          {children}
+          <PayWall />
+        </DeviceDateTimeProvider>
+      </UserProvider>
     </HydrationBoundary>
   );
 }

--- a/apps/web/src/app/[locale]/(space)/layout.tsx
+++ b/apps/web/src/app/[locale]/(space)/layout.tsx
@@ -4,7 +4,9 @@ import { SessionRefresher } from "@/components/session-refresher";
 import { PayWall } from "@/features/billing/components/pay-wall";
 import { SpaceProvider } from "@/features/space/client";
 import { TimeZoneMismatchDialog } from "@/features/user/components/timezone-mismatch-dialog";
+import { UserProvider } from "@/features/user/components/user-provider";
 import { getLocale } from "@/i18n/server/get-locale";
+import { getSession } from "@/lib/auth";
 import { DateTimeProvider } from "@/lib/datetime/client";
 import { getPathname } from "@/lib/pathname";
 import { buildSafeRedirectUrl } from "@/lib/utils/redirect";
@@ -17,11 +19,13 @@ export default async function Layout({
 }) {
   const helpers = await createPrivateSSRHelper();
 
-  const [locale, user, space] = await Promise.all([
+  const [locale, session, space] = await Promise.all([
     getLocale(),
-    helpers.user.getMe.fetch(),
+    getSession(),
     helpers.spaces.getCurrent.fetch(),
   ]);
+
+  const user = session?.user;
 
   if (!space) {
     const pathname = await getPathname();
@@ -34,17 +38,19 @@ export default async function Layout({
     <HydrationBoundary state={dehydrate(helpers.queryClient)}>
       <SessionRefresher />
       <TimeZoneMismatchDialog homeTimeZone={user?.timeZone} />
-      <DateTimeProvider
-        locale={locale}
-        timeZone={user?.timeZone}
-        timeFormat={user?.timeFormat}
-        weekStart={user?.weekStart ?? undefined}
-      >
-        <SpaceProvider>
-          {children}
-          <PayWall />
-        </SpaceProvider>
-      </DateTimeProvider>
+      <UserProvider user={user ?? null}>
+        <DateTimeProvider
+          locale={locale}
+          timeZone={user?.timeZone}
+          timeFormat={user?.timeFormat}
+          weekStart={user?.weekStart ?? undefined}
+        >
+          <SpaceProvider>
+            {children}
+            <PayWall />
+          </SpaceProvider>
+        </DateTimeProvider>
+      </UserProvider>
     </HydrationBoundary>
   );
 }

--- a/apps/web/src/app/[locale]/invite/[urlId]/invite-page.tsx
+++ b/apps/web/src/app/[locale]/invite/[urlId]/invite-page.tsx
@@ -8,12 +8,12 @@ import { EventCard } from "@/features/poll/components/event-card";
 import { PollFooter } from "@/features/poll/components/poll-footer";
 import { ResponsiveResults } from "@/features/poll/components/responsive-results";
 import { VotingForm } from "@/features/poll/components/voting-form";
+import { useUser } from "@/features/user/components/user-provider";
 import { Trans } from "@/i18n/client";
-import { trpc } from "@/trpc/client";
 
 const GoToApp = () => {
   const poll = usePoll();
-  const { data: user } = trpc.user.getMe.useQuery();
+  const { user } = useUser();
 
   if (!user || user.id !== poll.userId) {
     return null;

--- a/apps/web/src/app/[locale]/invite/[urlId]/page.tsx
+++ b/apps/web/src/app/[locale]/invite/[urlId]/page.tsx
@@ -6,7 +6,9 @@ import { notFound } from "next/navigation";
 import { cache } from "react";
 import { SessionRefresher } from "@/components/session-refresher";
 import { PermissionProvider } from "@/features/poll/client";
+import { UserProvider } from "@/features/user/components/user-provider";
 import { getLocale } from "@/i18n/server/get-locale";
+import { getSession } from "@/lib/auth";
 import { DeviceDateTimeProvider } from "@/lib/datetime/device";
 import { getDeviceDateTimeConfig } from "@/lib/datetime/server";
 import { decryptToken } from "@/lib/session";
@@ -48,9 +50,9 @@ export default async function Page(props: {
 
   const token = (await props.searchParams).token;
 
-  const [locale, user, deviceDateTimeConfig] = await Promise.all([
+  const [locale, session, deviceDateTimeConfig] = await Promise.all([
     getLocale(),
-    trpc.user.getMe.fetch(),
+    getSession(),
     getDeviceDateTimeConfig(),
     trpc.polls.get.prefetch({ urlId: params.urlId }),
     trpc.polls.participants.list.prefetch({ pollId: params.urlId, token }),
@@ -68,17 +70,19 @@ export default async function Page(props: {
   return (
     <HydrationBoundary state={dehydrate(trpc.queryClient)}>
       <SessionRefresher />
-      <DeviceDateTimeProvider
-        locale={locale}
-        timeZone={deviceDateTimeConfig.timeZone}
-        timeFormat={deviceDateTimeConfig.timeFormat}
-      >
-        <Providers>
-          <PermissionProvider impersonatedUserId={impersonatedUserId}>
-            <InvitePageLoader />
-          </PermissionProvider>
-        </Providers>
-      </DeviceDateTimeProvider>
+      <UserProvider user={session?.user ?? null}>
+        <DeviceDateTimeProvider
+          locale={locale}
+          timeZone={deviceDateTimeConfig.timeZone}
+          timeFormat={deviceDateTimeConfig.timeFormat}
+        >
+          <Providers>
+            <PermissionProvider impersonatedUserId={impersonatedUserId}>
+              <InvitePageLoader />
+            </PermissionProvider>
+          </Providers>
+        </DeviceDateTimeProvider>
+      </UserProvider>
     </HydrationBoundary>
   );
 }

--- a/apps/web/src/features/poll/client.tsx
+++ b/apps/web/src/features/poll/client.tsx
@@ -3,6 +3,7 @@ import { useParams, usePathname } from "next/navigation";
 import React from "react";
 
 import { useParticipants } from "@/features/poll/components/participants-provider";
+import { useUser } from "@/features/user/components/user-provider";
 import { trpc } from "@/trpc/client";
 
 export const usePoll = () => {
@@ -42,7 +43,7 @@ export const PermissionProvider = ({
 export const usePermissions = () => {
   const poll = usePoll();
   const context = React.useContext(PermissionsContext);
-  const { data: user } = trpc.user.getMe.useQuery();
+  const { user } = useUser();
   const role = useRole();
   const { participants } = useParticipants();
   return {

--- a/apps/web/src/features/user/components/user-provider.tsx
+++ b/apps/web/src/features/user/components/user-provider.tsx
@@ -4,14 +4,19 @@ import { useRouter } from "next/navigation";
 import React from "react";
 import type { UserAbility } from "@/features/user/ability";
 import { defineAbilityFor } from "@/features/user/ability";
+import type { UserDTO } from "@/features/user/schema";
 import { authClient } from "@/lib/auth-client";
 import { isOwner } from "@/lib/utils/permissions";
-import { trpc } from "@/trpc/client";
 
-export function useUser() {
-  const [user] = trpc.user.getMe.useSuspenseQuery();
-  const router = useRouter();
+const UserContext = React.createContext<UserDTO | null | undefined>(undefined);
 
+export function UserProvider({
+  user,
+  children,
+}: {
+  user: UserDTO | null;
+  children: React.ReactNode;
+}) {
   const userId = user?.id;
   const isGuest = user?.isGuest;
 
@@ -20,6 +25,17 @@ export function useUser() {
       posthog.identify(userId);
     }
   }, [userId, isGuest]);
+
+  return <UserContext.Provider value={user}>{children}</UserContext.Provider>;
+}
+
+export function useUser() {
+  const user = React.useContext(UserContext);
+  const router = useRouter();
+
+  if (user === undefined) {
+    throw new Error("useUser must be used within a UserProvider");
+  }
 
   return React.useMemo(() => {
     return {

--- a/apps/web/src/trpc/routers/user.ts
+++ b/apps/web/src/trpc/routers/user.ts
@@ -7,16 +7,9 @@ import { getNotificationPreferences } from "@/features/notifications/data";
 import { activityEventTypes } from "@/features/notifications/schema";
 import { defineAbilityFor } from "@/features/user/ability";
 import { track } from "@/lib/posthog";
-import { privateProcedure, publicProcedure, router } from "../trpc";
+import { privateProcedure, router } from "../trpc";
 
 export const user = router({
-  getMe: publicProcedure.query(async ({ ctx }) => {
-    if (!ctx.user) {
-      return null;
-    }
-
-    return ctx.user;
-  }),
   getAuthed: privateProcedure.query(async ({ ctx }) => {
     return ctx.user;
   }),


### PR DESCRIPTION
## Summary

`user.getMe` returned `ctx.user` untouched, so tRPC was pure transport for the session snapshot. This removes the procedure and feeds the same data through a real React context instead:

- `features/user/components/user-provider.tsx` is a provider again: server layouts read `getSession()` and pass the `UserDTO` as a prop; `useUser` reads context and keeps its exact signature, so all nine consumer components are untouched.
- Mounted in the three surfaces that previously hydrated the query cache: `(optional-space)` layout, `(space)` layout, and the invite page (whose `getMe.fetch()` was already dead server-side, existing only to hydrate the client cache).
- The two direct `trpc.user.getMe.useQuery()` calls (`GoToApp` on the invite page, `usePermissions` in `features/poll/client.tsx`) now use `useUser()`.
- `posthog.identify` moves into the provider, running once instead of in every `useUser` consumer.

No behavior change: the data source (cookie-cache session snapshot, no DB read) and freshness model (re-render via `router.refresh()` after guest sign-in; no invalidations existed) are identical. Auth gating is unchanged — it lived in the SSR helper creation, which stays.

Follow-up: `user.getAuthed` gets the same treatment in RAL-1379.

## Test plan

- `pnpm type-check`, `pnpm check`, `pnpm test:unit` all pass
- Grep confirms zero `getMe` references remain

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added centralized access to the signed-in user across application pages and components.
  * Improved session-based authentication handling for layouts, invitations, polls, and date/time preferences.
  * Added a protected endpoint for retrieving authenticated user details.

* **Bug Fixes**
  * Improved consistency of user information and permissions across the application.
  * Prevented authenticated user data from being accessed outside the appropriate provider context.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->