### PR TITLE
🐛 Show plain-text support email, not just a mailto: link

### DIFF
--- a/apps/docs/contact/support.mdx
+++ b/apps/docs/contact/support.mdx
@@ -11,7 +11,7 @@ If you have any questions, feedback or suggestions, please get in touch. We'd lo
     icon="envelope"
     href="mailto:support@rallly.co"
   >
-    Send an email
+    Email us at `support@rallly.co`
   </Card>
   <Card
     title="Discord"

--- a/apps/landing/public/locales/en/common.json
+++ b/apps/landing/public/locales/en/common.json
@@ -16,7 +16,7 @@
   "licensingThankYouNextStepsActivateLicense": "How to Activate Your License",
   "licensingThankYouNextStepsInstallation": "Installation Guide",
   "licensingThankYouSubtitle": "Your Rallly self-hosted license is confirmed. We're excited to have you on board!",
-  "licensingThankYouSupportPrompt": "Need help or have questions? Visit our <0>self-hosted docs</0> or <1>contact us</1>.",
+  "licensingThankYouSupportPrompt": "Need help or have questions? Visit our <0>self-hosted docs</0> or email us at <1>support@rallly.co</1>.",
   "licensingThankYouTitle": "Thank You for Your Purchase!",
   "links": "Links",
   "login": "Login",

--- a/apps/landing/src/app/[locale]/licensing/thank-you/page.tsx
+++ b/apps/landing/src/app/[locale]/licensing/thank-you/page.tsx
@@ -86,7 +86,7 @@ export default async function LicensingThankYouPage(props: {
             <Trans
               t={t}
               i18nKey="licensingThankYouSupportPrompt"
-              defaults="Need help or have questions? Visit our <0>self-hosted docs</0> or <1>contact us</1>."
+              defaults="Need help or have questions? Visit our <0>self-hosted docs</0> or email us at <1>support@rallly.co</1>."
               components={[
                 <a
                   key="self-hosted-docs"
@@ -96,7 +96,7 @@ export default async function LicensingThankYouPage(props: {
                 <a
                   key="contact-us"
                   href="mailto:support@rallly.co"
-                  className="underline"
+                  className="select-all underline"
                 />,
               ]}
             />

--- a/apps/web/public/locales/en/app.json
+++ b/apps/web/public/locales/en/app.json
@@ -142,6 +142,7 @@
   "connectGoogleCalendar": "Google Calendar",
   "connectMicrosoftCalendar": "Microsoft Calendar",
   "contactSupport": "Contact Support",
+  "contactSupportEmail": "Or email us at <0>support@rallly.co</0>",
   "content": "Content",
   "continue": "Continue",
   "continueWithEmail": "Continue with email",

--- a/apps/web/src/app/[locale]/(space)/settings/billing/components/contact-support-link.tsx
+++ b/apps/web/src/app/[locale]/(space)/settings/billing/components/contact-support-link.tsx
@@ -8,17 +8,32 @@ import { Trans } from "@/i18n/client";
 
 export function ContactSupportLink() {
   return (
-    <a
-      href="mailto:support@rallly.co"
-      className={buttonVariants()}
-      onClick={() => {
-        posthog?.capture("space_billing:support_button_click");
-      }}
-    >
-      <Icon>
-        <SendIcon />
-      </Icon>
-      <Trans i18nKey="contactSupport" defaults="Contact Support" />
-    </a>
+    <div className="flex flex-col items-start gap-3">
+      <a
+        href="mailto:support@rallly.co"
+        className={buttonVariants()}
+        onClick={() => {
+          posthog?.capture("space_billing:support_button_click");
+        }}
+      >
+        <Icon>
+          <SendIcon />
+        </Icon>
+        <Trans i18nKey="contactSupport" defaults="Contact Support" />
+      </a>
+      <p className="text-muted-foreground text-sm">
+        <Trans
+          i18nKey="contactSupportEmail"
+          defaults="Or email us at <0>support@rallly.co</0>"
+          components={[
+            <a
+              key="email"
+              href="mailto:support@rallly.co"
+              className="select-all font-medium text-foreground"
+            />,
+          ]}
+        />
+      </p>
+    </div>
   );
 }


### PR DESCRIPTION
## Description

Fixes RAL-1397.

A user reported that clicking the support page's email card does nothing for Gmail (webmail) users, since no desktop client is registered for `mailto:`. The address `support@rallly.co` was only ever a `mailto:` `href` and never shown as text, so those users couldn't copy it either and were left with no way to reach support.

This displays `support@rallly.co` as visible, selectable text everywhere a `mailto:`-only affordance had the same failure mode, while keeping the existing `mailto:` links intact:

- **Support docs** (`apps/docs/contact/support.mdx`) — email card body now reads `Email us at support@rallly.co` instead of "Send an email".
- **Billing support section** (`contact-support-link.tsx`) — added a `select-all` plain-text line beneath the Contact Support button.
- **Licensing thank-you page** (`licensing/thank-you/page.tsx`) — the sentence now reads "email us at support@rallly.co" (address visible) instead of a bare "contact us" link.

The terms-of-use and privacy-policy pages already render the address as text, so they were left unchanged.

### Notes for reviewers

- New i18n key `contactSupportEmail` (web) was generated via `pnpm i18n:scan`. The changed default on the existing landing key `licensingThankYouSupportPrompt` was corrected in the source JSON by hand, since the scanner preserves existing values. Translations flow through Crowdin as usual.

## Checklist

- [x] I have performed a self-review of my code
- [x] My code follows the code style of this project
- [x] I have commented my code, particularly in hard-to-understand areas

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added direct access to `support@rallly.co` from billing settings alongside the existing Contact Support option.
  * Updated licensing and support messaging to display the support email address.
  * Added improved email-link styling for easier copying.

* **Documentation**
  * Updated support documentation to provide the recommended support email address.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->