### PR TITLE
🔥 Remove redundant new_participant_dialog:success_view event

### DIFF
--- a/apps/web/src/features/poll/components/new-participant-modal.tsx
+++ b/apps/web/src/features/poll/components/new-participant-modal.tsx
@@ -242,15 +242,6 @@ export const NewParticipantForm = (props: NewParticipantModalProps) => {
                 pollId: poll.id,
                 timeZone,
               });
-              posthog?.capture("new_participant_dialog:success_view", {
-                pollId: poll.id,
-                spaceId: poll.spaceId,
-                tier: poll.space?.tier,
-                $groups: {
-                  poll: poll.id,
-                  ...(poll.spaceId ? { space: poll.spaceId } : {}),
-                },
-              });
               props.onSubmit?.(newParticipant);
             } catch (error) {
               if (error instanceof TRPCClientError) {


### PR DESCRIPTION
## Description

Removes the client-side `new_participant_dialog:success_view` PostHog capture from the new participant dialog.

The event fired immediately after the `addParticipant` mutation resolved, at exactly the moment the server tracks `poll_response_submit` inside that same mutation (`apps/web/src/trpc/routers/polls/participants.ts`). The two were 1:1 duplicates, and the server event is strictly better: richer properties (`has_email`, `has_note`, `note_length`, `total_responses`), not lost to ad blockers, and correctly personless for guests.

Notes for reviewers:

- Any PostHog insight or funnel built on `success_view` should be repointed at `poll_response_submit`. Its properties are snake_case (`poll_id`) rather than the dialog events' camelCase (`pollId`), so property filters need renaming too.
- The other two dialog events (`new_participant_dialog:create_poll_button_click`, `new_participant_dialog:add_note_button_click`) are untouched since they have no server-side counterpart.

## Checklist

Please check off all the following items with an "x" in the boxes before requesting a review.

- [x] I have performed a self-review of my code
- [x] My code follows the code style of this project
- [x] I have commented my code, particularly in hard-to-understand areas

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Analytics**
  * Removed tracking for the successful participant-added dialog event.
* **Bug Fixes**
  * Preserved successful participant submission behavior after the add operation completes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->