### PR TITLE
💄 Use default button variant for add description button

### DIFF
--- a/apps/web/src/features/poll/components/forms/poll-details-form.tsx
+++ b/apps/web/src/features/poll/components/forms/poll-details-form.tsx
@@ -80,9 +80,8 @@ const DescriptionField = () => {
       <div>
         <Button
           type="button"
-          variant="link"
           size="sm"
-          className="h-auto p-0 text-muted-foreground hover:text-foreground"
+          className="rounded-full"
           onClick={() => setOpened(true)}
         >
           <PlusIcon data-icon="inline-start" />


### PR DESCRIPTION
## Summary
- Change the "Add description" button in the poll details form from a link-style text button to the default button variant with `rounded-full`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the collapsed poll description control with a rounded button style for a cleaner, more consistent appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->