### PR TITLE
📈 Send space group properties from SpaceProvider

### DIFF
--- a/apps/web/src/features/space/client.tsx
+++ b/apps/web/src/features/space/client.tsx
@@ -44,8 +44,14 @@ export function SpaceProvider({
   children: React.ReactNode;
 }) {
   React.useEffect(() => {
-    posthog?.group("space", space.id);
-  }, [space.id]);
+    // Property names must match the server-side identifyGroup payloads.
+    // posthog-js only re-sends $groupidentify when these values change.
+    posthog?.group("space", space.id, {
+      name: space.name,
+      tier: space.tier,
+      custom_branding: space.showBranding,
+    });
+  }, [space.id, space.name, space.tier, space.showBranding]);
 
   const primaryColorVars =
     space.showBranding && space.primaryColor

--- a/apps/web/src/features/space/client.tsx
+++ b/apps/web/src/features/space/client.tsx
@@ -50,8 +50,17 @@ export function SpaceProvider({
       name: space.name,
       tier: space.tier,
       custom_branding: space.showBranding,
+      member_count: space.memberCount,
+      seat_count: space.seatCount,
     });
-  }, [space.id, space.name, space.tier, space.showBranding]);
+  }, [
+    space.id,
+    space.name,
+    space.tier,
+    space.showBranding,
+    space.memberCount,
+    space.seatCount,
+  ]);
 
   const primaryColorVars =
     space.showBranding && space.primaryColor

--- a/apps/web/src/features/space/data.ts
+++ b/apps/web/src/features/space/data.ts
@@ -61,6 +61,8 @@ export function createSpaceDTO(space: {
   tier: DBSpaceTier;
   primaryColor?: string | null;
   showBranding: boolean;
+  memberCount: number;
+  seatCount: number;
 }): SpaceDTO {
   return {
     id: space.id as AuthorizedSpaceId,
@@ -68,6 +70,8 @@ export function createSpaceDTO(space: {
     ownerId: space.ownerId,
     tier: isSelfHosted ? "pro" : space.tier,
     role: fromDBRole(space.role),
+    memberCount: space.memberCount,
+    seatCount: space.seatCount,
     image: space.image ?? undefined,
     primaryColor: space.primaryColor ?? undefined,
     showBranding: space.showBranding,
@@ -195,7 +199,16 @@ export const getActiveSpaceForUser = cache(async (userId: string) => {
       lastSelectedAt: "desc",
     },
     include: {
-      space: true,
+      space: {
+        include: {
+          _count: { select: { members: true } },
+          subscriptions: {
+            where: { active: true },
+            select: { quantity: true },
+            take: 1,
+          },
+        },
+      },
     },
   });
 
@@ -206,5 +219,7 @@ export const getActiveSpaceForUser = cache(async (userId: string) => {
   return createSpaceDTO({
     ...spaceMember.space,
     role: spaceMember.role,
+    memberCount: spaceMember.space._count.members,
+    seatCount: spaceMember.space.subscriptions[0]?.quantity ?? 1,
   });
 });

--- a/apps/web/src/features/space/mutations.ts
+++ b/apps/web/src/features/space/mutations.ts
@@ -31,7 +31,12 @@ export async function createSpace({
     },
   });
 
-  return createSpaceDTO({ ...space, role: "ADMIN" });
+  return createSpaceDTO({
+    ...space,
+    role: "ADMIN",
+    memberCount: 1,
+    seatCount: 1,
+  });
 }
 
 export async function updateSpace({

--- a/apps/web/src/features/space/types.ts
+++ b/apps/web/src/features/space/types.ts
@@ -12,6 +12,8 @@ export type SpaceDTO = {
   ownerId: string;
   tier: "hobby" | "pro";
   role: MemberRole;
+  memberCount: number;
+  seatCount: number;
   image?: string;
   primaryColor?: string;
   showBranding: boolean;

--- a/apps/web/src/trpc/routers/spaces.ts
+++ b/apps/web/src/trpc/routers/spaces.ts
@@ -55,6 +55,12 @@ export const spaces = router({
             tier: true,
             primaryColor: true,
             showBranding: true,
+            _count: { select: { members: true } },
+            subscriptions: {
+              where: { active: true },
+              select: { quantity: true },
+              take: 1,
+            },
           },
         },
       },
@@ -64,6 +70,8 @@ export const spaces = router({
       createSpaceDTO({
         ...spaceMember.space,
         role: spaceMember.role,
+        memberCount: spaceMember.space._count.members,
+        seatCount: spaceMember.space.subscriptions[0]?.quantity ?? 1,
       }),
     );
   }),


### PR DESCRIPTION
## Summary

The client-side space group identify in `SpaceProvider` only sent the group key, so spaces that predate the server-side `identifyGroup` calls (or missed them) have no group properties in PostHog.

This passes the full space property set from the `SpaceDTO` in `posthog.group()`, which fires a `$groupidentify` with `$group_set` attributed to the visiting user. Any space a member visits heals on load, and renames, tier changes, branding toggles, membership changes, and seat changes observed client-side keep the properties from drifting stale.

Properties sent: `name`, `tier`, `custom_branding`, `member_count`, `seat_count` — names match the server-side `identifyGroup` payloads.

`SpaceDTO` gains `memberCount` (members aggregate) and `seatCount` (active subscription quantity, 1 for hobby). Both ride along in the existing space queries via `_count` and a filtered `subscriptions` select — no extra round trips.

## Notes

- `type` is only known at setup time and stays server-side only.
- No per-pageview event volume: posthog-js stores the last-sent group properties in persistence and only re-sends `$groupidentify` when they change.
- This complements the scheduled backfill script — dormant spaces still need it; this covers active spaces going forward.

## Test plan

- `pnpm --filter @rallly/web type-check`
- `biome check` on the changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Analytics**
  * Enhanced space analytics payload to include additional space details such as name, tier, branding status, member count, and seat count.
  * Analytics are now refreshed when these space attributes change, not just when the space ID changes.
* **New Features**
  * Added member count and seat count to the Space data returned by space listings and active space fetches.
  * Ensured seat and member counts are populated via active subscription data, with sensible defaults when unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->