### PR TITLE
🐛 Fix purge-guest-profiles exiting early on eventually-consistent reads

### DIFF
--- a/packages/posthog/src/scripts/purge-guest-profiles.ts
+++ b/packages/posthog/src/scripts/purge-guest-profiles.ts
@@ -36,10 +36,16 @@ const SAMPLE_SIZE = 50;
 // CRUD endpoints are rate limited to 480/min org-wide
 const DELETE_INTERVAL_MS = 800;
 const MAX_RATE_LIMIT_RETRIES = 5;
+// The persons list endpoint (ClickHouse) lags behind bulk_delete. When it hands
+// back an empty page but the count still reports matches, back off and retry
+// before treating the filter as exhausted.
+const EMPTY_PAGE_BACKOFF_MS = 5000;
+const MAX_EMPTY_PAGE_RETRIES = 12;
 
 const GUEST_FILTERS = [
   {
     label: "email is not set",
+    countQuery: "SELECT count() FROM persons WHERE isNull(properties.email)",
     properties: [
       {
         key: "email",
@@ -51,6 +57,7 @@ const GUEST_FILTERS = [
   },
   {
     label: "email is empty string",
+    countQuery: "SELECT count() FROM persons WHERE properties.email = ''",
     properties: [
       { key: "email", operator: "exact", value: "", type: "person" },
     ],
@@ -282,21 +289,46 @@ async function verifyCanary() {
 
 async function purge({
   properties,
+  countQuery,
   label,
 }: {
   properties: unknown[];
+  countQuery: string;
   label: string;
 }) {
   console.info(`\n🗑️  Purging profiles where ${label}…`);
   let deleted = 0;
   let previousFirstId: string | number | undefined;
   let stuckCycles = 0;
+  // The persons list endpoint reads from ClickHouse and is eventually
+  // consistent: right after a bulk_delete it can briefly return a partial or
+  // empty page while the deletes propagate. A single empty page is therefore
+  // NOT proof the work is done — confirm against the authoritative count and
+  // retry a few times before concluding the filter is exhausted.
+  let emptyPages = 0;
 
   for (;;) {
     const page = await fetchGuestPage({ properties, limit: PAGE_SIZE });
+
     if (page.length === 0) {
-      break;
+      const remaining = await hogqlCount(countQuery);
+      if (remaining === 0) {
+        break;
+      }
+      emptyPages++;
+      if (emptyPages >= MAX_EMPTY_PAGE_RETRIES) {
+        throw new Error(
+          `Persons list returned empty ${emptyPages} times but the count still reports ${remaining} matching profile(s). Read replica may be lagging — aborting so the run isn't silently left incomplete.`,
+        );
+      }
+      console.info(
+        `• Empty page but ${remaining} still match — waiting for read replica (retry ${emptyPages}/${MAX_EMPTY_PAGE_RETRIES})`,
+      );
+      await sleep(EMPTY_PAGE_BACKOFF_MS);
+      continue;
     }
+
+    emptyPages = 0;
 
     if (page[0].id === previousFirstId) {
       stuckCycles++;
@@ -321,7 +353,10 @@ async function purge({
     await sleep(DELETE_INTERVAL_MS);
   }
 
-  console.info(`✅ Done — ${deleted} profile(s) deleted where ${label}.`);
+  const remaining = await hogqlCount(countQuery);
+  console.info(
+    `✅ Done — ${deleted} profile(s) deleted where ${label}. Count now reports ${remaining} matching.`,
+  );
   return deleted;
 }
 


### PR DESCRIPTION
## Problem

The `purge-guest-profiles` script ends prematurely, reporting a clean success while leaving ~99.7% of guest profiles undeleted. In the last run it deleted **6,179** profiles then stopped — a live count confirmed **1,883,558** guests still remained (preflight had reported 1,889,734).

It was not erroring or failing silently. It exited `0` on a **false termination condition**.

## Root cause

The purge loop drove its termination off the `/persons/` list endpoint. That endpoint reads from ClickHouse and is **eventually consistent**. PostHog's person deletion is asynchronous — `bulk_delete` inserts tombstones rather than removing rows in place, and reads reconcile those tombstones at query time.

Under the loop's rapid-fire `bulk_delete` calls (every 800ms), the persons list query runs against a table mid-churn and can return a **partial page** or, at the wrong moment, an **empty page** — even though millions of matching profiles remain. The fingerprint is visible in the run logs: page sizes bounced (897, 342, 64, 833…), never a clean 1000, then one read returned 0.

The old loop treated the first `page.length === 0` as "done" and broke. The existing `stuckCycles` guard didn't help — it only fires when `page[0].id` is *identical* three times running, but the shifting result set returned different first-ids each cycle.

## Fix

- An empty page no longer terminates the loop. It re-checks the authoritative HogQL `count()` and only breaks when that reports **zero**.
- If the count still shows matches, it backs off (5s) and retries — up to 12 times (~1 min) — to let the read replica catch up, then continues deleting.
- Exhausting the retries with a non-zero count now **throws**, so an incomplete run surfaces loudly instead of exiting `0`.
- The final line prints the residual count for verification.

## Testing

- Type-checks clean (`tsc --noEmit`).
- Biome passed via pre-commit hook.
- Not run against production — `--apply` touches live PostHog data and needs explicit sign-off. Recommend a dry run to confirm counts before the next `--apply`.

## Notes for reviewer

- This is a long-running job by nature: ~1.9M guests ÷ 1000/page × 0.8s ≈ **25+ minutes**, plus propagation waits. Expect it to churn, not sprint. `bulk_delete` caps at 1000 ids/call, so `PAGE_SIZE` can't go higher.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved guest-profile purging to handle temporary inconsistencies between profile listings and deletion results.
  * Added retry and backoff behavior when profiles may still exist despite an empty result page.
  * Enhanced completion reporting with the authoritative count of remaining matching profiles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->