### PR TITLE
✨ Alert actions, indigo primary variant, and pending invite cleanup on downgrade

### DIFF
--- a/apps/web/public/locales/en/app.json
+++ b/apps/web/public/locales/en/app.json
@@ -501,6 +501,7 @@
   "pendingInvites": "Pending Invites",
   "pendingInvitesDescription": "Invite other users to share your space.",
   "pendingInvitesUpgradeDescription": "Upgrade to Pro to invite members to your space.",
+  "pendingInvitesUpgradeTitle": "Invite members",
   "perSeatMonth": "/seat/mo",
   "personal": "Personal",
   "planFree": "Free",

--- a/apps/web/public/locales/en/app.json
+++ b/apps/web/public/locales/en/app.json
@@ -501,7 +501,6 @@
   "pendingInvites": "Pending Invites",
   "pendingInvitesDescription": "Invite other users to share your space.",
   "pendingInvitesUpgradeDescription": "Upgrade to Pro to invite members to your space.",
-  "pendingInvitesUpgradeTitle": "Invite members",
   "perSeatMonth": "/seat/mo",
   "personal": "Personal",
   "planFree": "Free",

--- a/apps/web/src/app/[locale]/(space)/settings/members/page-client.tsx
+++ b/apps/web/src/app/[locale]/(space)/settings/members/page-client.tsx
@@ -1,7 +1,12 @@
 "use client";
 
 import { posthog } from "@rallly/posthog/client";
-import { Alert, AlertAction, AlertDescription } from "@rallly/ui/alert";
+import {
+  Alert,
+  AlertAction,
+  AlertDescription,
+  AlertTitle,
+} from "@rallly/ui/alert";
 import { Badge } from "@rallly/ui/badge";
 import { Button } from "@rallly/ui/button";
 import { InfoIcon, SparklesIcon } from "lucide-react";
