### PR TITLE
✨ Disable comments by default for new polls

### DIFF
--- a/apps/web/src/app/api/private/[...route]/route.ts
+++ b/apps/web/src/app/api/private/[...route]/route.ts
@@ -305,7 +305,7 @@ app.post(
             requireParticipantEmail: input.requireEmail,
             hideParticipants: input.hideParticipants,
             hideScores: input.hideScores,
-            disableComments: input.disableComments,
+            disableComments: poll.disableComments,
             isGuest: false,
           },
           groups: {

--- a/apps/web/src/app/api/private/schemas.ts
+++ b/apps/web/src/app/api/private/schemas.ts
@@ -106,7 +106,8 @@ export const createPollInputSchema = z
       example: false,
     }),
     disableComments: z.boolean().optional().openapi({
-      description: "Disable the comments section",
+      description:
+        "Disable the comments section. Defaults to true: new polls have comments disabled unless this is set to false.",
       example: false,
     }),
     spaceId: z.string().optional().openapi({

--- a/apps/web/src/features/poll/components/create-poll.tsx
+++ b/apps/web/src/features/poll/components/create-poll.tsx
@@ -72,7 +72,7 @@ export const CreatePoll: React.FunctionComponent = () => {
       options: [],
       hideScores: false,
       hideParticipants: false,
-      disableComments: false,
+      disableComments: true,
       duration: 60,
       lockTimeZone: false,
       allDay: false,

--- a/apps/web/src/features/poll/components/forms/poll-settings.tsx
+++ b/apps/web/src/features/poll/components/forms/poll-settings.tsx
@@ -9,7 +9,7 @@ import {
 import { FormField } from "@rallly/ui/form";
 import { Switch } from "@rallly/ui/switch";
 import { AtSignIcon, EyeIcon, MessageCircleIcon, VoteIcon } from "lucide-react";
-import type React from "react";
+import React from "react";
 import { useFormContext } from "react-hook-form";
 import { showPayWall, useIsFree } from "@/features/billing/client";
 import { ProBadge } from "@/features/billing/components/pro-badge";
@@ -31,6 +31,8 @@ const PollSetting = ({
 }) => {
   const form = useFormContext<PollSettingsFormData>();
   const isFree = useIsFree();
+  const titleId = React.useId();
+  const descriptionId = React.useId();
 
   return (
     <FormField
@@ -41,15 +43,23 @@ const PollSetting = ({
         <label className="flex cursor-pointer select-none items-start gap-x-3 rounded-xl border bg-card p-3 hover:bg-card-accent">
           <Icon className="size-4 shrink-0 translate-y-0.5 text-muted-foreground" />
           <div className="grow">
-            <div className="flex items-center gap-x-2 font-medium text-sm">
+            <div
+              id={titleId}
+              className="flex items-center gap-x-2 font-medium text-sm"
+            >
               {title}
               {pro && isFree ? <ProBadge /> : null}
             </div>
-            <div className="mt-1 text-muted-foreground text-xs">
+            <div
+              id={descriptionId}
+              className="mt-1 text-muted-foreground text-xs"
+            >
               {description}
             </div>
           </div>
           <Switch
+            aria-labelledby={titleId}
+            aria-describedby={descriptionId}
             checked={!!field.value}
             onCheckedChange={(checked) => {
               if (checked && pro && isFree) {
@@ -60,6 +70,11 @@ const PollSetting = ({
                 });
               } else {
                 field.onChange(checked);
+                if (name === "disableComments") {
+                  posthog?.capture("poll_settings:comments_toggle_click", {
+                    enabled: !checked,
+                  });
+                }
               }
             }}
           />

--- a/apps/web/src/features/poll/mutations.ts
+++ b/apps/web/src/features/poll/mutations.ts
@@ -63,6 +63,7 @@ export const createPoll = async ({
       timeZone: true,
       status: true,
       createdAt: true,
+      disableComments: true,
       user: {
         select: {
           name: true,

--- a/apps/web/tests/new-poll-page.ts
+++ b/apps/web/tests/new-poll-page.ts
@@ -23,7 +23,13 @@ export class NewPollPage {
     await this.page.goto("/new");
   }
 
-  async create({ name }: { name: string }): Promise<CreatePollSuccessDialog> {
+  async create({
+    name,
+    enableComments,
+  }: {
+    name: string;
+    enableComments?: boolean;
+  }): Promise<CreatePollSuccessDialog> {
     const page = this.page;
 
     await page.getByLabel(/title|event/i).fill(name);
@@ -44,6 +50,11 @@ export class NewPollPage {
     await page.getByText("7", { exact: true }).first().click();
     await page.getByText("10", { exact: true }).first().click();
     await page.getByText("15", { exact: true }).first().click();
+
+    if (enableComments) {
+      // Comments are off by default; turn the "Disable comments" setting off
+      await page.getByRole("switch", { name: /disable comments/i }).click();
+    }
 
     await page.getByRole("button", { name: /create poll/i }).click();
 

--- a/apps/web/tests/vote-and-comment.spec.ts
+++ b/apps/web/tests/vote-and-comment.spec.ts
@@ -16,7 +16,10 @@ test.describe(() => {
 
     const newPollPage = new NewPollPage(page);
     await newPollPage.goto();
-    const dialog = await newPollPage.create({ name: "Monthly Meetup" });
+    const dialog = await newPollPage.create({
+      name: "Monthly Meetup",
+      enableComments: true,
+    });
     pollPage = await dialog.goToPollPage();
 
     // Extract the poll ID from the URL

--- a/packages/database/prisma/migrations/20260730120000_default_disable_comments_to_true/migration.sql
+++ b/packages/database/prisma/migrations/20260730120000_default_disable_comments_to_true/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "polls" ALTER COLUMN "disable_comments" SET DEFAULT true;

--- a/packages/database/prisma/models/poll.prisma
+++ b/packages/database/prisma/models/poll.prisma
@@ -48,7 +48,7 @@ model Poll {
   scheduledEventId        String?           @map("scheduled_event_id")
   hideParticipants        Boolean           @default(false) @map("hide_participants")
   hideScores              Boolean           @default(false) @map("hide_scores")
-  disableComments         Boolean           @default(false) @map("disable_comments")
+  disableComments         Boolean           @default(true) @map("disable_comments")
   requireParticipantEmail Boolean           @default(false) @map("require_participant_email")
   muted                   Boolean           @default(false)
 

--- a/packages/database/prisma/seed.ts
+++ b/packages/database/prisma/seed.ts
@@ -115,7 +115,8 @@ async function main() {
         scheduledEventId: poll.scheduledEventId,
         hideParticipants: poll.hideParticipants,
         hideScores: poll.hideScores,
-        disableComments: poll.disableComments,
+        // Seed polls model pre-existing data, which predates the comments-off default
+        disableComments: poll.disableComments ?? false,
         requireParticipantEmail: poll.requireParticipantEmail,
         kind,
       },


### PR DESCRIPTION
Part 2 of the discussions swap (RAL-1470). With response notes shipped in #2789, new polls now default to comments off unless the host opts in. This is a transition instrument: removal follows, gated on the re-enable rate this change lets us measure.

## Changes

- **Default flip, all creation paths**: `disable_comments` column default flipped to `true` (migration alters the default only — existing rows untouched) and the create form defaults the toggle on. The web create flow, quick create, and API v1 all inherit the new default; omitted values fall through to the column default.
- **Opt in stays**: the existing Disable comments toggle in poll settings is unchanged and becomes the re-enable path.
- **Instrumentation**: toggling the comments setting emits `poll_settings:comments_toggle_click` with an `enabled` property, so the re-enable rate is measurable without a DB query. The API `poll_create` event now reports the persisted `disableComments` value instead of echoing the raw input (which is undefined when omitted).
- **API docs**: the `disableComments` field description in the private API schema documents the new default.
- **Accessibility**: the poll settings switches had no accessible names (the wrapping label does not name a button based switch); they now get `aria-labelledby`/`aria-describedby`.
- **Seeds/tests**: seed polls keep comments on (they model pre-existing data); the vote and comment spec now opts into comments at creation, which also exercises the re-enable path end to end.

## Release notes (self hosted)

> New polls are now created with comments disabled. The Disable comments toggle in poll settings is unchanged — turn it off to enable comments on a poll. Existing polls are unaffected.

## Testing

- Unit tests pass (`pnpm test:unit`)
- Playwright: vote-and-comment, accessibility, create-delete-poll, edit-options, cross-timezone specs pass
- Lint and type-check clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - New polls now have comments disabled by default, with an option to enable them during creation.
  - Improved accessibility for poll comment settings with clearer switch labeling.

- **Bug Fixes**
  - Poll activity tracking now accurately reflects the saved comments setting.
  - Existing poll data remains compatible during database seeding.

- **Tests**
  - Updated poll creation and voting/comment coverage for the new comments behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->