### PR TITLE
✨ Accept wall-clock datetimes in API poll slot times

### DIFF
--- a/apps/web/src/app/api/private/examples.ts
+++ b/apps/web/src/app/api/private/examples.ts
@@ -18,7 +18,7 @@ export const createPollRequestExamples = {
   timePoll: {
     summary: "Time poll (explicit times)",
     description:
-      "Use `slots` with ISO datetime strings to offer specific time slots. Times are UTC and displayed to participants in the poll's `timezone`.",
+      "Use `slots` with ISO datetime strings to offer specific time slots. Datetimes without an offset are interpreted as wall-clock in the poll's `timezone` — the example below offers 09:00 and 14:00 in London. Append `Z` or an offset to specify an absolute instant instead.",
     value: {
       title: "Project kickoff",
       location: "Zoom",
@@ -26,9 +26,9 @@ export const createPollRequestExamples = {
         duration: 60,
         timezone: "Europe/London",
         times: [
-          "2026-08-03T09:00:00Z",
-          "2026-08-03T14:00:00Z",
-          "2026-08-04T09:00:00Z",
+          "2026-08-03T09:00:00",
+          "2026-08-03T14:00:00",
+          "2026-08-04T09:00:00",
         ],
       },
     } satisfies CreatePollInput,
@@ -65,7 +65,7 @@ export const createPollRequestExamples = {
         duration: 90,
         timezone: "Europe/Berlin",
         times: [
-          "2026-08-01T10:00:00Z",
+          "2026-08-01T10:00:00",
           {
             startDate: "2026-08-03",
             endDate: "2026-08-05",

--- a/apps/web/src/app/api/private/schemas.ts
+++ b/apps/web/src/app/api/private/schemas.ts
@@ -33,7 +33,7 @@ const slotsInputSchema = z
     }),
     timezone: timezoneSchema.optional().openapi({
       description:
-        "IANA timezone. Datetime strings without an offset are interpreted in this timezone. If omitted, offset-less datetimes are treated as floating times (UTC).",
+        "IANA timezone. Datetime strings without an offset are interpreted in this timezone. If omitted, offset-less datetimes are treated as floating times (no timezone conversion) and the poll has no timezone set.",
       example: "Europe/London",
     }),
     times: z

--- a/apps/web/src/app/api/private/schemas.ts
+++ b/apps/web/src/app/api/private/schemas.ts
@@ -33,15 +33,16 @@ const slotsInputSchema = z
     }),
     timezone: timezoneSchema.optional().openapi({
       description:
-        "IANA timezone. If not provided, times will be stored as UTC and no timezone will be set on the poll (indicating floating times).",
+        "IANA timezone. Datetime strings without an offset are interpreted in this timezone. If omitted, offset-less datetimes are treated as floating times (UTC).",
       example: "Europe/London",
     }),
     times: z
       .array(
         z.union([
-          z.iso.datetime().openapi({
-            description: "ISO datetime start time",
-            example: "2025-01-15T09:00:00Z",
+          z.iso.datetime({ local: true, offset: true }).openapi({
+            description:
+              "ISO datetime start time. Strings without an offset are interpreted as wall-clock in `timezone` (e.g. `2025-01-15T09:00:00` with `timezone: Europe/London` means 09:00 in London). Strings with an offset or `Z` are treated as absolute instants.",
+            example: "2025-01-15T09:00:00",
           }),
           slotGeneratorSchema,
         ]),


### PR DESCRIPTION
## Summary
- `slots.times` in the private API only accepted UTC-suffixed strings (`z.iso.datetime()` default). Callers had to pre-convert to UTC even though `slots.timezone` already declared the intended zone, and the misleading example encouraged mixing 09:00Z with `timezone: "Europe/London"` (which actually means 10:00 in London).
- The parser at `apps/web/src/app/api/private/utils/time-slots.ts` has always supported the wall-clock case — `dayjs(value).tz(timeZone, true)` when there is no offset. Only the schema was gating those inputs (and existing tests at `time-slots.test.ts:21` cover the branch).
- Loosen the schema to `z.iso.datetime({ local: true, offset: true })` and rewrite the `timePoll` / `mixedTimes` examples to use wall-clock times.

Semantics:
- `"2026-08-03T09:00:00"` + `timezone: "Europe/London"` → 09:00 London (parsed as wall-clock in the poll's timezone).
- `"2026-08-03T09:00:00Z"` or `+02:00` → absolute instant, timezone becomes display-only.
- No timezone → floating time (unchanged).

## Test plan
- [x] `pnpm test:unit src/app/api/private/utils/time-slots.test.ts` — all 18 tests pass; the existing "datetime without offset using provided timezone" case now reaches production via the API.
- [ ] Manually POST to `/api/v1/polls` with a wall-clock `times` array + `timezone` and verify the created poll options land at the expected instants.
- [ ] Verify OpenAPI docs render the new description and wall-clock example.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified ISO datetime handling: values without an offset are interpreted as wall-clock times in the provided `timezone`, while datetimes with an explicit offset or `Z` represent absolute instants.
  * Updated `timePoll` and `mixedTimes` examples to use offset-less local datetime strings where appropriate.
  * Refined timezone-related validation and API documentation to reflect floating-time behavior when `timezone` is omitted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->