### PR TITLE
🐛 Fix SSR bailout on the forgot password page

### DIFF
--- a/apps/web/src/app/[locale]/(auth)/forgot-password/page.tsx
+++ b/apps/web/src/app/[locale]/(auth)/forgot-password/page.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from "next";
 import { notFound } from "next/navigation";
+import { Trans } from "react-i18next/TransWithoutContext";
 import { env } from "@/env";
-import { Trans } from "@/i18n/client";
 import { getTranslation } from "@/i18n/server";
 import { redirectIfLoggedIn } from "@/lib/auth";
 import {
@@ -20,15 +20,23 @@ export default async function ForgotPasswordPage() {
     notFound();
   }
   await redirectIfLoggedIn();
+  const { t } = await getTranslation();
 
   return (
     <AuthPageContainer>
       <AuthPageHeader>
         <AuthPageTitle>
-          <Trans i18nKey="forgotPasswordTitle" defaults="Forgot Password" />
+          <Trans
+            t={t}
+            ns="app"
+            i18nKey="forgotPasswordTitle"
+            defaults="Forgot Password"
+          />
         </AuthPageTitle>
         <AuthPageDescription>
           <Trans
+            t={t}
+            ns="app"
             i18nKey="forgotPasswordDescription"
             defaults="Enter your email address and we'll send you a link to reset your password."
           />
@@ -39,6 +47,8 @@ export default async function ForgotPasswordPage() {
       </AuthPageContent>
       <AuthPageExternal>
         <Trans
+          t={t}
+          ns="app"
           i18nKey="forgotPasswordFooter"
           defaults="Remember your password? <a>Back to login</a>"
           components={{


### PR DESCRIPTION
## Problem

`/forgot-password` deterministically failed server-side rendering and fell back to client rendering. Every full page load streamed a Suspense fallback template (`data-dgst`) wrapping the whole page and logged this on the server:

```
Element type is invalid: expected a string (for built-in components) or a
class/function (for composite components) but got: undefined.
```

Users saw a working page because React recovered client-side, but SSR was broken and the error spammed server logs.

## Root cause

Bisecting the page isolated the footer:

```tsx
<Trans // client Trans from @/i18n/client, rendered by a server component
  i18nKey="forgotPasswordFooter"
  components={{ a: <LinkWithRedirectTo ... /> }}
/>
```

The failure needs two ingredients, which is why the identical footer on `/reset-password` works:

1. A JSX element passed in a **non-children prop** (`components`) across the server→client boundary.
2. A **dynamic render** — `redirectIfLoggedIn()` reads request headers; `await headers()` alone reproduces it. `/reset-password` calls no dynamic API, so it escapes.

With both present, the interpolated element's type deserializes as `undefined` in the SSR-side Flight stream (Next 16.2.6). A patched react-dom-server confirmed the undefined element is the interpolated `<a>` inside react-i18next's `Trans` — even with a plain `<a />`, so it isn't specific to `LinkWithRedirectTo`. The browser-bound payload serializes the same element correctly, which is why hydration recovery succeeds. Framework bug, but easy to stop tripping.

## Fix

Render the page's translations server-side with `Trans` from `react-i18next/TransWithoutContext` and `t` from `getTranslation()` — the pattern `login/verify` already uses (it calls `redirectIfLoggedIn()` + interpolated `Trans` and SSRs fine). No element crosses the boundary as a prop; `LinkWithRedirectTo` ends up in children position, which serializes correctly.

Same landmine exists in `control-panel/branding` (broken, same pattern in a dynamic segment) and `reset-password` (works today, one refactor away from breaking) — tracked separately.

## Verification

`curl -s <host>/forgot-password | grep -o 'data-dgst[^>]*'` now returns nothing; the footer link and email form are present in the streamed HTML; `/reset-password` and `/login` remain clean; no "Element type is invalid" in server logs; biome + type-check pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved localization on the forgot-password page.
  * Ensured the page title, description, and footer display the correct translations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->