### PR TITLE
♻️ Migrate spaces.getSeats to a server component read

### DIFF
--- a/apps/web/src/app/[locale]/(space)/settings/members/page-client.tsx
+++ b/apps/web/src/app/[locale]/(space)/settings/members/page-client.tsx
@@ -40,11 +40,16 @@ import { InviteDropdownMenu } from "./components/invite-dropdown-menu";
 import { InviteMemberButton } from "./components/invite-member-button";
 import { MemberDropdownMenu } from "./components/member-dropdown-menu";
 
-export function MembersSettingsPageClient() {
+export function MembersSettingsPageClient({
+  totalSeats,
+  usedSeats,
+}: {
+  totalSeats: number;
+  usedSeats: number;
+}) {
   const space = useSpace();
   const [members] = trpc.spaces.listMembers.useSuspenseQuery();
   const [invites] = trpc.spaces.listInvites.useSuspenseQuery();
-  const [seats] = trpc.spaces.getSeats.useSuspenseQuery();
   const canInviteMembers = space.getAbility().can("invite", "Member");
   const hasInactiveMembers = space.data.tier === "hobby" && members.total > 1;
 
@@ -225,21 +230,21 @@ export function MembersSettingsPageClient() {
                   ) : null}
                   <div className="flex items-center gap-4">
                     <InviteMemberButton
-                      usedSeats={seats.used}
-                      totalSeats={seats.total}
+                      usedSeats={usedSeats}
+                      totalSeats={totalSeats}
                     />
                     <p className="font-medium text-sm">
                       <Trans
                         i18nKey="seatUsage"
                         defaults="{usedSeats} of {totalSeats} seats used"
                         values={{
-                          usedSeats: seats.used,
-                          totalSeats: seats.total,
+                          usedSeats,
+                          totalSeats,
                         }}
                       />
                     </p>
                   </div>
-                  {seats.total - seats.used <= 0 ? (
+                  {totalSeats - usedSeats <= 0 ? (
                     <Alert variant="info">
                       <InfoIcon />
                       <AlertDescription>

--- a/apps/web/src/app/[locale]/(space)/settings/members/page.tsx
+++ b/apps/web/src/app/[locale]/(space)/settings/members/page.tsx
@@ -1,21 +1,30 @@
 import { dehydrate, HydrationBoundary } from "@tanstack/react-query";
 import type { Metadata } from "next";
+import { getActiveSpace, getSpaceSeatCount } from "@/features/space/data";
+import { getTotalSeatsForSpace } from "@/features/space/utils";
 import { getTranslation } from "@/i18n/server";
 import { createPrivateSSRHelper } from "@/trpc/server/create-ssr-helper";
 import { MembersSettingsPageClient } from "./page-client";
 
 export default async function MembersSettingsPage() {
-  const helpers = await createPrivateSSRHelper();
+  const [space, helpers] = await Promise.all([
+    getActiveSpace(),
+    createPrivateSSRHelper(),
+  ]);
 
-  await Promise.all([
+  const [totalSeats, usedSeats] = await Promise.all([
+    getTotalSeatsForSpace(space.id),
+    getSpaceSeatCount(space.id),
     helpers.spaces.listMembers.prefetch(),
     helpers.spaces.listInvites.prefetch(),
-    helpers.spaces.getSeats.prefetch(),
   ]);
 
   return (
     <HydrationBoundary state={dehydrate(helpers.queryClient)}>
-      <MembersSettingsPageClient />
+      <MembersSettingsPageClient
+        totalSeats={totalSeats}
+        usedSeats={usedSeats}
+      />
     </HydrationBoundary>
   );
 }

--- a/apps/web/src/trpc/routers/spaces.ts
+++ b/apps/web/src/trpc/routers/spaces.ts
@@ -143,15 +143,6 @@ export const spaces = router({
       role: fromDBRole(invite.role),
     }));
   }),
-  getSeats: spaceProcedure.query(async ({ ctx }) => {
-    const [total, used] = await Promise.all([
-      getTotalSeatsForSpace(ctx.space.id),
-      getSpaceSeatCount(ctx.space.id),
-    ]);
-
-    return { total, used };
-  }),
-
   // ── Mutations ────────────────────────────────────────────────────────
   create: privateProcedure
     .use(createRateLimitMiddleware("space_create", 5, "1 m"))


### PR DESCRIPTION
Removes the `spaces.getSeats` tRPC query and serves seat usage from the server on the members settings page (RAL-1387).

## Changes

- The members settings page composes the existing `getTotalSeatsForSpace` (utils) and `getSpaceSeatCount` (data) reads, scoped via `getActiveSpace()`, and passes `totalSeats`/`usedSeats` down as props — same pattern the billing page already uses.
- `MembersSettingsPageClient` takes the seat counts as props instead of `useSuspenseQuery`.
- Deleted the `spaces.getSeats` procedure. There were no client-side cache invalidations to remove; seat counts change through member/invite mutations, which are covered by `router.refresh()` in `useSafeAction`.

No new cached read was added in `features/space/data.ts` — one call site composing two existing functions doesn't earn a wrapper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Updated member settings to display seat usage and availability accurately.
  - Invitation controls now reflect the current number of available seats.

- **Bug Fixes**
  - Improved seat availability handling when inviting members.
  - Updated invitation role data handling for more consistent results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->