### PR TITLE
📈 Track attribution surfaces before gating removal behind Pro

### DIFF
--- a/apps/web/src/features/poll/components/new-participant-modal.tsx
+++ b/apps/web/src/features/poll/components/new-participant-modal.tsx
@@ -149,28 +149,6 @@ export const NewParticipantForm = (props: NewParticipantModalProps) => {
   const [showNote, setShowNote] = React.useState(false);
   const addParticipant = useAddParticipantMutation();
 
-  const { isSubmitSuccessful } = formState;
-  const successTracked = React.useRef(false);
-  React.useEffect(() => {
-    if (!isSubmitSuccessful) {
-      successTracked.current = false;
-      return;
-    }
-    if (successTracked.current) {
-      return;
-    }
-    successTracked.current = true;
-    posthog?.capture("new_participant_dialog:success_view", {
-      pollId: poll.id,
-      spaceId: poll.spaceId,
-      tier: poll.space?.tier,
-      $groups: {
-        poll: poll.id,
-        ...(poll.spaceId ? { space: poll.spaceId } : {}),
-      },
-    });
-  }, [isSubmitSuccessful, poll.id, poll.spaceId, poll.space?.tier]);
-
   if (formState.isSubmitSuccessful) {
     return (
       <>
@@ -263,6 +241,15 @@ export const NewParticipantForm = (props: NewParticipantModalProps) => {
                 note: data.note,
                 pollId: poll.id,
                 timeZone,
+              });
+              posthog?.capture("new_participant_dialog:success_view", {
+                pollId: poll.id,
+                spaceId: poll.spaceId,
+                tier: poll.space?.tier,
+                $groups: {
+                  poll: poll.id,
+                  ...(poll.spaceId ? { space: poll.spaceId } : {}),
+                },
               });
               props.onSubmit?.(newParticipant);
             } catch (error) {

--- a/apps/web/src/features/poll/components/new-participant-modal.tsx
+++ b/apps/web/src/features/poll/components/new-participant-modal.tsx
@@ -149,6 +149,21 @@ export const NewParticipantForm = (props: NewParticipantModalProps) => {
   const [showNote, setShowNote] = React.useState(false);
   const addParticipant = useAddParticipantMutation();
 
+  const { isSubmitSuccessful } = formState;
+  React.useEffect(() => {
+    if (isSubmitSuccessful) {
+      posthog?.capture("new_participant_dialog:success_view", {
+        pollId: poll.id,
+        spaceId: poll.spaceId,
+        tier: poll.space?.tier,
+        $groups: {
+          poll: poll.id,
+          ...(poll.spaceId ? { space: poll.spaceId } : {}),
+        },
+      });
+    }
+  }, [isSubmitSuccessful, poll.id, poll.spaceId, poll.space?.tier]);
+
   if (formState.isSubmitSuccessful) {
     return (
       <>

--- a/apps/web/src/features/poll/components/new-participant-modal.tsx
+++ b/apps/web/src/features/poll/components/new-participant-modal.tsx
@@ -150,18 +150,25 @@ export const NewParticipantForm = (props: NewParticipantModalProps) => {
   const addParticipant = useAddParticipantMutation();
 
   const { isSubmitSuccessful } = formState;
+  const successTracked = React.useRef(false);
   React.useEffect(() => {
-    if (isSubmitSuccessful) {
-      posthog?.capture("new_participant_dialog:success_view", {
-        pollId: poll.id,
-        spaceId: poll.spaceId,
-        tier: poll.space?.tier,
-        $groups: {
-          poll: poll.id,
-          ...(poll.spaceId ? { space: poll.spaceId } : {}),
-        },
-      });
+    if (!isSubmitSuccessful) {
+      successTracked.current = false;
+      return;
     }
+    if (successTracked.current) {
+      return;
+    }
+    successTracked.current = true;
+    posthog?.capture("new_participant_dialog:success_view", {
+      pollId: poll.id,
+      spaceId: poll.spaceId,
+      tier: poll.space?.tier,
+      $groups: {
+        poll: poll.id,
+        ...(poll.spaceId ? { space: poll.spaceId } : {}),
+      },
+    });
   }, [isSubmitSuccessful, poll.id, poll.spaceId, poll.space?.tier]);
 
   if (formState.isSubmitSuccessful) {

--- a/apps/web/src/features/poll/components/poll-footer.tsx
+++ b/apps/web/src/features/poll/components/poll-footer.tsx
@@ -24,7 +24,7 @@ export function PollFooter() {
             <Link
               prefetch={false}
               className="rounded-none border-b border-b-gray-500 font-semibold hover:text-primary"
-              href="https://rallly.co?utm_source=poll&utm_medium=powered_by"
+              href="https://rallly.co?utm_source=rallly&utm_medium=poll&utm_campaign=powered_by"
               onClick={() => {
                 posthog?.capture("poll_footer:powered_by_link_click", {
                   pollId: poll.id,

--- a/apps/web/src/features/poll/components/poll-footer.tsx
+++ b/apps/web/src/features/poll/components/poll-footer.tsx
@@ -1,10 +1,13 @@
 "use client";
+import { posthog } from "@rallly/posthog/client";
 import Link from "next/link";
 import { useBranding } from "@/features/branding/client";
+import { usePoll } from "@/features/poll/client";
 import { Trans } from "@/i18n/client";
 
 export function PollFooter() {
   const { hideAttribution } = useBranding();
+  const poll = usePoll();
 
   if (hideAttribution) {
     return null;
@@ -21,7 +24,18 @@ export function PollFooter() {
             <Link
               prefetch={false}
               className="rounded-none border-b border-b-gray-500 font-semibold hover:text-primary"
-              href="https://rallly.co"
+              href="https://rallly.co?utm_source=poll&utm_medium=powered_by"
+              onClick={() => {
+                posthog?.capture("poll_footer:powered_by_link_click", {
+                  pollId: poll.id,
+                  spaceId: poll.spaceId,
+                  tier: poll.space?.tier,
+                  $groups: {
+                    poll: poll.id,
+                    ...(poll.spaceId ? { space: poll.spaceId } : {}),
+                  },
+                });
+              }}
             />
           ),
         }}

--- a/apps/web/src/lib/posthog.ts
+++ b/apps/web/src/lib/posthog.ts
@@ -29,8 +29,10 @@ export function posthog() {
  * noRestrictedImports in apps/web/biome.json) so the guest decision cannot
  * be forgotten at individual capture sites. Guests are captured as anonymous
  * events (no person profile — they are transient and rarely convert);
- * identified users get person processing as usual. Group analytics is
- * unaffected either way.
+ * identified users get person processing as usual. Note: PostHog drops
+ * group associations on personless events, so `groups` passed here only
+ * take effect for identified users — put poll/space/tier on plain
+ * properties when guest events need them.
  *
  * When a guest's client-side anonymous distinct_id is known (read from the
  * posthog-js persistence cookie via getClientAnonymousDistinctId), guest

--- a/apps/web/src/trpc/routers/polls/participants.ts
+++ b/apps/web/src/trpc/routers/polls/participants.ts
@@ -333,6 +333,8 @@ export const participants = router({
                 title: true,
                 space: {
                   select: {
+                    id: true,
+                    tier: true,
                     showBranding: true,
                     primaryColor: true,
                     image: true,
@@ -384,6 +386,11 @@ export const participants = router({
             event: "poll_response_submit",
             properties: {
               participant_id: participant.id,
+              // plain properties, not groups: guest events are personless and
+              // PostHog drops group associations without person processing
+              poll_id: pollId,
+              space_id: participant.poll.space?.id,
+              tier: participant.poll.space?.tier,
               has_email: !!email,
               has_note: !!participant.note,
               note_length: participant.note?.length,

--- a/packages/emails/src/components/powered-by.tsx
+++ b/packages/emails/src/components/powered-by.tsx
@@ -30,7 +30,7 @@ export async function PoweredBy({
           a: (
             <Link
               color={chrome.primaryColor}
-              href="https://rallly.co?utm_source=email&utm_medium=transactional"
+              href="https://rallly.co?utm_source=email&utm_medium=powered_by"
             />
           ),
         }}

--- a/packages/emails/src/components/powered-by.tsx
+++ b/packages/emails/src/components/powered-by.tsx
@@ -30,7 +30,7 @@ export async function PoweredBy({
           a: (
             <Link
               color={chrome.primaryColor}
-              href="https://rallly.co?utm_source=email&utm_medium=powered_by"
+              href="https://rallly.co?utm_source=rallly&utm_medium=email&utm_campaign=powered_by"
             />
           ),
         }}


### PR DESCRIPTION
## Description

We're considering offering removal of the "Powered by Rallly" attribution as a Pro feature. Before gating it, we need a baseline for what attribution is worth as a growth loop (participant → host conversion). This PR instruments the three attribution surfaces:

- **Poll footer** — the `rallly.co` link was completely untracked. It now carries `?utm_source=poll&utm_medium=powered_by` and captures `poll_footer:powered_by_link_click` with poll/space context and groups, matching the shape of the existing `new_participant_dialog` events.
- **Email footer** — retagged from `utm_medium=transactional` to `utm_medium=powered_by`, so a single `utm_medium=powered_by` filter identifies all attribution-driven traffic, with `utm_source` (`poll`/`email`) splitting the surfaces.
- **Success dialog** — restores `new_participant_dialog:success_view`. The event still exists in PostHog but its capture was removed from the code at some point, leaving the "Create your own poll" CTA click event with no view denominator. Reusing the same event name keeps historical continuity.

Reviewer notes: click tracking is a floor for attribution value (most of it is dark funnel — participants who see the name and sign up later); the cohort analysis for that runs on `register`/`$pageview` joins in PostHog and needs no further code. No i18n changes — link hrefs and analytics only.

## Checklist

- [x] I have performed a self-review of my code
- [x] My code follows the code style of this project
- [x] I have commented my code, particularly in hard-to-understand areas

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Analytics**
  * Improved tracking for participant sign-ups and powered-by link clicks.
  * Added poll, space, tier, and group context to relevant engagement events.
  * Captured successful participant sign-ups immediately after completion.

* **Improvements**
  * Standardized campaign tracking parameters across powered-by links in the app and emails.
  * Improved attribution consistency for powered-by links in polls and email communications.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->