### PR TITLE
🐛 Stop firing $groupidentify on every dashboard page load

### DIFF
--- a/apps/web/src/features/space/actions.ts
+++ b/apps/web/src/features/space/actions.ts
@@ -178,6 +178,16 @@ export const updateSpaceAction = authActionClient
       primaryColor: parsedInput.primaryColor,
     });
 
+    if (parsedInput.name) {
+      identifyGroup({
+        groupType: "space",
+        groupKey: space.id,
+        properties: {
+          name: parsedInput.name,
+        },
+      });
+    }
+
     track(ctx.user, {
       event: "space_update",
       properties: {

--- a/apps/web/src/features/space/client.tsx
+++ b/apps/web/src/features/space/client.tsx
@@ -44,23 +44,13 @@ export function SpaceProvider({
   children: React.ReactNode;
 }) {
   React.useEffect(() => {
-    // Property names must match the server-side identifyGroup payloads.
-    // posthog-js only re-sends $groupidentify when these values change.
-    posthog?.group("space", space.id, {
-      name: space.name,
-      tier: space.tier,
-      custom_branding: space.showBranding,
-      member_count: space.memberCount,
-      seat_count: space.seatCount,
-    });
-  }, [
-    space.id,
-    space.name,
-    space.tier,
-    space.showBranding,
-    space.memberCount,
-    space.seatCount,
-  ]);
+    // No properties here — posthog-js captures $groupidentify on EVERY
+    // group() call that passes properties (no diffing), which fired one
+    // event per page load. Without properties it only fires when the
+    // group key changes. Group properties are maintained by the
+    // server-side identifyGroup calls on the mutations that change them.
+    posthog?.group("space", space.id);
+  }, [space.id]);
 
   const primaryColorVars =
     space.showBranding && space.primaryColor

--- a/apps/web/src/features/space/member/actions.ts
+++ b/apps/web/src/features/space/member/actions.ts
@@ -20,7 +20,7 @@ import {
   removeMemberSchema,
 } from "@/features/space/member/schema";
 import { AppError } from "@/lib/errors/app-error";
-import { track } from "@/lib/posthog";
+import { identifyGroup, track } from "@/lib/posthog";
 import { authActionClient } from "@/lib/safe-action/server";
 
 async function requireActiveSpace(user: { id: string }) {
@@ -97,6 +97,14 @@ export const acceptInviteAction = authActionClient
     });
 
     if (result.ok) {
+      identifyGroup({
+        groupType: "space",
+        groupKey: parsedInput.spaceId,
+        properties: {
+          member_count: result.memberCount,
+        },
+      });
+
       track(ctx.user, {
         event: "space_member_join",
         properties: {
@@ -171,6 +179,14 @@ export const removeMemberAction = authActionClient
 
     const { removedUserId, memberCount } = await removeMember({
       memberId: parsedInput.memberId,
+    });
+
+    identifyGroup({
+      groupType: "space",
+      groupKey: member.spaceId,
+      properties: {
+        member_count: memberCount,
+      },
     });
 
     track(ctx.user, {

--- a/apps/web/src/trpc/routers/spaces.ts
+++ b/apps/web/src/trpc/routers/spaces.ts
@@ -5,7 +5,7 @@ import { createSpaceDTO } from "@/features/space/data";
 import { effectiveSpaceMemberWhere } from "@/features/space/member/utils";
 import type { SpaceDTO } from "@/features/space/types";
 import { fromDBRole } from "@/features/space/utils";
-import { track } from "@/lib/posthog";
+import { identifyGroup, track } from "@/lib/posthog";
 import { privateProcedure, router, spaceProcedure } from "../trpc";
 
 export const spaces = router({
@@ -172,6 +172,14 @@ export const spaces = router({
       where: { spaceId: ctx.space.id },
     });
 
+    identifyGroup({
+      groupType: "space",
+      groupKey: ctx.space.id,
+      properties: {
+        member_count: memberCount,
+      },
+    });
+
     track(ctx.user, {
       event: "space_member_leave",
       properties: {
@@ -248,6 +256,14 @@ export const spaces = router({
 
       const memberCount = await prisma.spaceMember.count({
         where: { spaceId: input.spaceId },
+      });
+
+      identifyGroup({
+        groupType: "space",
+        groupKey: input.spaceId,
+        properties: {
+          member_count: memberCount,
+        },
       });
 
       track(ctx.user, {


### PR DESCRIPTION
## Problem

`$groupidentify` event volume in PostHog is unusually high. The cause is the `posthog.group()` call in `SpaceProvider`, which passed group properties on every mount. The code comment claimed posthog-js only re-sends `$groupidentify` when values change — that is false. Verified against the pinned posthog-js 1.407.2: `group()` captures `$groupidentify` unconditionally whenever a properties object is passed; there is no diffing. Since `SpaceProvider` wraps the entire `(space)` layout, this fired roughly one event per hard page load per logged-in user.

## Fix

- **Client**: call `posthog.group("space", space.id)` with no properties. Client events still get `$groups` attribution, and `$groupidentify` now only fires when the stored group key changes (that path is diffed via persistence).
- **Server**: keep group properties fresh at the mutations that change them, closing the gaps the client call was papering over:
  - `member_count` → `identifyGroup` on invite accept, member remove, and both leave mutations (all already computed `memberCount` for their `track()` calls)
  - `name` → `identifyGroup` on space rename (`updateSpaceAction`)
  - `tier` / `seat_count` were already covered by billing webhooks, `custom_branding` by its toggle action, initial values by space create

## Known drift (accepted)

Account deletion cascades memberships away without an identify, so `member_count` can drift slightly until the next member mutation on that space. Not worth wiring the reaper for.

## Verification

- `pnpm check` clean, `pnpm type-check` clean, 310 unit tests pass
- HogQL to confirm the drop after deploy:

```sql
SELECT toStartOfDay(timestamp) AS day, properties.$lib AS lib, count() AS events
FROM events
WHERE event = '$groupidentify' AND timestamp > now() - INTERVAL 14 DAY
GROUP BY day, lib ORDER BY day
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved space analytics accuracy when names, membership counts, or membership status change.
  * Updated tracking to refresh space details after edits, invites, member removals, and departures.
  * Reduced redundant analytics updates when space details remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->