### PR TITLE
🐛 Raise Mailpit email capture timeout to fix flaky CI tests

### DIFF
--- a/apps/web/tests/vote-and-comment.spec.ts
+++ b/apps/web/tests/vote-and-comment.spec.ts
@@ -44,9 +44,7 @@ test.describe(() => {
 
     await invitePage.addParticipant("Anne", "test@example.com");
 
-    const { email } = await captureOne("test@example.com", {
-      wait: 5000,
-    });
+    const { email } = await captureOne("test@example.com");
 
     await expect(page.locator("text='Anne'")).toBeVisible();
 

--- a/packages/test-helpers/src/mailpit.ts
+++ b/packages/test-helpers/src/mailpit.ts
@@ -84,7 +84,7 @@ export async function captureOne(
   to: string,
   options: { wait?: number } = {},
 ): Promise<{ email: MailpitMessage }> {
-  const timeout = options.wait ?? 5000;
+  const timeout = options.wait ?? 30_000;
   const deadline = Date.now() + timeout;
 
   while (Date.now() < deadline) {


### PR DESCRIPTION
## Problem

The "new user › user registration" test in `apps/web/tests/authentication.spec.ts` fails intermittently in CI with:

```
No email received for test@example.com within 5000ms
```

Example: a [run that failed](https://github.com/lukevella/rallly/actions/runs/29813340452/job/88578992923) on a PR that only touched `crowdin.yml`.

The 5s default polling window in `captureOne` (`packages/test-helpers/src/mailpit.ts`) is too tight for CI runners under load. All email-dependent tests go through this helper (`getCode`, `getPasswordResetLink`, `captureEmailHTML`, and direct `captureOne` calls in `rsvp-confirmation-email.spec.ts` and `vote-and-comment.spec.ts`), so they all share the same flake risk.

## Fix

- Raise the default `captureOne` timeout from 5s to 30s (in line with typical Playwright expect polling budgets). The helper polls every 100ms and returns as soon as the email arrives, so passing tests are unaffected — only the failure deadline moves.
- Remove the explicit `wait: 5000` override in `vote-and-comment.spec.ts` so it inherits the new default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved email capture reliability by allowing more time for messages to arrive during voting-related flows.
  * Updated automated checks to use the improved default email wait time.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->