### PR TITLE
🔧 Register delete-orphaned-anonymous-users house-keeping cron

### DIFF
--- a/apps/web/vercel.json
+++ b/apps/web/vercel.json
@@ -22,6 +22,10 @@
     {
       "path": "/api/house-keeping/remove-deleted-users",
       "schedule": "0 7 * * *"
+    },
+    {
+      "path": "/api/house-keeping/delete-orphaned-anonymous-users",
+      "schedule": "30 7 * * *"
     }
   ]
 }


### PR DESCRIPTION
## Summary

#2764 added the `delete-orphaned-anonymous-users` house-keeping endpoint, its supporting indexes (`20260723000000`), and integration tests — but never registered the job in `apps/web/vercel.json`, so it ships as dead code.

This registers it at 07:30 UTC daily, following the existing 30-minute spacing after `remove-deleted-users` (07:00).

The mutation only deletes anonymous users past the session TTL with no polls, comments, participants, or event invites, and re-applies those guards at delete time, so a user who becomes non-orphaned between snapshot and delete is skipped.

Part of the v4.12.0 release prep (RAL-1474). Should merge before tagging so the notes can advertise the cleanup job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added a daily automated cleanup job for orphaned anonymous accounts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->