### PR TITLE
🐛 Use deleteMany in guest-to-user-migration test cleanup

### DIFF
--- a/apps/web/tests/guest-to-user-migration.spec.ts
+++ b/apps/web/tests/guest-to-user-migration.spec.ts
@@ -17,7 +17,7 @@ test.describe.serial(() => {
 
   test.afterAll(async () => {
     // Clean up the test user
-    await prisma.user.delete({
+    await prisma.user.deleteMany({
       where: {
         email: testUser.email,
       },


### PR DESCRIPTION
## Problem

In [guest-to-user-migration.spec.ts](https://github.com/lukevella/rallly/blob/main/apps/web/tests/guest-to-user-migration.spec.ts), the `test.afterAll` hook cleans up with `prisma.user.delete`. When the test fails before registration completes (seen in a flaky CI run of #2783), the user was never created and the delete throws `PrismaClientKnownRequestError` ("No record was found for a delete"), adding a confusing second error to the report.

## Fix

Use `prisma.user.deleteMany`, which is a no-op on zero rows.

Checked the rest of `apps/web/tests/` for the same pattern — this is the only `prisma.<model>.delete(` call in a test hook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test cleanup to remove all matching test accounts, helping prevent leftover test data between runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->