### PR TITLE
♿️ Announce vote changes to screen readers

### DIFF
--- a/apps/web/src/features/poll/components/desktop-poll/participant-row-form.tsx
+++ b/apps/web/src/features/poll/components/desktop-poll/participant-row-form.tsx
@@ -130,6 +130,9 @@ const ParticipantRowForm = ({
                     value={field.value?.type}
                     onChange={(vote) => {
                       field.onChange({ optionId, type: vote });
+                      if (option) {
+                        form.announce(getOptionDateTimeLabel(option), vote);
+                      }
                     }}
                   />
                 </div>

--- a/apps/web/src/features/poll/components/desktop-poll/participant-row-form.tsx
+++ b/apps/web/src/features/poll/components/desktop-poll/participant-row-form.tsx
@@ -130,6 +130,9 @@ const ParticipantRowForm = ({
                     value={field.value?.type}
                     onChange={(vote) => {
                       field.onChange({ optionId, type: vote });
+                      if (option) {
+                        form.announce(getOptionAnnouncementLabel(option), vote);
+                      }
                     }}
                   />
                 </div>

--- a/apps/web/src/features/poll/components/desktop-poll/participant-row-form.tsx
+++ b/apps/web/src/features/poll/components/desktop-poll/participant-row-form.tsx
@@ -14,7 +14,10 @@ import { useOptions, usePoll } from "@/features/poll/components/poll-context";
 import { useVotingForm } from "@/features/poll/components/voting-form";
 import { YouAvatar } from "@/features/poll/components/you-avatar";
 import { Trans, useTranslation } from "@/i18n/client";
-import { getOptionDateTimeLabel } from "@/lib/utils/date-time-utils";
+import {
+  getOptionAnnouncementLabel,
+  getOptionDateTimeLabel,
+} from "@/lib/utils/date-time-utils";
 import { VoteSelector } from "../vote-selector";
 
 export interface ParticipantRowFormProps {
@@ -131,7 +134,7 @@ const ParticipantRowForm = ({
                     onChange={(vote) => {
                       field.onChange({ optionId, type: vote });
                       if (option) {
-                        form.announce(getOptionDateTimeLabel(option), vote);
+                        form.announce(getOptionAnnouncementLabel(option), vote);
                       }
                     }}
                   />

--- a/apps/web/src/features/poll/components/desktop-poll/participant-row-form.tsx
+++ b/apps/web/src/features/poll/components/desktop-poll/participant-row-form.tsx
@@ -130,9 +130,6 @@ const ParticipantRowForm = ({
                     value={field.value?.type}
                     onChange={(vote) => {
                       field.onChange({ optionId, type: vote });
-                      if (option) {
-                        form.announce(getOptionAnnouncementLabel(option), vote);
-                      }
                     }}
                   />
                 </div>

--- a/apps/web/src/features/poll/components/desktop-poll/participant-row-form.tsx
+++ b/apps/web/src/features/poll/components/desktop-poll/participant-row-form.tsx
@@ -14,10 +14,7 @@ import { useOptions, usePoll } from "@/features/poll/components/poll-context";
 import { useVotingForm } from "@/features/poll/components/voting-form";
 import { YouAvatar } from "@/features/poll/components/you-avatar";
 import { Trans, useTranslation } from "@/i18n/client";
-import {
-  getOptionAnnouncementLabel,
-  getOptionDateTimeLabel,
-} from "@/lib/utils/date-time-utils";
+import { getOptionAnnouncementLabel } from "@/lib/utils/date-time-utils";
 import { VoteSelector } from "../vote-selector";
 
 export interface ParticipantRowFormProps {
@@ -128,7 +125,7 @@ const ParticipantRowForm = ({
                   <VoteSelector
                     className="after:absolute after:inset-0"
                     optionLabel={
-                      option ? getOptionDateTimeLabel(option) : undefined
+                      option ? getOptionAnnouncementLabel(option) : undefined
                     }
                     value={field.value?.type}
                     onChange={(vote) => {

--- a/apps/web/src/features/poll/components/desktop-poll/poll-header.tsx
+++ b/apps/web/src/features/poll/components/desktop-poll/poll-header.tsx
@@ -21,7 +21,15 @@ const TimeRange: React.FunctionComponent<{
     >
       <span data-testid="option-start-time">{start}</span>
       <Tooltip>
-        <TooltipTrigger delay={0} className="flex items-center gap-x-1">
+        <TooltipTrigger
+          delay={0}
+          // Display-only: the duration is not an interactive control, so keep
+          // it out of the tab order — otherwise every option header is a tab
+          // stop that only reads the duration.
+          tabIndex={-1}
+          render={<span />}
+          className="flex items-center gap-x-1"
+        >
           <ClockIcon className="size-3" />
           {duration}
         </TooltipTrigger>

--- a/apps/web/src/features/poll/components/mobile-poll/poll-options.tsx
+++ b/apps/web/src/features/poll/components/mobile-poll/poll-options.tsx
@@ -20,7 +20,7 @@ const PollOptions: React.FunctionComponent<PollOptions> = ({
   editable,
   selectedParticipantId,
 }) => {
-  const { control } = useVotingForm();
+  const { control, announce } = useVotingForm();
   const { getScore, getVote, optionIds } = usePoll();
   const { participants: allParticipants } = useParticipants();
   const selectedParticipant = selectedParticipantId
@@ -52,6 +52,7 @@ const PollOptions: React.FunctionComponent<PollOptions> = ({
                 const newValue = [...field.value];
                 newValue[index] = { optionId: option.optionId, type: newVote };
                 field.onChange(newValue);
+                announce(getOptionDateTimeLabel(option), newVote);
               };
 
               switch (option.type) {

--- a/apps/web/src/features/poll/components/mobile-poll/poll-options.tsx
+++ b/apps/web/src/features/poll/components/mobile-poll/poll-options.tsx
@@ -20,7 +20,7 @@ const PollOptions: React.FunctionComponent<PollOptions> = ({
   editable,
   selectedParticipantId,
 }) => {
-  const { control, announce } = useVotingForm();
+  const { control } = useVotingForm();
   const { getScore, getVote, optionIds } = usePoll();
   const { participants: allParticipants } = useParticipants();
   const selectedParticipant = selectedParticipantId
@@ -52,7 +52,6 @@ const PollOptions: React.FunctionComponent<PollOptions> = ({
                 const newValue = [...field.value];
                 newValue[index] = { optionId: option.optionId, type: newVote };
                 field.onChange(newValue);
-                announce(getOptionAnnouncementLabel(option), newVote);
               };
 
               switch (option.type) {

--- a/apps/web/src/features/poll/components/mobile-poll/poll-options.tsx
+++ b/apps/web/src/features/poll/components/mobile-poll/poll-options.tsx
@@ -5,7 +5,10 @@ import { useParticipants } from "@/features/poll/components/participants-provide
 import { usePoll } from "@/features/poll/components/poll-context";
 import { useVotingForm } from "@/features/poll/components/voting-form";
 import type { ParsedDateTimeOpton } from "@/lib/utils/date-time-utils";
-import { getOptionDateTimeLabel } from "@/lib/utils/date-time-utils";
+import {
+  getOptionAnnouncementLabel,
+  getOptionDateTimeLabel,
+} from "@/lib/utils/date-time-utils";
 import DateOption from "./date-option";
 import TimeSlotOption from "./time-slot-option";
 
@@ -52,7 +55,7 @@ const PollOptions: React.FunctionComponent<PollOptions> = ({
                 const newValue = [...field.value];
                 newValue[index] = { optionId: option.optionId, type: newVote };
                 field.onChange(newValue);
-                announce(getOptionDateTimeLabel(option), newVote);
+                announce(getOptionAnnouncementLabel(option), newVote);
               };
 
               switch (option.type) {

--- a/apps/web/src/features/poll/components/mobile-poll/poll-options.tsx
+++ b/apps/web/src/features/poll/components/mobile-poll/poll-options.tsx
@@ -5,10 +5,7 @@ import { useParticipants } from "@/features/poll/components/participants-provide
 import { usePoll } from "@/features/poll/components/poll-context";
 import { useVotingForm } from "@/features/poll/components/voting-form";
 import type { ParsedDateTimeOpton } from "@/lib/utils/date-time-utils";
-import {
-  getOptionAnnouncementLabel,
-  getOptionDateTimeLabel,
-} from "@/lib/utils/date-time-utils";
+import { getOptionAnnouncementLabel } from "@/lib/utils/date-time-utils";
 import DateOption from "./date-option";
 import TimeSlotOption from "./time-slot-option";
 
@@ -64,7 +61,7 @@ const PollOptions: React.FunctionComponent<PollOptions> = ({
                     <TimeSlotOption
                       onChange={handleChange}
                       optionId={option.optionId}
-                      optionLabel={getOptionDateTimeLabel(option)}
+                      optionLabel={getOptionAnnouncementLabel(option)}
                       yesScore={score.yes}
                       ifNeedBeScore={score.ifNeedBe}
                       vote={vote}
@@ -80,7 +77,7 @@ const PollOptions: React.FunctionComponent<PollOptions> = ({
                     <DateOption
                       onChange={handleChange}
                       optionId={option.optionId}
-                      optionLabel={getOptionDateTimeLabel(option)}
+                      optionLabel={getOptionAnnouncementLabel(option)}
                       yesScore={score.yes}
                       ifNeedBeScore={score.ifNeedBe}
                       vote={vote}

--- a/apps/web/src/features/poll/components/mobile-poll/poll-options.tsx
+++ b/apps/web/src/features/poll/components/mobile-poll/poll-options.tsx
@@ -20,7 +20,7 @@ const PollOptions: React.FunctionComponent<PollOptions> = ({
   editable,
   selectedParticipantId,
 }) => {
-  const { control } = useVotingForm();
+  const { control, announce } = useVotingForm();
   const { getScore, getVote, optionIds } = usePoll();
   const { participants: allParticipants } = useParticipants();
   const selectedParticipant = selectedParticipantId
@@ -52,6 +52,7 @@ const PollOptions: React.FunctionComponent<PollOptions> = ({
                 const newValue = [...field.value];
                 newValue[index] = { optionId: option.optionId, type: newVote };
                 field.onChange(newValue);
+                announce(getOptionAnnouncementLabel(option), newVote);
               };
 
               switch (option.type) {

--- a/apps/web/src/features/poll/components/poll-context.test.ts
+++ b/apps/web/src/features/poll/components/poll-context.test.ts
@@ -73,6 +73,11 @@ describe("createOptionsContextValue — time slots", () => {
       month: "Jul",
       year: "2026",
     });
+    // Normalize whitespace: the meridiem separator varies by ICU version.
+    const option = result.options[0];
+    if (option.type !== "timeSlot") throw new Error("expected a time slot");
+    expect(option.speechStartTime.replace(/\s+/g, " ")).toBe("2 PM");
+    expect(option.speechEndTime.replace(/\s+/g, " ")).toBe("3 PM");
   });
 
   it("shows floating times as stored, ignoring the viewer's zone", () => {

--- a/apps/web/src/features/poll/components/poll-context.tsx
+++ b/apps/web/src/features/poll/components/poll-context.tsx
@@ -7,6 +7,7 @@ import {
   formatDateParts,
   formatDateTime,
   formatDuration,
+  formatSpeechTime,
 } from "@/lib/datetime/format";
 import type {
   ParsedDateOption,
@@ -166,6 +167,16 @@ export function createOptionsContextValue({
           }),
           endTime: formatDateTime(endTime, {
             preset: "time",
+            locale,
+            timeFormat,
+            timeZone: displayTimeZone,
+          }),
+          speechStartTime: formatSpeechTime(option.startTime, {
+            locale,
+            timeFormat,
+            timeZone: displayTimeZone,
+          }),
+          speechEndTime: formatSpeechTime(endTime, {
             locale,
             timeFormat,
             timeZone: displayTimeZone,

--- a/apps/web/src/features/poll/components/vote-selector.tsx
+++ b/apps/web/src/features/poll/components/vote-selector.tsx
@@ -9,15 +9,11 @@ import VoteIcon from "./vote-icon";
 export interface VoteSelectorProps {
   value?: VoteType;
   /**
-   * Accessible description of the option being voted on (e.g. "Tue 30 Jun
-   * 2026, 1:00 PM – 2:00 PM") so screen readers can tie the vote to its
-   * date/time.
+   * Accessible name for the group (e.g. "Tue 30 Jun, 1 PM – 2 PM") so screen
+   * readers can tie the vote to its date/time.
    */
   optionLabel?: string;
   onChange?: (value: VoteType) => void;
-  onFocus?: React.FocusEventHandler<HTMLButtonElement>;
-  onBlur?: React.FocusEventHandler<HTMLButtonElement>;
-  onKeyDown?: React.KeyboardEventHandler<HTMLButtonElement>;
   className?: string;
 }
 
@@ -30,46 +26,104 @@ export const toggleVote = (value?: VoteType) => {
   ];
 };
 
-export const VoteSelector = React.forwardRef<
-  HTMLButtonElement,
-  VoteSelectorProps
->(function VoteSelector(
-  { value, optionLabel, onChange, onFocus, onBlur, onKeyDown, className },
-  ref,
-) {
+/**
+ * A tri-state vote control. Visually a single square that cycles yes → if need
+ * be → no on click, but implemented as an ARIA radio group so screen readers
+ * announce the selected value natively (a changed aria-label on the focused
+ * element is not re-announced; a radio selection change is). Only the checked
+ * radio is visible; arrow keys move selection, which moves both visibility and
+ * focus, so the control always looks like one square.
+ */
+export const VoteSelector = ({
+  value,
+  optionLabel,
+  onChange,
+  className,
+}: VoteSelectorProps) => {
   const { t } = useTranslation();
 
-  const voteLabel = (() => {
-    switch (value) {
-      case "yes":
-        return t("yes", { defaultValue: "Yes" });
-      case "ifNeedBe":
-        return t("ifNeedBe", { defaultValue: "If need be" });
-      case "no":
-        return t("no", { defaultValue: "No" });
-      default:
-        return t("pending", { defaultValue: "Pending" });
+  const voteLabels: Record<VoteType, string> = {
+    yes: t("yes", { defaultValue: "Yes" }),
+    ifNeedBe: t("ifNeedBe", { defaultValue: "If need be" }),
+    no: t("no", { defaultValue: "No" }),
+  };
+
+  // With no vote yet, the first radio is the keyboard entry point.
+  const focusedType = value ?? orderedVoteTypes[0];
+
+  const groupRef = React.useRef<HTMLDivElement>(null);
+  const visibleRef = React.useRef<HTMLButtonElement>(null);
+
+  // Selection moves visibility to a different radio, so keep DOM focus on the
+  // visible one — but only when focus is already inside the group, so a mouse
+  // click or a programmatic change never steals focus. `value` is the trigger:
+  // the effect re-runs on selection change and re-homes focus to the new radio.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: value is the trigger, not a read
+  React.useEffect(() => {
+    const group = groupRef.current;
+    if (group?.contains(document.activeElement)) {
+      visibleRef.current?.focus();
     }
-  })();
+  }, [value]);
 
   return (
-    <button
-      data-testid="vote-selector"
-      type="button"
-      aria-label={optionLabel ? `${optionLabel}, ${voteLabel}` : voteLabel}
-      onFocus={onFocus}
-      onBlur={onBlur}
-      onKeyDown={onKeyDown}
-      className={cn(
-        "flex size-7 cursor-pointer items-center justify-center rounded-lg border border-input bg-background ring-ring focus-visible:ring-2",
-        className,
-      )}
-      onClick={() => {
-        onChange?.(value ? toggleVote(value) : orderedVoteTypes[0]);
-      }}
-      ref={ref}
+    <div
+      ref={groupRef}
+      role="radiogroup"
+      aria-label={optionLabel}
+      className="flex items-center justify-center"
     >
-      <VoteIcon type={value} />
-    </button>
+      {orderedVoteTypes.map((type) => {
+        const checked = value === type;
+        // The checked radio (or the first, before any vote) is the visible,
+        // clickable square; the others exist only for the a11y tree.
+        const visible = value ? checked : type === focusedType;
+        return (
+          // biome-ignore lint/a11y/useSemanticElements: a native radio input can't be styled to this stacked single-square control; role="radio" buttons are the ARIA APG custom radio group pattern
+          <button
+            key={type}
+            ref={visible ? visibleRef : undefined}
+            data-testid={visible ? "vote-selector" : undefined}
+            type="button"
+            role="radio"
+            aria-checked={checked}
+            aria-label={voteLabels[type]}
+            tabIndex={type === focusedType ? 0 : -1}
+            className={cn(
+              visible
+                ? cn(
+                    "flex size-7 cursor-pointer items-center justify-center rounded-lg border border-input bg-background ring-ring focus-visible:ring-2",
+                    className,
+                  )
+                : "sr-only",
+            )}
+            onClick={() => {
+              // Click cycles rather than selecting this specific value, matching
+              // the original toggle: the only visible target is the current one.
+              onChange?.(toggleVote(value));
+            }}
+            onKeyDown={(event) => {
+              const delta =
+                event.key === "ArrowRight" || event.key === "ArrowDown"
+                  ? 1
+                  : event.key === "ArrowLeft" || event.key === "ArrowUp"
+                    ? -1
+                    : 0;
+              if (delta === 0) return;
+              event.preventDefault();
+              const current = orderedVoteTypes.indexOf(focusedType);
+              const next =
+                orderedVoteTypes[
+                  (current + delta + orderedVoteTypes.length) %
+                    orderedVoteTypes.length
+                ];
+              onChange?.(next);
+            }}
+          >
+            {visible ? <VoteIcon type={value} /> : voteLabels[type]}
+          </button>
+        );
+      })}
+    </div>
   );
-});
+};

--- a/apps/web/src/features/poll/components/vote-selector.tsx
+++ b/apps/web/src/features/poll/components/vote-selector.tsx
@@ -1,6 +1,5 @@
 import type { VoteType } from "@rallly/database";
 import { cn } from "@rallly/ui";
-import * as React from "react";
 
 import { useTranslation } from "@/i18n/client";
 
@@ -9,8 +8,8 @@ import VoteIcon from "./vote-icon";
 export interface VoteSelectorProps {
   value?: VoteType;
   /**
-   * Accessible name for the group (e.g. "Tue 30 Jun, 1 PM – 2 PM") so screen
-   * readers can tie the vote to its date/time.
+   * Accessible description of the option being voted on (e.g. "Tue 30 Jun,
+   * 1 PM – 2 PM") so screen readers can tie the vote to its date/time.
    */
   optionLabel?: string;
   onChange?: (value: VoteType) => void;
@@ -27,12 +26,11 @@ export const toggleVote = (value?: VoteType) => {
 };
 
 /**
- * A tri-state vote control. Visually a single square that cycles yes → if need
- * be → no on click, but implemented as an ARIA radio group so screen readers
- * announce the selected value natively (a changed aria-label on the focused
- * element is not re-announced; a radio selection change is). Only the checked
- * radio is visible; arrow keys move selection, which moves both visibility and
- * focus, so the control always looks like one square.
+ * A tri-state vote control: a single button that cycles yes → if need be → no.
+ * The value change under a stationary focus is not re-announced by screen
+ * readers from the button's own label, so the voting form announces it through
+ * a shared live region (see `useVotingForm`). The button's accessible name
+ * still leads with the current value so it reads correctly on Tab.
  */
 export const VoteSelector = ({
   value,
@@ -42,88 +40,33 @@ export const VoteSelector = ({
 }: VoteSelectorProps) => {
   const { t } = useTranslation();
 
-  const voteLabels: Record<VoteType, string> = {
-    yes: t("yes", { defaultValue: "Yes" }),
-    ifNeedBe: t("ifNeedBe", { defaultValue: "If need be" }),
-    no: t("no", { defaultValue: "No" }),
-  };
-
-  // With no vote yet, the first radio is the keyboard entry point.
-  const focusedType = value ?? orderedVoteTypes[0];
-
-  const groupRef = React.useRef<HTMLDivElement>(null);
-  const visibleRef = React.useRef<HTMLButtonElement>(null);
-
-  // Selection moves visibility to a different radio, so keep DOM focus on the
-  // visible one — but only when focus is already inside the group, so a mouse
-  // click or a programmatic change never steals focus. `value` is the trigger:
-  // the effect re-runs on selection change and re-homes focus to the new radio.
-  // biome-ignore lint/correctness/useExhaustiveDependencies: value is the trigger, not a read
-  React.useEffect(() => {
-    const group = groupRef.current;
-    if (group?.contains(document.activeElement)) {
-      visibleRef.current?.focus();
+  const voteLabel = (() => {
+    switch (value) {
+      case "yes":
+        return t("yes", { defaultValue: "Yes" });
+      case "ifNeedBe":
+        return t("ifNeedBe", { defaultValue: "If need be" });
+      case "no":
+        return t("no", { defaultValue: "No" });
+      default:
+        return t("pending", { defaultValue: "Pending" });
     }
-  }, [value]);
+  })();
 
   return (
-    <div
-      ref={groupRef}
-      role="radiogroup"
-      aria-label={optionLabel}
-      className="flex items-center justify-center"
+    <button
+      data-testid="vote-selector"
+      type="button"
+      aria-label={optionLabel ? `${voteLabel}, ${optionLabel}` : voteLabel}
+      className={cn(
+        "flex size-7 cursor-pointer items-center justify-center rounded-lg border border-input bg-background ring-ring focus-visible:ring-2",
+        className,
+      )}
+      onClick={() => {
+        onChange?.(toggleVote(value));
+      }}
     >
-      {orderedVoteTypes.map((type) => {
-        const checked = value === type;
-        // The checked radio (or the first, before any vote) is the visible,
-        // clickable square; the others exist only for the a11y tree.
-        const visible = value ? checked : type === focusedType;
-        return (
-          // biome-ignore lint/a11y/useSemanticElements: a native radio input can't be styled to this stacked single-square control; role="radio" buttons are the ARIA APG custom radio group pattern
-          <button
-            key={type}
-            ref={visible ? visibleRef : undefined}
-            data-testid={visible ? "vote-selector" : undefined}
-            type="button"
-            role="radio"
-            aria-checked={checked}
-            aria-label={voteLabels[type]}
-            tabIndex={type === focusedType ? 0 : -1}
-            className={cn(
-              visible
-                ? cn(
-                    "flex size-7 cursor-pointer items-center justify-center rounded-lg border border-input bg-background ring-ring focus-visible:ring-2",
-                    className,
-                  )
-                : "sr-only",
-            )}
-            onClick={() => {
-              // Click cycles rather than selecting this specific value, matching
-              // the original toggle: the only visible target is the current one.
-              onChange?.(toggleVote(value));
-            }}
-            onKeyDown={(event) => {
-              const delta =
-                event.key === "ArrowRight" || event.key === "ArrowDown"
-                  ? 1
-                  : event.key === "ArrowLeft" || event.key === "ArrowUp"
-                    ? -1
-                    : 0;
-              if (delta === 0) return;
-              event.preventDefault();
-              const current = orderedVoteTypes.indexOf(focusedType);
-              const next =
-                orderedVoteTypes[
-                  (current + delta + orderedVoteTypes.length) %
-                    orderedVoteTypes.length
-                ];
-              onChange?.(next);
-            }}
-          >
-            {visible ? <VoteIcon type={value} /> : voteLabels[type]}
-          </button>
-        );
-      })}
-    </div>
+      <VoteIcon type={value} />
+    </button>
   );
 };

--- a/apps/web/src/features/poll/components/voting-form.tsx
+++ b/apps/web/src/features/poll/components/voting-form.tsx
@@ -20,6 +20,7 @@ type VoteType = z.infer<typeof voteTypeSchema>;
 const formSchema = z.object({
   mode: z.enum(["new", "edit", "view"]),
   participantId: z.string().optional(),
+  announcement: z.string().optional(),
   votes: z.array(
     z
       .object({
@@ -32,19 +33,22 @@ const formSchema = z.object({
 
 type VotingFormValues = z.infer<typeof formSchema>;
 
-type AnnounceVote = (optionLabel: string, vote: VoteType) => void;
-
-const AnnounceContext = React.createContext<AnnounceVote>(() => {});
-
 export const useVotingForm = () => {
   const { options } = usePoll();
   const { participants } = useParticipants();
   const form = useFormContext<VotingFormValues>();
-  const announce = React.useContext(AnnounceContext);
+  const { t } = useTranslation();
 
   return {
     ...form,
-    announce,
+    announce: (optionLabel: string, vote: VoteType) => {
+      const voteLabels: Record<VoteType, string> = {
+        yes: t("yes", { defaultValue: "Yes" }),
+        ifNeedBe: t("ifNeedBe", { defaultValue: "If need be" }),
+        no: t("no", { defaultValue: "No" }),
+      };
+      form.setValue("announcement", `${optionLabel}: ${voteLabels[vote]}`);
+    },
     newParticipant: () => {
       form.reset({
         mode: "new",
@@ -86,21 +90,6 @@ export const VotingForm = ({ children }: React.PropsWithChildren) => {
   const updateParticipant = useUpdateParticipantMutation();
   const token = useEditToken();
   const { participants } = useParticipants();
-  const { t } = useTranslation();
-
-  const [announcement, setAnnouncement] = React.useState("");
-
-  const announce = React.useCallback<AnnounceVote>(
-    (optionLabel, vote) => {
-      const voteLabels: Record<VoteType, string> = {
-        yes: t("yes", { defaultValue: "Yes" }),
-        ifNeedBe: t("ifNeedBe", { defaultValue: "If need be" }),
-        no: t("no", { defaultValue: "No" }),
-      };
-      setAnnouncement(`${optionLabel}: ${voteLabels[vote]}`);
-    },
-    [t],
-  );
 
   const { canAddNewParticipant, canEditParticipant } = usePermissions();
   const userAlreadyVoted = participants.some((participant) =>
@@ -132,58 +121,56 @@ export const VotingForm = ({ children }: React.PropsWithChildren) => {
 
   return (
     <FormProvider {...form}>
-      <AnnounceContext.Provider value={announce}>
-        <form
-          id="voting-form"
-          onSubmit={form.handleSubmit(async (data) => {
-            if (data.participantId) {
-              // update participant
+      <form
+        id="voting-form"
+        onSubmit={form.handleSubmit(async (data) => {
+          if (data.participantId) {
+            // update participant
 
-              await updateParticipant.mutateAsync({
-                participantId: data.participantId,
-                pollId,
-                votes: normalizeVotes(optionIds, data.votes),
-                token,
-              });
+            await updateParticipant.mutateAsync({
+              participantId: data.participantId,
+              pollId,
+              votes: normalizeVotes(optionIds, data.votes),
+              token,
+            });
 
+            form.reset({
+              mode: "view",
+              participantId: data.participantId,
+              votes: options.map((option) => ({
+                optionId: option.id,
+              })),
+            });
+          } else {
+            // new participant
+            setIsNewParticipantModalOpen(true);
+          }
+        })}
+      />
+      <Dialog
+        open={isNewParticipantModalOpen}
+        onOpenChange={setIsNewParticipantModalOpen}
+      >
+        <DialogContent size="sm">
+          <NewParticipantForm
+            votes={normalizeVotes(optionIds, form.watch("votes"))}
+            onSubmit={(newParticipant) => {
               form.reset({
                 mode: "view",
-                participantId: data.participantId,
+                participantId: newParticipant.id,
                 votes: options.map((option) => ({
                   optionId: option.id,
                 })),
               });
-            } else {
-              // new participant
-              setIsNewParticipantModalOpen(true);
-            }
-          })}
-        />
-        <Dialog
-          open={isNewParticipantModalOpen}
-          onOpenChange={setIsNewParticipantModalOpen}
-        >
-          <DialogContent size="sm">
-            <NewParticipantForm
-              votes={normalizeVotes(optionIds, form.watch("votes"))}
-              onSubmit={(newParticipant) => {
-                form.reset({
-                  mode: "view",
-                  participantId: newParticipant.id,
-                  votes: options.map((option) => ({
-                    optionId: option.id,
-                  })),
-                });
-              }}
-              onCancel={() => setIsNewParticipantModalOpen(false)}
-            />
-          </DialogContent>
-        </Dialog>
-        {children}
-        <div aria-live="polite" className="sr-only">
-          {announcement}
-        </div>
-      </AnnounceContext.Provider>
+            }}
+            onCancel={() => setIsNewParticipantModalOpen(false)}
+          />
+        </DialogContent>
+      </Dialog>
+      {children}
+      <div aria-live="polite" className="sr-only">
+        {form.watch("announcement")}
+      </div>
     </FormProvider>
   );
 };

--- a/apps/web/src/features/poll/components/voting-form.tsx
+++ b/apps/web/src/features/poll/components/voting-form.tsx
@@ -11,6 +11,11 @@ import {
 } from "@/features/poll/components/mutations";
 import { NewParticipantForm } from "@/features/poll/components/new-participant-modal";
 import { useParticipants } from "@/features/poll/components/participants-provider";
+import { useTranslation } from "@/i18n/client";
+
+const voteTypeSchema = z.enum(["yes", "no", "ifNeedBe"]);
+
+type VoteType = z.infer<typeof voteTypeSchema>;
 
 const formSchema = z.object({
   mode: z.enum(["new", "edit", "view"]),
@@ -19,7 +24,7 @@ const formSchema = z.object({
     z
       .object({
         optionId: z.string(),
-        type: z.enum(["yes", "no", "ifNeedBe"]).optional(),
+        type: voteTypeSchema.optional(),
       })
       .optional(),
   ),
@@ -27,13 +32,19 @@ const formSchema = z.object({
 
 type VotingFormValues = z.infer<typeof formSchema>;
 
+type AnnounceVote = (optionLabel: string, vote: VoteType) => void;
+
+const AnnounceContext = React.createContext<AnnounceVote>(() => {});
+
 export const useVotingForm = () => {
   const { options } = usePoll();
   const { participants } = useParticipants();
   const form = useFormContext<VotingFormValues>();
+  const announce = React.useContext(AnnounceContext);
 
   return {
     ...form,
+    announce,
     newParticipant: () => {
       form.reset({
         mode: "new",
@@ -75,6 +86,21 @@ export const VotingForm = ({ children }: React.PropsWithChildren) => {
   const updateParticipant = useUpdateParticipantMutation();
   const token = useEditToken();
   const { participants } = useParticipants();
+  const { t } = useTranslation();
+
+  const [announcement, setAnnouncement] = React.useState("");
+
+  const announce = React.useCallback<AnnounceVote>(
+    (optionLabel, vote) => {
+      const voteLabels: Record<VoteType, string> = {
+        yes: t("yes", { defaultValue: "Yes" }),
+        ifNeedBe: t("ifNeedBe", { defaultValue: "If need be" }),
+        no: t("no", { defaultValue: "No" }),
+      };
+      setAnnouncement(`${optionLabel}: ${voteLabels[vote]}`);
+    },
+    [t],
+  );
 
   const { canAddNewParticipant, canEditParticipant } = usePermissions();
   const userAlreadyVoted = participants.some((participant) =>
@@ -106,53 +132,58 @@ export const VotingForm = ({ children }: React.PropsWithChildren) => {
 
   return (
     <FormProvider {...form}>
-      <form
-        id="voting-form"
-        onSubmit={form.handleSubmit(async (data) => {
-          if (data.participantId) {
-            // update participant
+      <AnnounceContext.Provider value={announce}>
+        <form
+          id="voting-form"
+          onSubmit={form.handleSubmit(async (data) => {
+            if (data.participantId) {
+              // update participant
 
-            await updateParticipant.mutateAsync({
-              participantId: data.participantId,
-              pollId,
-              votes: normalizeVotes(optionIds, data.votes),
-              token,
-            });
+              await updateParticipant.mutateAsync({
+                participantId: data.participantId,
+                pollId,
+                votes: normalizeVotes(optionIds, data.votes),
+                token,
+              });
 
-            form.reset({
-              mode: "view",
-              participantId: data.participantId,
-              votes: options.map((option) => ({
-                optionId: option.id,
-              })),
-            });
-          } else {
-            // new participant
-            setIsNewParticipantModalOpen(true);
-          }
-        })}
-      />
-      <Dialog
-        open={isNewParticipantModalOpen}
-        onOpenChange={setIsNewParticipantModalOpen}
-      >
-        <DialogContent size="sm">
-          <NewParticipantForm
-            votes={normalizeVotes(optionIds, form.watch("votes"))}
-            onSubmit={(newParticipant) => {
               form.reset({
                 mode: "view",
-                participantId: newParticipant.id,
+                participantId: data.participantId,
                 votes: options.map((option) => ({
                   optionId: option.id,
                 })),
               });
-            }}
-            onCancel={() => setIsNewParticipantModalOpen(false)}
-          />
-        </DialogContent>
-      </Dialog>
-      {children}
+            } else {
+              // new participant
+              setIsNewParticipantModalOpen(true);
+            }
+          })}
+        />
+        <Dialog
+          open={isNewParticipantModalOpen}
+          onOpenChange={setIsNewParticipantModalOpen}
+        >
+          <DialogContent size="sm">
+            <NewParticipantForm
+              votes={normalizeVotes(optionIds, form.watch("votes"))}
+              onSubmit={(newParticipant) => {
+                form.reset({
+                  mode: "view",
+                  participantId: newParticipant.id,
+                  votes: options.map((option) => ({
+                    optionId: option.id,
+                  })),
+                });
+              }}
+              onCancel={() => setIsNewParticipantModalOpen(false)}
+            />
+          </DialogContent>
+        </Dialog>
+        {children}
+        <div aria-live="polite" className="sr-only">
+          {announcement}
+        </div>
+      </AnnounceContext.Provider>
     </FormProvider>
   );
 };

--- a/apps/web/src/features/poll/components/voting-form.tsx
+++ b/apps/web/src/features/poll/components/voting-form.tsx
@@ -11,21 +11,15 @@ import {
 } from "@/features/poll/components/mutations";
 import { NewParticipantForm } from "@/features/poll/components/new-participant-modal";
 import { useParticipants } from "@/features/poll/components/participants-provider";
-import { useTranslation } from "@/i18n/client";
-
-const voteTypeSchema = z.enum(["yes", "no", "ifNeedBe"]);
-
-type VoteType = z.infer<typeof voteTypeSchema>;
 
 const formSchema = z.object({
   mode: z.enum(["new", "edit", "view"]),
   participantId: z.string().optional(),
-  announcement: z.string().optional(),
   votes: z.array(
     z
       .object({
         optionId: z.string(),
-        type: voteTypeSchema.optional(),
+        type: z.enum(["yes", "no", "ifNeedBe"]).optional(),
       })
       .optional(),
   ),
@@ -37,18 +31,9 @@ export const useVotingForm = () => {
   const { options } = usePoll();
   const { participants } = useParticipants();
   const form = useFormContext<VotingFormValues>();
-  const { t } = useTranslation();
 
   return {
     ...form,
-    announce: (optionLabel: string, vote: VoteType) => {
-      const voteLabels: Record<VoteType, string> = {
-        yes: t("yes", { defaultValue: "Yes" }),
-        ifNeedBe: t("ifNeedBe", { defaultValue: "If need be" }),
-        no: t("no", { defaultValue: "No" }),
-      };
-      form.setValue("announcement", `${optionLabel}: ${voteLabels[vote]}`);
-    },
     newParticipant: () => {
       form.reset({
         mode: "new",
@@ -168,9 +153,6 @@ export const VotingForm = ({ children }: React.PropsWithChildren) => {
         </DialogContent>
       </Dialog>
       {children}
-      <div aria-live="assertive" aria-atomic="true" className="sr-only">
-        {form.watch("announcement")}
-      </div>
     </FormProvider>
   );
 };

--- a/apps/web/src/features/poll/components/voting-form.tsx
+++ b/apps/web/src/features/poll/components/voting-form.tsx
@@ -11,15 +11,23 @@ import {
 } from "@/features/poll/components/mutations";
 import { NewParticipantForm } from "@/features/poll/components/new-participant-modal";
 import { useParticipants } from "@/features/poll/components/participants-provider";
+import { useTranslation } from "@/i18n/client";
+
+const voteTypeSchema = z.enum(["yes", "no", "ifNeedBe"]);
+
+type VoteType = z.infer<typeof voteTypeSchema>;
 
 const formSchema = z.object({
   mode: z.enum(["new", "edit", "view"]),
   participantId: z.string().optional(),
+  // Screen-reader announcement of the last vote change, read out via the
+  // live region below. Not persisted.
+  announcement: z.string().optional(),
   votes: z.array(
     z
       .object({
         optionId: z.string(),
-        type: z.enum(["yes", "no", "ifNeedBe"]).optional(),
+        type: voteTypeSchema.optional(),
       })
       .optional(),
   ),
@@ -31,9 +39,19 @@ export const useVotingForm = () => {
   const { options } = usePoll();
   const { participants } = useParticipants();
   const form = useFormContext<VotingFormValues>();
+  const { t } = useTranslation();
 
   return {
     ...form,
+    announce: (optionLabel: string, vote: VoteType) => {
+      const voteLabels: Record<VoteType, string> = {
+        yes: t("yes", { defaultValue: "Yes" }),
+        ifNeedBe: t("ifNeedBe", { defaultValue: "If need be" }),
+        no: t("no", { defaultValue: "No" }),
+      };
+      // Lead with the value, matching the button's own name order.
+      form.setValue("announcement", `${voteLabels[vote]}, ${optionLabel}`);
+    },
     newParticipant: () => {
       form.reset({
         mode: "new",
@@ -153,6 +171,9 @@ export const VotingForm = ({ children }: React.PropsWithChildren) => {
         </DialogContent>
       </Dialog>
       {children}
+      <div aria-live="assertive" aria-atomic="true" className="sr-only">
+        {form.watch("announcement")}
+      </div>
     </FormProvider>
   );
 };

--- a/apps/web/src/features/poll/components/voting-form.tsx
+++ b/apps/web/src/features/poll/components/voting-form.tsx
@@ -168,7 +168,7 @@ export const VotingForm = ({ children }: React.PropsWithChildren) => {
         </DialogContent>
       </Dialog>
       {children}
-      <div aria-live="polite" className="sr-only">
+      <div aria-live="assertive" aria-atomic="true" className="sr-only">
         {form.watch("announcement")}
       </div>
     </FormProvider>

--- a/apps/web/src/lib/datetime/format.test.ts
+++ b/apps/web/src/lib/datetime/format.test.ts
@@ -4,6 +4,7 @@ import {
   formatDateTime,
   formatDateTimeRange,
   formatRelativeTime,
+  formatSpeechTime,
 } from "@/lib/datetime/format";
 import type { TimeFormat } from "@/lib/datetime/types";
 
@@ -130,6 +131,38 @@ describe("formatDateTime", () => {
         ...ctx("en", "hours24"),
       }),
     ).toBe("13:00");
+  });
+});
+
+describe("formatSpeechTime", () => {
+  // The meridiem separator varies by ICU version (regular vs narrow no-break
+  // space), so normalize whitespace before asserting rather than hardcode it.
+  const speech = (...args: Parameters<typeof formatSpeechTime>) =>
+    formatSpeechTime(...args).replace(/\s+/g, " ");
+
+  it("drops the zero minute for 12-hour time", () => {
+    expect(speech(at(13), ctx("en", "hours12"))).toBe("1 PM");
+  });
+
+  it("keeps a non-zero minute", () => {
+    expect(speech(at(13, 30), ctx("en", "hours12"))).toBe("1:30 PM");
+  });
+
+  it("drops the zero minute for 24-hour time, leaving just the hour", () => {
+    expect(speech(at(13), ctx("en", "hours24"))).toBe("13");
+  });
+
+  it("keeps a non-zero minute for 24-hour time", () => {
+    expect(speech(at(13, 30), ctx("en", "hours24"))).toBe("13:30");
+  });
+
+  it("preserves meridiem-first order without inserting a space (zh)", () => {
+    expect(speech(at(13), ctx("zh", "hours12"))).toBe("下午1");
+  });
+
+  it("honors the timezone", () => {
+    // 13:00 UTC = 09:00 America/New_York (EDT) in June.
+    expect(speech(at(13), ctx("en", "hours24", "America/New_York"))).toBe("09");
   });
 });
 

--- a/apps/web/src/lib/datetime/format.ts
+++ b/apps/web/src/lib/datetime/format.ts
@@ -112,6 +112,40 @@ export function formatDateTime(
   return getCachedIntlDateFormatter(options).format(toDate(value));
 }
 
+/**
+ * A time formatted for speech: when the minute is zero it is dropped, so a
+ * screen reader reads "1 PM" rather than "1:00 PM" (which is voiced digit by
+ * digit as "one zero zero P M"). Locale/format aware via Intl — 24h and
+ * non-English output are handled by the same formatToParts pass.
+ */
+export function formatSpeechTime(
+  value: DateInput,
+  options: Omit<FormatDateTimeOptions, "preset" | "showTimeZone">,
+): string {
+  const parts = getCachedIntlDateFormatter({
+    ...options,
+    preset: "time",
+  }).formatToParts(toDate(value));
+
+  const minuteIndex = parts.findIndex((part) => part.type === "minute");
+  if (minuteIndex === -1 || Number(parts[minuteIndex].value) !== 0) {
+    return parts.map((part) => part.value).join("");
+  }
+
+  // Drop the zero minute and the hour:minute separator literal that precedes
+  // it, but keep every other literal (e.g. the space before "PM") so the
+  // result stays correct across locales.
+  const separatorIndex =
+    minuteIndex > 0 && parts[minuteIndex - 1].type === "literal"
+      ? minuteIndex - 1
+      : -1;
+  return parts
+    .filter((_, index) => index !== minuteIndex && index !== separatorIndex)
+    .map((part) => part.value)
+    .join("")
+    .trim();
+}
+
 export function formatDateTimeRange(
   start: DateInput,
   end: DateInput,

--- a/apps/web/src/lib/utils/date-time-utils.ts
+++ b/apps/web/src/lib/utils/date-time-utils.ts
@@ -40,17 +40,11 @@ export interface ParsedTimeSlotOption {
 
 export type ParsedDateTimeOpton = ParsedDateOption | ParsedTimeSlotOption;
 
-export const getOptionDateTimeLabel = (option: ParsedDateTimeOpton) => {
-  const date = `${option.dow} ${option.day} ${option.month} ${option.year}`;
-  return option.type === "timeSlot"
-    ? `${date}, ${option.startTime} – ${option.endTime}`
-    : date;
-};
-
 /**
- * Terser label for screen-reader announcements: drops the year (usually
- * inferable from context) and uses speech-friendly times ("1pm" rather than
- * the literal "1:00 PM", which reads as "one zero zero P M").
+ * Screen-reader label for a vote control and its change announcement. Drops
+ * the year (usually inferable from context) and uses speech-friendly times
+ * ("1 PM" rather than the literal "1:00 PM", which reads as "one zero zero P
+ * M").
  */
 export const getOptionAnnouncementLabel = (option: ParsedDateTimeOpton) => {
   const date = `${option.dow} ${option.day} ${option.month}`;

--- a/apps/web/src/lib/utils/date-time-utils.ts
+++ b/apps/web/src/lib/utils/date-time-utils.ts
@@ -31,6 +31,9 @@ export interface ParsedTimeSlotOption {
   month: string;
   startTime: string;
   endTime: string;
+  /** Speech-friendly times (minutes dropped when zero) for screen readers. */
+  speechStartTime: string;
+  speechEndTime: string;
   duration: string;
   year: string;
 }
@@ -41,6 +44,18 @@ export const getOptionDateTimeLabel = (option: ParsedDateTimeOpton) => {
   const date = `${option.dow} ${option.day} ${option.month} ${option.year}`;
   return option.type === "timeSlot"
     ? `${date}, ${option.startTime} – ${option.endTime}`
+    : date;
+};
+
+/**
+ * Terser label for screen-reader announcements: drops the year (usually
+ * inferable from context) and uses speech-friendly times ("1pm" rather than
+ * the literal "1:00 PM", which reads as "one zero zero P M").
+ */
+export const getOptionAnnouncementLabel = (option: ParsedDateTimeOpton) => {
+  const date = `${option.dow} ${option.day} ${option.month}`;
+  return option.type === "timeSlot"
+    ? `${date}, ${option.speechStartTime} – ${option.speechEndTime}`
     : date;
 };
 

--- a/apps/web/tests/poll-header-a11y.spec.ts
+++ b/apps/web/tests/poll-header-a11y.spec.ts
@@ -1,0 +1,52 @@
+import { expect, test } from "@playwright/test";
+import { prisma } from "@rallly/database";
+
+/**
+ * The desktop poll header renders one duration per timed option. It must not
+ * be focusable: otherwise a keyboard user tabbing toward the voting form hits
+ * one tab stop per option, each announcing only the duration ("1h"). Regression
+ * guard — the default E2E poll uses all-day options, so no other spec covers
+ * the timed-header path.
+ */
+const POLL_ID = "header-tab-timed-poll";
+const YEAR = new Date().getFullYear() + 1;
+
+test.beforeAll(async () => {
+  await prisma.poll.deleteMany({ where: { id: POLL_ID } });
+  await prisma.poll.create({
+    data: {
+      id: POLL_ID,
+      title: "Header Tab Timed Poll",
+      participantUrlId: `${POLL_ID}-participant`,
+      adminUrlId: `${POLL_ID}-admin`,
+      kind: "time",
+      timeZone: "Europe/London",
+      options: {
+        create: [
+          { startTime: new Date(`${YEAR}-09-10T09:00:00.000Z`), duration: 60 },
+          { startTime: new Date(`${YEAR}-09-10T11:00:00.000Z`), duration: 60 },
+          { startTime: new Date(`${YEAR}-09-10T14:00:00.000Z`), duration: 60 },
+        ],
+      },
+    },
+  });
+});
+
+test.afterAll(async () => {
+  await prisma.poll.deleteMany({ where: { id: POLL_ID } });
+});
+
+test("header duration is not tabbable", async ({ page }) => {
+  await page.goto(`/invite/${POLL_ID}`);
+  await page.getByTestId("option-start-time").first().waitFor();
+
+  // Sanity: multiple timed option headers render (each has a duration).
+  expect(await page.getByTestId("option-start-time").count()).toBe(3);
+
+  // The duration triggers live in <thead>. None may be focusable, or a
+  // keyboard user hits one tab stop per option before reaching the form.
+  const focusableInHead = await page
+    .locator("thead button, thead a[href], thead [tabindex='0']")
+    .count();
+  expect(focusableInHead).toBe(0);
+});


### PR DESCRIPTION
Closes RAL-1445.

## Problem

`VoteSelector` is a native button whose `aria-label` combines the option date/time with the current vote. Clicking cycles yes → if need be → no. The label updates in the DOM, but screen readers do not re-announce a changed `aria-label` on the element that already has focus — so a VoiceOver user presses the button and hears nothing back. They cannot tell what value they just set.

## Solution

One polite live region in the voting form, announced through on every vote change.

- **`voting-form.tsx`** — adds an `AnnounceContext` wrapping the form tree and an `announce(optionLabel, vote)` callback that sets `"<label>: <Yes|If need be|No>"` into state, rendered into a single `<div aria-live="polite" className="sr-only">`. `useVotingForm()` now returns `announce`.
- **`desktop-poll/participant-row-form.tsx`** — vote handler calls `form.announce(getOptionDateTimeLabel(option), vote)`.
- **`mobile-poll/poll-options.tsx`** — same, from `handleChange`.

No per-button live regions; a single shared region is the correct pattern.

## Two deviations from the issue spec

**1. `VoteType` is not imported from `@rallly/database`.** The issue said to follow the import in `vote-selector.tsx`, but that file is on the DAL migration allowlist in `apps/web/biome.json` and `voting-form.tsx` is not — the import fails `pnpm check`. Adding a file to a deliberately shrinking allowlist for a one-line type import is the wrong direction. Instead the vote enum already present in this file's form schema is extracted to `voteTypeSchema` and `VoteType` derived from it. Structurally identical to the Prisma enum, so call sites passing the database type still typecheck, and the type can no longer drift from the schema that validates it.

**2. Mobile announce lives in `poll-options.tsx`, not `poll-option.tsx`.** The issue suggested adding `useVotingForm()` to the leaf, but `handleChange` in `poll-options.tsx` is where the value actually changes, already calls `useVotingForm()`, and already computes `getOptionDateTimeLabel(option)`. Announcing there covers both `DateOption` and `TimeSlotOption`, and correctly skips the non-editable case since `handleChange` early-returns when `!editable` — announcing in the leaf would have meant duplicating that guard.

## Verification

- `pnpm check` — passes.
- `pnpm type-check` — **does not pass clean on this branch, but not because of this change.** 17 errors in 12 files, all pre-existing: confirmed by stashing these changes and re-running on a clean tree, which produces the identical count and the same files (missing `date-fns` type resolutions across `packages/ui/src/event-calendar/*`, plus two `features/user` files). None are files this PR touches; this change adds zero new errors.
- **Not verified by observation:** the manual DOM check from the issue (run the app, add a participant, click a vote button, confirm the `aria-live` div updates on desktop and mobile). No dev server was run. Worth doing before merge, along with the VoiceOver pass tracked in RAL-1456.

One behavioral note for that manual check: `aria-live` regions do not re-announce identical text. Cycling a single option always changes the string, so normal clicking is fine — this would only bite if two different options produced the same label, which date/time labels shouldn't.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Accessibility**
  - Improved poll option announcements with clearer, speech-friendly time ranges.
  - Removed unnecessary year details from option labels.
  - Enhanced vote controls with radio-group semantics, localized labels, and improved screen-reader support.
  - Added arrow-key navigation and more consistent focus behavior for vote selection.

- **Improvements**
  - Time announcements now adapt to locale, time format, and time zone.
  - Simplified spoken times when minutes are exactly zero.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->