### PR TITLE
💄 Use AlertAction for password setup alert buttons

### DIFF
--- a/apps/web/src/app/[locale]/(space)/(dashboard)/password-setup-alert.tsx
+++ b/apps/web/src/app/[locale]/(space)/(dashboard)/password-setup-alert.tsx
@@ -1,6 +1,11 @@
 "use client";
 import { buttonVariants } from "@rallly/ui";
-import { Alert, AlertDescription, AlertTitle } from "@rallly/ui/alert";
+import {
+  Alert,
+  AlertAction,
+  AlertDescription,
+  AlertTitle,
+} from "@rallly/ui/alert";
 import { Button } from "@rallly/ui/button";
 import { KeyRoundIcon } from "lucide-react";
 import { AnimatePresence } from "motion/react";
@@ -38,24 +43,16 @@ function PasswordSetupAlertInner() {
               />
             </AlertTitle>
             <AlertDescription>
-              <p>
-                <Trans
-                  i18nKey="setupPasswordAlertDesc"
-                  defaults="Set up a password to make logging in faster and more convenient."
-                />
-              </p>
-              <div className="mt-4 flex items-center gap-2">
-                <Link
-                  href="/settings/security"
-                  className={buttonVariants({ variant: "primary" })}
-                >
-                  <Trans
-                    i18nKey="setupPasswordButton"
-                    defaults="Set up password"
-                  />
-                </Link>
+              <Trans
+                i18nKey="setupPasswordAlertDesc"
+                defaults="Set up a password to make logging in faster and more convenient."
+              />
+            </AlertDescription>
+            <AlertAction>
+              <div className="flex items-center gap-2">
                 <Button
                   variant="ghost"
+                  size="sm"
                   onClick={() => {
                     setDismissed("1");
                   }}
@@ -65,8 +62,17 @@ function PasswordSetupAlertInner() {
                     defaults="Don't show again"
                   />
                 </Button>
+                <Link
+                  href="/settings/security"
+                  className={buttonVariants({ variant: "primary", size: "sm" })}
+                >
+                  <Trans
+                    i18nKey="setupPasswordButton"
+                    defaults="Set up password"
+                  />
+                </Link>
               </div>
-            </AlertDescription>
+            </AlertAction>
           </Alert>
         </m.div>
       ) : null}


### PR DESCRIPTION
## Description

Fixes RAL-1394.

The "Set up password" primary button in the dashboard password setup alert rendered with an underline and the wrong text color on hover.

**Cause:** the button-styled `<Link>` sat inside `AlertDescription`, which deliberately styles descendant anchors so that prose links in alert copy look like links:

```
[&_a]:underline [&_a]:underline-offset-3 [&_a]:hover:text-foreground
```

The button-styled link was collateral damage from rules meant for inline text links.

**Fix:** move both actions into `AlertAction`, the component that already exists for this. It is a sibling of `AlertDescription`, so the anchor rules never reach it, and `alertVariants` already handles placement via the `has-data-[slot=alert-action]` grid columns. This matches the existing usage in the members settings alert.

`packages/ui` is untouched — the change is confined to the one alert.

### Incidental changes from the restructure

- Dropped the wrapping `<p>`; the description is now a single line of text, so `[&_p:not(:last-child)]:mb-4` had nothing to do.
- Both buttons use `size="sm"` and "Don't show again" comes before the primary, matching the members settings alert.

### Verification

Computed styles on the link, measured with Playwright against the real compiled Tailwind output:

| | rest | hover |
|---|---|---|
| `text-decoration-line` | `none` | `none` |
| `color` | white (`primary-foreground`) | white — not overridden |
| `background-color` | `#4f46e5` | `primary/90` |

`pnpm check` and `pnpm type-check` both pass.

**Note for reviewer:** verification was done by reconstructing the alert from the exact class strings in the source and compiling them through the project's Tailwind 4, not by driving the running app. That is sound for a pure CSS-cascade question, but it does not prove the alert renders correctly in the dashboard with the real theme — worth a quick visual check.

## Checklist

- [x] I have performed a self-review of my code
- [x] My code follows the code style of this project
- [x] I have commented my code, particularly in hard-to-understand areas

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Refined the password setup alert layout and spacing for a cleaner, more compact presentation.
  - Updated alert actions with consistent small-sized buttons and improved alignment.
  - Streamlined the alert description rendering for a more polished appearance.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->