### PR TITLE
♻️ Remove spaces.getCurrent from tRPC

### DIFF
--- a/apps/web/src/app/[locale]/(space)/layout.tsx
+++ b/apps/web/src/app/[locale]/(space)/layout.tsx
@@ -1,31 +1,50 @@
-import { dehydrate, HydrationBoundary } from "@tanstack/react-query";
 import { redirect } from "next/navigation";
 import { SessionRefresher } from "@/components/session-refresher";
 import { PayWall } from "@/features/billing/components/pay-wall";
 import { SpaceProvider } from "@/features/space/client";
+import { getActiveSpaceForUser } from "@/features/space/data";
 import { TimeZoneMismatchDialog } from "@/features/user/components/timezone-mismatch-dialog";
 import { UserProvider } from "@/features/user/components/user-provider";
 import { getLocale } from "@/i18n/server/get-locale";
-import { getSession } from "@/lib/auth";
+import { getSessionState } from "@/lib/auth";
 import { DateTimeProvider } from "@/lib/datetime/client";
+import { InvalidSessionError } from "@/lib/errors/invalid-session-error";
 import { getPathname } from "@/lib/pathname";
 import { buildSafeRedirectUrl } from "@/lib/utils/redirect";
-import { createPrivateSSRHelper } from "@/trpc/server/create-ssr-helper";
 
 export default async function Layout({
   children,
 }: {
   children: React.ReactNode;
 }) {
-  const helpers = await createPrivateSSRHelper();
+  const state = await getSessionState();
 
-  const [locale, session, space] = await Promise.all([
+  // An unreadable session (store unreachable, transient failure) is not
+  // "logged out". Redirecting to /login on it is one leg of the / ↔ /login
+  // redirect loop — fail the render instead so the user gets
+  // the error boundary's retry page.
+  if (state.status === "error") {
+    throw new Error("Failed to read session");
+  }
+
+  const user =
+    state.status === "authenticated" ? state.session.user : undefined;
+
+  if (!user || user.isGuest) {
+    const pathname = await getPathname();
+    redirect(
+      buildSafeRedirectUrl({ destination: "/login", returnUrl: pathname }),
+    );
+  }
+
+  if (user.banned) {
+    throw new InvalidSessionError();
+  }
+
+  const [locale, space] = await Promise.all([
     getLocale(),
-    getSession(),
-    helpers.spaces.getCurrent.fetch(),
+    getActiveSpaceForUser(user.id),
   ]);
-
-  const user = session?.user;
 
   if (!space) {
     const pathname = await getPathname();
@@ -35,22 +54,22 @@ export default async function Layout({
   }
 
   return (
-    <HydrationBoundary state={dehydrate(helpers.queryClient)}>
+    <>
       <SessionRefresher />
-      <TimeZoneMismatchDialog homeTimeZone={user?.timeZone} />
-      <UserProvider user={user ?? null}>
+      <TimeZoneMismatchDialog homeTimeZone={user.timeZone} />
+      <UserProvider user={user}>
         <DateTimeProvider
           locale={locale}
-          timeZone={user?.timeZone}
-          timeFormat={user?.timeFormat}
-          weekStart={user?.weekStart ?? undefined}
+          timeZone={user.timeZone}
+          timeFormat={user.timeFormat}
+          weekStart={user.weekStart}
         >
-          <SpaceProvider>
+          <SpaceProvider space={space}>
             {children}
             <PayWall />
           </SpaceProvider>
         </DateTimeProvider>
       </UserProvider>
-    </HydrationBoundary>
+    </>
   );
 }

--- a/apps/web/src/app/[locale]/(space)/layout.tsx
+++ b/apps/web/src/app/[locale]/(space)/layout.tsx
@@ -1,68 +1,36 @@
-import { redirect } from "next/navigation";
 import { SessionRefresher } from "@/components/session-refresher";
 import { PayWall } from "@/features/billing/components/pay-wall";
 import { SpaceProvider } from "@/features/space/client";
-import { getActiveSpaceForUser } from "@/features/space/data";
+import { getActiveSpace } from "@/features/space/data";
 import { TimeZoneMismatchDialog } from "@/features/user/components/timezone-mismatch-dialog";
 import { UserProvider } from "@/features/user/components/user-provider";
 import { getLocale } from "@/i18n/server/get-locale";
-import { getSessionState } from "@/lib/auth";
+import { getSession } from "@/lib/auth";
 import { DateTimeProvider } from "@/lib/datetime/client";
-import { InvalidSessionError } from "@/lib/errors/invalid-session-error";
-import { getPathname } from "@/lib/pathname";
-import { buildSafeRedirectUrl } from "@/lib/utils/redirect";
 
 export default async function Layout({
   children,
 }: {
   children: React.ReactNode;
 }) {
-  const state = await getSessionState();
-
-  // An unreadable session (store unreachable, transient failure) is not
-  // "logged out". Redirecting to /login on it is one leg of the / ↔ /login
-  // redirect loop — fail the render instead so the user gets
-  // the error boundary's retry page.
-  if (state.status === "error") {
-    throw new Error("Failed to read session");
-  }
-
-  const user =
-    state.status === "authenticated" ? state.session.user : undefined;
-
-  if (!user || user.isGuest) {
-    const pathname = await getPathname();
-    redirect(
-      buildSafeRedirectUrl({ destination: "/login", returnUrl: pathname }),
-    );
-  }
-
-  if (user.banned) {
-    throw new InvalidSessionError();
-  }
-
-  const [locale, space] = await Promise.all([
+  const [locale, session, space] = await Promise.all([
     getLocale(),
-    getActiveSpaceForUser(user.id),
+    getSession(),
+    getActiveSpace(),
   ]);
 
-  if (!space) {
-    const pathname = await getPathname();
-    redirect(
-      buildSafeRedirectUrl({ destination: "/setup", returnUrl: pathname }),
-    );
-  }
+  const user = session?.user;
 
   return (
     <>
       <SessionRefresher />
-      <TimeZoneMismatchDialog homeTimeZone={user.timeZone} />
-      <UserProvider user={user}>
+      <TimeZoneMismatchDialog homeTimeZone={user?.timeZone} />
+      <UserProvider user={user ?? null}>
         <DateTimeProvider
           locale={locale}
-          timeZone={user.timeZone}
-          timeFormat={user.timeFormat}
-          weekStart={user.weekStart}
+          timeZone={user?.timeZone}
+          timeFormat={user?.timeFormat}
+          weekStart={user?.weekStart}
         >
           <SpaceProvider space={space}>
             {children}

--- a/apps/web/src/app/[locale]/(space)/settings/billing/page.tsx
+++ b/apps/web/src/app/[locale]/(space)/settings/billing/page.tsx
@@ -25,10 +25,7 @@ import {
   SettingsPageTitle,
 } from "@/components/settings-layout";
 import { getSpaceSubscription } from "@/features/billing/data";
-import {
-  getActiveSpaceForUser,
-  getSpaceSeatCount,
-} from "@/features/space/data";
+import { getActiveSpace, getSpaceSeatCount } from "@/features/space/data";
 import { defineAbilityForMember } from "@/features/space/member/ability";
 import { getCurrentUser } from "@/features/user/data";
 import { Trans } from "@/i18n/client";
@@ -60,16 +57,7 @@ export default async function BillingSettingsPage({
     );
   }
 
-  const space = await getActiveSpaceForUser(user.id);
-
-  if (!space) {
-    redirect(
-      buildSafeRedirectUrl({
-        destination: "/setup",
-        returnUrl: await getPathname(),
-      }),
-    );
-  }
+  const space = await getActiveSpace();
 
   const ability = defineAbilityForMember({
     user: { id: user.id },

--- a/apps/web/src/features/space/client.tsx
+++ b/apps/web/src/features/space/client.tsx
@@ -1,59 +1,51 @@
 "use client";
 
 import { posthog } from "@rallly/posthog/client";
-import { useRouter } from "next/navigation";
 import React from "react";
-import { RouterLoadingIndicator } from "@/components/router-loading-indicator";
 import { getPrimaryColorVars } from "@/features/branding/utils";
 import { defineAbilityForMember } from "@/features/space/member/ability";
+import type { SpaceDTO } from "@/features/space/types";
 import { trpc } from "@/trpc/client";
 import { defineAbilityForSpace } from "./ability";
 
-export const useSpace = () => {
-  const [user] = trpc.user.getAuthed.useSuspenseQuery();
-  const [data] = trpc.spaces.getCurrent.useSuspenseQuery();
+const SpaceContext = React.createContext<SpaceDTO | null>(null);
 
-  if (!data) {
-    throw new Error("No active space found");
+export const useSpace = () => {
+  const space = React.useContext(SpaceContext);
+  const [user] = trpc.user.getAuthed.useSuspenseQuery();
+
+  if (!space) {
+    throw new Error("useSpace must be used within a SpaceProvider");
   }
 
   return React.useMemo(
     () => ({
-      data,
-      getAbility: () => defineAbilityForSpace(data),
+      data: space,
+      getAbility: () => defineAbilityForSpace(space),
       getMemberAbility: () =>
         defineAbilityForMember({
           user: { id: user.id },
           space: {
-            id: data.id,
-            ownerId: data.ownerId,
-            role: data.role,
+            id: space.id,
+            ownerId: space.ownerId,
+            role: space.role,
           },
         }),
     }),
-    [data, user.id],
+    [space, user.id],
   );
 };
 
-export function SpaceProvider({ children }: { children: React.ReactNode }) {
-  const router = useRouter();
-  const { data: space, isLoading } = trpc.spaces.getCurrent.useQuery();
-
+export function SpaceProvider({
+  space,
+  children,
+}: {
+  space: SpaceDTO;
+  children: React.ReactNode;
+}) {
   React.useEffect(() => {
-    if (!isLoading && !space) {
-      router.replace("/setup");
-    }
-  }, [isLoading, space, router]);
-
-  React.useEffect(() => {
-    if (space?.id) {
-      posthog?.group("space", space.id);
-    }
-  }, [space?.id]);
-
-  if (!space) {
-    return <RouterLoadingIndicator />;
-  }
+    posthog?.group("space", space.id);
+  }, [space.id]);
 
   const primaryColorVars =
     space.showBranding && space.primaryColor
@@ -61,9 +53,10 @@ export function SpaceProvider({ children }: { children: React.ReactNode }) {
       : null;
 
   return (
-    <div data-space-branding style={{ display: "contents" }}>
-      {primaryColorVars ? (
-        <style>{`
+    <SpaceContext.Provider value={space}>
+      <div data-space-branding style={{ display: "contents" }}>
+        {primaryColorVars ? (
+          <style>{`
           html.light [data-space-branding] {
             --primary: ${primaryColorVars.light};
             --primary-foreground: ${primaryColorVars.lightForeground};
@@ -73,8 +66,9 @@ export function SpaceProvider({ children }: { children: React.ReactNode }) {
             --primary-foreground: ${primaryColorVars.darkForeground};
           }
         `}</style>
-      ) : null}
-      {children}
-    </div>
+        ) : null}
+        {children}
+      </div>
+    </SpaceContext.Provider>
   );
 }

--- a/apps/web/src/features/space/components/space-dropdown.tsx
+++ b/apps/web/src/features/space/components/space-dropdown.tsx
@@ -22,6 +22,7 @@ import {
 } from "lucide-react";
 import Link from "next/link";
 import { setActiveSpaceAction } from "@/features/space/actions";
+import { useSpace } from "@/features/space/client";
 import { SpaceTierLabel } from "@/features/space/components/space-tier";
 import { Trans } from "@/i18n/client";
 import { useSafeAction } from "@/lib/safe-action/client";
@@ -31,22 +32,12 @@ import { SpaceIcon } from "./space-icon";
 
 export function SpaceDropdown() {
   const { data: spaces = [] } = trpc.spaces.list.useQuery();
-  const { data: activeSpace } = trpc.spaces.getCurrent.useQuery();
+  const { data: activeSpace } = useSpace();
 
-  const utils = trpc.useUtils();
-  const setActiveSpace = useSafeAction(setActiveSpaceAction, {
-    onSuccess: () => {
-      utils.spaces.getCurrent.invalidate();
-    },
-  });
+  const setActiveSpace = useSafeAction(setActiveSpaceAction);
   const newSpaceDialog = useDialog();
 
-  if (!activeSpace) {
-    // This should never happen
-    return null;
-  }
-
-  const selectedSpaceId = activeSpace?.id;
+  const selectedSpaceId = activeSpace.id;
 
   return (
     <>

--- a/apps/web/src/features/space/data.ts
+++ b/apps/web/src/features/space/data.ts
@@ -5,12 +5,17 @@ import type {
   SpaceTier as DBSpaceTier,
 } from "@rallly/database";
 import { prisma } from "@rallly/database";
+import { redirect } from "next/navigation";
 import { cache } from "react";
 
 import type { MemberDTO } from "@/features/space/member/types";
 import type { AuthorizedSpaceId, SpaceDTO } from "@/features/space/types";
 import { fromDBRole } from "@/features/space/utils";
+import { getSessionState } from "@/lib/auth";
 import { isSelfHosted } from "@/lib/constants";
+import { InvalidSessionError } from "@/lib/errors/invalid-session-error";
+import { getPathname } from "@/lib/pathname";
+import { buildSafeRedirectUrl } from "@/lib/utils/redirect";
 
 function createMemberDTO(member: {
   id: string;
@@ -111,6 +116,55 @@ export function getSpaceBranding(spaceId: string) {
     },
   });
 }
+
+/**
+ * The active space for the signed-in user, gated for server rendering:
+ * redirects to /login when unauthenticated or a guest, redirects to /setup
+ * when the user has no space, and throws InvalidSessionError when banned.
+ * React cached, so every page and layout that needs the space in a request
+ * shares one gate and one query. Server component/page use only — the
+ * redirects make it unsuitable for route handlers and tRPC procedures.
+ */
+export const getActiveSpace = cache(async () => {
+  const state = await getSessionState();
+
+  // An unreadable session (store unreachable, transient failure) is not
+  // "logged out" — redirecting to /login on it is one leg of a redirect
+  // loop. Fail the render instead so the user gets the error boundary's
+  // retry page.
+  if (state.status === "error") {
+    throw new Error("Failed to read session");
+  }
+
+  const user =
+    state.status === "authenticated" ? state.session.user : undefined;
+
+  if (!user || user.isGuest) {
+    redirect(
+      buildSafeRedirectUrl({
+        destination: "/login",
+        returnUrl: await getPathname(),
+      }),
+    );
+  }
+
+  if (user.banned) {
+    throw new InvalidSessionError();
+  }
+
+  const space = await getActiveSpaceForUser(user.id);
+
+  if (!space) {
+    redirect(
+      buildSafeRedirectUrl({
+        destination: "/setup",
+        returnUrl: await getPathname(),
+      }),
+    );
+  }
+
+  return space;
+});
 
 export const getActiveSpaceForUser = cache(async (userId: string) => {
   const spaceMember = await prisma.spaceMember.findFirst({

--- a/apps/web/src/trpc/routers/spaces.ts
+++ b/apps/web/src/trpc/routers/spaces.ts
@@ -9,7 +9,6 @@ import { getInstanceBranding } from "@/emails/branding";
 import { defineAbilityForSpace } from "@/features/space/ability";
 import {
   createSpaceDTO,
-  getActiveSpaceForUser,
   getMember,
   getSpaceSeatCount,
 } from "@/features/space/data";
@@ -68,9 +67,6 @@ export const spaces = router({
         role: spaceMember.role,
       }),
     );
-  }),
-  getCurrent: privateProcedure.query(async ({ ctx }) => {
-    return await getActiveSpaceForUser(ctx.user.id);
   }),
   listMembers: spaceProcedure.query(async ({ ctx }) => {
     const [members, totalCount] = await Promise.all([


### PR DESCRIPTION
Removes the `spaces.getCurrent` tRPC procedure and serves the active space from the `(space)` server layout through React context instead of the query cache.

Closes [RAL-1377](https://linear.app/rallly/issue/RAL-1377/remove-spacesgetcurrent-from-trpc)

## Changes

- **`getActiveSpace()`** — new React cached read in `features/space/data.ts` that owns the auth gate at the data layer: `getSessionState` with unauthenticated/guest → `/login` redirect, banned → `InvalidSessionError`, unreadable session → render failure (redirect loop guard), no space → `/setup` redirect. Because layouts don't re-render on soft navigations, gating in the layout alone wouldn't cover page transitions — any page that fetches space data calls `getActiveSpace()` and the gate runs where the fetch happens, deduped per request by `cache()`.
- **`SpaceProvider`** is now a plain React context that takes `space: SpaceDTO` as a prop. The PostHog `space` group call and branding CSS vars are unchanged. The client side `/setup` redirect is gone — the server gate covers it (delete/leave flows `router.push("/")` which re-runs the layout).
- **`useSpace()`** reads the context and keeps its return shape (`data`, `getAbility`, `getMemberAbility`), so the nine downstream consumers are untouched. It still uses `trpc.user.getAuthed` for the member ability (separate migration).
- **`(space)/layout.tsx`** no longer uses the tRPC SSR helper — it calls `getActiveSpace()` and passes the result to `SpaceProvider`. Nested layouts still create their own helpers and hydration boundaries, so their prefetches are unaffected.
- **Billing settings page** reuses `getActiveSpace()` instead of its own `getActiveSpaceForUser` + `/setup` redirect block.
- **`SpaceDropdown`** reads the active space from `useSpace()`. The `utils.spaces.getCurrent.invalidate()` after `setActiveSpaceAction` is dropped — `useSafeAction` already calls `router.refresh()` on success, which re-runs the layout and delivers the new space through context.
- The `getCurrent` procedure is deleted from `trpc/routers/spaces.ts`.

## Not in scope

- `spaceProcedure` in `trpc/trpc.ts` still calls `getActiveSpaceForUser` for the remaining space procedures.
- `spaces.list` and `user.getAuthed`/`user.getMe` are separate migrations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Centralized “active space” resolution during server rendering with consistent authentication and onboarding redirects.
  * Updated space state to flow through a shared provider, improving consistency across the app.
  * Space dropdown now reflects the active space from in-app context.

* **Bug Fixes**
  * Improved handling of invalid/unreadable sessions and banned users (access is blocked appropriately).
  * Removed inconsistent loading/prefetch behavior that could lead to mismatched space state.

* **Chores**
  * Simplified session/space hydration handling to streamline the initial render.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->