### PR TITLE
🐛 Fix broken Crowdin project link in translation docs

### DIFF
--- a/apps/docs/contribute/translations.mdx
+++ b/apps/docs/contribute/translations.mdx
@@ -5,13 +5,13 @@ description: Help translate Rallly into your language
 ---
 
 Rallly is made available in different languages by volunteer translators.
-Translations can be submitted through [Crowdin](https://crwd.in/rallly).
+Translations can be submitted through [Crowdin](https://crowdin.com/project/rallly).
 Submitting translations is super easy and doesn't require any coding skills.
 
 ## Sign Up to Crowdin
 
 The first thing you need to do is [create a Crowdin account](https://accounts.crowdin.com/register). Crowdin offers a user-friendly interface to submit translations.
-You can then join the project using this link: https://crwd.in/rallly
+You can then join the project using this link: https://crowdin.com/project/rallly
 
 Once you've joined the project:
 


### PR DESCRIPTION
## Problem

The `https://crwd.in/rallly` short link in the translation contribution docs no longer redirects to the Crowdin project, so contributors can't reach it.

## Fix

Replace both occurrences of the broken `crwd.in/rallly` short link with the canonical `https://crowdin.com/project/rallly` URL (the same one already used in the README).

Fixes #2767

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated translation contribution instructions with the current Crowdin project URL.
  * Revised the Crowdin sign-up guidance while preserving the existing instructional flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->