### PR TITLE
💄 Remove redundant author name from comment quote block

### DIFF
--- a/packages/emails/src/templates/new-comment.tsx
+++ b/packages/emails/src/templates/new-comment.tsx
@@ -83,12 +83,7 @@ async function NewCommentEmail({
               paddingLeft: "16px",
             }}
           >
-            <Text style={{ margin: 0, fontWeight: "bold" }} small>
-              {authorName}
-            </Text>
-            <Text style={{ margin: "8px 0 0", whiteSpace: "pre-wrap" }}>
-              {content}
-            </Text>
+            <Text style={{ margin: 0, whiteSpace: "pre-wrap" }}>{content}</Text>
           </Section>
           <Text small light={true}>
             <Trans


### PR DESCRIPTION
Follow-up to #2784. The sentence above the quote block already says "{authorName} has commented on {title}", so repeating the name inside the quote block was redundant. The left border and indent are sufficient to mark the content as a quoted artifact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved new-comment email formatting by displaying comment text consistently.
  * Preserved line breaks and removed unnecessary spacing and author label styling from the highlighted comment section.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->