### PR TITLE
🐛 Remove invisible Turnstile widget from layout flow

### DIFF
--- a/apps/web/src/app/[locale]/(auth)/login/components/login-email-form.tsx
+++ b/apps/web/src/app/[locale]/(auth)/login/components/login-email-form.tsx
@@ -1,7 +1,6 @@
 "use client";
 import { zodResolver } from "@hookform/resolvers/zod";
 import type { TurnstileInstance } from "@marsidev/react-turnstile";
-import { Turnstile } from "@marsidev/react-turnstile";
 import { Button } from "@rallly/ui/button";
 import {
   Form,
@@ -19,6 +18,7 @@ import { useForm } from "react-hook-form";
 import * as z from "zod";
 
 import { setVerificationEmail } from "@/app/[locale]/(auth)/login/actions";
+import { Turnstile } from "@/components/turnstile";
 import { Trans, useTranslation } from "@/i18n/client";
 import { authClient } from "@/lib/auth-client";
 import { useFeatureFlag } from "@/lib/feature-flags/client";
@@ -285,13 +285,7 @@ export function LoginWithEmailForm({
           <Turnstile
             ref={turnstileRef}
             siteKey={turnstileSiteKey}
-            options={{
-              language: i18n.language,
-              size: "flexible",
-              // Solves invisibly in the background; only shows up when
-              // Cloudflare requires an interactive challenge.
-              appearance: "interaction-only",
-            }}
+            language={i18n.language}
           />
         ) : null}
         <div>

--- a/apps/web/src/app/[locale]/e/[id]/components/rsvp-verify-email.tsx
+++ b/apps/web/src/app/[locale]/e/[id]/components/rsvp-verify-email.tsx
@@ -2,7 +2,6 @@
 
 import { zodResolver } from "@hookform/resolvers/zod";
 import type { TurnstileInstance } from "@marsidev/react-turnstile";
-import { Turnstile } from "@marsidev/react-turnstile";
 import { Button } from "@rallly/ui/button";
 import {
   Dialog,
@@ -24,6 +23,7 @@ import React from "react";
 import { useForm } from "react-hook-form";
 import * as z from "zod";
 import { InputOTP } from "@/components/input-otp";
+import { Turnstile } from "@/components/turnstile";
 import { Trans, useTranslation } from "@/i18n/client";
 import { authClient } from "@/lib/auth-client";
 import { useFeatureFlag } from "@/lib/feature-flags/client";
@@ -175,13 +175,7 @@ export function RsvpVerifyEmail({
             <Turnstile
               ref={turnstileRef}
               siteKey={turnstileSiteKey}
-              options={{
-                language: i18n.language,
-                size: "flexible",
-                // Solves invisibly in the background; only shows up when
-                // Cloudflare requires an interactive challenge.
-                appearance: "interaction-only",
-              }}
+              language={i18n.language}
               onSuccess={(token) => {
                 void sendOtp(token);
               }}

--- a/apps/web/src/components/turnstile.tsx
+++ b/apps/web/src/components/turnstile.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+import type { TurnstileInstance } from "@marsidev/react-turnstile";
+import { Turnstile as TurnstileWidget } from "@marsidev/react-turnstile";
+import React from "react";
+
+/**
+ * Cloudflare Turnstile in interaction-only mode. Solves invisibly in the
+ * background; the widget only appears when Cloudflare requires an
+ * interactive challenge. While invisible, the container is removed from
+ * the layout entirely so space-y/gap parents don't add a gap around it —
+ * via inline style, since the library's own inline display would
+ * override a class.
+ */
+export function Turnstile({
+  ref,
+  siteKey,
+  language,
+  onSuccess,
+}: {
+  ref?: React.Ref<TurnstileInstance>;
+  siteKey: string;
+  language: string;
+  onSuccess?: (token: string) => void;
+}) {
+  const [isInteractive, setIsInteractive] = React.useState(false);
+
+  return (
+    <TurnstileWidget
+      ref={ref}
+      siteKey={siteKey}
+      style={isInteractive ? undefined : { display: "none" }}
+      onBeforeInteractive={() => setIsInteractive(true)}
+      onAfterInteractive={() => setIsInteractive(false)}
+      onSuccess={onSuccess}
+      options={{
+        language,
+        size: "flexible",
+        appearance: "interaction-only",
+      }}
+    />
+  );
+}


### PR DESCRIPTION
## Description

The Cloudflare Turnstile widget on the login form runs in `appearance: interaction-only` mode, which solves invisibly, but its container div stays in the DOM with an inline `display: flex`. Sitting between the email input and the submit button inside the form's `space-y-4`, the zero-height div picked up its own spacing margin and doubled the gap from 16px to 32px.

This extracts a shared `Turnstile` wrapper (`apps/web/src/components/turnstile.tsx`) that keeps the container `display: none` until Cloudflare requests an interactive challenge (`onBeforeInteractive`), and hides it again after (`onAfterInteractive`). The hiding has to be an inline style because the library's own inline `display` overrides any class. Both call sites (login form and the RSVP verify dialog, which had the same latent issue inside `DialogContent`'s gap layout) now use the wrapper, which also bakes in the shared `size: flexible` + `interaction-only` options.

Verified locally with Cloudflare test keys: gap measures exactly 16px, the invisible solve still produces a token while hidden, and the full email login flow completes. The un-hide path on a forced interactive challenge can't be exercised with the always-pass test key, so worth a glance in production.

## Checklist

- [x] I have performed a self-review of my code
- [x] My code follows the code style of this project
- [x] I have commented my code, particularly in hard-to-understand areas

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a shared CAPTCHA experience to email login and RSVP verification flows.
  * CAPTCHA language now follows the selected app language.
  * CAPTCHA widgets adapt their visibility and sizing during interactive challenges.

* **Bug Fixes**
  * Improved CAPTCHA behavior by hiding the widget when no user interaction is required and showing it only when a challenge appears.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->