### PR TITLE
💄 Render space tier with muted foreground in space dropdown

### DIFF
--- a/apps/web/src/app/[locale]/(space)/settings/billing/components/hobby-plan-card.tsx
+++ b/apps/web/src/app/[locale]/(space)/settings/billing/components/hobby-plan-card.tsx
@@ -3,7 +3,10 @@
 import { posthog } from "@rallly/posthog/client";
 import { Button } from "@rallly/ui/button";
 import { showPayWall } from "@/features/billing/client";
-import { SpaceTierIcon } from "@/features/space/components/space-tier";
+import {
+  SpaceTierIcon,
+  SpaceTierLabel,
+} from "@/features/space/components/space-tier";
 import { Trans } from "@/i18n/client";
 import {
   PlanCard,
@@ -25,7 +28,9 @@ export function HobbyPlanCard({ className }: { className?: string }) {
           <SpaceTierIcon tier="hobby" />
         </PlanCardIcon>
         <PlanCardContent>
-          <PlanCardTitle>Hobby</PlanCardTitle>
+          <PlanCardTitle>
+            <SpaceTierLabel tier="hobby" />
+          </PlanCardTitle>
           <PlanCardDescription>
             <Trans
               i18nKey="seatCount"

--- a/apps/web/src/app/[locale]/(space)/settings/billing/components/pro-plan-card.tsx
+++ b/apps/web/src/app/[locale]/(space)/settings/billing/components/pro-plan-card.tsx
@@ -11,7 +11,10 @@ import type {
   BillingInterval,
   SubscriptionStatus,
 } from "@/features/billing/schema";
-import { SpaceTierIcon } from "@/features/space/components/space-tier";
+import {
+  SpaceTierIcon,
+  SpaceTierLabel,
+} from "@/features/space/components/space-tier";
 import { Trans } from "@/i18n/client";
 import { useDateTime, useDateTimeConfig } from "@/lib/datetime/client";
 import { useSafeAction } from "@/lib/safe-action/client";
@@ -71,7 +74,9 @@ export function ProPlanCard({
         </PlanCardIcon>
         <PlanCardContent>
           <div className="flex items-center gap-x-2">
-            <PlanCardTitle>Pro</PlanCardTitle>
+            <PlanCardTitle>
+              <SpaceTierLabel tier="pro" />
+            </PlanCardTitle>
             <SubscriptionStatusBadge status={status} />
           </div>
           <PlanCardDescription className="flex items-center">

--- a/apps/web/src/features/space/components/space-dropdown.tsx
+++ b/apps/web/src/features/space/components/space-dropdown.tsx
@@ -21,9 +21,9 @@ import {
   UserPlusIcon,
 } from "lucide-react";
 import Link from "next/link";
+import { PLAN_NAMES } from "@/features/billing/constants";
 import { setActiveSpaceAction } from "@/features/space/actions";
 import { useSpace } from "@/features/space/client";
-import { SpaceTierLabel } from "@/features/space/components/space-tier";
 import { Trans } from "@/i18n/client";
 import { useSafeAction } from "@/lib/safe-action/client";
 import { trpc } from "@/trpc/client";
@@ -61,8 +61,8 @@ export function SpaceDropdown() {
             <div className="truncate font-medium text-sm">
               {activeSpace.name}
             </div>
-            <div className="text-xs">
-              <SpaceTierLabel tier={activeSpace.tier} />
+            <div className="text-muted-foreground text-xs">
+              {activeSpace.tier === "pro" ? PLAN_NAMES.PRO : PLAN_NAMES.HOBBY}
             </div>
           </div>
           <Icon>

--- a/apps/web/src/features/space/components/space-dropdown.tsx
+++ b/apps/web/src/features/space/components/space-dropdown.tsx
@@ -21,9 +21,9 @@ import {
   UserPlusIcon,
 } from "lucide-react";
 import Link from "next/link";
-import { PLAN_NAMES } from "@/features/billing/constants";
 import { setActiveSpaceAction } from "@/features/space/actions";
 import { useSpace } from "@/features/space/client";
+import { SpaceTierLabel } from "@/features/space/components/space-tier";
 import { Trans } from "@/i18n/client";
 import { useSafeAction } from "@/lib/safe-action/client";
 import { trpc } from "@/trpc/client";
@@ -62,7 +62,7 @@ export function SpaceDropdown() {
               {activeSpace.name}
             </div>
             <div className="text-muted-foreground text-xs">
-              {activeSpace.tier === "pro" ? PLAN_NAMES.PRO : PLAN_NAMES.HOBBY}
+              <SpaceTierLabel tier={activeSpace.tier} />
             </div>
           </div>
           <Icon>

--- a/apps/web/src/features/space/components/space-tier.tsx
+++ b/apps/web/src/features/space/components/space-tier.tsx
@@ -7,9 +7,9 @@ import type { SpaceTier } from "@/features/space/schema";
 export const SpaceTierLabel = ({ tier }: { tier: SpaceTier }) => {
   switch (tier) {
     case "hobby":
-      return <span className="text-foreground">{PLAN_NAMES.HOBBY}</span>;
+      return <span className="text-muted-foreground">{PLAN_NAMES.HOBBY}</span>;
     case "pro":
-      return <span className="text-foreground">{PLAN_NAMES.PRO}</span>;
+      return <span className="text-muted-foreground">{PLAN_NAMES.PRO}</span>;
   }
 };
 

--- a/apps/web/src/features/space/components/space-tier.tsx
+++ b/apps/web/src/features/space/components/space-tier.tsx
@@ -1,7 +1,17 @@
 "use client";
 
 import { HandHeartIcon, SparklesIcon } from "lucide-react";
+import { PLAN_NAMES } from "@/features/billing/constants";
 import type { SpaceTier } from "@/features/space/schema";
+
+export const SpaceTierLabel = ({ tier }: { tier: SpaceTier }) => {
+  switch (tier) {
+    case "hobby":
+      return PLAN_NAMES.HOBBY;
+    case "pro":
+      return PLAN_NAMES.PRO;
+  }
+};
 
 export const SpaceTierIcon = ({ tier }: { tier: SpaceTier }) => {
   switch (tier) {

--- a/apps/web/src/features/space/components/space-tier.tsx
+++ b/apps/web/src/features/space/components/space-tier.tsx
@@ -1,17 +1,7 @@
 "use client";
 
 import { HandHeartIcon, SparklesIcon } from "lucide-react";
-import { PLAN_NAMES } from "@/features/billing/constants";
 import type { SpaceTier } from "@/features/space/schema";
-
-export const SpaceTierLabel = ({ tier }: { tier: SpaceTier }) => {
-  switch (tier) {
-    case "hobby":
-      return <span className="text-muted-foreground">{PLAN_NAMES.HOBBY}</span>;
-    case "pro":
-      return <span className="text-muted-foreground">{PLAN_NAMES.PRO}</span>;
-  }
-};
 
 export const SpaceTierIcon = ({ tier }: { tier: SpaceTier }) => {
   switch (tier) {


### PR DESCRIPTION
## Summary
- Render the space tier label in the space dropdown with `text-muted-foreground` instead of `text-foreground`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **UI Updates**
  * Updated the space dropdown to show the active tier (Hobby/Pro) with muted tier styling while keeping the same dropdown behavior.
  * Updated the Hobby and Pro billing plan cards to render their plan titles using the shared tier label, ensuring consistent tier display.
* **Refactor**
  * Streamlined tier label rendering so tier text output is consistent across the space-related UI.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->