### PR TITLE
✨ Add MaxCharLength donut indicator and cap comments at 2000 characters

### DIFF
--- a/apps/web/public/locales/en/app.json
+++ b/apps/web/public/locales/en/app.json
@@ -116,6 +116,7 @@
   "changePassword": "Change Password",
   "changePasswordDescription": "Update your password to keep your account secure",
   "changeRole": "Change role",
+  "charactersRemaining": "{count, plural, one {# character remaining} other {# characters remaining}}",
   "checkForConflicts": "Toggle which calendars to check for conflicts",
   "cityTime": "{city} Time",
   "clockPreferences": "Clock Preferences",

--- a/apps/web/src/features/poll/components/discussion.tsx
+++ b/apps/web/src/features/poll/components/discussion.tsx
@@ -16,6 +16,7 @@ import {
   DropdownMenuTrigger,
 } from "@rallly/ui/dropdown-menu";
 import { Input } from "@rallly/ui/input";
+import { MaxCharLength } from "@rallly/ui/max-char-length";
 import { toast } from "@rallly/ui/sonner";
 import { Textarea } from "@rallly/ui/textarea";
 import { MoreHorizontalIcon, TrashIcon } from "lucide-react";
@@ -30,6 +31,10 @@ import {
 } from "@/features/poll/components/participant";
 import { useParticipants } from "@/features/poll/components/participants-provider";
 import TruncatedLinkify from "@/features/poll/components/truncated-linkify";
+import {
+  MAX_COMMENT_AUTHOR_NAME_LENGTH,
+  MAX_COMMENT_LENGTH,
+} from "@/features/poll/schema";
 import { useUser } from "@/features/user/client";
 import { Trans, useTranslation } from "@/i18n/client";
 import { RelativeTime } from "@/lib/datetime/relative-time";
