### PR TITLE
📝 Add request examples for poll creation scenarios to API docs

### DIFF
--- a/apps/web/src/app/api/private/[...route]/route.test.ts
+++ b/apps/web/src/app/api/private/[...route]/route.test.ts
@@ -58,7 +58,9 @@ vi.mock("@/lib/kv", () => ({
 import { prisma } from "@rallly/database";
 import { after } from "next/server";
 import { hashApiKey, verifyApiKey } from "@/features/api-keys/utils";
+import { createPollRequestExamples } from "../examples";
 import {
+  createPollInputSchema,
   createPollSuccessResponseSchema,
   deletePollSuccessResponseSchema,
   getPollParticipantsSuccessResponseSchema,
@@ -708,6 +710,26 @@ describe("Private API - /polls", () => {
       expect(res.status).toBe(200);
       const json = await res.json();
       expect(json.info.title).toBe("Rallly Private API");
+    });
+
+    it("should include create poll request examples that match the input schema", async () => {
+      const res = await app.request("/api/private/openapi");
+
+      expect(res.status).toBe(200);
+      const json = await res.json();
+      const media =
+        json.paths["/api/private/polls"].post.requestBody.content[
+          "application/json"
+        ];
+      expect(Object.keys(media.examples)).toEqual(
+        Object.keys(createPollRequestExamples),
+      );
+
+      for (const example of Object.values(createPollRequestExamples)) {
+        const result = createPollInputSchema.safeParse(example.value);
+        expect(result.error).toBeUndefined();
+        expect(result.success).toBe(true);
+      }
     });
 
     it("should return docs page", async () => {

--- a/apps/web/src/app/api/private/[...route]/route.ts
+++ b/apps/web/src/app/api/private/[...route]/route.ts
@@ -6,7 +6,7 @@ import { Hono } from "hono";
 import { handle } from "hono/vercel";
 import {
   describeRoute,
-  openAPIRouteHandler,
+  generateSpecs,
   resolver,
   validator,
 } from "hono-openapi";
@@ -14,6 +14,7 @@ import { getPollParticipants, getPollResults } from "@/features/poll/data";
 import { createPoll, deletePoll } from "@/features/poll/mutations";
 import type { AuthorizedSpaceId } from "@/features/space/types";
 import { isMaintenanceModeEnabled } from "@/lib/maintenance";
+import { createPollRequestExamples } from "../examples";
 import {
   createPollInputSchema,
   createPollSuccessResponseSchema,
@@ -119,9 +120,8 @@ const rateLimitExceededResponse = {
   },
 };
 
-app.get(
-  "/openapi",
-  openAPIRouteHandler(app, {
+async function buildOpenApiSpec() {
+  const spec = await generateSpecs(app, {
     documentation: {
       info: {
         title: "Rallly Private API",
@@ -143,8 +143,29 @@ app.get(
         },
       },
     },
-  }),
-);
+  });
+
+  // hono-openapi's validator middleware owns the request body schema and
+  // overwrites any content set via describeRoute, so named examples have to
+  // be attached to the generated spec instead.
+  const createPollRequestBody =
+    spec.paths["/api/private/polls"]?.post?.requestBody;
+  if (createPollRequestBody && "content" in createPollRequestBody) {
+    const media = createPollRequestBody.content?.["application/json"];
+    if (media) {
+      media.examples = createPollRequestExamples;
+    }
+  }
+
+  return spec;
+}
+
+let openApiSpec: Awaited<ReturnType<typeof buildOpenApiSpec>> | undefined;
+
+app.get("/openapi", async (c) => {
+  openApiSpec ??= await buildOpenApiSpec();
+  return c.json(openApiSpec);
+});
 
 app.get(
   "/docs",
@@ -162,8 +183,14 @@ app.post(
   describeRoute({
     tags: ["Polls"],
     summary: "Create a poll",
-    description:
-      "Creates a new poll with the specified options or slot generators.",
+    description: [
+      "Creates a new poll. Provide the poll options in one of two ways:",
+      "",
+      "- `dates` — a list of calendar dates. Each date becomes an all-day option (date poll).",
+      "- `slots` — time-based options that share a fixed `duration` in minutes. Each entry in `slots.times` is either an ISO datetime for an explicit slot, or a slot generator that expands into recurring slots within a time window across a date range. Generated slots start every `interval` minutes (defaults to `duration`) and must fit entirely between `startTime` and `endTime`.",
+      "",
+      "`dates` and `slots` are mutually exclusive, and a poll can have at most 100 options. See the request examples for common scenarios.",
+    ].join("\n"),
     security: [{ bearerAuth: [] }],
     responses: {
       200: {

--- a/apps/web/src/app/api/private/examples.ts
+++ b/apps/web/src/app/api/private/examples.ts
@@ -1,0 +1,79 @@
+import type * as z from "zod";
+import type { createPollInputSchema } from "./schemas";
+
+type CreatePollInput = z.input<typeof createPollInputSchema>;
+
+export const createPollRequestExamples = {
+  datePoll: {
+    summary: "Date poll (all-day options)",
+    description:
+      "Use `dates` to let participants pick between calendar days. Each date becomes an all-day option.",
+    value: {
+      title: "Team offsite",
+      description: "Which days work for a two day offsite?",
+      dates: ["2026-08-03", "2026-08-04", "2026-08-05"],
+    } satisfies CreatePollInput,
+  },
+  timePoll: {
+    summary: "Time poll (explicit times)",
+    description:
+      "Use `slots` with ISO datetime strings to offer specific time slots. Times are UTC and displayed to participants in the poll's `timezone`.",
+    value: {
+      title: "Project kickoff",
+      location: "Zoom",
+      slots: {
+        duration: 60,
+        timezone: "Europe/London",
+        times: [
+          "2026-08-03T09:00:00Z",
+          "2026-08-03T14:00:00Z",
+          "2026-08-04T09:00:00Z",
+        ],
+      },
+    } satisfies CreatePollInput,
+  },
+  slotGenerator: {
+    summary: "Time poll (slot generator)",
+    description:
+      "Use a slot generator to expand recurring slots across a date range. This example generates 30 minute slots at 09:00, 10:00 and 11:00 (New York time) every weekday between 3-7 August.",
+    value: {
+      title: "Interview availability",
+      slots: {
+        duration: 30,
+        timezone: "America/New_York",
+        times: [
+          {
+            startDate: "2026-08-03",
+            endDate: "2026-08-07",
+            days: ["mon", "tue", "wed", "thu", "fri"],
+            startTime: "09:00",
+            endTime: "12:00",
+            interval: 60,
+          },
+        ],
+      },
+    } satisfies CreatePollInput,
+  },
+  mixedTimes: {
+    summary: "Time poll (explicit times + generator)",
+    description:
+      "`slots.times` can mix ISO datetime strings and slot generators. When `interval` is omitted it defaults to `duration`, so this generator produces back to back 90 minute slots at 14:00 and 15:30 on Monday and Wednesday.",
+    value: {
+      title: "Product workshop",
+      slots: {
+        duration: 90,
+        timezone: "Europe/Berlin",
+        times: [
+          "2026-08-01T10:00:00Z",
+          {
+            startDate: "2026-08-03",
+            endDate: "2026-08-05",
+            days: ["mon", "wed"],
+            startTime: "14:00",
+            endTime: "17:00",
+          },
+        ],
+      },
+    } satisfies CreatePollInput,
+  },
+};


### PR DESCRIPTION
## Description

Adds named OpenAPI request body examples to the create poll endpoint so the Scalar docs at `/api/private/docs` show a selectable example for each common scenario:

- **Date poll** — all-day options via `dates`
- **Time poll (explicit times)** — `slots` with ISO datetime strings
- **Slot generator** — recurring weekday slots across a date range with an `interval`
- **Mixed** — explicit times and a generator in the same `times` array, showing that `interval` defaults to `duration`

Also expands the endpoint description to explain the two input modes (`dates` vs `slots`), slot generator semantics (slots must fit inside the time window, interval defaults to duration), mutual exclusivity, and the 100 option cap.

### Reviewer notes

- The examples can't be attached via `describeRoute`: hono-openapi's validator middleware overwrites any `requestBody.content` set there (shallow spread in its spec merge, validator wins). The `/openapi` route now builds the spec with `generateSpecs` and injects the examples into the generated document, with a comment explaining why.
- Example values are checked two ways: `satisfies z.input<typeof createPollInputSchema>` at compile time, and a new test that parses each example value with `createPollInputSchema` and asserts the examples appear in the generated spec, so they can't drift from the contract.

## Checklist

- [x] I have performed a self-review of my code
- [x] My code follows the code style of this project
- [x] I have commented my code, particularly in hard-to-understand areas

🤖 Generated with [Claude Code](https://claude.com/claude-code)