### PR TITLE
💄 Auto-continue email login once Turnstile succeeds

### DIFF
--- a/apps/web/src/app/[locale]/(auth)/login/components/login-email-form.tsx
+++ b/apps/web/src/app/[locale]/(auth)/login/components/login-email-form.tsx
@@ -50,6 +50,7 @@ export function LoginWithEmailForm({
   const [showPasswordField, setShowPasswordField] = React.useState(false);
   const [showCaptcha, setShowCaptcha] = React.useState(false);
   const turnstileRef = React.useRef<TurnstileInstance>(null);
+  const pendingTokenSubmitRef = React.useRef(false);
   const [turnstileToken, setTurnstileToken] = React.useState<string | null>(
     null,
   );
@@ -66,141 +67,147 @@ export function LoginWithEmailForm({
   const getLoginMethod = trpc.auth.getLoginMethod.useMutation();
   const isPasswordLogin = showPasswordField && !!form.watch("password");
 
+  const submit = async (
+    { identifier, password }: { identifier: string; password?: string },
+    captchaToken: string | null,
+  ) => {
+    const validatedRedirectTo = validateRedirectUrl(
+      searchParams?.get("redirectTo"),
+    );
+
+    if (password) {
+      const res = await authClient.signIn.email({
+        email: identifier,
+        password,
+      });
+
+      if (res.error) {
+        switch (res.error.code) {
+          case "INVALID_EMAIL_OR_PASSWORD":
+            form.setError("password", {
+              message: t("passwordOrEmailIncorrect", {
+                defaultValue: "Invalid email or password",
+              }),
+            });
+            break;
+          case "BANNED_USER":
+            form.setError("identifier", {
+              message: t("authErrorsUserBanned", {
+                defaultValue:
+                  "This account has been banned. Please contact support if you believe this is an error.",
+              }),
+            });
+            break;
+          default:
+            form.setError("password", {
+              message: res.error.message,
+            });
+            break;
+        }
+        return;
+      }
+
+      window.location.href = validatedRedirectTo ?? "/";
+
+      return;
+    }
+
+    if (!showPasswordField) {
+      const res = await getLoginMethod.mutateAsync({
+        email: identifier,
+      });
+
+      if (res.method === "credential") {
+        // show password field
+        setShowPasswordField(true);
+        return;
+      }
+    }
+
+    // The OTP send is captcha-gated. Reveal the widget on the first
+    // attempt; onSuccess finishes this submit with the fresh token.
+    if (isTurnstileEnabled && !captchaToken) {
+      pendingTokenSubmitRef.current = true;
+      setShowCaptcha(true);
+      return;
+    }
+
+    try {
+      // When registration is enabled a "sign-in" OTP either signs
+      // into an existing account or creates one on verification, so
+      // known and unknown emails behave identically. When it's
+      // disabled, "email-verification" only reaches existing users.
+      const res = await authClient.emailOtp.sendVerificationOtp({
+        email: identifier,
+        type: isRegistrationEnabled ? "sign-in" : "email-verification",
+        fetchOptions: captchaToken
+          ? {
+              headers: {
+                "x-captcha-response": captchaToken,
+              },
+            }
+          : undefined,
+      });
+
+      if (res.error) {
+        switch (res.error.code) {
+          case "MISSING_RESPONSE":
+          case "VERIFICATION_FAILED":
+            form.setError("root", {
+              message: t("captchaFailed", {
+                defaultValue: "Verification failed. Please try again.",
+              }),
+            });
+            break;
+          case "EMAIL_BLOCKED":
+            form.setError("identifier", {
+              message: t("authErrorsEmailBlocked"),
+            });
+            break;
+          case "TEMPORARY_EMAIL_NOT_ALLOWED":
+            form.setError("identifier", {
+              message: t("temporaryEmailNotAllowed"),
+            });
+            break;
+          case "BANNED_USER":
+            form.setError("identifier", {
+              message: t("authErrorsUserBanned", {
+                defaultValue:
+                  "This account has been banned. Please contact support if you believe this is an error.",
+              }),
+            });
+            break;
+          default:
+            form.setError("identifier", {
+              message: res.error.message,
+            });
+            break;
+        }
+        return;
+      }
+
+      await setVerificationEmail(identifier);
+
+      router.push(
+        `/login/verify${
+          validatedRedirectTo
+            ? `?redirectTo=${encodeURIComponent(validatedRedirectTo)}`
+            : ""
+        }`,
+      );
+    } finally {
+      if (isTurnstileEnabled) {
+        setTurnstileToken(null);
+        turnstileRef.current?.reset();
+      }
+    }
+  };
+
   return (
     <Form {...form}>
       <form
         className="space-y-4"
-        onSubmit={handleSubmit(async ({ identifier, password }) => {
-          const validatedRedirectTo = validateRedirectUrl(
-            searchParams?.get("redirectTo"),
-          );
-
-          if (password) {
-            const res = await authClient.signIn.email({
-              email: identifier,
-              password,
-            });
-
-            if (res.error) {
-              switch (res.error.code) {
-                case "INVALID_EMAIL_OR_PASSWORD":
-                  form.setError("password", {
-                    message: t("passwordOrEmailIncorrect", {
-                      defaultValue: "Invalid email or password",
-                    }),
-                  });
-                  break;
-                case "BANNED_USER":
-                  form.setError("identifier", {
-                    message: t("authErrorsUserBanned", {
-                      defaultValue:
-                        "This account has been banned. Please contact support if you believe this is an error.",
-                    }),
-                  });
-                  break;
-                default:
-                  form.setError("password", {
-                    message: res.error.message,
-                  });
-                  break;
-              }
-              return;
-            }
-
-            window.location.href = validatedRedirectTo ?? "/";
-
-            return;
-          }
-
-          if (!showPasswordField) {
-            const res = await getLoginMethod.mutateAsync({
-              email: identifier,
-            });
-
-            if (res.method === "credential") {
-              // show password field
-              setShowPasswordField(true);
-              return;
-            }
-          }
-
-          // The OTP send is captcha-gated. Reveal the widget on the first
-          // attempt and wait for a token before sending.
-          if (isTurnstileEnabled && !turnstileToken) {
-            setShowCaptcha(true);
-            return;
-          }
-
-          try {
-            // When registration is enabled a "sign-in" OTP either signs
-            // into an existing account or creates one on verification, so
-            // known and unknown emails behave identically. When it's
-            // disabled, "email-verification" only reaches existing users.
-            const res = await authClient.emailOtp.sendVerificationOtp({
-              email: identifier,
-              type: isRegistrationEnabled ? "sign-in" : "email-verification",
-              fetchOptions: turnstileToken
-                ? {
-                    headers: {
-                      "x-captcha-response": turnstileToken,
-                    },
-                  }
-                : undefined,
-            });
-
-            if (res.error) {
-              switch (res.error.code) {
-                case "MISSING_RESPONSE":
-                case "VERIFICATION_FAILED":
-                  form.setError("root", {
-                    message: t("captchaFailed", {
-                      defaultValue: "Verification failed. Please try again.",
-                    }),
-                  });
-                  break;
-                case "EMAIL_BLOCKED":
-                  form.setError("identifier", {
-                    message: t("authErrorsEmailBlocked"),
-                  });
-                  break;
-                case "TEMPORARY_EMAIL_NOT_ALLOWED":
-                  form.setError("identifier", {
-                    message: t("temporaryEmailNotAllowed"),
-                  });
-                  break;
-                case "BANNED_USER":
-                  form.setError("identifier", {
-                    message: t("authErrorsUserBanned", {
-                      defaultValue:
-                        "This account has been banned. Please contact support if you believe this is an error.",
-                    }),
-                  });
-                  break;
-                default:
-                  form.setError("identifier", {
-                    message: res.error.message,
-                  });
-                  break;
-              }
-              return;
-            }
-
-            await setVerificationEmail(identifier);
-
-            router.push(
-              `/login/verify${
-                validatedRedirectTo
-                  ? `?redirectTo=${encodeURIComponent(validatedRedirectTo)}`
-                  : ""
-              }`,
-            );
-          } finally {
-            if (isTurnstileEnabled) {
-              setTurnstileToken(null);
-              turnstileRef.current?.reset();
-            }
-          }
-        })}
+        onSubmit={handleSubmit((values) => submit(values, turnstileToken))}
       >
         <FormField
           control={form.control}
@@ -278,6 +285,12 @@ export function LoginWithEmailForm({
             }}
             onSuccess={(token) => {
               setTurnstileToken(token);
+              // Finish the submit that was interrupted to solve the captcha.
+              // One-shot so widget resets can't re-trigger sends on their own.
+              if (pendingTokenSubmitRef.current) {
+                pendingTokenSubmitRef.current = false;
+                void handleSubmit((values) => submit(values, token))();
+              }
             }}
             onError={() => {
               setTurnstileToken(null);

--- a/apps/web/src/app/[locale]/(auth)/login/components/login-email-form.tsx
+++ b/apps/web/src/app/[locale]/(auth)/login/components/login-email-form.tsx
@@ -287,9 +287,13 @@ export function LoginWithEmailForm({
               setTurnstileToken(token);
               // Finish the submit that was interrupted to solve the captcha.
               // One-shot so widget resets can't re-trigger sends on their own.
+              // Skipped if the user started typing a password meanwhile —
+              // auto-submitting would attempt a login with a partial password.
               if (pendingTokenSubmitRef.current) {
                 pendingTokenSubmitRef.current = false;
-                void handleSubmit((values) => submit(values, token))();
+                if (!form.getValues("password")) {
+                  void handleSubmit((values) => submit(values, token))();
+                }
               }
             }}
             onError={() => {

--- a/apps/web/src/app/[locale]/(auth)/login/components/login-email-form.tsx
+++ b/apps/web/src/app/[locale]/(auth)/login/components/login-email-form.tsx
@@ -48,12 +48,7 @@ export function LoginWithEmailForm({
   const loginWithEmailSchema = useLoginWithEmailSchema();
   const searchParams = useSearchParams();
   const [showPasswordField, setShowPasswordField] = React.useState(false);
-  const [showCaptcha, setShowCaptcha] = React.useState(false);
   const turnstileRef = React.useRef<TurnstileInstance>(null);
-  const pendingTokenSubmitRef = React.useRef(false);
-  const [turnstileToken, setTurnstileToken] = React.useState<string | null>(
-    null,
-  );
   const form = useForm({
     defaultValues: {
       identifier: "",
@@ -67,10 +62,13 @@ export function LoginWithEmailForm({
   const getLoginMethod = trpc.auth.getLoginMethod.useMutation();
   const isPasswordLogin = showPasswordField && !!form.watch("password");
 
-  const submit = async (
-    { identifier, password }: { identifier: string; password?: string },
-    captchaToken: string | null,
-  ) => {
+  const submit = async ({
+    identifier,
+    password,
+  }: {
+    identifier: string;
+    password?: string;
+  }) => {
     const validatedRedirectTo = validateRedirectUrl(
       searchParams?.get("redirectTo"),
     );
@@ -124,12 +122,23 @@ export function LoginWithEmailForm({
       }
     }
 
-    // The OTP send is captcha-gated. Reveal the widget on the first
-    // attempt; onSuccess finishes this submit with the fresh token.
-    if (isTurnstileEnabled && !captchaToken) {
-      pendingTokenSubmitRef.current = true;
-      setShowCaptcha(true);
-      return;
+    // The OTP send is captcha-gated. The widget starts solving in the
+    // background on mount, so this usually resolves instantly; if
+    // Cloudflare demands interaction the widget becomes visible and we
+    // wait here while the button shows its loading state.
+    let captchaToken: string | undefined;
+    if (isTurnstileEnabled) {
+      try {
+        captchaToken = await turnstileRef.current?.getResponsePromise(120_000);
+      } catch {
+        form.setError("root", {
+          message: t("captchaFailed", {
+            defaultValue: "Verification failed. Please try again.",
+          }),
+        });
+        turnstileRef.current?.reset();
+        return;
+      }
     }
 
     try {
@@ -196,8 +205,8 @@ export function LoginWithEmailForm({
         }`,
       );
     } finally {
+      // Tokens are single-use; start a fresh solve for any retry.
       if (isTurnstileEnabled) {
-        setTurnstileToken(null);
         turnstileRef.current?.reset();
       }
     }
@@ -205,10 +214,7 @@ export function LoginWithEmailForm({
 
   return (
     <Form {...form}>
-      <form
-        className="space-y-4"
-        onSubmit={handleSubmit((values) => submit(values, turnstileToken))}
-      >
+      <form className="space-y-4" onSubmit={handleSubmit(submit)}>
         <FormField
           control={form.control}
           name="identifier"
@@ -275,33 +281,16 @@ export function LoginWithEmailForm({
         {form.formState.errors.root?.message ? (
           <FormMessage>{form.formState.errors.root.message}</FormMessage>
         ) : null}
-        {showCaptcha && isTurnstileEnabled && turnstileSiteKey ? (
+        {isTurnstileEnabled && turnstileSiteKey ? (
           <Turnstile
             ref={turnstileRef}
             siteKey={turnstileSiteKey}
             options={{
               language: i18n.language,
               size: "flexible",
-            }}
-            onSuccess={(token) => {
-              setTurnstileToken(token);
-              // Finish the submit that was interrupted to solve the captcha.
-              // One-shot so widget resets can't re-trigger sends on their own.
-              // Skipped if the user started typing a password meanwhile —
-              // auto-submitting would attempt a login with a partial password.
-              if (pendingTokenSubmitRef.current) {
-                pendingTokenSubmitRef.current = false;
-                if (!form.getValues("password")) {
-                  void handleSubmit((values) => submit(values, token))();
-                }
-              }
-            }}
-            onError={() => {
-              setTurnstileToken(null);
-            }}
-            onExpire={() => {
-              setTurnstileToken(null);
-              turnstileRef.current?.reset();
+              // Solves invisibly in the background; only shows up when
+              // Cloudflare requires an interactive challenge.
+              appearance: "interaction-only",
             }}
           />
         ) : null}
@@ -309,7 +298,6 @@ export function LoginWithEmailForm({
           <Button
             size="xl"
             loading={form.formState.isSubmitting}
-            disabled={showCaptcha && !isPasswordLogin && !turnstileToken}
             type="submit"
             className="w-full"
             variant="primary"

--- a/apps/web/src/app/[locale]/e/[id]/components/rsvp-verify-email.tsx
+++ b/apps/web/src/app/[locale]/e/[id]/components/rsvp-verify-email.tsx
@@ -178,6 +178,9 @@ export function RsvpVerifyEmail({
               options={{
                 language: i18n.language,
                 size: "flexible",
+                // Solves invisibly in the background; only shows up when
+                // Cloudflare requires an interactive challenge.
+                appearance: "interaction-only",
               }}
               onSuccess={(token) => {
                 void sendOtp(token);


### PR DESCRIPTION
## What changed

When email login was captcha-gated, the first submit revealed the Turnstile widget and returned, so users had to click the login button a second time after solving.

The widget is now mounted from page load (when the captcha flag is on) with `appearance: "interaction-only"`, so it solves invisibly in the background while the user types their email. The OTP send awaits `turnstileRef.current.getResponsePromise()` inside the same submit:

- Common case: the background solve already finished, the promise resolves instantly, and the user never sees a captcha or a second click.
- Challenge case: the widget becomes visible, the submit waits (up to 120s) while the button shows its loading state, and continues as soon as the challenge is solved.
- Failure case: the promise rejects and maps to the existing `captchaFailed` root error; the widget resets for a clean retry.

Compared to the conditional-render approach this deletes the interrupted-submit machinery entirely (`showCaptcha`/token state, pending-submit ref, re-entrant auto-submit and its loop and partial-password guards) — there's no re-entrancy, just one continuous submit.

The RSVP verify dialog gets the same `appearance: "interaction-only"` so its widget is also invisible unless a challenge is required; its send flow already auto-triggers from `onSuccess` and is otherwise unchanged.

## Notes for review

- Turnstile only gates the OTP email send; the password login path is unaffected.
- Trade-off: the Cloudflare script now loads for every login page visitor, including OAuth/password users. `siteverify` is still only called on the OTP send.
- Tokens are single-use, so the widget resets after every send attempt to back any retry with a fresh solve.
- No behavior change when Turnstile is disabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved email login flow when CAPTCHA/Turnstile protection is enabled, ensuring submissions complete smoothly after CAPTCHA.
  * Added more reliable handling when users submit before a CAPTCHA token is ready, preventing failed OTP sends.
  * Updated Turnstile behavior to use an “interaction-only” configuration, appearing invisibly until Cloudflare requires a challenge.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->