### PR TITLE
💄 Use AlertAction for invite page creator alert Manage button

### DIFF
--- a/apps/web/src/app/[locale]/invite/[urlId]/invite-page.tsx
+++ b/apps/web/src/app/[locale]/invite/[urlId]/invite-page.tsx
@@ -24,10 +24,12 @@ const GoToApp = () => {
     <Alert variant="primary">
       <CrownIcon />
       <AlertDescription>
-        <Trans
-          i18nKey="eventHostDescription"
-          defaults="You are the creator of this poll"
-        />
+        <p>
+          <Trans
+            i18nKey="eventHostDescription"
+            defaults="You are the creator of this poll"
+          />
+        </p>
       </AlertDescription>
       <AlertAction>
         <Link

--- a/apps/web/src/app/[locale]/invite/[urlId]/invite-page.tsx
+++ b/apps/web/src/app/[locale]/invite/[urlId]/invite-page.tsx
@@ -1,5 +1,6 @@
 "use client";
-import { Alert, AlertDescription } from "@rallly/ui/alert";
+import { buttonVariants } from "@rallly/ui";
+import { Alert, AlertAction, AlertDescription } from "@rallly/ui/alert";
 import { ArrowUpRightIcon, CrownIcon } from "lucide-react";
 import Link from "next/link";
 import { usePoll } from "@/features/poll/client";
@@ -23,25 +24,21 @@ const GoToApp = () => {
     <Alert variant="primary">
       <CrownIcon />
       <AlertDescription>
-        <div className="flex w-full flex-1 items-center gap-2">
-          <p className="flex-1">
-            <Trans
-              i18nKey="eventHostDescription"
-              defaults="You are the creator of this poll"
-            />
-          </p>
-          <div>
-            <Link
-              className="inline-flex items-center gap-2 hover:underline"
-              href={`/poll/${poll.id}`}
-              prefetch={false}
-            >
-              <Trans i18nKey="manage" defaults="Manage" />
-              <ArrowUpRightIcon className="size-4" />
-            </Link>
-          </div>
-        </div>
+        <Trans
+          i18nKey="eventHostDescription"
+          defaults="You are the creator of this poll"
+        />
       </AlertDescription>
+      <AlertAction>
+        <Link
+          className={buttonVariants({ variant: "primary", size: "sm" })}
+          href={`/poll/${poll.id}`}
+          prefetch={false}
+        >
+          <Trans i18nKey="manage" defaults="Manage" />
+          <ArrowUpRightIcon className="size-4" />
+        </Link>
+      </AlertAction>
     </Alert>
   );
 };


### PR DESCRIPTION
## Summary

The invite page shows a "You are the creator of this poll" alert to the poll creator with a Manage link. This alert hand-rolled a flex layout inside `AlertDescription` instead of using the `AlertAction` slot, unlike the other alerts in the app (members settings, password setup).

This change moves the Manage link into `AlertAction` and styles it as a proper primary button, letting the `Alert` grid handle responsive placement.

## Changes

- Move the Manage link from inside `AlertDescription` into an `AlertAction` slot
- Style the link with `buttonVariants({ variant: "primary", size: "sm" })` instead of a bare hover-underline link
- Remove the now-unnecessary flex wrapper markup

No copy or behavior changes — same text, same `/poll/${poll.id}` destination.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated the host alert on the invitation page for a cleaner, more consistent layout.
  * Restyled the “Manage” action as a prominent alert button while preserving navigation to poll management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->