### PR TITLE
🔒 Hide "create your own poll" CTA from the poll organizer

### DIFF
--- a/apps/web/src/features/poll/components/new-participant-modal.tsx
+++ b/apps/web/src/features/poll/components/new-participant-modal.tsx
@@ -102,6 +102,7 @@ export const NewParticipantForm = (props: NewParticipantModalProps) => {
   const { timeZone } = useDateTimeConfig();
   const { user, createGuestIfNeeded } = useUser();
   const isLoggedIn = user && !user.isGuest;
+  const isOrganizer = user?.id === poll.userId;
   const form = useForm({
     resolver: zodResolver(schema),
     defaultValues: {
@@ -147,37 +148,39 @@ export const NewParticipantForm = (props: NewParticipantModalProps) => {
             defaults="Back to poll"
           />
         </Button>
-        <div className="flex flex-col items-center text-center">
-          <p className="text-muted-foreground text-sm">
-            <Trans
-              i18nKey="newParticipantDialogCreatePollPrompt"
-              defaults="Need to schedule something yourself?"
-            />
-          </p>
-          <Link
-            href="/new"
-            className={buttonVariants({ variant: "link" })}
-            onClick={() => {
-              posthog?.capture(
-                "new_participant_dialog:create_poll_button_click",
-                {
-                  pollId: poll.id,
-                  spaceId: poll.spaceId,
-                  tier: poll.space?.tier,
-                  $groups: {
-                    poll: poll.id,
-                    ...(poll.spaceId ? { space: poll.spaceId } : {}),
+        {!isOrganizer ? (
+          <div className="flex flex-col items-center text-center">
+            <p className="text-muted-foreground text-sm">
+              <Trans
+                i18nKey="newParticipantDialogCreatePollPrompt"
+                defaults="Need to schedule something yourself?"
+              />
+            </p>
+            <Link
+              href="/new"
+              className={buttonVariants({ variant: "link" })}
+              onClick={() => {
+                posthog?.capture(
+                  "new_participant_dialog:create_poll_button_click",
+                  {
+                    pollId: poll.id,
+                    spaceId: poll.spaceId,
+                    tier: poll.space?.tier,
+                    $groups: {
+                      poll: poll.id,
+                      ...(poll.spaceId ? { space: poll.spaceId } : {}),
+                    },
                   },
-                },
-              );
-            }}
-          >
-            <Trans
-              i18nKey="newParticipantDialogCreatePoll"
-              defaults="Create your own poll"
-            />
-          </Link>
-        </div>
+                );
+              }}
+            >
+              <Trans
+                i18nKey="newParticipantDialogCreatePoll"
+                defaults="Create your own poll"
+              />
+            </Link>
+          </div>
+        ) : null}
       </>
     );
   }

--- a/apps/web/tests/invite-page.ts
+++ b/apps/web/tests/invite-page.ts
@@ -19,9 +19,6 @@ export class InvitePage {
     await page.click("text='Submit'");
 
     await expect(page.getByText("Your response has been saved")).toBeVisible();
-    await expect(
-      page.getByRole("link", { name: "Create your own poll" }),
-    ).toHaveAttribute("href", "/new");
     await page.click("button >> text='Back to poll'");
   }
 }


### PR DESCRIPTION
## What

The voting success dialog (shipped in #2734) showed the "Create your own poll" prompt to **all** users after they submit a response, including the poll's organizer.

This gates that CTA on `isOrganizer` (`user.id === poll.userId`) so the organizer no longer sees the upsell — it only makes sense for participants who aren't already the one scheduling.

## Behavior

- Participants: unchanged — still see the success state + "Create your own poll" prompt.
- Organizer: sees the success confirmation and "Back to poll" button, but not the create-poll prompt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * The post-submission prompt and “create your own poll” link are now hidden when the current user is the poll organizer.
  * For non-organizers, the “your response has been saved” flow and personal poll call-to-action remain accessible after submitting.
* **Tests**
  * Updated the invite page flow test to assert the saved confirmation message before continuing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->