### PR TITLE
🐛 Give invite member submit button its own i18n key

### DIFF
--- a/apps/web/public/locales/en/app.json
+++ b/apps/web/public/locales/en/app.json
@@ -345,6 +345,7 @@
   "inviteLink": "Invite Link",
   "inviteMember": "Invite member",
   "inviteMemberDescription": "Invite a new member to your space",
+  "inviteMemberFormSubmit": "Send invite",
   "inviteMembersUpsellDescription": "Invite members to manage polls and events together in this space.",
   "inviteParticipantLinkInfo": "Anyone with this link will be able to vote on your poll.",
   "inviteParticipantsDescription": "Copy and share the invite link to start gathering responses from your participants.",

--- a/apps/web/src/app/[locale]/(space)/settings/members/components/invite-member-dialog.tsx
+++ b/apps/web/src/app/[locale]/(space)/settings/members/components/invite-member-dialog.tsx
@@ -224,7 +224,7 @@ export function InviteMemberForm({ onSuccess }: { onSuccess?: () => void }) {
             loading={inviteMember.isPending}
             type="submit"
           >
-            <Trans i18nKey="inviteMember" defaults="Send invite" />
+            <Trans i18nKey="inviteMemberFormSubmit" defaults="Send invite" />
           </Button>
         </div>
       </form>

--- a/apps/web/tests/space-members.spec.ts
+++ b/apps/web/tests/space-members.spec.ts
@@ -93,9 +93,7 @@ test.describe("Space members", () => {
     await page.getByRole("button", { name: "Invite member" }).click();
     const dialog = page.getByRole("dialog");
     await dialog.getByLabel("Email").fill(inviteeEmail);
-    // The submit button's "Send invite" defaults are shadowed by the
-    // reused inviteMember key, so it renders "Invite member" too.
-    await dialog.getByRole("button", { name: "Invite member" }).click();
+    await dialog.getByRole("button", { name: "Send invite" }).click();
 
     await expect(page.getByText("Invitation sent")).toBeVisible();
     await expect(memberRow(page, inviteeEmail)).toBeVisible();


### PR DESCRIPTION
## Problem

In the invite member dialog on the space members settings page, the form submit button rendered `<Trans i18nKey="inviteMember" defaults="Send invite" />`. The `inviteMember` key already exists (used by the dialog trigger and title as "Invite member"), so the `defaults` was silently ignored and both buttons rendered "Invite member".

## Fix

The submit button gets its own key, `inviteMemberFormSubmit`, following the convention of prefixing single-use keys with the component name. The key was generated with `pnpm i18n:scan`, no locale files were edited by hand.

Since #2729 merged with the old shadowed label selector, this PR also updates `space-members.spec.ts` to click "Send invite" and removes the workaround comment.

## Verification

Ran `apps/web/tests/space-members.spec.ts` locally on the rebased branch: all 5 tests pass.

Found while writing e2e tests in #2729 (RAL-1404).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the member invitation form’s submit button text to clearly display “Send invite.”
* **Documentation**
  * Added English localization support for the updated invite-member submit label.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->