### PR TITLE
✅ Stop Next env files leaking into the Playwright test server

### DIFF
--- a/apps/web/playwright.config.ts
+++ b/apps/web/playwright.config.ts
@@ -25,6 +25,14 @@ export default defineConfig({
     command: ci ? `next start --port ${port}` : `next dev --port ${port}`,
     url: baseURL,
     reuseExistingServer: !ci,
+    env: {
+      // Next layers env files from apps/web (notably the developer's .env) on
+      // top of the process env, leaking dev vars into the test server — e.g.
+      // NEXT_PUBLIC_COOKIE_DOMAIN breaks every authenticated flow. @next/env
+      // skips env file loading entirely when this flag is set, so the server
+      // only sees the .env.test values loaded above.
+      __NEXT_PROCESSED_ENV: "true",
+    },
   },
   reporter: [
     [ci ? "github" : "list"],


### PR DESCRIPTION
## Problem

Local Playwright integration runs are poisoned by the developer's `apps/web/.env`. `playwright.config.ts` loads `.env.test` into the process env and starts `next dev`, but `@next/env` then layers `.env.test.local`/`.env.test`/`.env` from disk on top for any key the process env doesn't already define. Every key in the dev `.env` that `.env.test` doesn't set leaks into the test server.

`NEXT_PUBLIC_COOKIE_DOMAIN` is the worst case: session cookies get the dev domain (`.rallly.test`), the test browser on localhost rejects them, and every authenticated flow fails with "This method requires a user". `KV_REST_API_URL`/`TOKEN`, Stripe, and OAuth vars leak the same way.

## Fix

Set `__NEXT_PROCESSED_ENV=true` in `webServer.env`. `@next/env`'s `processEnv()` treats the env as already processed and skips env file loading entirely, so the server only sees the `.env.test` values the Playwright config loaded. This masks every current and future dev var rather than blocklisting known ones. Playwright merges `webServer.env` over `process.env`, so `.env.test` values pass through unchanged.

Caveat: the flag is internal to `@next/env` (verified against Next 16.2.6; all startup paths call `loadEnvConfig` with `forceReload=false`, which honors the guard). An env file edit while the test server is running would still force a reload.

## Verification

With a poisoned `apps/web/.env` present (copy of the real dev one, including `NEXT_PUBLIC_COOKIE_DOMAIN=.rallly.test`):
- Before: `vote-and-comment.spec.ts` fails in `beforeAll` (guest session cookies dropped)
- After: all 4 tests pass

Without `.env`: spec still passes; full suite matches the clean-tree baseline (the pre-existing, ordering-dependent `user registration` timeout occurs identically with and without this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved end-to-end test environment consistency by preventing duplicate loading of Next.js environment files.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->