### PR TITLE
🐛 Declare API_BASE_URL in turbo globalEnv to restore the api-host rewrite

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -65,6 +65,7 @@
   "globalEnv": [
     "ALLOWED_EMAILS",
     "ANALYZE",
+    "API_BASE_URL",
     "AWS_ACCESS_KEY_ID",
     "AWS_REGION",
     "AWS_SECRET_ACCESS_KEY",


### PR DESCRIPTION
## Problem

The api-host rewrite in `apps/web/next.config.ts` is dead in production Vercel builds. `rewrites()` reads `process.env.API_BASE_URL` at build time, but the variable is not declared in `turbo.json` `globalEnv`, and turbo 2 strict env mode strips undeclared vars from the build environment — so `rewrites()` returns `[]`.

Verified 2026-07-31: https://api.rallly.co/status returns the app HTML shell while https://app.rallly.co/api/status returns the status JSON.

## Fix

Add `API_BASE_URL` to `globalEnv` so the rewrite is generated at build time. This also makes turbo cache-bust when the value changes.

## Notes

- This makes api.rallly.co live again (currently it serves the app shell).
- Known constraint: Next.js rewrites don't rewrite `request.url` for route handlers, so Hono `basePath` routing under `/api/private` may 404 through the rewritten host. Plain route handlers like `/api/status` work fine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added `API_BASE_URL` to the build environment configuration, enabling it to be recognized consistently across development and production workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->