### PR TITLE
🔒️ Prevent space admins from removing or demoting the space owner

### DIFF
--- a/apps/web/src/features/space/member/ability.test.ts
+++ b/apps/web/src/features/space/member/ability.test.ts
@@ -1,0 +1,100 @@
+import { subject } from "@casl/ability";
+import { describe, expect, it } from "vitest";
+import { defineAbilityForMember } from "./ability";
+import type { MemberDTO } from "./types";
+
+const SPACE_ID = "space-1";
+const OWNER_ID = "user-owner";
+const ADMIN_ID = "user-admin";
+const MEMBER_ID = "user-member";
+
+function makeMember(overrides: Partial<MemberDTO>): MemberDTO {
+  return {
+    id: "member-row",
+    name: "Test User",
+    email: "test@example.com",
+    userId: MEMBER_ID,
+    spaceId: SPACE_ID,
+    role: "member",
+    isOwner: false,
+    ...overrides,
+  };
+}
+
+describe("defineAbilityForMember", () => {
+  describe("non-owner admin", () => {
+    const ability = defineAbilityForMember({
+      user: { id: ADMIN_ID },
+      space: { id: SPACE_ID, ownerId: OWNER_ID, role: "admin" },
+    });
+
+    const owner = makeMember({
+      id: "member-owner",
+      userId: OWNER_ID,
+      role: "admin",
+      isOwner: true,
+    });
+
+    it("cannot remove the space owner", () => {
+      expect(ability.can("delete", subject("SpaceMember", owner))).toBe(false);
+    });
+
+    it("cannot change the space owner's role", () => {
+      expect(ability.can("update", subject("SpaceMember", owner))).toBe(false);
+    });
+
+    it("cannot remove themselves", () => {
+      const self = makeMember({
+        id: "member-admin",
+        userId: ADMIN_ID,
+        role: "admin",
+      });
+      expect(ability.can("delete", subject("SpaceMember", self))).toBe(false);
+      expect(ability.can("update", subject("SpaceMember", self))).toBe(false);
+    });
+
+    it("cannot act on members of another space", () => {
+      const otherSpaceMember = makeMember({
+        id: "member-other",
+        spaceId: "space-2",
+      });
+      expect(
+        ability.can("delete", subject("SpaceMember", otherSpaceMember)),
+      ).toBe(false);
+      expect(
+        ability.can("update", subject("SpaceMember", otherSpaceMember)),
+      ).toBe(false);
+    });
+
+    it("can remove and update a regular member", () => {
+      const regularMember = makeMember({});
+      expect(ability.can("delete", subject("SpaceMember", regularMember))).toBe(
+        true,
+      );
+      expect(ability.can("update", subject("SpaceMember", regularMember))).toBe(
+        true,
+      );
+    });
+  });
+
+  describe("owner admin", () => {
+    const ability = defineAbilityForMember({
+      user: { id: OWNER_ID },
+      space: { id: SPACE_ID, ownerId: OWNER_ID, role: "admin" },
+    });
+
+    it("can remove and update other admins", () => {
+      const otherAdmin = makeMember({
+        id: "member-admin",
+        userId: ADMIN_ID,
+        role: "admin",
+      });
+      expect(ability.can("delete", subject("SpaceMember", otherAdmin))).toBe(
+        true,
+      );
+      expect(ability.can("update", subject("SpaceMember", otherAdmin))).toBe(
+        true,
+      );
+    });
+  });
+});

--- a/apps/web/src/features/space/member/ability.ts
+++ b/apps/web/src/features/space/member/ability.ts
@@ -94,4 +94,7 @@ function defineSpaceAdminRules(
   cannot(["delete", "update"], "SpaceMember", {
     userId: ctx.user.id,
   });
+  cannot(["delete", "update"], "SpaceMember", {
+    userId: ctx.space.ownerId,
+  });
 }

--- a/apps/web/src/features/space/member/actions.ts
+++ b/apps/web/src/features/space/member/actions.ts
@@ -168,6 +168,13 @@ export const removeMemberAction = authActionClient
       });
     }
 
+    if (member.isOwner) {
+      throw new AppError({
+        code: "FORBIDDEN",
+        message: "The space owner cannot be removed",
+      });
+    }
+
     const ability = defineAbilityForMember({ user: ctx.user, space });
 
     if (ability.cannot("delete", subject("SpaceMember", member))) {
@@ -213,6 +220,13 @@ export const changeMemberRoleAction = authActionClient
       throw new AppError({
         code: "NOT_FOUND",
         message: "Member not found",
+      });
+    }
+
+    if (member.isOwner) {
+      throw new AppError({
+        code: "FORBIDDEN",
+        message: "The space owner's role cannot be changed",
       });
     }
 


### PR DESCRIPTION
Fixes RAL-1472.

## Problem

A non-owner space admin could remove the space owner or demote them to member, permanently locking the owner out of their own space. The admin ruleset granted `update`/`delete` on `SpaceMember` scoped to the space and only subtracted the caller's own membership row — nothing shielded the owner, whose membership is just another row. Both server actions (`removeMemberAction`, `changeMemberRoleAction`) and the members UI dropdown gate solely on this ability, so the actions were reachable through the normal UI.

## Fix

- **Primary**: add an owner-protection `cannot` rule to `defineSpaceAdminRules` in `features/space/member/ability.ts`. Since the server actions and the members UI read the same ability, this closes the actions and disables the UI affordance in one edit.
- **Defensive**: guard `removeMemberAction` and `changeMemberRoleAction` with an explicit `member.isOwner` check that throws `FORBIDDEN`.

## Tests

New `ability.test.ts` regression suite:
- non-owner admin cannot delete/update the owner's membership (failed before the fix)
- self-protection and space-scoping controls still hold
- admin can still manage regular members; owner can still manage other admins

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented space owners from being removed.
  * Prevented changes to the space owner’s role.
  * Corrected member-management permissions so administrators cannot modify or remove the space owner, while authorized owners retain appropriate controls.
  * Added coverage for member-management authorization scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->