### PR TITLE
♻️ Set new space as active before closing create dialog

### DIFF
--- a/apps/web/src/features/space/actions.ts
+++ b/apps/web/src/features/space/actions.ts
@@ -14,6 +14,7 @@ import {
   updateSpaceShowBranding,
 } from "@/features/space/mutations";
 import {
+  createSpaceSchema,
   spaceImageUploadSchema,
   updateSpaceImageSchema,
   updateSpaceSchema,
@@ -87,7 +88,7 @@ export const setActiveSpaceAction = authActionClient
 export const createSpaceAction = authActionClient
   .metadata({ actionName: "create_space" })
   .use(createRateLimitMiddleware(5, "1 m"))
-  .inputSchema(z.object({ name: z.string().min(1).max(100) }))
+  .inputSchema(createSpaceSchema)
   .action(async ({ ctx, parsedInput }) => {
     const space = await createSpace({
       name: parsedInput.name,
@@ -101,7 +102,7 @@ export const createSpaceAction = authActionClient
         name: space.name,
         member_count: 1,
         seat_count: 1,
-        tier: "hobby",
+        tier: space.tier,
       },
     });
 

--- a/apps/web/src/features/space/actions.ts
+++ b/apps/web/src/features/space/actions.ts
@@ -7,6 +7,7 @@ import { getActiveSpaceForUser } from "@/features/space/data";
 import { defineAbilityForMember } from "@/features/space/member/ability";
 import { effectiveSpaceMemberWhere } from "@/features/space/member/utils";
 import {
+  createSpace,
   removeSpaceImage,
   updateSpace,
   updateSpaceImage,
@@ -21,7 +22,10 @@ import {
 import { setActiveSpace } from "@/features/user/mutations";
 import { AppError } from "@/lib/errors/app-error";
 import { identifyGroup, track } from "@/lib/posthog";
-import { authActionClient } from "@/lib/safe-action/server";
+import {
+  authActionClient,
+  createRateLimitMiddleware,
+} from "@/lib/safe-action/server";
 import { getImageUploadUrl } from "@/lib/storage/image-upload";
 
 async function requireSpaceWithUpdateAbility(user: { id: string }) {
@@ -78,6 +82,40 @@ export const setActiveSpaceAction = authActionClient
         space: parsedInput.spaceId,
       },
     });
+  });
+
+export const createSpaceAction = authActionClient
+  .metadata({ actionName: "create_space" })
+  .use(createRateLimitMiddleware(5, "1 m"))
+  .inputSchema(z.object({ name: z.string().min(1).max(100) }))
+  .action(async ({ ctx, parsedInput }) => {
+    const space = await createSpace({
+      name: parsedInput.name,
+      ownerId: ctx.user.id,
+    });
+
+    identifyGroup({
+      groupType: "space",
+      groupKey: space.id,
+      properties: {
+        name: space.name,
+        member_count: 1,
+        seat_count: 1,
+        tier: "hobby",
+      },
+    });
+
+    track(ctx.user, {
+      event: "space_create",
+      properties: {
+        space_name: space.name,
+      },
+      groups: {
+        space: space.id,
+      },
+    });
+
+    return space;
   });
 
 export const updateSpaceAction = authActionClient

--- a/apps/web/src/features/space/components/create-space-dialog.tsx
+++ b/apps/web/src/features/space/components/create-space-dialog.tsx
@@ -20,18 +20,14 @@ import {
 } from "@rallly/ui/form";
 import { Input } from "@rallly/ui/input";
 import { useForm } from "react-hook-form";
-import * as z from "zod";
 import { createSpaceAction } from "@/features/space/actions";
+import { createSpaceSchema } from "@/features/space/schema";
 import { Trans } from "@/i18n/client";
 import { useSafeAction } from "@/lib/safe-action/client";
 
