### PR TITLE
✨ Change default sender name to "Rallly Notifications"

### DIFF
--- a/apps/docs/self-hosting/configuration.mdx
+++ b/apps/docs/self-hosting/configuration.mdx
@@ -32,7 +32,7 @@ All configuration lives in the `.env` file at the root of your self-hosted stack
   Sender address for all transactional emails. Falls back to `SUPPORT_EMAIL` if not set.
 </ParamField>
 
-<ParamField path="NOREPLY_EMAIL_NAME" default="Rallly">
+<ParamField path="NOREPLY_EMAIL_NAME" default="Rallly Notifications">
   Sender name for all transactional emails.
 </ParamField>
 

--- a/apps/web/src/env.ts
+++ b/apps/web/src/env.ts
@@ -71,7 +71,7 @@ export const env = createEnv({
      */
     SUPPORT_EMAIL: z.email(),
     NOREPLY_EMAIL: z.email().optional(),
-    NOREPLY_EMAIL_NAME: z.string().default("Rallly"),
+    NOREPLY_EMAIL_NAME: z.string().default("Rallly Notifications"),
 
     /**
      * S3 Configuration

--- a/packages/emails/src/send.tsx
+++ b/packages/emails/src/send.tsx
@@ -25,7 +25,7 @@ export type SendArgs<P> = {
 function resolveFrom(from?: From): From {
   return (
     from ?? {
-      name: process.env.NOREPLY_EMAIL_NAME ?? "Rallly",
+      name: process.env.NOREPLY_EMAIL_NAME ?? "Rallly Notifications",
       address: process.env.NOREPLY_EMAIL || process.env.SUPPORT_EMAIL || "",
     }
   );


### PR DESCRIPTION
Follow-up to #2784 (RAL-1468 reply-trap mitigation). Changes the default From display name for all transactional email from "Rallly" to "Rallly Notifications", signaling that the mail is automated without requiring the `NOREPLY_EMAIL_NAME` env var to be set.

- `packages/emails/src/send.tsx` — the operative default (the emails package reads `process.env` directly)
- `apps/web/src/env.ts` — schema default kept in sync
- `apps/docs/self-hosting/configuration.mdx` — documented default updated

Self-hosters who haven't set `NOREPLY_EMAIL_NAME` will see the From name change on upgrade; the override behaves as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Updated the default sender name for transactional emails to **“Rallly Notifications”**.
  * Updated the self-hosting configuration documentation to reflect the new default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->