### PR TITLE
📝 Rework support contact page messaging

### DIFF
--- a/apps/docs/contact/support.mdx
+++ b/apps/docs/contact/support.mdx
@@ -5,13 +5,18 @@ description: Get in touch with us if you need help with anything
 
 If you have any questions, feedback or suggestions, please get in touch. We'd love to hear from you!
 
+<Tip>
+  Check out the [FAQ](/faq) page to see if your question has already been
+  answered.
+</Tip>
+
 <CardGroup cols={2}>
   <Card
     title="Email (recommended)"
     icon="envelope"
     href="mailto:support@rallly.co"
   >
-    Email us at `support@rallly.co`
+    Send us an email
   </Card>
   <Card
     title="Discord"
@@ -23,6 +28,5 @@ If you have any questions, feedback or suggestions, please get in touch. We'd lo
 </CardGroup>
 
 <Note>
-  Check out the [FAQ](/faq) page to see if your question has already been
-  answered.
+  If the link above doesn't work, email us at `support@rallly.co`.
 </Note>

--- a/apps/docs/contact/support.mdx
+++ b/apps/docs/contact/support.mdx
@@ -28,5 +28,6 @@ If you have any questions, feedback or suggestions, please get in touch. We'd lo
 </CardGroup>
 
 <Note>
-  If the link above doesn't work, email us at `support@rallly.co`.
+  If the email link doesn't open your email client, email us at
+  `support@rallly.co`.
 </Note>


### PR DESCRIPTION
## Description

Reworks the messaging on the support contact page of the docs:

- Moved the FAQ suggestion above the contact cards as a `<Tip>` so it acts as deflection before someone reaches for a contact option.
- Simplified the email card copy to "Send us an email" instead of repeating the address.
- Added a `<Note>` below the cards with the plain-text address as a fallback for users whose mailto links don't open a mail client.

## Checklist

- [x] I have performed a self-review of my code
- [x] My code follows the code style of this project
- [x] I have commented my code, particularly in hard-to-understand areas

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a frequently asked questions tip above the support options.
  * Updated the email support card wording to “Send us an email.”
  * Replaced the FAQ link in the support note with instructions to contact support by email.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->