### PR TITLE
✅ Add e2e tests for the space member invite flow

### DIFF
--- a/apps/web/tests/space-members.spec.ts
+++ b/apps/web/tests/space-members.spec.ts
@@ -1,0 +1,218 @@
+import type { Page } from "@playwright/test";
+import { expect, test } from "@playwright/test";
+import { prisma } from "@rallly/database";
+import { getSpaceInviteLink } from "@rallly/test-helpers";
+import {
+  createUserInDb,
+  loginWithEmail,
+  upgradeSpaceToPro,
+} from "./test-utils";
+
+const runId = Date.now().toString(36);
+const createdUserIds: string[] = [];
+
+/**
+ * Creates a user whose personal space is upgraded to pro with the given
+ * number of seats.
+ */
+async function createSpaceAdmin({
+  name,
+  seats,
+}: {
+  name: string;
+  seats: number;
+}) {
+  const email = `${name.toLowerCase().replace(/\s/g, "-")}-${runId}@example.com`;
+  const user = await createUserInDb({ email, name });
+  createdUserIds.push(user.id);
+
+  const space = await prisma.space.findFirstOrThrow({
+    where: { ownerId: user.id },
+  });
+  await upgradeSpaceToPro({ spaceId: space.id, userId: user.id, seats });
+
+  return { user, space, email };
+}
+
+async function createMemberInDb({
+  spaceId,
+  name,
+}: {
+  spaceId: string;
+  name: string;
+}) {
+  const email = `${name.toLowerCase().replace(/\s/g, "-")}-${runId}@example.com`;
+  const user = await createUserInDb({ email, name });
+  createdUserIds.push(user.id);
+
+  await prisma.spaceMember.create({
+    data: {
+      spaceId,
+      userId: user.id,
+      role: "MEMBER",
+    },
+  });
+
+  return { user, email };
+}
+
+function memberRow(page: Page, text: string) {
+  return page.getByRole("listitem").filter({ hasText: text });
+}
+
+async function gotoMembersSettings(page: Page, email: string) {
+  await loginWithEmail(page, { email });
+  await page.goto("/settings/members");
+  await page.getByRole("heading", { name: "Members" }).waitFor();
+}
+
+test.afterAll(async () => {
+  if (createdUserIds.length > 0) {
+    await prisma.user.deleteMany({
+      where: { id: { in: createdUserIds } },
+    });
+    createdUserIds.length = 0;
+  }
+});
+
+test.describe("Space members", () => {
+  test("admin can invite a member who joins via the emailed link", async ({
+    page,
+    browser,
+  }) => {
+    // Two OTP logins plus email roundtrips don't fit the default timeout
+    // against a dev server.
+    test.setTimeout(90_000);
+
+    const owner = await createSpaceAdmin({ name: "Invite Owner", seats: 3 });
+    const inviteeEmail = `invitee-${runId}@example.com`;
+
+    await gotoMembersSettings(page, owner.email);
+    await expect(page.getByText("1 of 3 seats used")).toBeVisible();
+
+    await page.getByRole("button", { name: "Invite member" }).click();
+    const dialog = page.getByRole("dialog");
+    await dialog.getByLabel("Email").fill(inviteeEmail);
+    // The submit button's "Send invite" defaults are shadowed by the
+    // reused inviteMember key, so it renders "Invite member" too.
+    await dialog.getByRole("button", { name: "Invite member" }).click();
+
+    await expect(page.getByText("Invitation sent")).toBeVisible();
+    await expect(memberRow(page, inviteeEmail)).toBeVisible();
+    await expect(
+      memberRow(page, inviteeEmail).getByText(`Invited by ${owner.user.name}`),
+    ).toBeVisible();
+
+    // Capture the invite email before triggering the invitee's login so
+    // the OTP capture doesn't pick it up instead.
+    const inviteLink = await getSpaceInviteLink(inviteeEmail);
+
+    const invitee = await createUserInDb({
+      email: inviteeEmail,
+      name: "Invited Member",
+    });
+    createdUserIds.push(invitee.id);
+
+    const inviteeContext = await browser.newContext();
+    const inviteePage = await inviteeContext.newPage();
+    await loginWithEmail(inviteePage, { email: inviteeEmail });
+    await inviteePage.goto(inviteLink);
+    await inviteePage.getByRole("button", { name: "Accept Invite" }).click();
+    await expect(
+      inviteePage.getByText("Successfully joined the space!"),
+    ).toBeVisible();
+    await inviteeContext.close();
+
+    await page.reload();
+    await expect(memberRow(page, "Invited Member")).toBeVisible();
+    await expect(
+      memberRow(page, inviteeEmail).getByText(`Invited by ${owner.user.name}`),
+    ).toBeHidden();
+    await expect(page.getByText("2 of 3 seats used")).toBeVisible();
+  });
+
+  test("admin can cancel a pending invite", async ({ page }) => {
+    const owner = await createSpaceAdmin({ name: "Cancel Owner", seats: 3 });
+    const inviteeEmail = `cancel-invitee-${runId}@example.com`;
+
+    await prisma.spaceMemberInvite.create({
+      data: {
+        spaceId: owner.space.id,
+        email: inviteeEmail,
+        role: "MEMBER",
+        inviterId: owner.user.id,
+      },
+    });
+
+    await gotoMembersSettings(page, owner.email);
+
+    const inviteRow = memberRow(page, inviteeEmail);
+    await expect(inviteRow).toBeVisible();
+    await inviteRow.getByRole("button", { name: "More options" }).click();
+    await page.getByRole("menuitem", { name: "Cancel invite" }).click();
+    await page.getByRole("button", { name: "Confirm" }).click();
+
+    await expect(page.getByText("Invite canceled successfully")).toBeVisible();
+    await expect(inviteRow).toBeHidden();
+  });
+
+  test("admin can change a member's role", async ({ page }) => {
+    const owner = await createSpaceAdmin({ name: "Role Owner", seats: 3 });
+    const member = await createMemberInDb({
+      spaceId: owner.space.id,
+      name: "Role Member",
+    });
+
+    await gotoMembersSettings(page, owner.email);
+
+    const row = memberRow(page, member.email);
+    await expect(row.getByText("Member", { exact: true })).toBeVisible();
+    await row.getByRole("button", { name: "More options" }).click();
+    await page.getByRole("menuitem", { name: "Make admin" }).click();
+
+    await expect(page.getByText("Role changed successfully")).toBeVisible();
+    await expect(row.getByText("Admin", { exact: true })).toBeVisible();
+  });
+
+  test("admin can remove a member", async ({ page }) => {
+    const owner = await createSpaceAdmin({ name: "Remove Owner", seats: 3 });
+    const member = await createMemberInDb({
+      spaceId: owner.space.id,
+      name: "Removable Member",
+    });
+
+    await gotoMembersSettings(page, owner.email);
+    await expect(page.getByText("2 of 3 seats used")).toBeVisible();
+
+    const row = memberRow(page, member.email);
+    await row.getByRole("button", { name: "More options" }).click();
+    await page.getByRole("menuitem", { name: "Remove member" }).click();
+    await page.getByRole("button", { name: "Confirm" }).click();
+
+    await expect(page.getByText("Member removed successfully")).toBeVisible();
+    await expect(row).toBeHidden();
+
+    // Seat usage is rendered from the server and doesn't update in place
+    // yet — assert the persisted state after a reload.
+    await page.reload();
+    await expect(page.getByText("1 of 3 seats used")).toBeVisible();
+  });
+
+  test("invite button is disabled when all seats are used", async ({
+    page,
+  }) => {
+    const owner = await createSpaceAdmin({ name: "Full Owner", seats: 1 });
+
+    await gotoMembersSettings(page, owner.email);
+
+    await expect(page.getByText("1 of 1 seats used")).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: "Invite member" }),
+    ).toBeDisabled();
+    await expect(
+      page.getByText(
+        "Increase the number of seats in this space from the billing page.",
+      ),
+    ).toBeVisible();
+  });
+});

