### PR TITLE
🔧 Add preserve_hierarchy to crowdin.yml for CLI compatibility

### DIFF
--- a/crowdin.yml
+++ b/crowdin.yml
@@ -1,5 +1,6 @@
 project_id_env: CROWDIN_PROJECT_ID
 api_token_env: CROWDIN_PERSONAL_TOKEN
+preserve_hierarchy: true
 pull_request_title: 🌐 New Crowdin updates
 commit_message: '[ci skip]'
 files:


### PR DESCRIPTION
The Crowdin GitHub integration stores files under full repo paths (branch-namespaced, e.g. `/main/apps/web/public/locales/en/app.json`) because VCS integrations default `preserve_hierarchy` to `true`. The Crowdin CLI defaults it to `false`, so any local `crowdin upload translations -b main` fails with `file 'app.json' is missing in the project`.

Setting it explicitly is a no-op for the integration (matches its default) and makes the CLI resolve files correctly.

Verified: `crowdin upload translations -b main -l de` failed before this change and succeeds with it.

Part of RAL-1400 (Crowdin PR fix workflow).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated translation file handling to preserve the original directory and file structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->