### PR TITLE
💄 Replace icon with spinner on loading icon buttons

### DIFF
--- a/apps/web/src/features/poll/components/notification-toggle.tsx
+++ b/apps/web/src/features/poll/components/notification-toggle.tsx
@@ -61,6 +61,7 @@ export function NotificationToggle() {
         render={
           <Button
             variant="ghost"
+            size="icon"
             aria-pressed={poll.muted}
             aria-label={
               poll.muted

--- a/packages/ui/src/button.tsx
+++ b/packages/ui/src/button.tsx
@@ -24,6 +24,7 @@ const Button = ({
   ...props
 }: ButtonPrimitive.Props &
   VariantProps<typeof buttonVariants> & { loading?: boolean }) => {
+  const isIconButton = size?.startsWith("icon");
   return (
     <ButtonPrimitive
       className={cn(
@@ -31,6 +32,7 @@ const Button = ({
         buttonVariants({ variant, size }),
         {
           "pointer-events-none": loading,
+          "[&_svg:not([data-slot=spinner])]:hidden": loading && isIconButton,
         },
         className,
       )}
@@ -38,7 +40,8 @@ const Button = ({
     >
       {loading ? (
         <Loader2Icon
-          data-icon="inline-start"
+          data-slot="spinner"
+          data-icon={isIconButton ? undefined : "inline-start"}
           className="size-4 animate-spin opacity-75"
         />
       ) : null}


### PR DESCRIPTION
## Summary

- When a `Button` with an icon size (`icon`, `icon-xs`, `icon-sm`, `icon-lg`) is in a loading state, the spinner now replaces the icon instead of rendering next to it. Child icons are hidden via CSS (`[&_svg:not([data-slot=spinner])]:hidden`) so `sr-only` labels stay in the DOM for screen readers.
- Non-icon sizes are unchanged — the spinner still renders inline-start next to the label.
- The poll notification toggle now uses `size="icon"` so it gets this behavior. Its rendered size is unchanged (36×36px before and after).

## Test plan

- Toggle notifications on a poll and confirm the bell icon is replaced by the spinner while the mutation is pending.
- Confirm loading buttons with text labels (non-icon sizes) still show spinner + label as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved loading behavior for icon-only buttons.
  * Prevented non-loading icons from appearing alongside the loading spinner.
* **Style**
  * Updated the notification toggle to use the compact icon button style.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->