@@ -66,13 +71,15 @@ function NewCommentForm({
 
   const pollId = poll.id;
 
-  const { register, reset, control, handleSubmit, formState } =
+  const { register, reset, control, handleSubmit, formState, watch } =
     useForm<CommentForm>({
       defaultValues: {
         authorName,
         content: "",
       },
     });
+
+  const contentLength = watch("content").length;
 
   const addComment = trpc.polls.comments.add.useMutation({
     onError: (error) => {
@@ -94,8 +101,19 @@ function NewCommentForm({
           id="comment"
           className="w-full"
           autoFocus={true}
+          maxLength={MAX_COMMENT_LENGTH}
           placeholder={t("commentPlaceholder")}
           {...register("content", { validate: requiredString })}
+        />
+        <MaxCharLength
+          className="mt-1 flex justify-end"
+          length={contentLength}
+          maxLength={MAX_COMMENT_LENGTH}
+          label={t("charactersRemaining", {
+            defaultValue:
+              "{count, plural, one {# character remaining} other {# characters remaining}}",
+            count: MAX_COMMENT_LENGTH - contentLength,
+          })}
         />
       </div>
       <div
@@ -112,6 +130,7 @@ function NewCommentForm({
             <Input
               placeholder={t("yourName")}
               className="lg:w-48"
+              maxLength={MAX_COMMENT_AUTHOR_NAME_LENGTH}
               data-1p-ignore="true"
               aria-invalid={!!formState.errors.authorName}
               {...field}

--- a/apps/web/src/features/poll/components/forms/poll-details-form.tsx
+++ b/apps/web/src/features/poll/components/forms/poll-details-form.tsx
@@ -153,6 +153,12 @@ const DescriptionField = () => {
                 linkVisit: t("richTextLinkVisit", {
                   defaultValue: "Open link in new tab",
                 }),
+                charactersRemaining: (count) =>
+                  t("charactersRemaining", {
+                    defaultValue:
+                      "{count, plural, one {# character remaining} other {# characters remaining}}",
+                    count,
+                  }),
               }}
             />
             {fieldState.error ? (

--- a/apps/web/src/features/poll/schema.ts
+++ b/apps/web/src/features/poll/schema.ts
@@ -7,6 +7,13 @@ import * as z from "zod";
 // content is rejected.
 export const MAX_POLL_DESCRIPTION_LENGTH = 8000;
 
+// Comment content ships in the new-comment notification email, so it must be
+// bounded. Prod p90 is ~200 chars; legitimate long comments reach ~2000.
+export const MAX_COMMENT_LENGTH = 2000;
+
+// Flows into the email subject line.
+export const MAX_COMMENT_AUTHOR_NAME_LENGTH = 100;
+
 export const pollStatusSchema = z.enum([
   "open",
   "closed",

--- a/apps/web/src/trpc/routers/polls/comments.ts
+++ b/apps/web/src/trpc/routers/polls/comments.ts
@@ -8,6 +8,10 @@ import * as z from "zod";
 import { getInstanceBranding } from "@/emails/branding";
 import { getNotificationRecipient } from "@/features/notifications/data";
 import { hasPollAdminAccess } from "@/features/poll/data";
+import {
+  MAX_COMMENT_AUTHOR_NAME_LENGTH,
+  MAX_COMMENT_LENGTH,
+} from "@/features/poll/schema";
 import { track } from "@/lib/posthog";
 import {
   createRateLimitMiddleware,
@@ -84,8 +88,12 @@ export const comments = router({
     .input(
       z.object({
         pollId: z.string(),
-        authorName: z.string().trim().min(1),
-        content: z.string().trim().min(1),
+        authorName: z
+          .string()
+          .trim()
+          .min(1)
+          .max(MAX_COMMENT_AUTHOR_NAME_LENGTH),
+        content: z.string().trim().min(1).max(MAX_COMMENT_LENGTH),
       }),
     )
     .mutation(async ({ ctx, input }) => {

--- a/apps/web/src/trpc/routers/polls/comments.ts
+++ b/apps/web/src/trpc/routers/polls/comments.ts
@@ -116,7 +116,9 @@ export const comments = router({
           });
         }
 
-        authorName = user.name;
+        // Stored names (e.g. from OAuth sign-up) aren't guaranteed to satisfy
+        // the schema cap, so bound them here too.
+        authorName = user.name.trim().slice(0, MAX_COMMENT_AUTHOR_NAME_LENGTH);
       }
 
       const { content, pollId } = input;

--- a/packages/ui/src/max-char-length.test.tsx
+++ b/packages/ui/src/max-char-length.test.tsx
@@ -1,0 +1,72 @@
+import { render } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { MaxCharLength } from "./max-char-length";
+
+function renderIndicator(length: number, maxLength = 2000) {
+  return render(
+    <MaxCharLength
+      length={length}
+      maxLength={maxLength}
+      label={`${maxLength - length} characters remaining`}
+    />,
+  );
+}
+
+describe("MaxCharLength", () => {
+  it("stays hidden below the 85% threshold", () => {
+    const { container } = renderIndicator(1699);
+    expect(container.querySelector("svg")).toBeNull();
+    expect(container.textContent).toBe("");
+  });
+
+  it("shows the donut and remaining count at the threshold", () => {
+    const { container } = renderIndicator(1700);
+    expect(container.querySelector("svg")).not.toBeNull();
+    expect(container.textContent).toContain("300");
+  });
+
+  it("announces the remaining count via a polite live region", () => {
+    const { container } = renderIndicator(1900);
+    const liveRegion = container.querySelector("[aria-live='polite']");
+    expect(liveRegion?.textContent).toBe("100 characters remaining");
+  });
+
+  it("keeps the live region empty below the threshold", () => {
+    const { container } = renderIndicator(100);
+    const liveRegion = container.querySelector("[aria-live='polite']");
+    expect(liveRegion).not.toBeNull();
+    expect(liveRegion?.textContent).toBe("");
+  });
+
+  it("fills the ring proportionally", () => {
+    const { container } = renderIndicator(1800);
+    const [, arc] = Array.from(container.querySelectorAll("circle"));
+    const circumference = Number.parseFloat(
+      arc.getAttribute("stroke-dasharray") ?? "0",
+    );
+    const offset = Number.parseFloat(
+      arc.getAttribute("stroke-dashoffset") ?? "0",
+    );
+    expect(offset / circumference).toBeCloseTo(0.1, 5);
+  });
+
+  it("marks the at-limit state with a full ring and a zero count", () => {
+    const { container } = renderIndicator(2000);
+    const [, arc] = Array.from(container.querySelectorAll("circle"));
+    expect(Number.parseFloat(arc.getAttribute("stroke-dashoffset") ?? "")).toBe(
+      0,
+    );
+    expect(arc.classList.contains("stroke-destructive")).toBe(true);
+    expect(container.textContent).toContain("0");
+  });
+
+  it("clamps the ring and shows a negative count when over the limit", () => {
+    const { container } = renderIndicator(2100);
+    const [, arc] = Array.from(container.querySelectorAll("circle"));
+    expect(Number.parseFloat(arc.getAttribute("stroke-dashoffset") ?? "")).toBe(
+      0,
+    );
+    expect(container.textContent).toContain("-100");
+  });
+});

--- a/packages/ui/src/max-char-length.tsx
+++ b/packages/ui/src/max-char-length.tsx
@@ -1,0 +1,82 @@
+"use client";
+
+import { cn } from "./lib/utils";
+
+// Stay out of the way until the user is within ~15% of the cap.
+const VISIBILITY_THRESHOLD = 0.85;
+
+const SIZE = 16;
+const STROKE_WIDTH = 2;
+const RADIUS = (SIZE - STROKE_WIDTH) / 2;
+const CIRCUMFERENCE = 2 * Math.PI * RADIUS;
+
+export function MaxCharLength({
+  length,
+  maxLength,
+  label,
+  className,
+}: {
+  length: number;
+  maxLength: number;
+  /** Localized description of the remaining count (e.g. "12 characters
+   * remaining"). Announced to screen readers while the indicator is shown. */
+  label: string;
+  className?: string;
+}) {
+  const remaining = maxLength - length;
+  const atLimit = remaining <= 0;
+  const show = length >= maxLength * VISIBILITY_THRESHOLD;
+  const progress = Math.min(length / maxLength, 1);
+
+  return (
+    <span className={cn("inline-flex items-center gap-1.5", className)}>
+      <span aria-live="polite" className="sr-only">
+        {show ? label : null}
+      </span>
+      {show ? (
+        <>
+          <svg
+            aria-hidden="true"
+            width={SIZE}
+            height={SIZE}
+            viewBox={`0 0 ${SIZE} ${SIZE}`}
+            className="-rotate-90"
+          >
+            <circle
+              cx={SIZE / 2}
+              cy={SIZE / 2}
+              r={RADIUS}
+              fill="none"
+              strokeWidth={STROKE_WIDTH}
+              className="stroke-border"
+            />
+            <circle
+              cx={SIZE / 2}
+              cy={SIZE / 2}
+              r={RADIUS}
+              fill="none"
+              strokeWidth={STROKE_WIDTH}
+              strokeLinecap="round"
+              strokeDasharray={CIRCUMFERENCE}
+              strokeDashoffset={CIRCUMFERENCE * (1 - progress)}
+              className={atLimit ? "stroke-destructive" : "stroke-primary"}
+            />
+          </svg>
+          {/* The remaining count doubles as the non-color at-limit signal: it
+           * reads 0 (or negative) exactly when the ring is full. */}
+          <span
+            aria-hidden="true"
+            className={cn(
+              "text-xs tabular-nums",
+              atLimit
+                ? "font-medium text-destructive"
+                : "text-muted-foreground",
+            )}
+          >
+            {remaining}
+          </span>
+        </>
+      ) : null}
+    </span>
+  );
+}

--- a/packages/ui/src/rich-text-editor.tsx
+++ b/packages/ui/src/rich-text-editor.tsx
@@ -25,6 +25,7 @@ import {
   InputGroupInput,
 } from "./input-group";
 import { cn } from "./lib/utils";
+import { MaxCharLength } from "./max-char-length";
 import { Popover, PopoverContent, PopoverTrigger } from "./popover";
 
 // Exported so tests exercise the exact extension set — including the
@@ -88,6 +89,9 @@ export function RichTextEditor({
     linkApply: string;
     linkRemove: string;
     linkVisit: string;
+    /** Localized remaining-count text for the character limit indicator,
+     * e.g. (12) => "12 characters remaining". */
+    charactersRemaining: (remaining: number) => string;
   };
 }) {
   const editor = useEditor({
@@ -144,7 +148,11 @@ export function RichTextEditor({
       <EditorContent editor={editor} />
       {maxLength ? (
         <InputGroupAddon align="block-end" className="justify-end">
-          <CharacterCount editor={editor} maxLength={maxLength} />
+          <CharacterLimit
+            editor={editor}
+            maxLength={maxLength}
+            charactersRemaining={labels.charactersRemaining}
+          />
         </InputGroupAddon>
       ) : null}
       <LinkBubbleMenu editor={editor} labels={labels} />
@@ -152,12 +160,14 @@ export function RichTextEditor({
   );
 }
 
-function CharacterCount({
+function CharacterLimit({
   editor,
   maxLength,
+  charactersRemaining,
 }: {
   editor: TiptapEditor;
   maxLength: number;
+  charactersRemaining: (remaining: number) => string;
 }) {
   const { length } = useEditorState({
     editor,
@@ -166,22 +176,12 @@ function CharacterCount({
     selector: (ctx) => ({ length: ctx.editor.getMarkdown().length }),
   });
 
-  const over = length > maxLength;
-  // Stay out of the way until the user is within ~15% of the cap.
-  if (!over && length < maxLength * 0.85) {
-    return null;
-  }
-
   return (
-    <span
-      aria-live="polite"
-      className={cn(
-        "text-xs tabular-nums",
-        over ? "font-medium text-destructive" : "text-muted-foreground",
-      )}
-    >
-      {length}/{maxLength}
-    </span>
+    <MaxCharLength
+      length={length}
+      maxLength={maxLength}
+      label={charactersRemaining(maxLength - length)}
+    />
   );
 }
 


### PR DESCRIPTION
Fixes RAL-1466

## What changed

- **New `MaxCharLength` component in `@rallly/ui`** — a small donut indicator showing characters used vs limit. It stays hidden until the user reaches 85% of the cap, fills proportionally, and switches to a distinct at-limit state (full destructive ring + remaining count in destructive, medium weight). The remaining count is announced via an `aria-live="polite"` region using a localized plural message, and the at-limit state is carried by the visible count (0 or negative) as well as color.
- **Rich text editor** — the plain text `CharacterCount` is removed and replaced with `MaxCharLength` (description limit stays 8000). The editor's `labels` prop gains a `charactersRemaining(remaining)` formatter so the localized text comes from the app.
- **Comment form** — the comment textarea now caps input at 2000 characters (`maxLength` attribute) and shows the donut as the user approaches the limit. The author name input caps at 100.
- **Server side** — `comments.add` rejects `content` over 2000 and `authorName` over 100 characters. Both limits live as shared constants in `apps/web/src/features/poll/schema.ts` next to `MAX_POLL_DESCRIPTION_LENGTH`.

## Verification

- Unit tests for `MaxCharLength` (threshold visibility, live region text, proportional fill, at-limit and over-limit states); full unit suite passes
- Verified in the browser on both surfaces: comment box donut at 1750/2000 and at-limit at 2000; description editor donut at 7200/8000
- Verified server side against a dev instance: 2001-char content → `BAD_REQUEST` ("Too big: expected string to have <=2000 characters"), 2000-char content → accepted, 101-char author name → `BAD_REQUEST`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a reusable “characters remaining” indicator with a progress ring and screen-reader updates to poll comment forms and rich-text editors.
  * Added localized, ICU-pluralized “characters remaining” messaging.
  * Enforced maximum lengths for poll comment content and author names across the UI and notifications.

* **Bug Fixes**
  * Tightened server-side validation to prevent oversized comment content and author names.
  * Trimmed and truncated derived author names to the configured maximum.

* **Tests**
  * Added a complete test suite for the character-limit indicator component.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->