-const createSpaceFormSchema = z.object({
-  name: z.string().min(1).max(100),
-});
-
 export function CreateSpaceDialog(props: DialogProps) {
   const form = useForm({
-    resolver: zodResolver(createSpaceFormSchema),
+    resolver: zodResolver(createSpaceSchema),
     defaultValues: {
       name: "",
     },

--- a/apps/web/src/features/space/components/create-space-dialog.tsx
+++ b/apps/web/src/features/space/components/create-space-dialog.tsx
@@ -19,19 +19,17 @@ import {
   FormMessage,
 } from "@rallly/ui/form";
 import { Input } from "@rallly/ui/input";
-import { toast } from "@rallly/ui/sonner";
 import { useForm } from "react-hook-form";
 import * as z from "zod";
-import { Trans, useTranslation } from "@/i18n/client";
-import { trpc } from "@/trpc/client";
+import { createSpaceAction } from "@/features/space/actions";
+import { Trans } from "@/i18n/client";
+import { useSafeAction } from "@/lib/safe-action/client";
 
 const createSpaceFormSchema = z.object({
   name: z.string().min(1).max(100),
 });
 
 export function CreateSpaceDialog(props: DialogProps) {
-  const { t } = useTranslation();
-
   const form = useForm({
     resolver: zodResolver(createSpaceFormSchema),
     defaultValues: {
@@ -39,11 +37,7 @@ export function CreateSpaceDialog(props: DialogProps) {
     },
   });
 
-  const createSpace = trpc.spaces.create.useMutation({
-    onSuccess: () => {
-      form.reset();
-    },
-  });
+  const createSpace = useSafeAction(createSpaceAction);
 
   return (
     <Dialog {...props}>
@@ -61,24 +55,12 @@ export function CreateSpaceDialog(props: DialogProps) {
             </DialogDescription>
           </DialogHeader>
           <form
-            onSubmit={form.handleSubmit(({ name }) => {
-              props.onOpenChange?.(false);
-              toast.promise(
-                createSpace.mutateAsync({
-                  name,
-                }),
-                {
-                  loading: t("createSpaceLoading", {
-                    defaultValue: "Creating space...",
-                  }),
-                  success: t("createSpaceSuccess", {
-                    defaultValue: "Space created successfully",
-                  }),
-                  error: t("createSpaceError", {
-                    defaultValue: "Failed to create space",
-                  }),
-                },
-              );
+            onSubmit={form.handleSubmit(async ({ name }) => {
+              const result = await createSpace.executeAsync({ name });
+              if (result?.data) {
+                props.onOpenChange?.(false);
+                form.reset();
+              }
             })}
           >
             <FormField

--- a/apps/web/src/features/space/schema.ts
+++ b/apps/web/src/features/space/schema.ts
@@ -6,6 +6,10 @@ export type MemberRole = z.infer<typeof memberRoleSchema>;
 export const spaceTierSchema = z.enum(["hobby", "pro"]);
 export type SpaceTier = z.infer<typeof spaceTierSchema>;
 
+export const createSpaceSchema = z.object({
+  name: z.string().min(1).max(100),
+});
+
 export const updateSpaceSchema = z.object({
   name: z.string().min(1).max(100).optional(),
   primaryColor: z

--- a/apps/web/src/trpc/routers/spaces.ts
+++ b/apps/web/src/trpc/routers/spaces.ts
@@ -5,16 +5,10 @@ import * as z from "zod";
 import { createSpaceDTO } from "@/features/space/data";
 import { defineAbilityForMember } from "@/features/space/member/ability";
 import { effectiveSpaceMemberWhere } from "@/features/space/member/utils";
-import { createSpace } from "@/features/space/mutations";
 import type { SpaceDTO } from "@/features/space/types";
 import { fromDBRole } from "@/features/space/utils";
-import { identifyGroup, track } from "@/lib/posthog";
-import {
-  createRateLimitMiddleware,
-  privateProcedure,
-  router,
-  spaceProcedure,
-} from "../trpc";
+import { track } from "@/lib/posthog";
+import { privateProcedure, router, spaceProcedure } from "../trpc";
 
 export const spaces = router({
   // ── Queries ──────────────────────────────────────────────────────────
@@ -127,39 +121,6 @@ export const spaces = router({
     }));
   }),
   // ── Mutations ────────────────────────────────────────────────────────
-  create: privateProcedure
-    .use(createRateLimitMiddleware("space_create", 5, "1 m"))
-    .input(z.object({ name: z.string().min(1).max(100) }))
-    .mutation(async ({ ctx, input }) => {
-      const space = await createSpace({
-        name: input.name,
-        ownerId: ctx.user.id,
-      });
-
-      identifyGroup({
-        groupType: "space",
-        groupKey: space.id,
-        properties: {
-          name: space.name,
-          member_count: 1,
-          seat_count: 1,
-          tier: "hobby",
-        },
-      });
-
-      track(ctx.user, {
-        event: "space_create",
-        properties: {
-          space_name: space.name,
-        },
-        groups: {
-          space: space.id,
-        },
-      });
-
-      return space;
-    }),
-
   delete: spaceProcedure.mutation(async ({ ctx }) => {
     const memberAbility = defineAbilityForMember({
       user: ctx.user,


### PR DESCRIPTION
## What

When creating a space from the space dropdown, the dialog now stays open until the space is created and the app has switched to it, then closes. Previously the dialog closed immediately on submit while the create mutation ran fire-and-forget, so the UI kept showing the old active space until the next refresh.

Also migrates `spaces.create` from a tRPC mutation to a `createSpaceAction` server action, aligning with the "tRPC is queries only — writes are server actions" convention.

## Why

`createSpace` already stamps `lastSelectedAt` on the new owner member row, so the new space is the active space server-side (active space = newest `lastSelectedAt`). The only gap was client-side: nothing refreshed the server components before the dialog closed. Awaiting the action via `useSafeAction` (which runs `router.refresh()` on success) makes the switch visible before dismissing.

## Changes

- **Add `createSpaceAction`** (`features/space/actions.ts`) — auth server action, preserves the `create_space` 5/min rate limit, carries over the `identifyGroup` / `track("space_create")` calls, returns the space DTO.
- **Rewrite `CreateSpaceDialog`** — `await createSpace.executeAsync({ name })`; close + reset only on success (`result?.data`). The submit button spins through create + refresh. On failure the dialog stays open with the standard error toast.
- **Delete `spaces.create`** tRPC mutation and prune now-unused imports (`createSpace`, `identifyGroup`, `createRateLimitMiddleware`).

## Reviewer notes

- No behavioral change to `setActiveSpaceAction` (still used by the dropdown radio switch) — the new space is made active implicitly via `createSpace`'s `lastSelectedAt`, not a separate switch call.
- Verified: `pnpm type-check` and `pnpm check` pass; no remaining references to `trpc.spaces.create`.
- Manual browser smoke test not run (no dev environment in this session).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a secure space-creation flow with validated input and request rate limiting.
  * Space creation now logs product analytics for created spaces.
  * Updated the space creation dialog to submit via the authenticated action flow and automatically close/reset after success.
* **Bug Fixes**
  * Improved space creation consistency by removing the previous tRPC-based submission path.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->