--- a/apps/web/tests/test-utils.ts
+++ b/apps/web/tests/test-utils.ts
@@ -46,6 +46,45 @@ export async function createUserInDb({
   });
 }
 
+/**
+ * Upgrades a space to pro with an active subscription. Seat totals are
+ * derived from the subscription quantity in cloud-hosted mode, so tests
+ * that exercise seat limits must seed one.
+ */
+export async function upgradeSpaceToPro({
+  spaceId,
+  userId,
+  seats,
+}: {
+  spaceId: string;
+  userId: string;
+  seats: number;
+}) {
+  await prisma.$transaction([
+    prisma.space.update({
+      where: { id: spaceId },
+      data: { tier: "pro" },
+    }),
+    prisma.subscription.create({
+      data: {
+        id: `sub_test_${spaceId}`,
+        priceId: "price_test",
+        quantity: seats,
+        subscriptionItemId: `si_test_${spaceId}`,
+        amount: 700 * seats,
+        status: "active",
+        active: true,
+        currency: "USD",
+        interval: "month",
+        periodStart: new Date(),
+        periodEnd: dayjs().add(1, "month").toDate(),
+        userId,
+        spaceId,
+      },
+    }),
+  ]);
+}
+
 export async function createSpaceInDb({
   name,
   ownerId,

--- a/packages/test-helpers/src/email.ts
+++ b/packages/test-helpers/src/email.ts
@@ -12,6 +12,21 @@ export async function getCode(email: string): Promise<string> {
 }
 
 /**
+ * Extract the space invite link from the email HTML
+ */
+export async function getSpaceInviteLink(email: string): Promise<string> {
+  const html = await captureEmailHTML(email);
+  const $ = load(html);
+
+  const inviteLink = $("#inviteUrl").attr("href");
+  if (!inviteLink) {
+    throw new Error("Invite link not found in email");
+  }
+
+  return inviteLink;
+}
+
+/**
  * Extract the password reset link from the email HTML
  */
 export async function getPasswordResetLink(email: string): Promise<string> {

--- a/packages/test-helpers/src/index.ts
+++ b/packages/test-helpers/src/index.ts
@@ -1,4 +1,4 @@
-export { getCode, getPasswordResetLink } from "./email";
+export { getCode, getPasswordResetLink, getSpaceInviteLink } from "./email";
 export { loginWithEmail } from "./login";
 export {
   captureEmailHTML,


### PR DESCRIPTION
Adds Playwright coverage for the space member invite flow (RAL-1404), as a prerequisite for migrating the member mutations to server actions (RAL-1403) and the members page rewrite (RAL-1385/RAL-1386).

## Coverage

- Admin invites a member from the members settings page: pending invite appears, the invitee receives the email, logs in, and joins via the emailed accept link; the owner then sees the new member and updated seat usage
- Cancel a pending invite
- Change a member's role
- Remove a member
- Invite button disabled and billing alert shown when all seats are used

## Supporting changes

- `getSpaceInviteLink` added to `@rallly/test-helpers` (extracts the `#inviteUrl` link, same pattern as `getPasswordResetLink`)
- `upgradeSpaceToPro` test util: seat totals come from the active subscription quantity in cloud-hosted mode, so the pro space setup seeds a `Subscription` row

## Notes

- The invite email must be captured before triggering the invitee's OTP login — both go to the same address and the mailpit helper picks the oldest unread message
- Found in passing: the invite dialog's submit button declares `defaults="Send invite"` but reuses the `inviteMember` key, so it actually renders "Invite member". Left as is here (the dialog gets touched in RAL-1403); the test documents it
- The seat counter doesn't update in place after removing a member (nothing invalidated `getSeats` before this either) — the remove test asserts persisted state after a reload; the global `router.refresh()` from the server action migration will make it live

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added end-to-end coverage for space member management.
  * Verified member invitations, invite links, seat usage, and pending-invite cancellation.
  * Added coverage for changing member roles and removing members.
  * Confirmed inviting is disabled when no seats remain and that explanatory messaging is displayed.
  * Added test support for Pro seat limits and retrieving invitation links from email.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->