### PR TITLE
📈 Track poll creation through the API in PostHog

### DIFF
--- a/apps/web/src/app/api/private/[...route]/route.test.ts
+++ b/apps/web/src/app/api/private/[...route]/route.test.ts
@@ -9,6 +9,8 @@ const mockClosePoll = vi.fn();
 const mockGetPollResults = vi.fn();
 const mockGetPollParticipants = vi.fn();
 const mockListPolls = vi.fn();
+const mockTrack = vi.fn();
+const mockIdentifyGroup = vi.fn();
 
 vi.mock("@/features/poll/mutations", () => ({
   deletePoll: (...args: unknown[]) => mockDeletePoll(...args),
@@ -57,6 +59,12 @@ vi.mock("next/server", () => ({
 
 vi.mock("@/lib/kv", () => ({
   redis: null,
+}));
+
+vi.mock("@/lib/posthog", () => ({
+  track: (...args: unknown[]) => mockTrack(...args),
+  identifyGroup: (...args: unknown[]) => mockIdentifyGroup(...args),
+  flushPostHog: vi.fn(),
 }));
 
 import { prisma } from "@rallly/database";
@@ -472,6 +480,40 @@ describe("Private API - /polls", () => {
       );
     });
 
+    it("should track poll creation with source api and kind date", async () => {
+      const res = await app.request("/api/private/polls", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${testApiKey}`,
+        },
+        body: JSON.stringify({
+          title: "Team offsite",
+          dates: ["2025-01-15"],
+        }),
+      });
+
+      expect(res.status).toBe(200);
+      expect(mockTrack).toHaveBeenCalledWith(
+        { id: "test-user-id", isGuest: false },
+        expect.objectContaining({
+          event: "poll_create",
+          properties: expect.objectContaining({
+            kind: "date",
+            source: "api",
+          }),
+          groups: { poll: "test-poll-id", space: "test-space-id" },
+        }),
+      );
+      expect(mockIdentifyGroup).toHaveBeenCalledWith(
+        expect.objectContaining({
+          groupType: "poll",
+          groupKey: "test-poll-id",
+          properties: expect.objectContaining({ kind: "date" }),
+        }),
+      );
+    });
+
     it("should save location when provided", async () => {
       const res = await app.request("/api/private/polls", {
         method: "POST",
@@ -565,6 +607,59 @@ describe("Private API - /polls", () => {
         expect.objectContaining({
           title: "Team sync",
           timeZone: "Europe/London",
+        }),
+      );
+    });
+
+    it("should track poll creation with source api and kind time", async () => {
+      mockCreatePoll.mockResolvedValueOnce({
+        id: "test-poll-id",
+        title: "Team sync",
+        description: null,
+        location: null,
+        timeZone: "Europe/London",
+        status: "open",
+        createdAt: new Date("2025-01-10T12:00:00Z"),
+        user: { name: "Test User", image: null },
+        options: [
+          {
+            id: "opt-1",
+            startTime: new Date("2025-01-15T09:00:00Z"),
+            duration: 30,
+          },
+        ],
+      });
+
+      const res = await app.request("/api/private/polls", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${testApiKey}`,
+        },
+        body: JSON.stringify({
+          title: "Team sync",
+          slots: {
+            duration: 30,
+            timezone: "Europe/London",
+            times: ["2025-01-15T09:00:00Z"],
+          },
+        }),
+      });
+
+      expect(res.status).toBe(200);
+      expect(mockTrack).toHaveBeenCalledWith(
+        { id: "test-user-id", isGuest: false },
+        expect.objectContaining({
+          event: "poll_create",
+          properties: expect.objectContaining({
+            kind: "time",
+            source: "api",
+          }),
+        }),
+      );
+      expect(mockIdentifyGroup).toHaveBeenCalledWith(
+        expect.objectContaining({
+          properties: expect.objectContaining({ kind: "time" }),
         }),
       );
     });

--- a/apps/web/src/app/api/private/[...route]/route.ts
+++ b/apps/web/src/app/api/private/[...route]/route.ts
@@ -10,6 +10,7 @@ import {
   resolver,
   validator,
 } from "hono-openapi";
+import { after } from "next/server";
 import {
   getPollParticipants,
   getPollResults,
@@ -18,6 +19,7 @@ import {
 import { closePoll, createPoll, deletePoll } from "@/features/poll/mutations";
 import type { AuthorizedSpaceId } from "@/features/space/types";
 import { isMaintenanceModeEnabled } from "@/lib/maintenance";
+import { flushPostHog, identifyGroup, track } from "@/lib/posthog";
 import {
   createPollRequestExamples,
   patchPollRequestExamples,
@@ -269,6 +271,54 @@ app.post(
       organizerUserId = spaceMember.user.id;
     }
 
+    const trackPollCreated = (poll: Awaited<ReturnType<typeof createPoll>>) => {
+      const kind = poll.options.some((o) => o.duration > 0) ? "time" : "date";
+
+      identifyGroup({
+        groupType: "poll",
+        groupKey: poll.id,
+        properties: {
+          name: poll.title,
+          status: poll.status,
+          kind,
+          created_at: poll.createdAt,
+          comment_count: 0,
+          option_count: poll.options.length,
+          has_location: !!poll.location,
+          has_description: !!poll.description,
+          timezone: poll.timeZone,
+          muted: false,
+        },
+      });
+
+      track(
+        { id: organizerUserId, isGuest: false },
+        {
+          event: "poll_create",
+          properties: {
+            title: poll.title,
+            kind,
+            source: "api",
+            optionCount: poll.options.length,
+            hasLocation: !!poll.location,
+            hasDescription: !!poll.description,
+            timezone: poll.timeZone,
+            requireParticipantEmail: input.requireEmail,
+            hideParticipants: input.hideParticipants,
+            hideScores: input.hideScores,
+            disableComments: input.disableComments,
+            isGuest: false,
+          },
+          groups: {
+            poll: poll.id,
+            space: spaceId,
+          },
+        },
+      );
+
+      after(() => flushPostHog());
+    };
+
     // Process dates (all-day options)
     if (input.dates) {
       if (input.dates.length > MAX_OPTIONS) {
@@ -310,6 +360,8 @@ app.post(
         options,
         spaceId,
       });
+
+      trackPollCreated(poll);
 
       return c.json(
         createPollSuccessResponseSchema.parse(toPollResponseBody(poll)),
@@ -380,6 +432,8 @@ app.post(
       options,
       spaceId,
     });
+
+    trackPollCreated(poll);
 
     return c.json(
       createPollSuccessResponseSchema.parse(toPollResponseBody(poll)),

--- a/apps/web/src/trpc/routers/polls.ts
+++ b/apps/web/src/trpc/routers/polls.ts
@@ -267,6 +267,7 @@ export const polls = router({
           properties: {
             title: poll.title,
             kind,
+            source: "web",
             optionCount: poll.options.length,
             hasLocation: !!location,
             hasDescription: !!description,


### PR DESCRIPTION
## Problem

The programmatic poll-creation path (`POST /api/private/polls`) emitted **no** PostHog event, so polls created through the API were invisible in analytics. There was also no way to break poll creations down by where they came from.

## Changes

- On the API path, fire a `poll_create` event **and** a poll-group `identifyGroup` on both the `dates` and `slots` branches, mirroring the web/tRPC path (kind, option count, location/description flags, timezone, settings).
- Introduce a `source` property on `poll_create`:
  - `source: "api"` on the programmatic path (this PR)
  - `source: "web"` on the tRPC/UI path (also included here, since #2748 merged with only `kind` — the `source` addition landed after that merge)
- Flush PostHog via `after(() => flushPostHog())` since the API route is short-lived serverless and the client batches.

`kind` is derived from the created poll's options: any option with `duration > 0` ⇒ `"time"`, otherwise `"date"` (all-day).

## Tests

Added two cases to the existing route test suite:
- dates → `poll_create` with `source: "api"`, `kind: "date"`, and matching group identify
- slots → `source: "api"`, `kind: "time"`

Mocked `@/lib/posthog` in the test (it pulls in `@/env`, which isn't validated under the test runner). All 69 tests pass; full type-check clean.

## Result

Poll creations can now be broken down in PostHog by `source` (web vs api) and `kind` (date vs time), across every creation path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Analytics**
  * Added poll creation analytics for polls created through the API.
  * Events now distinguish between date-based and time-based polls and include relevant poll and option details.
  * Web-created poll events now identify their source as the web application.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->