### PR TITLE
📈 Instrument the paywall funnel with trigger context

### DIFF
--- a/apps/web/src/app/[locale]/(space)/(dashboard)/components/upgrade-menu-item.tsx
+++ b/apps/web/src/app/[locale]/(space)/(dashboard)/components/upgrade-menu-item.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { posthog } from "@rallly/posthog/client";
 import { SidebarMenuButton, SidebarMenuItem } from "@rallly/ui/sidebar";
 import { SparklesIcon } from "lucide-react";
 import { showPayWall, useIsFree } from "@/features/billing/client";
@@ -18,8 +17,7 @@ export function UpgradeMenuItem() {
       <SidebarMenuButton
         variant="primary"
         onClick={() => {
-          posthog?.capture("space_sidebar:upgrade_button_click");
-          showPayWall();
+          showPayWall({ from: "sidebar" });
         }}
       >
         <SparklesIcon />

--- a/apps/web/src/app/[locale]/(space)/settings/api-keys/components/api-access-upgrade.tsx
+++ b/apps/web/src/app/[locale]/(space)/settings/api-keys/components/api-access-upgrade.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { posthog } from "@rallly/posthog/client";
 import { Button } from "@rallly/ui/button";
 import { TerminalIcon } from "lucide-react";
 import {
@@ -37,8 +36,7 @@ export function ApiAccessUpgrade() {
         <Button
           variant="primary"
           onClick={() => {
-            posthog?.capture("api_keys:upgrade_button_click");
-            showPayWall();
+            showPayWall({ from: "api-keys" });
           }}
         >
           <Trans i18nKey="upgradeToPro" defaults="Upgrade to Pro" />

--- a/apps/web/src/app/[locale]/(space)/settings/billing/components/hobby-plan-card.tsx
+++ b/apps/web/src/app/[locale]/(space)/settings/billing/components/hobby-plan-card.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { posthog } from "@rallly/posthog/client";
 import { Button } from "@rallly/ui/button";
 import { showPayWall } from "@/features/billing/client";
 import {
@@ -49,8 +48,7 @@ export function HobbyPlanCard({ className }: { className?: string }) {
         <Button
           variant="primary"
           onClick={() => {
-            showPayWall();
-            posthog?.capture("space_billing:upgrade_button_click");
+            showPayWall({ from: "billing-settings" });
           }}
         >
           <Trans i18nKey="upgradeToPro" defaults="Upgrade to Pro" />

--- a/apps/web/src/app/[locale]/(space)/settings/general/components/custom-branding-section.tsx
+++ b/apps/web/src/app/[locale]/(space)/settings/general/components/custom-branding-section.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { posthog } from "@rallly/posthog/client";
 import { Button } from "@rallly/ui/button";
 import { ColorPicker, parseColor } from "@rallly/ui/color-picker";
 import { Field, FieldGroup, FieldLabel } from "@rallly/ui/field";
@@ -60,8 +59,7 @@ export function CustomBrandingSection({
 
   const handleToggle = async (newChecked: boolean) => {
     if (isFree) {
-      posthog?.capture("branding_settings:paywall_trigger");
-      showPayWall();
+      showPayWall({ from: "custom-branding" });
       return;
     }
 

--- a/apps/web/src/app/[locale]/(space)/settings/members/components/invite-member-button.tsx
+++ b/apps/web/src/app/[locale]/(space)/settings/members/components/invite-member-button.tsx
@@ -33,7 +33,7 @@ export function InviteMemberButton({
               }),
             );
           } else if (space.getAbility().cannot("invite", "Member")) {
-            showPayWall();
+            showPayWall({ from: "space-members", action: "invite" });
           } else {
             inviteMemberDialog.trigger();
           }

--- a/apps/web/src/app/[locale]/(space)/settings/members/page-client.tsx
+++ b/apps/web/src/app/[locale]/(space)/settings/members/page-client.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { posthog } from "@rallly/posthog/client";
 import {
   Alert,
   AlertAction,
@@ -90,10 +89,10 @@ export function MembersSettingsPageClient({
                       <Button
                         size="sm"
                         onClick={() => {
-                          posthog?.capture(
-                            "members_settings:upgrade_button_click",
-                          );
-                          showPayWall();
+                          showPayWall({
+                            from: "space-members",
+                            action: "reactivate",
+                          });
                         }}
                       >
                         <Trans
@@ -166,8 +165,7 @@ export function MembersSettingsPageClient({
                   size="sm"
                   variant="link"
                   onClick={() => {
-                    posthog?.capture("members_settings:upgrade_button_click");
-                    showPayWall();
+                    showPayWall({ from: "space-members", action: "invite" });
                   }}
                 >
                   <Trans i18nKey="upgradeToPro" defaults="Upgrade to Pro" />

--- a/apps/web/src/features/billing/actions.ts
+++ b/apps/web/src/features/billing/actions.ts
@@ -13,6 +13,7 @@ import type {
 import { getStripe } from "@/features/billing/service";
 import { getActiveSpaceForUser } from "@/features/space/data";
 import { AppError } from "@/lib/errors/app-error";
+import { track } from "@/lib/posthog";
 import { authActionClient } from "@/lib/safe-action/server";
 import { validateRedirectUrl } from "@/lib/utils/redirect";
 
@@ -150,6 +151,16 @@ export const upgradeToProAction = authActionClient
         message: "Something went wrong while creating a checkout session",
       });
     }
+
+    track(ctx.user, {
+      event: "billing:checkout_start",
+      properties: {
+        interval: period === "yearly" ? "year" : "month",
+      },
+      groups: {
+        space: space.id,
+      },
+    });
 
     redirect(checkoutSession.url);
   });

--- a/apps/web/src/features/billing/client.tsx
+++ b/apps/web/src/features/billing/client.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { posthog } from "@rallly/posthog/client";
 import { create } from "zustand";
 import type { SpaceTier } from "@/features/space/schema";
 import { trpc } from "@/trpc/client";
@@ -14,16 +15,41 @@ export function useIsFree() {
   return useTier() === "hobby";
 }
 
+export type PayWallTrigger = {
+  from:
+    | "poll-settings"
+    | "manage-poll"
+    | "custom-branding"
+    | "api-keys"
+    | "space-members"
+    | "billing-settings"
+    | "sidebar";
+  setting?: string;
+  action?: string;
+  pollId?: string;
+};
+
 type PayWallStore = {
   isOpen: boolean;
-  show: () => void;
+  trigger: PayWallTrigger | null;
+  show: (trigger: PayWallTrigger) => void;
   hide: () => void;
 };
 
 export const usePayWallStore = create<PayWallStore>((set) => ({
   isOpen: false,
-  show: () => set({ isOpen: true }),
+  trigger: null,
+  show: (trigger) => {
+    posthog?.capture("trigger paywall", {
+      from: trigger.from,
+      setting: trigger.setting,
+      action: trigger.action,
+      poll_id: trigger.pollId,
+    });
+    set({ isOpen: true, trigger });
+  },
   hide: () => set({ isOpen: false }),
 }));
 
-export const showPayWall = () => usePayWallStore.getState().show();
+export const showPayWall = (trigger: PayWallTrigger) =>
+  usePayWallStore.getState().show(trigger);

--- a/apps/web/src/features/billing/components/pay-wall-dialog.tsx
+++ b/apps/web/src/features/billing/components/pay-wall-dialog.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { pricingData } from "@rallly/billing/pricing";
+import { posthog } from "@rallly/posthog/client";
 import { Button } from "@rallly/ui/button";
 import {
   Dialog,
@@ -33,6 +34,7 @@ import { UpgradeButton } from "@/features/billing/components/upgrade-button";
 import type { SpaceTier } from "@/features/space/schema";
 import { spaceTierSchema } from "@/features/space/schema";
 import { Trans } from "@/i18n/client";
+import { usePayWallStore } from "../client";
 import { PLAN_NAMES } from "../constants";
 
 function KeyBenefits({ children }: { children?: React.ReactNode }) {
@@ -117,6 +119,7 @@ export function PayWallDialog({
 }) {
   const [selectedPlan, setSelectedPlan] = React.useState<SpaceTier>("pro");
   const [isAnnual, setIsAnnual] = React.useState(false);
+  const trigger = usePayWallStore((state) => state.trigger);
 
   const handleChangePlan = (value: string) => {
     setSelectedPlan(spaceTierSchema.parse(value));
@@ -234,7 +237,20 @@ export function PayWallDialog({
               )}
               {selectedPlan === "pro" ? (
                 <TabsContent value="pro">
-                  <UpgradeButton className="w-full" annual={isAnnual}>
+                  <UpgradeButton
+                    className="w-full"
+                    annual={isAnnual}
+                    onClick={() => {
+                      posthog?.capture("paywall:upgrade_button_click", {
+                        from: trigger?.from,
+                        setting: trigger?.setting,
+                        action: trigger?.action,
+                        poll_id: trigger?.pollId,
+                        plan: selectedPlan,
+                        interval: isAnnual ? "year" : "month",
+                      });
+                    }}
+                  >
                     <Trans i18nKey="upgrade" defaults="Upgrade" />
                   </UpgradeButton>
                 </TabsContent>

--- a/apps/web/src/features/billing/components/upgrade-button.tsx
+++ b/apps/web/src/features/billing/components/upgrade-button.tsx
@@ -12,9 +12,11 @@ export const UpgradeButton = ({
   children,
   annual,
   className,
+  onClick,
 }: React.PropsWithChildren<{
   annual?: boolean;
   className?: string;
+  onClick?: () => void;
 }>) => {
   const pathname = usePathname();
   const router = useRouter();
@@ -29,6 +31,7 @@ export const UpgradeButton = ({
       variant="primary"
       loading={upgradeToPro.isExecuting}
       onClick={() => {
+        onClick?.();
         if (!user || user.isGuest) {
           router.push(`/register?redirectTo=${encodeURIComponent(pathname)}`);
           return;

--- a/apps/web/src/features/poll/components/forms/poll-settings.tsx
+++ b/apps/web/src/features/poll/components/forms/poll-settings.tsx
@@ -63,11 +63,7 @@ const PollSetting = ({
             checked={!!field.value}
             onCheckedChange={(checked) => {
               if (checked && pro && isFree) {
-                showPayWall();
-                posthog?.capture("trigger paywall", {
-                  setting: name,
-                  from: "poll-settings",
-                });
+                showPayWall({ from: "poll-settings", setting: name });
               } else {
                 field.onChange(checked);
                 if (name === "disableComments") {

--- a/apps/web/src/features/poll/components/manage-poll.tsx
+++ b/apps/web/src/features/poll/components/manage-poll.tsx
@@ -1,4 +1,3 @@
-import { posthog } from "@rallly/posthog/client";
 import { Button } from "@rallly/ui/button";
 import { useDialog } from "@rallly/ui/dialog";
 import {
@@ -157,11 +156,10 @@ const ManagePoll: React.FunctionComponent<{
                 disabled={!!poll.event}
                 onClick={() => {
                   if (isFree) {
-                    showPayWall();
-                    posthog?.capture("trigger paywall", {
-                      poll_id: poll.id,
+                    showPayWall({
                       from: "manage-poll",
                       action: "schedule",
+                      pollId: poll.id,
                     });
                   } else {
                     scheduleDialog.trigger();
@@ -183,11 +181,10 @@ const ManagePoll: React.FunctionComponent<{
           <DropdownMenuItem
             onClick={() => {
               if (isFree) {
-                showPayWall();
-                posthog?.capture("trigger paywall", {
-                  poll_id: poll.id,
-                  action: "duplicate",
+                showPayWall({
                   from: "manage-poll",
+                  action: "duplicate",
+                  pollId: poll.id,
                 });
               } else {
                 duplicateDialog.trigger();


### PR DESCRIPTION
Closes RAL-1481 (instrumentation scope).

## Problem

`trigger paywall` → `subscription_create` had no intermediate steps, so the ~97.5% drop-off was invisible. Worse, only 2 of 8 `showPayWall()` call sites actually emitted `trigger paywall` — the baseline undercounts paywall exposure. Three surfaces emitted their own one-off events instead (`branding_settings:paywall_trigger`, `api_keys:upgrade_button_click`, `space_billing:upgrade_button_click`, `space_sidebar:upgrade_button_click`, `members_settings:upgrade_button_click`) and three emitted nothing.

## Changes

**Centralized trigger capture.** `showPayWall()` now requires a typed trigger (`from` + optional `setting`/`action`/`pollId`) and the store captures `trigger paywall` itself, so every current and future call site is tracked with consistent properties. Existing property keys (`from`, `setting`, `action`, `poll_id`) are unchanged for continuity with the May–Jul baseline.

New `from` values: `custom-branding`, `api-keys`, `space-members` (actions `invite`/`reactivate`), `billing-settings`, `sidebar` — alongside the existing `poll-settings` and `manage-poll`. The redundant one-off events listed above are removed; their data is now in `trigger paywall` broken down by `from`.

**Dialog CTA event.** `paywall:upgrade_button_click` fires from the paywall dialog with the trigger context plus `plan` and `interval` (`month`/`year`). This is the high-volume experiment metric (~1,800 paywall persons/month vs 72 subs).

**Checkout start.** `billing:checkout_start` captured server-side in `upgradeToProAction` after the Stripe checkout session is created, with `interval` and the space group. Server-side because it's the truth for "reached Stripe" — guest clicks that bounce to /register don't count.

## Funnel

`trigger paywall` → `paywall:upgrade_button_click` → `billing:checkout_start` → `subscription_create`, joined per person (client identifies with userId; server events use userId via `track()`). Breakdown by `from` on the first step splits the funnel by trigger feature.

## Analysis notes

- `trigger paywall` volume will step up on deploy (six newly covered surfaces). Filter `from IN (poll-settings, manage-poll)` to compare against the historical baseline.
- Instant dismiss vs Stripe abandonment is now distinguishable: shown without click = dismissed; click without `billing:checkout_start` = guest or error; checkout start without `subscription_create` = Stripe abandonment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Upgrade prompts now retain the context that led to them, including sidebar, billing, branding, API access, member management, and poll actions.
  * Paywall experiences now better distinguish actions such as inviting or reactivating members and scheduling or duplicating polls.
  * Upgrade and checkout flows have improved event tracking to support more consistent product insights.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->