### PR TITLE
⏪️ Move settings back button to the sidebar header

### DIFF
--- a/apps/web/src/app/[locale]/(space)/settings/layout.tsx
+++ b/apps/web/src/app/[locale]/(space)/settings/layout.tsx
@@ -1,3 +1,4 @@
+import { buttonVariants } from "@rallly/ui";
 import { Icon } from "@rallly/ui/icon";
 import {
   Sidebar,
@@ -9,7 +10,6 @@ import {
   SidebarHeader,
   SidebarInset,
   SidebarMenu,
-  SidebarMenuButton,
   SidebarMenuItem,
   SidebarProvider,
   SidebarSeparator,
@@ -34,10 +34,18 @@ export default function Layout({ children }: { children?: React.ReactNode }) {
           <SidebarGroup>
             <SidebarGroupContent>
               <SidebarMenu>
-                <SidebarMenuItem className="flex h-9 items-center gap-2 px-2">
-                  <Icon>
-                    <SettingsIcon />
-                  </Icon>
+                <SidebarMenuItem className="flex items-center gap-3">
+                  <Link
+                    href="/"
+                    className={buttonVariants({
+                      variant: "ghost",
+                      size: "icon",
+                    })}
+                  >
+                    <Icon>
+                      <ArrowLeftIcon />
+                    </Icon>
+                  </Link>
                   <span className="font-medium text-sm">
                     <Trans i18nKey="settings" defaults="Settings" />
                   </span>
@@ -67,19 +75,6 @@ export default function Layout({ children }: { children?: React.ReactNode }) {
           <DeveloperSidebarMenu />
         </SidebarContent>
         <SidebarFooter>
-          <SidebarGroup>
-            <SidebarGroupContent>
-              <SidebarMenu>
-                <SidebarMenuItem>
-                  <SidebarMenuButton render={<Link href="/" />}>
-                    <ArrowLeftIcon />
-                    <Trans i18nKey="back" defaults="Back" />
-                  </SidebarMenuButton>
-                </SidebarMenuItem>
-              </SidebarMenu>
-            </SidebarGroupContent>
-          </SidebarGroup>
-          <SidebarSeparator className="my-1" />
           <NavUser />
         </SidebarFooter>
       </Sidebar>

--- a/apps/web/src/app/[locale]/(space)/settings/layout.tsx
+++ b/apps/web/src/app/[locale]/(space)/settings/layout.tsx
@@ -45,6 +45,9 @@ export default function Layout({ children }: { children?: React.ReactNode }) {
                     <Icon>
                       <ArrowLeftIcon />
                     </Icon>
+                    <span className="sr-only">
+                      <Trans i18nKey="back" defaults="Back" />
+                    </span>
                   </Link>
                   <span className="font-medium text-sm">
                     <Trans i18nKey="settings" defaults="Settings" />


### PR DESCRIPTION
Reverts #2662, which moved the back button from the settings sidebar header to the footer.

The header placement is the stronger pattern: exit affordances belong top left where users instinctively look to leave a sub context (browser back, Linear/Slack/Vercel settings all do this), the header row was otherwise a non interactive label, and the footer returns to holding just `NavUser`, matching the main app sidebar.

The revert conflicted with #2692 (layout signature change); resolved by keeping the current non async signature.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style / UI**
  * Updated the space settings sidebar header to use a ghost-style back icon link that returns to the home page.
  * Removed the separate “Back” menu section and its separator from the sidebar footer.
  * Simplified the sidebar footer to show only user navigation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->