### PR TITLE
🐛 Fix week calendar scrolling first selected slot to top

### DIFF
--- a/apps/web/src/features/poll/components/forms/poll-options-form/week-calendar.tsx
+++ b/apps/web/src/features/poll/components/forms/poll-options-form/week-calendar.tsx
@@ -22,7 +22,7 @@ import { useDateTime, useDateTimeConfig } from "@/lib/datetime/client";
 import { getBrowserTimeZone } from "@/lib/utils/date-time-utils";
 
 import DateNavigationToolbar from "./date-navigation-toolbar";
-import type { DateTimePickerProps } from "./types";
+import type { DateTimePickerProps, TimeOption } from "./types";
 import {
   DURATION_CAP_MINUTES,
   durationMinutes,
@@ -117,9 +117,19 @@ const WeekCalendar: React.FunctionComponent<DateTimePickerProps> = ({
   // biome-ignore lint/correctness/useExhaustiveDependencies: mount-only, reads latest options
   React.useEffect(() => {
     hasScrolledRef.current = true;
-    const firstSlot = options.find((option) => option.type === "timeSlot");
-    if (firstSlot) {
-      apiRef.current?.scrollToTime(new Date(firstSlot.start));
+    // `options` is in selection order, not chronological, so pick the earliest
+    // slot by start time. The naive `YYYY-MM-DDTHH:mm:ss` strings are
+    // fixed-width, so lexicographic min equals chronological min.
+    const earliestSlot = options.reduce<TimeOption | undefined>(
+      (earliest, option) =>
+        option.type === "timeSlot" &&
+        (!earliest || option.start < earliest.start)
+          ? option
+          : earliest,
+      undefined,
+    );
+    if (earliestSlot) {
+      apiRef.current?.scrollToTime(new Date(earliestSlot.start));
     }
   }, []);
 

--- a/apps/web/src/features/poll/components/forms/poll-options-form/week-calendar.tsx
+++ b/apps/web/src/features/poll/components/forms/poll-options-form/week-calendar.tsx
@@ -110,14 +110,18 @@ const WeekCalendar: React.FunctionComponent<DateTimePickerProps> = ({
     [formatDateTimeRange, formatTime],
   );
 
+  // Scroll to the earliest pre-existing slot exactly once, on mount, so the
+  // calendar opens on the user's existing options. Slots the user adds
+  // interactively must NOT trigger this — otherwise the first slot they select
+  // gets yanked to the top of the viewport.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: mount-only, reads latest options
   React.useEffect(() => {
-    if (hasScrolledRef.current) return;
+    hasScrolledRef.current = true;
     const firstSlot = options.find((option) => option.type === "timeSlot");
     if (firstSlot) {
-      hasScrolledRef.current = true;
       apiRef.current?.scrollToTime(new Date(firstSlot.start));
     }
-  }, [options]);
+  }, []);
 
   const handleSelectSlot = (slot: EventCalendarSlotDraft) => {
     // The all-day lane is a timed picker's dead zone: it would commit


### PR DESCRIPTION
## Description

When selecting a time slot in the week/day calendar poll picker, the **first** slot selected caused the scroll area to jump so that the new slot landed at the top of the viewport — disorienting, since the user had just clicked where they wanted it.

**Cause:** the mount-scroll effect in `week-calendar.tsx` was meant to scroll to the earliest pre-existing option once, on open. It was guarded by `hasScrolledRef`, but only set the flag *after* finding a slot. On an empty calendar no slot exists at mount, so the flag never flipped. The effect also depended on `[options]`, so the moment the user selected their first slot, `options` changed, the effect re-ran with the guard still `false`, and it scrolled that just-created slot to the top.

**Fix:** make the effect genuinely mount-only (`[]` deps) and set the flag unconditionally at the top. It now scrolls to a pre-existing option exactly once when the calendar opens, and never reacts to slots the user adds interactively.

The child time-grid registers its scroll handler in its own mount effect; child effects run before parent effects, so `apiRef.current?.scrollToTime` in this parent mount effect still lands after the handler is registered — same ordering the original code relied on.

## Checklist

- [x] I have performed a self-review of my code
- [x] My code follows the code style of this project
- [x] I have commented my code, particularly in hard-to-understand areas

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the weekly calendar’s initial positioning by scrolling to the earliest available time slot only when the form first opens.
  * Prevented the calendar from re-scrolling unexpectedly during later updates by restricting the behavior to the initial render.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->