### PR TITLE
✨ Include comment content in the new comment notification email

### DIFF
--- a/apps/web/src/trpc/routers/polls/comments.ts
+++ b/apps/web/src/trpc/routers/polls/comments.ts
@@ -161,6 +161,7 @@ export const comments = router({
               branding: await getInstanceBranding(),
               props: {
                 authorName,
+                content: newComment.content,
                 pollUrl: absoluteUrl(`/poll/${poll.id}`),
                 disableNotificationsUrl: absoluteUrl("/settings/notifications"),
                 title: poll.title,

--- a/packages/emails/locales/en/emails.json
+++ b/packages/emails/locales/en/emails.json
@@ -56,7 +56,7 @@
   "login_content2": "You're receiving this email because a request was made to login to <domain />. If this wasn't you, contact <a>{supportEmail}</a>.",
   "newComment_content": "<b>{authorName}</b> has commented on <b>{title}</b>.",
   "newComment_heading": "New Comment",
-  "newComment_preview": "Go to your poll to see what they said.",
+  "newComment_replyGuidance": "Replying to this email will not reach {authorName}. To respond, add a comment on the poll.",
   "newComment_subject": "{authorName} has commented on {title}",
   "newParticipant_content": "<b>{name}</b> has responded to <b>{title}</b>.",
   "newParticipant_content2": "Go to your poll to see the new response.",

--- a/packages/emails/src/templates/new-comment.tsx
+++ b/packages/emails/src/templates/new-comment.tsx
@@ -7,9 +7,11 @@ import { previewChrome } from "../components/preview-chrome";
 import {
   Body,
   Button,
+  borderColor,
   Container,
   Heading,
   Link,
+  Section,
   Text,
 } from "../components/styled-components";
 import { createEmailI18n } from "../i18n";
@@ -22,27 +24,31 @@ type NewCommentEmailProps = {
   chrome: EmailChrome;
   title: string;
   authorName: string;
+  content: string;
   pollUrl: string;
   disableNotificationsUrl: string;
 };
 
+const PREVIEW_LENGTH = 140;
+
 async function NewCommentEmail({
   title,
   authorName,
+  content,
   pollUrl,
   disableNotificationsUrl,
   locale = "en",
   chrome,
 }: NewCommentEmailProps) {
   const { t, i18n } = await createEmailI18n(locale);
+  const previewText =
+    content.length > PREVIEW_LENGTH
+      ? `${content.slice(0, PREVIEW_LENGTH)}…`
+      : content;
   return (
     <Html>
       <Head />
-      <Preview>
-        {t("newComment_preview", {
-          defaultValue: "Go to your poll to see what they said.",
-        })}
-      </Preview>
+      <Preview>{previewText}</Preview>
       <Body>
         <Container>
           <Img
@@ -69,6 +75,29 @@ async function NewCommentEmail({
               defaults="<b>{authorName}</b> has commented on <b>{title}</b>."
               components={{ b: <strong /> }}
               values={{ authorName, title }}
+            />
+          </Text>
+          <Section
+            style={{
+              borderLeft: `3px solid ${borderColor}`,
+              paddingLeft: "16px",
+            }}
+          >
+            <Text style={{ margin: 0, fontWeight: "bold" }} small>
+              {authorName}
+            </Text>
+            <Text style={{ margin: "8px 0 0", whiteSpace: "pre-wrap" }}>
+              {content}
+            </Text>
+          </Section>
+          <Text small light={true}>
+            <Trans
+              t={t}
+              i18n={i18n}
+              ns="emails"
+              i18nKey="newComment_replyGuidance"
+              defaults="Replying to this email will not reach {authorName}. To respond, add a comment on the poll."
+              values={{ authorName }}
             />
           </Text>
           <Button href={pollUrl} color={chrome.primaryColor}>
@@ -110,6 +139,8 @@ async function NewCommentEmail({
 NewCommentEmail.PreviewProps = {
   title: "Untitled Poll",
   authorName: "Someone",
+  content:
+    "Hi everyone! I can make most of these times work, but Tuesday afternoon would be best for me.\nLooking forward to it!",
   pollUrl: "https://rallly.co",
   disableNotificationsUrl: "https://rallly.co",
   locale: "en",


### PR DESCRIPTION
Closes RAL-1468. Phase 0 of the poll discussions removal: makes email the primary consumption channel for comments by including the comment text in the notification.

## Changes

- **Template** (`packages/emails/src/templates/new-comment.tsx`)
  - New required `content` prop, rendered as a quoted block (left border, attribution, `pre-wrap` so line breaks survive) below the "{authorName} has commented on {title}" line
  - Guidance line under the quote: replying to this email does not reach the commenter; responses happen on the poll. Steers people away from the unmonitored noreply mailbox
  - Inbox preview is now the start of the comment (trimmed to 140 chars with ellipsis), replacing the static `newComment_preview` copy (key removed by the scanner)
  - Subject line and view button unchanged
- **Caller** (`apps/web/src/trpc/routers/polls/comments.ts`) passes `content` from the created comment
- `pnpm i18n:scan` run for the new `newComment_replyGuidance` key

## Verification

- Rendered the template with hostile content (`<script>`, `<img onerror>`, quotes, newlines): user content is fully escaped by React, no markup interpretation, newlines preserved via `white-space: pre-wrap`
- `pnpm type-check` and Biome pass
- No truncation logic needed in the body: content is bounded at 2000 chars by RAL-1466 (#2782)

Reply-To routing and reply ingestion are deliberately out of scope (phase 1 decisions). The noreply autoresponder is an ops task, not code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Comment notification emails now display the full comment content.
  * Added clearer guidance explaining how recipients can respond to comments.

* **Improvements**
  * Comment content is presented in a distinct, readable section with preserved formatting.
  * Email previews now reflect the actual comment text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->