### PR TITLE
💬 Reposition when2meet-alternative page copy

### DIFF
--- a/apps/landing/public/locales/en/home.json
+++ b/apps/landing/public/locales/en/home.json
@@ -28,8 +28,8 @@
   "statsUsersRegistered": "{count, number, ::compact-short}+ registered users",
   "subheading": "Coordinate group meetings without the back-and-forth emails",
   "viaTrustpilot": "via Trustpilot",
-  "when2meetAlternative": "Still using When2Meet?",
-  "when2meetAlternativeDescription": "Create professional, ad-free meetings polls for free with Rallly.",
-  "when2meetAlternativeMetaDescription": "Find a better way to schedule meetings with Rallly, the top free alternative to When2Meet. Easy to use and free.",
-  "when2meetAlternativeMetaTitle": "Best When2Meet Alternative: Rallly"
+  "when2meetAlternative": "A Modern When2Meet Alternative",
+  "when2meetAlternativeDescription": "Rallly does everything you use When2Meet for, without the clunky parts. Create clean scheduling polls that work great on mobile, get notified when participants respond, and manage all your polls in one place. Free, without ads, and no account needed to vote. Coming from When2Meet or WhenIsGood? Rallly will feel instantly familiar.",
+  "when2meetAlternativeMetaDescription": "Rallly is a free When2Meet alternative with a clean interface, great mobile support, response notifications, and no ads. No account needed to vote.",
+  "when2meetAlternativeMetaTitle": "Best Free When2Meet Alternative | Rallly"
 }


### PR DESCRIPTION
## Context

GSC data (last 3 months) shows [/when2meet-alternative](https://rallly.co/when2meet-alternative) gets 72.6k impressions per quarter but only 381 clicks (0.52% CTR, avg position 8.3). The winnable slice is the ~4k impression "when2meet alternative" query cluster, where the page ranks 5.6–6.9. The current page copy is two sentences, the H1 is a rhetorical question with no keyword, and the description has a typo ("meetings polls").

Part of RAL-1476.

## Changes

English source strings only (`apps/landing/public/locales/en/home.json`) — translations follow via Crowdin:

- **H1**: "Still using When2Meet?" → "A Modern When2Meet Alternative" (target keyword now in the H1)
- **Description**: names the actual When2Meet pains (clunky UI, mobile, no notifications, no way to manage polls in one place) instead of a generic pitch, and mentions WhenIsGood to cover that query cluster (~400 impressions at position ~29, currently invisible)
- **Meta title**: adds "Free" — "when2meet alternative free" has its own query volume and free is the key switching motivator
- **Meta description**: concrete differentiators instead of "easy to use and free" twice

No structural page changes; the page template is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the English landing-page title, description, and metadata for the When2Meet alternative.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->