### PR TITLE
🔒 Show "create your own poll" CTA on cloud only

### DIFF
--- a/apps/web/src/features/poll/components/new-participant-modal.tsx
+++ b/apps/web/src/features/poll/components/new-participant-modal.tsx
@@ -23,6 +23,7 @@ import { CircleCheckIcon } from "lucide-react";
 import Link from "next/link";
 import { useForm } from "react-hook-form";
 import * as z from "zod";
+import { IfCloudHosted } from "@/components/environment";
 import { usePoll } from "@/features/poll/client";
 import { useAddParticipantMutation } from "@/features/poll/components/mutations";
 import VoteIcon from "@/features/poll/components/vote-icon";
@@ -166,37 +167,39 @@ export const NewParticipantForm = (props: NewParticipantModalProps) => {
             defaults="Back to poll"
           />
         </Button>
-        <div className="flex flex-col items-center text-center">
-          <p className="text-muted-foreground text-sm">
-            <Trans
-              i18nKey="newParticipantDialogCreatePollPrompt"
-              defaults="Need to schedule something yourself?"
-            />
-          </p>
-          <Link
-            href="/new"
-            className={buttonVariants({ variant: "link" })}
-            onClick={() => {
-              posthog?.capture(
-                "new_participant_dialog:create_poll_button_click",
-                {
-                  pollId: poll.id,
-                  spaceId: poll.spaceId,
-                  tier: poll.space?.tier,
-                  $groups: {
-                    poll: poll.id,
-                    ...(poll.spaceId ? { space: poll.spaceId } : {}),
+        <IfCloudHosted>
+          <div className="flex flex-col items-center text-center">
+            <p className="text-muted-foreground text-sm">
+              <Trans
+                i18nKey="newParticipantDialogCreatePollPrompt"
+                defaults="Need to schedule something yourself?"
+              />
+            </p>
+            <Link
+              href="/new"
+              className={buttonVariants({ variant: "link" })}
+              onClick={() => {
+                posthog?.capture(
+                  "new_participant_dialog:create_poll_button_click",
+                  {
+                    pollId: poll.id,
+                    spaceId: poll.spaceId,
+                    tier: poll.space?.tier,
+                    $groups: {
+                      poll: poll.id,
+                      ...(poll.spaceId ? { space: poll.spaceId } : {}),
+                    },
                   },
-                },
-              );
-            }}
-          >
-            <Trans
-              i18nKey="newParticipantDialogCreatePoll"
-              defaults="Create your own poll"
-            />
-          </Link>
-        </div>
+                );
+              }}
+            >
+              <Trans
+                i18nKey="newParticipantDialogCreatePoll"
+                defaults="Create your own poll"
+              />
+            </Link>
+          </div>
+        </IfCloudHosted>
       </>
     );
   }


### PR DESCRIPTION
## Summary

The post-vote "Create your own poll" prompt (added in #2734) was showing on all deployments. It should only appear on the cloud version of Rallly.

This wraps the prompt in the `<IfCloudHosted>` component so it is hidden on self-hosted instances.

## Changes

- `new-participant-modal.tsx`: wrap the create poll CTA block in `<IfCloudHosted>`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the participant invitation success screen to show the “Create your own poll” prompt only in cloud-hosted environments.
  * Preserved existing analytics tracking and link behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->