### PR TITLE
🚑️ Disable captcha when the Turnstile pair is incomplete

### DIFF
--- a/apps/web/src/app/[locale]/(auth)/login/components/login-email-form.tsx
+++ b/apps/web/src/app/[locale]/(auth)/login/components/login-email-form.tsx
@@ -21,11 +21,11 @@ import * as z from "zod";
 import { setVerificationEmail } from "@/app/[locale]/(auth)/login/actions";
 import { Trans, useTranslation } from "@/i18n/client";
 import { authClient } from "@/lib/auth-client";
+import { useFeatureFlag } from "@/lib/feature-flags/client";
 import { validateRedirectUrl } from "@/lib/utils/redirect";
 import { trpc } from "@/trpc/client";
 
 const turnstileSiteKey = process.env.NEXT_PUBLIC_TURNSTILE_SITE_KEY;
-const isTurnstileEnabled = !!turnstileSiteKey;
 
 function useLoginWithEmailSchema() {
   const { t } = useTranslation();
@@ -42,6 +42,8 @@ export function LoginWithEmailForm({
 }: {
   isRegistrationEnabled: boolean;
 }) {
+  const isCaptchaEnabled = useFeatureFlag("captcha");
+  const isTurnstileEnabled = isCaptchaEnabled && !!turnstileSiteKey;
   const router = useRouter();
   const loginWithEmailSchema = useLoginWithEmailSchema();
   const searchParams = useSearchParams();
@@ -266,7 +268,7 @@ export function LoginWithEmailForm({
         {form.formState.errors.root?.message ? (
           <FormMessage>{form.formState.errors.root.message}</FormMessage>
         ) : null}
-        {showCaptcha && turnstileSiteKey ? (
+        {showCaptcha && isTurnstileEnabled && turnstileSiteKey ? (
           <Turnstile
             ref={turnstileRef}
             siteKey={turnstileSiteKey}

--- a/apps/web/src/app/[locale]/e/[id]/components/rsvp-verify-email.tsx
+++ b/apps/web/src/app/[locale]/e/[id]/components/rsvp-verify-email.tsx
@@ -26,9 +26,9 @@ import * as z from "zod";
 import { InputOTP } from "@/components/input-otp";
 import { Trans, useTranslation } from "@/i18n/client";
 import { authClient } from "@/lib/auth-client";
+import { useFeatureFlag } from "@/lib/feature-flags/client";
 
 const turnstileSiteKey = process.env.NEXT_PUBLIC_TURNSTILE_SITE_KEY;
-const isTurnstileEnabled = !!turnstileSiteKey;
 
 const otpSchema = z.object({ otp: z.string().regex(/^\d{6}$/) });
 
@@ -39,6 +39,8 @@ export function RsvpVerifyEmail({
   email: string;
   name: string;
 }) {
+  const isCaptchaEnabled = useFeatureFlag("captcha");
+  const isTurnstileEnabled = isCaptchaEnabled && !!turnstileSiteKey;
   const { t, i18n } = useTranslation();
   const router = useRouter();
   const dialog = useDialog();
@@ -169,7 +171,7 @@ export function RsvpVerifyEmail({
               />
             </DialogDescription>
           </DialogHeader>
-          {turnstileSiteKey && !otpSent ? (
+          {isTurnstileEnabled && turnstileSiteKey && !otpSent ? (
             <Turnstile
               ref={turnstileRef}
               siteKey={turnstileSiteKey}

--- a/apps/web/src/lib/auth.ts
+++ b/apps/web/src/lib/auth.ts
@@ -57,18 +57,20 @@ if (env.OIDC_ISSUER_URL) {
 }
 
 // The site key renders the widget and the secret key verifies its tokens;
-// with only one of them set, captcha is either silently skipped or blocks
-// every OTP send. Fail at boot instead.
+// captcha only works with both, so a half-configured pair disables it.
+const isCaptchaEnabled =
+  !!env.TURNSTILE_SECRET_KEY && !!env.NEXT_PUBLIC_TURNSTILE_SITE_KEY;
+
 if (!!env.TURNSTILE_SECRET_KEY !== !!env.NEXT_PUBLIC_TURNSTILE_SITE_KEY) {
-  throw new Error(
-    "NEXT_PUBLIC_TURNSTILE_SITE_KEY and TURNSTILE_SECRET_KEY must be set together",
+  logger.warn(
+    "Captcha is disabled: NEXT_PUBLIC_TURNSTILE_SITE_KEY and TURNSTILE_SECRET_KEY must be set together",
   );
 }
 
 // Conditional plugins are typed as BetterAuthPlugin[] — they don't add user
 // fields so losing their specific types doesn't affect session type inference.
 const conditionalPlugins: BetterAuthPlugin[] = [
-  ...(env.TURNSTILE_SECRET_KEY
+  ...(isCaptchaEnabled && env.TURNSTILE_SECRET_KEY
     ? [
         captcha({
           provider: "cloudflare-turnstile",

--- a/apps/web/src/lib/feature-flags/config.ts
+++ b/apps/web/src/lib/feature-flags/config.ts
@@ -15,6 +15,10 @@ export const featureFlagConfig: FeatureFlagConfig = {
   billing: isBillingEnabled,
   feedback: isFeedbackEnabled,
   emailLogin: isEmailLoginEnabled,
+  // Both halves of the Turnstile pair are needed: the site key renders the
+  // widget and the secret verifies its tokens. With only one set, captcha
+  // is disabled rather than half working.
+  captcha: !!env.TURNSTILE_SECRET_KEY && !!env.NEXT_PUBLIC_TURNSTILE_SITE_KEY,
   registration: isEmailLoginEnabled && isRegistrationEnabled,
   calendars: isCalendarsEnabled,
   eventTypes: isEventTypesEnabled,

--- a/apps/web/src/lib/feature-flags/types.ts
+++ b/apps/web/src/lib/feature-flags/types.ts
@@ -3,6 +3,7 @@ export interface FeatureFlagConfig {
   billing: boolean;
   feedback: boolean;
   emailLogin: boolean;
+  captcha: boolean;
   registration: boolean;
   calendars: boolean;
   eventTypes: boolean;


### PR DESCRIPTION
The boot-time assertion added in #2689 (`NEXT_PUBLIC_TURNSTILE_SITE_KEY` and `TURNSTILE_SECRET_KEY` must be set together) runs at module scope, so `next build` evaluated it — and the production build environment holds only the `NEXT_PUBLIC` key, with the secret provided to the serving runtime. That failed the production deploy.

Rather than special-casing build phases, this degrades gracefully, matching how other optional integrations are gated:

- New `captcha` feature flag: enabled only when **both** keys are set.
- The better-auth captcha plugin registers only when the flag is on, so a half-configured pair can't block every OTP send.
- The login form and event RSVP dialog receive `isCaptchaEnabled` from the server and suppress the widget when it's off, so users never solve a captcha whose token nothing verifies.
- A half-configured pair logs a warning instead of throwing.

Verified locally with only the site key set: `next build` completes (this exact configuration reproduced the prod failure), `next start` boots and serves OTP sends with the plugin inactive, and the warning appears in the log.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Captcha configuration mismatches no longer prevent the application from starting.
  * Captcha is now enabled only when both required Turnstile settings are configured.
  * Login and RSVP verification flows show and require captcha only when the captcha feature is enabled.
  * Added a warning when captcha settings are incomplete.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->