### PR TITLE
✨ Add poll status to poll results API response

### DIFF
--- a/apps/web/src/app/api/private/[...route]/route.test.ts
+++ b/apps/web/src/app/api/private/[...route]/route.test.ts
@@ -960,6 +960,7 @@ describe("Private API - /polls", () => {
     it("should return aggregated vote results", async () => {
       mockGetPollResults.mockResolvedValue({
         pollId: "test-poll-id",
+        status: "open",
         participantCount: 5,
         highScore: 4003,
         options: [
@@ -1009,6 +1010,7 @@ describe("Private API - /polls", () => {
       expectMatchesContract(getPollResultsSuccessResponseSchema, json);
 
       expect(json.data.pollId).toBe("test-poll-id");
+      expect(json.data.status).toBe("open");
       expect(json.data.participantCount).toBe(5);
       expect(json.data.highScore).toBe(4003);
       expect(json.data.options).toHaveLength(3);
@@ -1019,9 +1021,41 @@ describe("Private API - /polls", () => {
       });
     });
 
+    it("should return the poll status for closed polls", async () => {
+      mockGetPollResults.mockResolvedValue({
+        pollId: "test-poll-id",
+        status: "closed",
+        participantCount: 1,
+        highScore: 1001,
+        options: [
+          {
+            id: "opt-1",
+            startTime: new Date("2025-01-15T09:00:00Z"),
+            duration: 30,
+            votes: [{ type: "yes", count: 1 }],
+            score: 1001,
+            isTopChoice: true,
+          },
+        ],
+      });
+
+      const res = await app.request("/api/private/polls/test-poll-id/results", {
+        method: "GET",
+        headers: {
+          Authorization: `Bearer ${testApiKey}`,
+        },
+      });
+
+      expect(res.status).toBe(200);
+      const json = await res.json();
+      expectMatchesContract(getPollResultsSuccessResponseSchema, json);
+      expect(json.data.status).toBe("closed");
+    });
+
     it("should handle ties for top choice", async () => {
       mockGetPollResults.mockResolvedValue({
         pollId: "test-poll-id",
+        status: "open",
         participantCount: 2,
         highScore: 2002,
         options: [
@@ -1063,6 +1097,7 @@ describe("Private API - /polls", () => {
     it("should prioritize total availability over yes votes", async () => {
       mockGetPollResults.mockResolvedValue({
         pollId: "test-poll-id",
+        status: "open",
         participantCount: 5,
         highScore: 5003,
         options: [
@@ -1108,6 +1143,7 @@ describe("Private API - /polls", () => {
     it("should use yes votes as tiebreaker when availability is equal", async () => {
       mockGetPollResults.mockResolvedValue({
         pollId: "test-poll-id",
+        status: "open",
         participantCount: 4,
         highScore: 4004,
         options: [

--- a/apps/web/src/app/api/private/schemas.ts
+++ b/apps/web/src/app/api/private/schemas.ts
@@ -240,6 +240,11 @@ export const getPollResultsSuccessResponseSchema = z
   .object({
     data: z.object({
       pollId: z.string().openapi({ example: "p_123abc" }),
+      status: pollStatusSchema.openapi({
+        description:
+          "Current poll status. Polls close automatically when all options are in the past.",
+        example: "open",
+      }),
       participantCount: z.int().nonnegative().openapi({
         description: "Total number of participants",
         example: 8,

--- a/apps/web/src/features/poll/data.ts
+++ b/apps/web/src/features/poll/data.ts
@@ -22,6 +22,7 @@ export async function getPollResults({
       },
       select: {
         id: true,
+        status: true,
         options: {
           select: {
             id: true,
@@ -105,6 +106,7 @@ export async function getPollResults({
 
   return {
     pollId: poll.id,
+    status: poll.status,
     participantCount: poll._count.participants,
     options,
     highScore,


### PR DESCRIPTION
## Description

Adds a `status` field (`open | closed | scheduled | canceled`) to the `GET /polls/:pollId/results` response.

API consumers that poll the results endpoint to watch for responses currently have no way to tell from that response whether a poll is still active. Since polls now auto-close when all options are in the past, a consumer polling for results can end up requesting closed polls indefinitely, burning rate limit on polls that will never change. `GET /polls/:pollId` already exposes `status`, but requiring a second request per poll doubles traffic for no benefit.

Changes:
- `getPollResults` in `features/poll/data.ts` selects and returns `poll.status`
- `GetPollResultsResponse` schema includes `status` via the existing `pollStatusSchema`, with an OpenAPI note that polls close automatically when all options are in the past
- Route tests updated; new test asserts `closed` status passes through

Purely additive, no breaking changes for existing consumers.

## Checklist

- [x] I have performed a self-review of my code
- [x] My code follows the code style of this project
- [x] I have commented my code, particularly in hard-to-understand areas

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Poll results now display the poll’s current status, including whether it is open or closed.
  * API documentation now describes the status field and its automatic closure behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->