@@ -97,6 +102,12 @@ export function MembersSettingsPageClient() {
           {!canInviteMembers ? (
             <Alert variant="primary">
               <SparklesIcon />
+              <AlertTitle>
+                <Trans
+                  i18nKey="pendingInvitesUpgradeTitle"
+                  defaults="Invite members"
+                />
+              </AlertTitle>
               <AlertDescription>
                 <Trans
                   i18nKey="pendingInvitesUpgradeDescription"

--- a/apps/web/src/app/[locale]/(space)/settings/members/page-client.tsx
+++ b/apps/web/src/app/[locale]/(space)/settings/members/page-client.tsx
@@ -1,12 +1,7 @@
 "use client";
 
 import { posthog } from "@rallly/posthog/client";
-import {
-  Alert,
-  AlertAction,
-  AlertDescription,
-  AlertTitle,
-} from "@rallly/ui/alert";
+import { Alert, AlertAction, AlertDescription } from "@rallly/ui/alert";
 import { Badge } from "@rallly/ui/badge";
 import { Button } from "@rallly/ui/button";
 import { InfoIcon, SparklesIcon } from "lucide-react";
@@ -102,12 +97,6 @@ export function MembersSettingsPageClient() {
           {!canInviteMembers ? (
             <Alert variant="primary">
               <SparklesIcon />
-              <AlertTitle>
-                <Trans
-                  i18nKey="pendingInvitesUpgradeTitle"
-                  defaults="Invite members"
-                />
-              </AlertTitle>
               <AlertDescription>
                 <Trans
                   i18nKey="pendingInvitesUpgradeDescription"

--- a/apps/web/src/app/[locale]/(space)/settings/members/page-client.tsx
+++ b/apps/web/src/app/[locale]/(space)/settings/members/page-client.tsx
@@ -106,7 +106,7 @@ export function MembersSettingsPageClient() {
               <AlertAction>
                 <Button
                   size="sm"
-                  variant="ghost"
+                  variant="link"
                   onClick={() => {
                     posthog?.capture("members_settings:upgrade_button_click");
                     showPayWall();

--- a/apps/web/src/app/[locale]/(space)/settings/members/page-client.tsx
+++ b/apps/web/src/app/[locale]/(space)/settings/members/page-client.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { posthog } from "@rallly/posthog/client";
-import { Alert, AlertDescription } from "@rallly/ui/alert";
+import { Alert, AlertAction, AlertDescription } from "@rallly/ui/alert";
 import { Badge } from "@rallly/ui/badge";
 import { Button } from "@rallly/ui/button";
 import { InfoIcon, SparklesIcon } from "lucide-react";
@@ -112,13 +112,14 @@ export function MembersSettingsPageClient() {
                 <Alert variant="primary">
                   <SparklesIcon />
                   <AlertDescription>
-                    <p>
-                      <Trans
-                        i18nKey="pendingInvitesUpgradeDescription"
-                        defaults="Upgrade to Pro to invite members to your space."
-                      />
-                    </p>
+                    <Trans
+                      i18nKey="pendingInvitesUpgradeDescription"
+                      defaults="Upgrade to Pro to invite members to your space."
+                    />
+                  </AlertDescription>
+                  <AlertAction>
                     <Button
+                      size="sm"
                       onClick={() => {
                         posthog?.capture(
                           "members_settings:upgrade_button_click",
@@ -128,7 +129,7 @@ export function MembersSettingsPageClient() {
                     >
                       <Trans i18nKey="upgradeToPro" defaults="Upgrade to Pro" />
                     </Button>
-                  </AlertDescription>
+                  </AlertAction>
                 </Alert>
               ) : (
                 <>

--- a/apps/web/src/app/[locale]/(space)/settings/members/page-client.tsx
+++ b/apps/web/src/app/[locale]/(space)/settings/members/page-client.tsx
@@ -94,45 +94,46 @@ export function MembersSettingsPageClient() {
               </StackedList>
             </PageSectionContent>
           </PageSection>
-          <PageSectionDivider />
-          <PageSection>
-            <PageSectionHeader>
-              <PageSectionTitle>
-                <Trans i18nKey="pendingInvites" defaults="Pending Invites" />
-              </PageSectionTitle>
-              <PageSectionDescription>
+          {!canInviteMembers ? (
+            <Alert variant="primary">
+              <SparklesIcon />
+              <AlertDescription>
                 <Trans
-                  i18nKey="pendingInvitesDescription"
-                  defaults="Invite other users to share your space."
+                  i18nKey="pendingInvitesUpgradeDescription"
+                  defaults="Upgrade to Pro to invite members to your space."
                 />
-              </PageSectionDescription>
-            </PageSectionHeader>
-            <PageSectionContent>
-              {!canInviteMembers ? (
-                <Alert variant="primary">
-                  <SparklesIcon />
-                  <AlertDescription>
+              </AlertDescription>
+              <AlertAction>
+                <Button
+                  size="sm"
+                  onClick={() => {
+                    posthog?.capture("members_settings:upgrade_button_click");
+                    showPayWall();
+                  }}
+                >
+                  <Trans i18nKey="upgradeToPro" defaults="Upgrade to Pro" />
+                </Button>
+              </AlertAction>
+            </Alert>
+          ) : (
+            <>
+              <PageSectionDivider />
+              <PageSection>
+                <PageSectionHeader>
+                  <PageSectionTitle>
                     <Trans
-                      i18nKey="pendingInvitesUpgradeDescription"
-                      defaults="Upgrade to Pro to invite members to your space."
+                      i18nKey="pendingInvites"
+                      defaults="Pending Invites"
                     />
-                  </AlertDescription>
-                  <AlertAction>
-                    <Button
-                      size="sm"
-                      onClick={() => {
-                        posthog?.capture(
-                          "members_settings:upgrade_button_click",
-                        );
-                        showPayWall();
-                      }}
-                    >
-                      <Trans i18nKey="upgradeToPro" defaults="Upgrade to Pro" />
-                    </Button>
-                  </AlertAction>
-                </Alert>
-              ) : (
-                <>
+                  </PageSectionTitle>
+                  <PageSectionDescription>
+                    <Trans
+                      i18nKey="pendingInvitesDescription"
+                      defaults="Invite other users to share your space."
+                    />
+                  </PageSectionDescription>
+                </PageSectionHeader>
+                <PageSectionContent>
                   {invites.length > 0 ? (
                     <StackedList>
                       {invites.map((invite) => (
@@ -223,10 +224,10 @@ export function MembersSettingsPageClient() {
                       </AlertDescription>
                     </Alert>
                   ) : null}
-                </>
-              )}
-            </PageSectionContent>
-          </PageSection>
+                </PageSectionContent>
+              </PageSection>
+            </>
+          )}
         </PageSectionGroup>
       </SettingsPageContent>
     </SettingsPage>

--- a/apps/web/src/app/[locale]/(space)/settings/members/page-client.tsx
+++ b/apps/web/src/app/[locale]/(space)/settings/members/page-client.tsx
@@ -106,6 +106,7 @@ export function MembersSettingsPageClient() {
               <AlertAction>
                 <Button
                   size="sm"
+                  variant="ghost"
                   onClick={() => {
                     posthog?.capture("members_settings:upgrade_button_click");
                     showPayWall();

--- a/apps/web/src/features/billing/webhook/mutations.ts
+++ b/apps/web/src/features/billing/webhook/mutations.ts
@@ -51,6 +51,10 @@ async function syncSpaceTier(tx: Prisma.TransactionClient, spaceId: string) {
     },
   });
 
+  if (tier === "hobby") {
+    await tx.spaceMemberInvite.deleteMany({ where: { spaceId } });
+  }
+
   return tier;
 }
 

--- a/packages/ui/src/alert.tsx
+++ b/packages/ui/src/alert.tsx
@@ -10,7 +10,7 @@ const alertVariants = cva(
     variants: {
       variant: {
         primary:
-          "border-transparent bg-primary *:data-[slot=alert-description]:text-primary-foreground/90 [&>svg]:text-primary-foreground",
+          "border-indigo-500/20 bg-indigo-500/10 text-indigo-900 *:data-[slot=alert-description]:text-indigo-900/90 dark:text-indigo-100 dark:*:data-[slot=alert-description]:text-indigo-100/90 [&>svg]:text-indigo-900/75 dark:[&>svg]:text-indigo-100/75",
         info: "border-blue-500/20 bg-blue-500/10 text-blue-900 *:data-[slot=alert-description]:text-blue-900/90 dark:text-blue-100 dark:*:data-[slot=alert-description]:text-blue-100/90 [&>svg]:text-blue-900/75 dark:[&>svg]:text-blue-100/75",
         warning:
           "border-yellow-500/20 bg-yellow-500/10 text-yellow-900 *:data-[slot=alert-description]:text-yellow-900/90 dark:text-yellow-100 dark:*:data-[slot=alert-description]:text-yellow-100/90 [&>svg]:text-yellow-900/75 dark:[&>svg]:text-yellow-100/75",

--- a/packages/ui/src/alert.tsx
+++ b/packages/ui/src/alert.tsx
@@ -75,7 +75,10 @@ function AlertAction({ className, ...props }: React.ComponentProps<"div">) {
   return (
     <div
       data-slot="alert-action"
-      className={cn("absolute top-2 right-2", className)}
+      className={cn(
+        "absolute top-1/2 right-2 -translate-y-1/2 group-has-data-[slot=alert-title]/alert:top-2 group-has-data-[slot=alert-title]/alert:translate-y-0",
+        className,
+      )}
       {...props}
     />
   );

--- a/packages/ui/src/alert.tsx
+++ b/packages/ui/src/alert.tsx
@@ -5,7 +5,7 @@ import type * as React from "react";
 import { cn } from "./lib/utils";
 
 const alertVariants = cva(
-  "group/alert relative grid w-full gap-0.5 rounded-lg border px-2.5 py-2 text-left text-sm has-[>svg]:has-data-[slot=alert-action]:grid-cols-[auto_1fr_auto] has-[>svg]:grid-cols-[auto_1fr] has-data-[slot=alert-action]:grid-cols-[1fr_auto] has-[>svg]:gap-x-2 has-data-[slot=alert-action]:gap-x-2 *:[svg:not([class*='size-'])]:size-4 *:[svg]:row-span-2 *:[svg]:translate-y-0.5 *:[svg]:text-current",
+  "group/alert relative grid w-full items-center gap-0.5 rounded-lg border px-2.5 py-2 text-left text-sm has-[>svg]:has-data-[slot=alert-action]:grid-cols-[auto_1fr_auto] has-[>svg]:grid-cols-[auto_1fr] has-data-[slot=alert-action]:grid-cols-[1fr_auto] has-data-[slot=alert-title]:items-start has-[>svg]:gap-x-2 has-data-[slot=alert-action]:gap-x-2 *:[svg:not([class*='size-'])]:size-4 *:[svg]:text-current has-data-[slot=alert-title]:*:[svg]:row-span-2 has-data-[slot=alert-title]:*:[svg]:translate-y-0.5",
   {
     variants: {
       variant: {
@@ -76,7 +76,7 @@ function AlertAction({ className, ...props }: React.ComponentProps<"div">) {
     <div
       data-slot="alert-action"
       className={cn(
-        "col-start-2 row-span-2 row-start-1 self-center justify-self-end group-has-[>svg]/alert:col-start-3 group-has-data-[slot=alert-title]/alert:self-start",
+        "col-start-2 justify-self-end group-has-[>svg]/alert:col-start-3 group-has-data-[slot=alert-title]/alert:row-span-2 group-has-data-[slot=alert-title]/alert:row-start-1",
         className,
       )}
       {...props}

--- a/packages/ui/src/alert.tsx
+++ b/packages/ui/src/alert.tsx
@@ -5,7 +5,7 @@ import type * as React from "react";
 import { cn } from "./lib/utils";
 
 const alertVariants = cva(
-  "relative grid w-full grid-cols-[0_1fr] items-start gap-y-0.5 rounded-xl border px-4 py-3 text-sm has-[>svg]:grid-cols-[calc(var(--spacing)*4)_1fr] has-[>svg]:gap-x-3 [&>svg]:size-4 [&>svg]:translate-y-0.5 [&>svg]:text-current",
+  "group/alert relative grid w-full gap-0.5 rounded-lg border px-2.5 py-2 text-left text-sm has-data-[slot=alert-action]:relative has-[>svg]:grid-cols-[auto_1fr] has-[>svg]:gap-x-2 has-data-[slot=alert-action]:pr-18 *:[svg:not([class*='size-'])]:size-4 *:[svg]:row-span-2 *:[svg]:translate-y-0.5 *:[svg]:text-current",
   {
     variants: {
       variant: {
@@ -46,7 +46,10 @@ function AlertTitle({ className, ...props }: React.ComponentProps<"div">) {
   return (
     <div
       data-slot="alert-title"
-      className={cn("col-start-2 line-clamp-1 min-h-4 font-medium", className)}
+      className={cn(
+        "font-medium group-has-[>svg]/alert:col-start-2 [&_a]:underline [&_a]:underline-offset-3 [&_a]:hover:text-foreground",
+        className,
+      )}
       {...props}
     />
   );
@@ -60,7 +63,7 @@ function AlertDescription({
     <div
       data-slot="alert-description"
       className={cn(
-        "col-start-2 grid justify-items-start gap-1 text-sm [&_p]:leading-5",
+        "text-balance text-muted-foreground text-sm md:text-pretty [&_a]:underline [&_a]:underline-offset-3 [&_a]:hover:text-foreground [&_p:not(:last-child)]:mb-4",
         className,
       )}
       {...props}
@@ -68,4 +71,14 @@ function AlertDescription({
   );
 }
 
-export { Alert, AlertTitle, AlertDescription };
+function AlertAction({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="alert-action"
+      className={cn("absolute top-2 right-2", className)}
+      {...props}
+    />
+  );
+}
+
+export { Alert, AlertTitle, AlertDescription, AlertAction };

--- a/packages/ui/src/alert.tsx
+++ b/packages/ui/src/alert.tsx
@@ -5,7 +5,7 @@ import type * as React from "react";
 import { cn } from "./lib/utils";
 
 const alertVariants = cva(
-  "group/alert relative grid w-full gap-0.5 rounded-lg border px-2.5 py-2 text-left text-sm has-data-[slot=alert-action]:relative has-[>svg]:grid-cols-[auto_1fr] has-[>svg]:gap-x-2 has-data-[slot=alert-action]:pr-18 *:[svg:not([class*='size-'])]:size-4 *:[svg]:row-span-2 *:[svg]:translate-y-0.5 *:[svg]:text-current",
+  "group/alert relative grid w-full gap-0.5 rounded-lg border px-2.5 py-2 text-left text-sm has-[>svg]:has-data-[slot=alert-action]:grid-cols-[auto_1fr_auto] has-[>svg]:grid-cols-[auto_1fr] has-data-[slot=alert-action]:grid-cols-[1fr_auto] has-[>svg]:gap-x-2 has-data-[slot=alert-action]:gap-x-2 *:[svg:not([class*='size-'])]:size-4 *:[svg]:row-span-2 *:[svg]:translate-y-0.5 *:[svg]:text-current",
   {
     variants: {
       variant: {
@@ -76,7 +76,7 @@ function AlertAction({ className, ...props }: React.ComponentProps<"div">) {
     <div
       data-slot="alert-action"
       className={cn(
-        "absolute top-1/2 right-2 -translate-y-1/2 group-has-data-[slot=alert-title]/alert:top-2 group-has-data-[slot=alert-title]/alert:translate-y-0",
+        "col-start-2 row-span-2 row-start-1 self-center justify-self-end group-has-[>svg]/alert:col-start-3 group-has-data-[slot=alert-title]/alert:self-start",
         className,
       )}
       {...props}


### PR DESCRIPTION
## Summary

Follow-up to #2698, which was merged before the later commits on the branch landed. This PR contains the remaining work:

### Alert component (`@rallly/ui`)
- Restyle the `primary` variant as a soft indigo tint using the same value pattern as `info` (it was previously solid `bg-primary`, so it no longer tracks custom space branding — this also changes the control panel branding page and the poll invite page, which use this variant)
- Adopt the new shadcn alert structure and add `AlertAction`, keeping all existing variants
- Lay out `AlertAction` as a real grid column instead of an absolute overlay, so the description wraps in its own column and can never run under the action, regardless of action width or locale
- Title-driven vertical alignment: alerts without a title render as a single row with icon, description, and action vertically centered; alerts with a title keep the two-row, top-aligned layout

### Members settings
- Hobby spaces no longer render the Pending Invites section at all — just the members list and an indigo upgrade alert with a SparklesIcon and an "Upgrade to Pro" action that opens the paywall (`members_settings:upgrade_button_click` PostHog event)

### Billing webhook
- `syncSpaceTier` deletes all pending invites for a space whenever the recomputed tier is hobby, in the same transaction as the tier write. Every subscription webhook path funnels through it, so all downgrade routes are covered. Idempotent, and stale invite emails hit the existing "No pending invite found" handling.

## Test plan

- [ ] Hobby space: members page shows only the members list plus the upgrade alert (no Pending Invites section); action button is vertically centered and never overlaps text at narrow widths
- [ ] Clicking "Upgrade to Pro" opens the paywall dialog
- [ ] Pro space: Pending Invites section renders as before
- [ ] Cancel a subscription (Stripe test clock or `customer.subscription.deleted` webhook): space's pending invites are deleted
- [ ] Alerts with titles elsewhere in the app keep top-aligned icon and content

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a clearer upgrade prompt when member invitations are unavailable.
  - Added improved alert actions for prominent upgrade buttons.

- **Bug Fixes**
  - Pending invitations and seat usage are now hidden when invitations are unavailable.
  - Pending member invitations are automatically cleared when a space changes to the Hobby tier.

- **Style**
  - Improved alert layout, spacing, typography, and link presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->