### PR TITLE
✅ Fix hydration race in registration test that broke full-suite runs

### DIFF
--- a/apps/web/tests/authentication.spec.ts
+++ b/apps/web/tests/authentication.spec.ts
@@ -29,7 +29,7 @@ test.describe.serial(() => {
   test.describe("new user", () => {
     test("user registration", async ({ page }) => {
       const registerPage = new RegisterPage(page);
-      registerPage.goto();
+      await registerPage.goto();
       await registerPage.register({
         name: "Test User",
         email: testUserEmail,

--- a/apps/web/tests/register-page.ts
+++ b/apps/web/tests/register-page.ts
@@ -22,13 +22,20 @@ export class RegisterPage {
     // appears. The OTP is reused across resends (resendStrategy: "reuse"),
     // so submitting more than once is safe.
     await expect(async () => {
+      const verifyHeading = this.page.getByRole("heading", {
+        name: "Verify Your Email",
+      });
+      // A previous attempt may have submitted successfully with the
+      // navigation landing only after its wait expired — the login form is
+      // gone at that point, so don't try to fill it again.
+      if (await verifyHeading.isVisible()) {
+        return;
+      }
       await this.page.getByPlaceholder("jessie.smith@example.com").fill(email);
       await this.page
         .getByRole("button", { name: "Continue with email" })
         .click();
-      await this.page
-        .getByRole("heading", { name: "Verify Your Email" })
-        .waitFor({ timeout: 5000 });
+      await verifyHeading.waitFor({ timeout: 5000 });
     }).toPass();
 
     // Handle verification code

--- a/apps/web/tests/register-page.ts
+++ b/apps/web/tests/register-page.ts
@@ -17,17 +17,22 @@ export class RegisterPage {
   }
 
   async register({ name, email }: { name: string; email: string }) {
-    // Request a verification code
-    await this.page.getByPlaceholder("jessie.smith@example.com").fill(email);
-    await this.page
-      .getByRole("button", { name: "Continue with email" })
-      .click();
+    // The login form is visible before React has hydrated it, so input that
+    // lands too early can be silently lost. Retry until the next screen
+    // appears. The OTP is reused across resends (resendStrategy: "reuse"),
+    // so submitting more than once is safe.
+    await expect(async () => {
+      await this.page.getByPlaceholder("jessie.smith@example.com").fill(email);
+      await this.page
+        .getByRole("button", { name: "Continue with email" })
+        .click();
+      await this.page
+        .getByRole("heading", { name: "Verify Your Email" })
+        .waitFor({ timeout: 5000 });
+    }).toPass();
 
     // Handle verification code
     const code = await getCode(email);
-    await this.page
-      .getByRole("heading", { name: "Verify Your Email" })
-      .waitFor();
     await this.page.getByLabel("Enter your 6-digit code").fill(code);
 
     // New accounts have no name and go through onboarding. The space name


### PR DESCRIPTION
## Description

`authentication.spec.ts › new user › user registration` consistently timed out (30s) in full-suite runs while passing in isolation, and because the file is a serial describe, its failure skipped the 15 tests after it.

The trace showed the cause: `RegisterPage.register()` filled the login form once with no retry, and the spec called `registerPage.goto()` without `await`. When earlier specs (`accessibility`, `admin-setup`) had already warmed the `/login` compile, the page loaded instantly and the fill landed on the pre-hydration DOM. React hook form then hydrated and reset the controlled input to its empty default, so the click submitted an empty form ("Please enter a valid email"). No OTP was ever requested, `getCode()` polled mailpit until the test timeout, and the rest of the file was skipped. Run alone, the cold first compile delayed the page enough for hydration to win, which is why the test passed in isolation.

This is the same pre-hydration input loss that `loginWithEmail` and the a11y spec already guard against with an `expect().toPass()` retry. This PR applies the same pattern to `RegisterPage.register()` (retry fill → click → wait for the Verify Your Email heading; resubmitting is safe because OTPs use `resendStrategy: "reuse"`) and adds the missing `await` on `goto()`. This also covers the other consumer, `guest-to-user-migration.spec.ts`.

Verified: the minimal repro (`accessibility` + `admin-setup` + `authentication`) failed before and passes after, and the full integration suite now passes (56 passed, 1 skipped).

## Checklist

- [x] I have performed a self-review of my code
- [x] My code follows the code style of this project
- [x] I have commented my code, particularly in hard-to-understand areas

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved registration flow reliability by waiting for the registration page to load before proceeding.
  * Added retry handling for email entry and continuation during registration.
  * Ensured verification codes are retrieved only after the email verification screen is ready.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->