### PR TITLE
fix(polls): prevent responding to poll options in the past

### DIFF
--- a/apps/web/src/trpc/routers/polls/participants.ts
+++ b/apps/web/src/trpc/routers/polls/participants.ts
@@ -7,6 +7,7 @@ import { absoluteUrl } from "@rallly/utils/absolute-url";
 import { TRPCError } from "@trpc/server";
 import { after } from "next/server";
 import * as z from "zod";
+import { getTranslations } from "@/i18n/server";
 import { getInstanceBranding, getSpaceBranding } from "@/emails/branding";
 import { getNotificationRecipient } from "@/features/notifications/data";
 import { hasPollAdminAccess } from "@/features/poll/data";
@@ -271,11 +272,17 @@ export const participants = router({
           (option) => option.startTime >= now,
         );
 
+        const t = await getTranslations({
+          locale: ctx.locale,
+        });
+
         if (options.length > 0 && futureOptions.length === 0) {
           throw new TRPCError({
             code: "BAD_REQUEST",
-            message:
-              "Cannot respond to a poll where all options are in the past",
+            message: t("errors.allOptionsInPast", {
+              defaultValue:
+                "Cannot respond to a poll where all options are in the past",
+            }),
           });
         }
 

--- a/apps/web/src/trpc/routers/polls/participants.ts
+++ b/apps/web/src/trpc/routers/polls/participants.ts
@@ -262,13 +262,29 @@ export const participants = router({
           },
           select: {
             id: true,
+            startTime: true,
           },
         });
 
-        const existingOptionIds = new Set(options.map((option) => option.id));
+        const now = new Date();
+        const futureOptions = options.filter(
+          (option) => option.startTime >= now,
+        );
+
+        if (options.length > 0 && futureOptions.length === 0) {
+          throw new TRPCError({
+            code: "BAD_REQUEST",
+            message:
+              "Cannot respond to a poll where all options are in the past",
+          });
+        }
+
+        const validOptionIds = new Set(
+          futureOptions.map((option) => option.id),
+        );
 
         const validVotes = votes.filter(({ optionId }) =>
-          existingOptionIds.has(optionId),
+          validOptionIds.has(optionId),
         );
 
         const participant = await prisma.participant.create({


### PR DESCRIPTION
Fixes #1677. Participants were previously able to submit responses to polls even when option start times were in the past. This PR updates the participant add mutation to validate option start times against current time, filtering out votes cast for past options.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented voting for poll options that have already started.
  * Participants can now vote only on options scheduled for the future.
  * Added clearer validation when no future voting options are available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->