### PR TITLE
♿ Give CommandDialog a default accessible name

### DIFF
--- a/apps/web/src/features/navigation/components/command-menu/command-menu.tsx
+++ b/apps/web/src/features/navigation/components/command-menu/command-menu.tsx
@@ -8,7 +8,7 @@ import {
   CommandItem,
   CommandList,
 } from "@rallly/ui/command";
-import { DialogDescription, DialogTitle, useDialog } from "@rallly/ui/dialog";
+import { useDialog } from "@rallly/ui/dialog";
 import { Icon } from "@rallly/ui/icon";
 import { PlusIcon } from "lucide-react";
 import { useRouter } from "next/navigation";
@@ -49,13 +49,13 @@ export function CommandMenu() {
   return (
     <>
       <CommandGlobalShortcut trigger={trigger} />
-      <CommandDialog {...dialogProps}>
-        <DialogTitle className="sr-only">
-          <Trans i18nKey="commandMenu" defaults="Command Menu" />
-        </DialogTitle>
-        <DialogDescription className="sr-only">
+      <CommandDialog
+        {...dialogProps}
+        title={<Trans i18nKey="commandMenu" defaults="Command Menu" />}
+        description={
           <Trans i18nKey="commandMenuDescription" defaults="Select a command" />
-        </DialogDescription>
+        }
+      >
         <CommandInput
           autoFocus={true}
           placeholder={t("commandMenuSearchPlaceholder", {

--- a/packages/ui/src/command.tsx
+++ b/packages/ui/src/command.tsx
@@ -5,7 +5,12 @@ import { SearchIcon } from "lucide-react";
 import * as React from "react";
 
 import type { DialogProps } from "./dialog";
-import { Dialog, DialogContent } from "./dialog";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogTitle,
+} from "./dialog";
 import { usePlatform } from "./hooks/use-platform";
 import { Icon } from "./icon";
 import { cn } from "./lib/utils";
@@ -25,12 +30,30 @@ const Command = React.forwardRef<
 ));
 Command.displayName = CommandPrimitive.displayName;
 
-type CommandDialogProps = DialogProps;
+type CommandDialogProps = DialogProps & {
+  /** Accessible name for the dialog. Rendered visually hidden by default so the
+   *  dialog always has a name; pass `null` to supply your own `DialogTitle`. */
+  title?: React.ReactNode;
+  description?: React.ReactNode;
+};
 
-const CommandDialog = ({ children, ...props }: CommandDialogProps) => {
+const CommandDialog = ({
+  children,
+  title = "Command Menu",
+  description,
+  ...props
+}: CommandDialogProps) => {
   return (
     <Dialog {...props}>
       <DialogContent showCloseButton={false} size="xl" className="p-0">
+        {title != null && (
+          <DialogTitle className="sr-only">{title}</DialogTitle>
+        )}
+        {description != null && (
+          <DialogDescription className="sr-only">
+            {description}
+          </DialogDescription>
+        )}
         <Command className="[&_[cmdk-group]:not([hidden])_~[cmdk-group]]:pt-0 [&_[cmdk-input-wrapper]_svg]:size-4 [&_[cmdk-item]_svg]:size-4 [[cmdk-group-heading]]:**:px-2 [[cmdk-group-heading]]:**:font-medium [[cmdk-group-heading]]:**:text-muted-foreground [[cmdk-group]]:**:px-2 [[cmdk-input]]:**:h-12 [[cmdk-item]]:**:p-2">
           {children}
         </Command>


### PR DESCRIPTION
## What

`CommandDialog` now renders a visually-hidden `DialogTitle` (and optional `DialogDescription`) by default, so every command menu built on it has an accessible name even if a consumer forgets to pass one. Both are overridable via new `title`/`description` props, and `title={null}` opts out when a consumer supplies its own.

The app's command menu (`command-menu.tsx`) now passes its translated strings through these props instead of rendering redundant `sr-only` children.

## Why

A shadscan a11y audit of `@rallly/ui` flagged `dialogs-have-accessible-names`: the `CommandDialog` primitive rendered `DialogContent` with no title, so any dialog built on it without an explicit title is unnamed for screen readers (and warns at runtime in base-ui). This makes the primitive safe by default rather than relying on every call site to remember.

## Scope note

The audit graded the package **40/100 (F)**, but almost all of that is an artifact of scanning a headless component library with an application ruleset — it looked for an app shell (error boundary, favicon, metadata, mounted toaster/command-menu/theme-hotkey) that lives in `apps/web`, not in the primitives package. This PR fixes the one genuine library-level defect; it does not add app-shell infrastructure to the library.

## Verification

- `pnpm --dir ./packages/ui check` — pass
- `pnpm --dir ./packages/ui test:unit` — pass (15 tests)
- `pnpm --dir ./apps/web type-check` — pass
- shadscan `dialogs-have-accessible-names`: `fail → advisory`, no other finding changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility**
  * Improved screen reader support for the command menu dialog with accessible titles and descriptions.
  * Added a default dialog title while preserving localized custom labels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->