### PR TITLE
🐛 Stop setup from creating a second space for existing accounts

### DIFF
--- a/apps/web/src/app/[locale]/setup/page.tsx
+++ b/apps/web/src/app/[locale]/setup/page.tsx
@@ -4,7 +4,7 @@ import { SetupFooter } from "@/app/[locale]/setup/components/setup-footer";
 import { SetupForm } from "@/app/[locale]/setup/components/setup-form";
 import { ThemeSwitcher } from "@/components/theme-switcher";
 import { Logo } from "@/features/branding/components/logo";
-import { getActiveSpaceForUser } from "@/features/space/data";
+import { getOwnedSpace } from "@/features/space/data";
 import { requireUser } from "@/features/user/loaders";
 import { Trans } from "@/i18n/client";
 import { getTranslation } from "@/i18n/server";
@@ -17,7 +17,11 @@ export default async function SetupPage(props: {
   const user = await requireUser();
   const searchParams = await props.searchParams;
 
-  const space = await getActiveSpaceForUser(user.id);
+  // Whether onboarding is done is "does a space exist", not "is one
+  // active": getActiveSpaceForUser hides memberships in hobby spaces the
+  // user doesn't own, so gating on it sent established accounts back here
+  // and had them create a second space.
+  const space = await getOwnedSpace(user.id);
 
   if (user.name && user.timeZone && user.timeFormat && space) {
     redirect(validateRedirectUrl(searchParams?.redirectTo) ?? "/");

--- a/apps/web/src/features/space/loaders.test.ts
+++ b/apps/web/src/features/space/loaders.test.ts
@@ -1,0 +1,139 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+const REDIRECT = "NEXT_REDIRECT";
+const NOT_FOUND = "NEXT_NOT_FOUND";
+
+const mockRedirect = vi.fn((url: string) => {
+  throw Object.assign(new Error(REDIRECT), { digest: `${REDIRECT};${url}` });
+});
+const mockNotFound = vi.fn(() => {
+  throw Object.assign(new Error(NOT_FOUND), { digest: NOT_FOUND });
+});
+
+vi.mock("next/navigation", () => ({
+  redirect: (url: string) => mockRedirect(url),
+  notFound: () => mockNotFound(),
+}));
+
+const mockGetSessionState = vi.fn();
+const mockGetActiveSpaceForUser = vi.fn();
+const mockGetOwnedSpace = vi.fn();
+
+vi.mock("@/lib/auth", () => ({
+  getSessionState: () => mockGetSessionState(),
+}));
+
+vi.mock("@/features/space/data", () => ({
+  getActiveSpaceForUser: (userId: string) => mockGetActiveSpaceForUser(userId),
+  getOwnedSpace: (userId: string) => mockGetOwnedSpace(userId),
+  getSpaceSeatCount: vi.fn(),
+  getTotalSeatsForSpace: vi.fn(),
+}));
+
+vi.mock("@/lib/pathname", () => ({
+  getPathname: () => Promise.resolve("/polls"),
+}));
+
+const completeUser = {
+  id: "user-1",
+  email: "user@example.com",
+  name: "Jessie Smith",
+  isGuest: false,
+  banned: false,
+  timeZone: "Europe/London",
+  timeFormat: "hours12",
+};
+
+const authenticatedAs = (user: Record<string, unknown>) => {
+  mockGetSessionState.mockResolvedValue({
+    status: "authenticated",
+    session: { user },
+  });
+};
+
+// getActiveSpace is React-cached, so each case needs a fresh module registry
+// or the first call's result leaks into the next test.
+const loadGate = async () => {
+  vi.resetModules();
+  const mod = await import("./loaders");
+  return mod.getActiveSpace;
+};
+
+describe("getActiveSpace", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns the active space when the user has one", async () => {
+    const space = { id: "space-1", name: "Personal" };
+    authenticatedAs(completeUser);
+    mockGetActiveSpaceForUser.mockResolvedValue(space);
+
+    const gate = await loadGate();
+
+    await expect(gate()).resolves.toEqual(space);
+    expect(mockRedirect).not.toHaveBeenCalled();
+    expect(mockNotFound).not.toHaveBeenCalled();
+  });
+
+  it("redirects to /setup when the user owns no space at all", async () => {
+    authenticatedAs(completeUser);
+    mockGetActiveSpaceForUser.mockResolvedValue(null);
+    mockGetOwnedSpace.mockResolvedValue(null);
+
+    const gate = await loadGate();
+
+    await expect(gate()).rejects.toThrow(REDIRECT);
+    expect(mockRedirect).toHaveBeenCalledWith(
+      expect.stringContaining("/setup"),
+    );
+  });
+
+  // The bug: an owned-but-inaccessible space used to fall through to the
+  // /setup redirect, where onboarding created a second space.
+  it("renders not-found when the user owns a space but none is active", async () => {
+    authenticatedAs(completeUser);
+    mockGetActiveSpaceForUser.mockResolvedValue(null);
+    mockGetOwnedSpace.mockResolvedValue({ id: "space-1" });
+
+    const gate = await loadGate();
+
+    await expect(gate()).rejects.toThrow(NOT_FOUND);
+    expect(mockNotFound).toHaveBeenCalled();
+    expect(mockRedirect).not.toHaveBeenCalled();
+  });
+
+  it("redirects to /setup when profile fields are missing, before reading spaces", async () => {
+    authenticatedAs({ ...completeUser, timeFormat: undefined });
+
+    const gate = await loadGate();
+
+    await expect(gate()).rejects.toThrow(REDIRECT);
+    expect(mockRedirect).toHaveBeenCalledWith(
+      expect.stringContaining("/setup"),
+    );
+    expect(mockGetActiveSpaceForUser).not.toHaveBeenCalled();
+  });
+
+  it("redirects to /login for a guest", async () => {
+    authenticatedAs({ ...completeUser, isGuest: true });
+
+    const gate = await loadGate();
+
+    await expect(gate()).rejects.toThrow(REDIRECT);
+    expect(mockRedirect).toHaveBeenCalledWith(
+      expect.stringContaining("/login"),
+    );
+  });
+
+  it("fails the render on an unreadable session instead of redirecting", async () => {
+    mockGetSessionState.mockResolvedValue({ status: "error" });
+
+    const gate = await loadGate();
+
+    await expect(gate()).rejects.toThrow("Failed to read session");
+    expect(mockRedirect).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/features/space/loaders.ts
+++ b/apps/web/src/features/space/loaders.ts
@@ -5,10 +5,12 @@ import { cache } from "react";
 
 import {
   getActiveSpaceForUser,
+  getOwnedSpace,
   getSpaceSeatCount,
   getTotalSeatsForSpace,
 } from "@/features/space/data";
 import { getSessionState } from "@/lib/auth";
+import { AppError } from "@/lib/errors/app-error";
 import { InvalidSessionError } from "@/lib/errors/invalid-session-error";
 import { getPathname } from "@/lib/pathname";
 import { buildSafeRedirectUrl } from "@/lib/utils/redirect";
@@ -16,8 +18,8 @@ import { buildSafeRedirectUrl } from "@/lib/utils/redirect";
 /**
  * The active space for the signed-in user, gated for server rendering:
  * redirects to /login when unauthenticated or a guest, redirects to /setup
- * when the user has no name, timezone, time format, or space, and throws
- * InvalidSessionError when banned.
+ * when the user has no name, timezone, time format, or space at all, and
+ * throws InvalidSessionError when banned.
  * React cached, so every page and layout that needs the space in a request
  * shares one gate and one query. Server component/page use only — the
  * redirects make it unsuitable for route handlers and tRPC procedures.
@@ -65,6 +67,18 @@ export const getActiveSpace = cache(async () => {
   const space = await getActiveSpaceForUser(user.id);
 
   if (!space) {
+    // Only send them to onboarding when they genuinely have no space.
+    // A user can resolve to no *active* space while still owning one
+    // (their only other memberships are ineffective, or their own
+    // membership row is gone) — /setup would bounce them straight back,
+    // so fail the render instead of looping.
+    if (await getOwnedSpace(user.id)) {
+      throw new AppError({
+        code: "NOT_FOUND",
+        message: "No accessible space for user",
+      });
+    }
+
     redirect(
       buildSafeRedirectUrl({
         destination: "/setup",

--- a/apps/web/src/features/space/loaders.ts
+++ b/apps/web/src/features/space/loaders.ts
@@ -1,6 +1,6 @@
 import "server-only";
 
-import { redirect } from "next/navigation";
+import { notFound, redirect } from "next/navigation";
 import { cache } from "react";
 
 import {
@@ -10,7 +10,6 @@ import {
   getTotalSeatsForSpace,
 } from "@/features/space/data";
 import { getSessionState } from "@/lib/auth";
-import { AppError } from "@/lib/errors/app-error";
 import { InvalidSessionError } from "@/lib/errors/invalid-session-error";
 import { getPathname } from "@/lib/pathname";
 import { buildSafeRedirectUrl } from "@/lib/utils/redirect";
@@ -71,12 +70,12 @@ export const getActiveSpace = cache(async () => {
     // A user can resolve to no *active* space while still owning one
     // (their only other memberships are ineffective, or their own
     // membership row is gone) — /setup would bounce them straight back,
-    // so fail the render instead of looping.
+    // so render the not-found page instead of looping. notFound() rather
+    // than a thrown AppError: nothing adapts AppError for server
+    // components, so it would reach the error boundary as an unexpected
+    // error, showing "Something went wrong" and reporting to Sentry.
     if (await getOwnedSpace(user.id)) {
-      throw new AppError({
-        code: "NOT_FOUND",
-        message: "No accessible space for user",
-      });
+      notFound();
     }
 
     redirect(


### PR DESCRIPTION
## Description

Fixes the onboarding/setup page being shown to accounts that are already set up, which had them create a duplicate space.

### Root cause

`/setup` decided whether onboarding was still needed using `getActiveSpaceForUser`, which is **not** "has a space" — it is "has an *effective* membership". On cloud, `effectiveSpaceMemberWhere` drops memberships in hobby-tier spaces the user does not own:

```ts
{ userId, OR: [{ space: { tier: "pro" } }, { space: { ownerId: userId } }] }
```

So a user whose only membership is a non-owned hobby space (invited into a Pro space that later downgraded, or a member of someone else's space) resolves to `null`. The active-space gate in `features/space/loaders.ts` bounced them to `/setup`, the page's identical guard also failed, and they were shown the onboarding form despite being fully set up. Submitting it created another space.

This became reachable in 0d804dbde ("Move space creation from registration to setup"). Before that, registration always created the space, so the missing-space branch never fired for an established account.

Worth noting for review: the setup **action** was already correct — it guards with `getOwnedSpace` and returns early. The page-level gate was the one asking the wrong question.

### Fix

Both gates now ask the same question the action already asked — "does a space exist at all", via `getOwnedSpace`:

- `apps/web/src/app/[locale]/setup/page.tsx` — redirects established users away instead of rendering the form.
- `apps/web/src/features/space/loaders.ts` — only redirects to `/setup` when the user genuinely owns no space. If they own one but cannot resolve an active one (ineffective memberships, or their own membership row was deleted), it throws `NOT_FOUND` rather than redirecting into `/setup`, which would now bounce straight back and loop.

### Verification

- `pnpm type-check` — 8/8 tasks pass
- `pnpm check` — clean on both changed files (the single warning is pre-existing in `packages/ui/src/rich-text-editor.tsx`)

### Not covered here

- **No test.** These are server-component redirect gates with no existing test harness, and I did not hand-start a dev server. If this should be locked in, the testable seam is a unit test over the gate logic — happy to add one.
- **Existing duplicate spaces are not cleaned up.** This stops new ones; accounts that already got a spurious "Personal" space still have it. That needs a separate data audit against prod.

## Checklist

- [x] I have performed a self-review of my code
- [x] My code follows the code style of this project
- [x] I have commented my code, particularly in hard-to-understand areas

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved onboarding routing so users with an existing/owned space aren’t sent back to setup.
  * Prevented redirect loops when a user owns a space but no active space is available.
  * Kept existing setup/login redirects for users without the necessary space or required session/profile details.
* **Tests**
  * Added a test suite covering the space access gate’s redirect and error-handling scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->