### PR TITLE
🐛 Redirect unregistered users to register page when upgrading from paywall

### DIFF
--- a/apps/web/src/features/billing/components/upgrade-button.tsx
+++ b/apps/web/src/features/billing/components/upgrade-button.tsx
@@ -1,9 +1,10 @@
 "use client";
 import { Button } from "@rallly/ui/button";
-import { usePathname } from "next/navigation";
+import { usePathname, useRouter } from "next/navigation";
 import type React from "react";
 
 import { upgradeToProAction } from "@/features/billing/actions";
+import { useUser } from "@/features/user/components/user-provider";
 import { Trans } from "@/i18n/client";
 import { useSafeAction } from "@/lib/safe-action/client";
 
@@ -16,6 +17,8 @@ export const UpgradeButton = ({
   className?: string;
 }>) => {
   const pathname = usePathname();
+  const router = useRouter();
+  const { user } = useUser();
   const upgradeToPro = useSafeAction(upgradeToProAction);
 
   return (
@@ -26,6 +29,10 @@ export const UpgradeButton = ({
       variant="primary"
       loading={upgradeToPro.isExecuting}
       onClick={() => {
+        if (!user || user.isGuest) {
+          router.push(`/register?redirectTo=${encodeURIComponent(pathname)}`);
+          return;
+        }
         upgradeToPro.execute({
           period: annual ? "yearly" : "monthly",
           returnPath: pathname,


### PR DESCRIPTION
## Description

Clicking **Upgrade** in the paywall dialog as a guest or logged-out user fired `upgradeToProAction`, which always fails since the action requires an authenticated registered user. The button now checks the current user first and sends unregistered users to `/register?redirectTo=<current page>` so they land back where they hit the paywall after signing up.

Register was chosen over login because a guest hitting the paywall almost certainly has no account, and the login page hard-errors on unknown emails. Returning users lose nothing: the register page footer links to login and preserves `redirectTo`.

Since `UpgradeButton` is only rendered inside `PayWallDialog`, this covers every paywall entry point (schedule, duplicate, poll settings, and the settings pages).

## Checklist

- [x] I have performed a self-review of my code
- [x] My code follows the code style of this project
- [x] I have commented my code, particularly in hard-to-understand areas

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Upgrade actions now guide signed-out and guest users to registration.
  * After registration, users can return to the page where they started.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->