### PR TITLE
🐛 Stop sending established accounts to setup over datetime fields

### DIFF
--- a/apps/web/src/app/[locale]/setup/page.tsx
+++ b/apps/web/src/app/[locale]/setup/page.tsx
@@ -23,7 +23,10 @@ export default async function SetupPage(props: {
   // and had them create a second space.
   const space = await getOwnedSpace(user.id);
 
-  if (user.name && user.timeZone && user.timeFormat && space) {
+  // Mirrors the gate in features/space/loaders.ts: name and a space are
+  // required, timezone and time format are not. The two conditions have to
+  // agree or the user ping-pongs between here and the app.
+  if (user.name && space) {
     redirect(validateRedirectUrl(searchParams?.redirectTo) ?? "/");
   }
 

--- a/apps/web/src/features/space/loaders.test.ts
+++ b/apps/web/src/features/space/loaders.test.ts
@@ -105,8 +105,8 @@ describe("getActiveSpace", () => {
     expect(mockRedirect).not.toHaveBeenCalled();
   });
 
-  it("redirects to /setup when profile fields are missing, before reading spaces", async () => {
-    authenticatedAs({ ...completeUser, timeFormat: undefined });
+  it("redirects to /setup when the name is missing, before reading spaces", async () => {
+    authenticatedAs({ ...completeUser, name: "" });
 
     const gate = await loadGate();
 
@@ -115,6 +115,23 @@ describe("getActiveSpace", () => {
       expect.stringContaining("/setup"),
     );
     expect(mockGetActiveSpaceForUser).not.toHaveBeenCalled();
+  });
+
+  // Long-standing accounts predate the timeZone/timeFormat columns. Both
+  // resolve without a stored value, so a null must not force onboarding.
+  it.each([
+    ["timeZone", { timeZone: undefined }],
+    ["timeFormat", { timeFormat: undefined }],
+    ["both", { timeZone: undefined, timeFormat: undefined }],
+  ])("does not redirect to /setup when %s is missing", async (_label, patch) => {
+    const space = { id: "space-1", name: "Personal" };
+    authenticatedAs({ ...completeUser, ...patch });
+    mockGetActiveSpaceForUser.mockResolvedValue(space);
+
+    const gate = await loadGate();
+
+    await expect(gate()).resolves.toEqual(space);
+    expect(mockRedirect).not.toHaveBeenCalled();
   });
 
   it("redirects to /login for a guest", async () => {

--- a/apps/web/src/features/space/loaders.ts
+++ b/apps/web/src/features/space/loaders.ts
@@ -51,10 +51,12 @@ export const getActiveSpace = cache(async () => {
   }
 
   // Accounts created through the OTP registration flow start without a
-  // name, timezone, or time format; /setup collects them before they can
-  // use the app. Pre-existing accounts missing any of these go through
-  // the same (prefilled) form once.
-  if (!user.name || !user.timeZone || !user.timeFormat) {
+  // name; /setup collects one before they can use the app. Timezone and
+  // time format are deliberately NOT gated on: both resolve without a
+  // stored value (zone from the per-visit cookie, format from
+  // getLocaleDefaults), and gating on them dragged long-standing accounts
+  // that predate those columns back through onboarding.
+  if (!user.name) {
     redirect(
       buildSafeRedirectUrl({
         destination: "/setup",


### PR DESCRIPTION
## Description

The active-space gate blocked on `name`, `timeZone` **and** `timeFormat`, redirecting anyone missing any of the three to `/setup`. `timeZone` and `timeFormat` were added to the user table later, so long-standing accounts have them null and were dragged back through onboarding.

### Impact (measured)

PostHog, since the gate shipped 2026-07-20:

| Metric | Count |
|---|---|
| `space_setup` events | 3,042 in 3 days |
| ...from accounts older than 1 day | **682** |
| ...from accounts older than 30 days | 398 |
| Oldest affected account | ~3.5 years |

All 682 pre-existing accounts fired `space_setup` against a space that already existed — the `getOwnedSpace` guard added in #2713 returned early every time, so **no data was created or changed**. The harm was pure friction: an onboarding form they had already completed, which changed nothing.

For comparison, `space_create` (the deliberate "create a space" action) fired 132 times over 30 days. Confirmed via the two distinct analytics events that every space created in this period came from `space_create`, not `space_setup` — there are no duplicate spaces to clean up.

### Why these fields don't need gating

Neither has to be stored for the app to render correctly:

- **timeZone** — `getDeviceDateTimeConfig()` reads a cookie refreshed on every visit
- **timeFormat** — `getLocaleDefaults(locale)` derives it from `Intl.DateTimeFormat().resolvedOptions().hourCycle`

`(space)/layout.tsx` already passes both as optional (`user?.timeZone`, `user?.timeFormat`). The gate was stricter than anything downstream required.

### Change

Gate on `name` only — the one field with no fallback, since it's shown in the UI and can't be derived. The setup page's redirect-away condition is updated to match, so the two conditions can't disagree and ping-pong a user between them.

### Verification

- 3 new cases (`timeZone` missing / `timeFormat` missing / both) — confirmed they **fail against the old gate** and pass with the fix
- `pnpm test:unit` — 303 web tests pass
- `pnpm type-check` — 8/8
- `pnpm check` — clean (one pre-existing warning in `packages/ui/src/rich-text-editor.tsx`)

### Follow-up not in this PR

The setup form calls `authClient.updateUser({ name, timeZone, timeFormat, locale })` before the space action. For those 682 users it may have overwritten a deliberate preference with a browser-detected value. Worth checking separately — it's the only candidate for actual data repair.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Users are no longer redirected to setup when only their time zone or time format is missing.
  * Setup continues to be required when a user’s name is missing or no owned space is available.
  * Existing redirect destinations are preserved during onboarding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->