### PR TITLE
♻️ Render server-side Trans without context in remaining server components

### DIFF
--- a/apps/web/src/app/[locale]/(auth)/reset-password/page.tsx
+++ b/apps/web/src/app/[locale]/(auth)/reset-password/page.tsx
@@ -18,13 +18,14 @@ export default async function ResetPasswordPage() {
   if (env.EMAIL_LOGIN_ENABLED === "false") {
     notFound();
   }
-  const { t } = await getTranslation();
+  const { t, i18n } = await getTranslation();
   return (
     <AuthPageContainer>
       <AuthPageHeader>
         <AuthPageTitle>
           <Trans
             t={t}
+            i18n={i18n}
             ns="app"
             i18nKey="resetPasswordTitle"
             defaults="Reset Password"
@@ -33,6 +34,7 @@ export default async function ResetPasswordPage() {
         <AuthPageDescription>
           <Trans
             t={t}
+            i18n={i18n}
             ns="app"
             i18nKey="resetPasswordDescription"
             defaults="Enter your new password below"
@@ -45,6 +47,7 @@ export default async function ResetPasswordPage() {
       <AuthPageExternal>
         <Trans
           t={t}
+          i18n={i18n}
           ns="app"
           i18nKey="resetPasswordFooter"
           defaults="<a>Back to login</a>"

--- a/apps/web/src/app/[locale]/(auth)/reset-password/page.tsx
+++ b/apps/web/src/app/[locale]/(auth)/reset-password/page.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from "next";
 import { notFound } from "next/navigation";
+import { Trans } from "react-i18next/TransWithoutContext";
 import { env } from "@/env";
-import { Trans } from "@/i18n/client";
 import { getTranslation } from "@/i18n/server";
 import {
   AuthPageContainer,
@@ -18,14 +18,22 @@ export default async function ResetPasswordPage() {
   if (env.EMAIL_LOGIN_ENABLED === "false") {
     notFound();
   }
+  const { t } = await getTranslation();
   return (
     <AuthPageContainer>
       <AuthPageHeader>
         <AuthPageTitle>
-          <Trans i18nKey="resetPasswordTitle" defaults="Reset Password" />
+          <Trans
+            t={t}
+            ns="app"
+            i18nKey="resetPasswordTitle"
+            defaults="Reset Password"
+          />
         </AuthPageTitle>
         <AuthPageDescription>
           <Trans
+            t={t}
+            ns="app"
             i18nKey="resetPasswordDescription"
             defaults="Enter your new password below"
           />
@@ -36,6 +44,8 @@ export default async function ResetPasswordPage() {
       </AuthPageContent>
       <AuthPageExternal>
         <Trans
+          t={t}
+          ns="app"
           i18nKey="resetPasswordFooter"
           defaults="<a>Back to login</a>"
           components={{

--- a/apps/web/src/app/[locale]/control-panel/branding/page.tsx
+++ b/apps/web/src/app/[locale]/control-panel/branding/page.tsx
@@ -42,7 +42,7 @@ async function loadData() {
 }
 
 async function SetEnvironmentVariableAlert({ variable }: { variable: string }) {
-  const { t } = await getTranslation();
+  const { t, i18n } = await getTranslation();
   return (
     <Alert>
       <CodeIcon />
@@ -50,6 +50,7 @@ async function SetEnvironmentVariableAlert({ variable }: { variable: string }) {
         <p>
           <Trans
             t={t}
+            i18n={i18n}
             ns="app"
             i18nKey="setEnvironmentVariable"
             defaults="This value can be changed by setting the <env /> environment variable."
@@ -74,17 +75,24 @@ export default async function BrandingPage() {
     hideAttribution,
     appName,
   } = await loadData();
-  const { t } = await getTranslation();
+  const { t, i18n } = await getTranslation();
 
   return (
     <SettingsPage>
       <SettingsPageHeader>
         <SettingsPageTitle>
-          <Trans t={t} ns="app" i18nKey="branding" defaults="Branding" />
+          <Trans
+            t={t}
+            i18n={i18n}
+            ns="app"
+            i18nKey="branding"
+            defaults="Branding"
+          />
         </SettingsPageTitle>
         <SettingsPageDescription>
           <Trans
             t={t}
+            i18n={i18n}
             ns="app"
             i18nKey="brandingDescription"
             defaults="View your instance branding configuration"
@@ -99,6 +107,7 @@ export default async function BrandingPage() {
               <p className="flex-1">
                 <Trans
                   t={t}
+                  i18n={i18n}
                   ns="app"
                   i18nKey="customBrandingAlertDescription"
                   defaults="Custom branding is available to Enterprise license holders as a paid add-on."
@@ -113,6 +122,7 @@ export default async function BrandingPage() {
                 >
                   <Trans
                     t={t}
+                    i18n={i18n}
                     ns="app"
                     i18nKey="learnMore"
                     defaults="Learn more"
@@ -126,11 +136,18 @@ export default async function BrandingPage() {
           <PageSection variant="card">
             <PageSectionHeader>
               <PageSectionTitle>
-                <Trans t={t} ns="app" i18nKey="general" defaults="General" />
+                <Trans
+                  t={t}
+                  i18n={i18n}
+                  ns="app"
+                  i18nKey="general"
+                  defaults="General"
+                />
               </PageSectionTitle>
               <PageSectionDescription>
                 <Trans
                   t={t}
+                  i18n={i18n}
                   ns="app"
                   i18nKey="brandingDescription"
                   defaults="View your instance branding configuration"
@@ -140,7 +157,13 @@ export default async function BrandingPage() {
             <PageSectionContent>
               <div className="space-y-2">
                 <div className="text-muted-foreground text-xs">
-                  <Trans t={t} ns="app" i18nKey="name" defaults="App Name" />
+                  <Trans
+                    t={t}
+                    i18n={i18n}
+                    ns="app"
+                    i18nKey="name"
+                    defaults="App Name"
+                  />
                 </div>
                 <Input value={appName} readOnly />
                 <SetEnvironmentVariableAlert variable="APP_NAME" />
@@ -150,11 +173,18 @@ export default async function BrandingPage() {
           <PageSection variant="card">
             <PageSectionHeader>
               <PageSectionTitle>
-                <Trans t={t} ns="app" i18nKey="colors" defaults="Colors" />
+                <Trans
+                  t={t}
+                  i18n={i18n}
+                  ns="app"
+                  i18nKey="colors"
+                  defaults="Colors"
+                />
               </PageSectionTitle>
               <PageSectionDescription>
                 <Trans
                   t={t}
+                  i18n={i18n}
                   ns="app"
                   i18nKey="colorsDescription"
                   defaults="Primary colors used for theming"
@@ -167,6 +197,7 @@ export default async function BrandingPage() {
                   <div className="text-muted-foreground text-xs">
                     <Trans
                       t={t}
+                      i18n={i18n}
                       ns="app"
                       i18nKey="primaryColor"
                       defaults="Primary Color"
@@ -187,6 +218,7 @@ export default async function BrandingPage() {
                   <div className="text-muted-foreground text-xs">
                     <Trans
                       t={t}
+                      i18n={i18n}
                       ns="app"
                       i18nKey="primaryColorDark"
                       defaults="Primary Color (Dark Mode)"
@@ -209,11 +241,18 @@ export default async function BrandingPage() {
           <PageSection variant="card">
             <PageSectionHeader>
               <PageSectionTitle>
-                <Trans t={t} ns="app" i18nKey="logos" defaults="Logos" />
+                <Trans
+                  t={t}
+                  i18n={i18n}
+                  ns="app"
+                  i18nKey="logos"
+                  defaults="Logos"
+                />
               </PageSectionTitle>
               <PageSectionDescription>
                 <Trans
                   t={t}
+                  i18n={i18n}
                   ns="app"
                   i18nKey="logosDescription"
                   defaults="Logo images used throughout the application"
@@ -224,7 +263,13 @@ export default async function BrandingPage() {
               <div className="space-y-6">
                 <div className="space-y-2">
                   <div className="text-muted-foreground text-xs">
-                    <Trans t={t} ns="app" i18nKey="logo" defaults="Logo" />
+                    <Trans
+                      t={t}
+                      i18n={i18n}
+                      ns="app"
+                      i18nKey="logo"
+                      defaults="Logo"
+                    />
                   </div>
                   <div className="flex items-center gap-4">
                     <div className="flex w-48 items-center justify-center overflow-hidden rounded border bg-white">
@@ -242,6 +287,7 @@ export default async function BrandingPage() {
                   <div className="text-muted-foreground text-xs">
                     <Trans
                       t={t}
+                      i18n={i18n}
                       ns="app"
                       i18nKey="logoDark"
                       defaults="Logo (Dark Mode)"
@@ -263,6 +309,7 @@ export default async function BrandingPage() {
                   <div className="text-muted-foreground text-xs">
                     <Trans
                       t={t}
+                      i18n={i18n}
                       ns="app"
                       i18nKey="logoIcon"
                       defaults="Logo Icon"
@@ -288,6 +335,7 @@ export default async function BrandingPage() {
               <PageSectionTitle>
                 <Trans
                   t={t}
+                  i18n={i18n}
                   ns="app"
                   i18nKey="attribution"
                   defaults="Attribution"
@@ -296,6 +344,7 @@ export default async function BrandingPage() {
               <PageSectionDescription>
                 <Trans
                   t={t}
+                  i18n={i18n}
                   ns="app"
                   i18nKey="attributionDescription"
                   defaults="Control the visibility of the attribution text"
@@ -307,6 +356,7 @@ export default async function BrandingPage() {
                 <div className="text-muted-foreground text-xs">
                   <Trans
                     t={t}
+                    i18n={i18n}
                     ns="app"
                     i18nKey="hideAttribution"
                     defaults="Hide Attribution"

--- a/apps/web/src/app/[locale]/control-panel/branding/page.tsx
+++ b/apps/web/src/app/[locale]/control-panel/branding/page.tsx
@@ -3,6 +3,7 @@ import { Input } from "@rallly/ui/input";
 import { Switch } from "@rallly/ui/switch";
 import { CodeIcon, GemIcon } from "lucide-react";
 import type { Metadata } from "next";
+import { Trans } from "react-i18next/TransWithoutContext";
 import {
   PageSection,
   PageSectionContent,
@@ -20,7 +21,6 @@ import {
 } from "@/components/settings-layout";
 import { getCustomBrandingConfig } from "@/features/branding/data";
 import { loadInstanceLicense } from "@/features/licensing/data";
-import { Trans } from "@/i18n/client";
 import { getTranslation } from "@/i18n/server";
 
 async function loadData() {
@@ -41,13 +41,16 @@ async function loadData() {
   };
 }
 
-function SetEnvironmentVariableAlert({ variable }: { variable: string }) {
+async function SetEnvironmentVariableAlert({ variable }: { variable: string }) {
+  const { t } = await getTranslation();
   return (
     <Alert>
       <CodeIcon />
       <AlertDescription>
         <p>
           <Trans
+            t={t}
+            ns="app"
             i18nKey="setEnvironmentVariable"
             defaults="This value can be changed by setting the <env /> environment variable."
             components={{
@@ -71,15 +74,18 @@ export default async function BrandingPage() {
     hideAttribution,
     appName,
   } = await loadData();
+  const { t } = await getTranslation();
 
   return (
     <SettingsPage>
       <SettingsPageHeader>
         <SettingsPageTitle>
-          <Trans i18nKey="branding" defaults="Branding" />
+          <Trans t={t} ns="app" i18nKey="branding" defaults="Branding" />
         </SettingsPageTitle>
         <SettingsPageDescription>
           <Trans
+            t={t}
+            ns="app"
             i18nKey="brandingDescription"
             defaults="View your instance branding configuration"
           />
@@ -92,6 +98,8 @@ export default async function BrandingPage() {
             <AlertDescription className="flex gap-2">
               <p className="flex-1">
                 <Trans
+                  t={t}
+                  ns="app"
                   i18nKey="customBrandingAlertDescription"
                   defaults="Custom branding is available to Enterprise license holders as a paid add-on."
                 />
@@ -103,7 +111,12 @@ export default async function BrandingPage() {
                   className="underline"
                   rel="noreferrer"
                 >
-                  <Trans i18nKey="learnMore" defaults="Learn more" />
+                  <Trans
+                    t={t}
+                    ns="app"
+                    i18nKey="learnMore"
+                    defaults="Learn more"
+                  />
                 </a>
               </p>
             </AlertDescription>
@@ -113,10 +126,12 @@ export default async function BrandingPage() {
           <PageSection variant="card">
             <PageSectionHeader>
               <PageSectionTitle>
-                <Trans i18nKey="general" defaults="General" />
+                <Trans t={t} ns="app" i18nKey="general" defaults="General" />
               </PageSectionTitle>
               <PageSectionDescription>
                 <Trans
+                  t={t}
+                  ns="app"
                   i18nKey="brandingDescription"
                   defaults="View your instance branding configuration"
                 />
@@ -125,7 +140,7 @@ export default async function BrandingPage() {
             <PageSectionContent>
               <div className="space-y-2">
                 <div className="text-muted-foreground text-xs">
-                  <Trans i18nKey="name" defaults="App Name" />
+                  <Trans t={t} ns="app" i18nKey="name" defaults="App Name" />
                 </div>
                 <Input value={appName} readOnly />
                 <SetEnvironmentVariableAlert variable="APP_NAME" />
@@ -135,10 +150,12 @@ export default async function BrandingPage() {
           <PageSection variant="card">
             <PageSectionHeader>
               <PageSectionTitle>
-                <Trans i18nKey="colors" defaults="Colors" />
+                <Trans t={t} ns="app" i18nKey="colors" defaults="Colors" />
               </PageSectionTitle>
               <PageSectionDescription>
                 <Trans
+                  t={t}
+                  ns="app"
                   i18nKey="colorsDescription"
                   defaults="Primary colors used for theming"
                 />
@@ -148,7 +165,12 @@ export default async function BrandingPage() {
               <div className="space-y-6">
                 <div className="space-y-2">
                   <div className="text-muted-foreground text-xs">
-                    <Trans i18nKey="primaryColor" defaults="Primary Color" />
+                    <Trans
+                      t={t}
+                      ns="app"
+                      i18nKey="primaryColor"
+                      defaults="Primary Color"
+                    />
                   </div>
                   <div className="flex items-center gap-2">
                     <div
@@ -164,6 +186,8 @@ export default async function BrandingPage() {
                 <div className="space-y-2">
                   <div className="text-muted-foreground text-xs">
                     <Trans
+                      t={t}
+                      ns="app"
                       i18nKey="primaryColorDark"
                       defaults="Primary Color (Dark Mode)"
                     />
@@ -185,10 +209,12 @@ export default async function BrandingPage() {
           <PageSection variant="card">
             <PageSectionHeader>
               <PageSectionTitle>
-                <Trans i18nKey="logos" defaults="Logos" />
+                <Trans t={t} ns="app" i18nKey="logos" defaults="Logos" />
               </PageSectionTitle>
               <PageSectionDescription>
                 <Trans
+                  t={t}
+                  ns="app"
                   i18nKey="logosDescription"
                   defaults="Logo images used throughout the application"
                 />
@@ -198,7 +224,7 @@ export default async function BrandingPage() {
               <div className="space-y-6">
                 <div className="space-y-2">
                   <div className="text-muted-foreground text-xs">
-                    <Trans i18nKey="logo" defaults="Logo" />
+                    <Trans t={t} ns="app" i18nKey="logo" defaults="Logo" />
                   </div>
                   <div className="flex items-center gap-4">
                     <div className="flex w-48 items-center justify-center overflow-hidden rounded border bg-white">
@@ -214,7 +240,12 @@ export default async function BrandingPage() {
                 </div>
                 <div className="space-y-2">
                   <div className="text-muted-foreground text-xs">
-                    <Trans i18nKey="logoDark" defaults="Logo (Dark Mode)" />
+                    <Trans
+                      t={t}
+                      ns="app"
+                      i18nKey="logoDark"
+                      defaults="Logo (Dark Mode)"
+                    />
                   </div>
                   <div className="flex items-center gap-4">
                     <div className="flex w-48 items-center justify-center overflow-hidden rounded border bg-gray-900">
@@ -230,7 +261,12 @@ export default async function BrandingPage() {
                 </div>
                 <div className="space-y-2">
                   <div className="text-muted-foreground text-xs">
-                    <Trans i18nKey="logoIcon" defaults="Logo Icon" />
+                    <Trans
+                      t={t}
+                      ns="app"
+                      i18nKey="logoIcon"
+                      defaults="Logo Icon"
+                    />
                   </div>
                   <div className="flex items-center gap-4">
                     <div className="flex size-16 items-center justify-center overflow-hidden rounded border bg-white">
@@ -250,10 +286,17 @@ export default async function BrandingPage() {
           <PageSection variant="card">
             <PageSectionHeader>
               <PageSectionTitle>
-                <Trans i18nKey="attribution" defaults="Attribution" />
+                <Trans
+                  t={t}
+                  ns="app"
+                  i18nKey="attribution"
+                  defaults="Attribution"
+                />
               </PageSectionTitle>
               <PageSectionDescription>
                 <Trans
+                  t={t}
+                  ns="app"
                   i18nKey="attributionDescription"
                   defaults="Control the visibility of the attribution text"
                 />
@@ -263,6 +306,8 @@ export default async function BrandingPage() {
               <div className="space-y-2">
                 <div className="text-muted-foreground text-xs">
                   <Trans
+                    t={t}
+                    ns="app"
                     i18nKey="hideAttribution"
                     defaults="Hide Attribution"
                   />

--- a/apps/web/src/features/licensing/components/license-limit-warning.tsx
+++ b/apps/web/src/features/licensing/components/license-limit-warning.tsx
@@ -1,8 +1,9 @@
 import Link from "next/link";
+import { Trans } from "react-i18next/TransWithoutContext";
 import { DEFAULT_SEAT_LIMIT } from "@/features/licensing/constants";
 import { loadInstanceLicense } from "@/features/licensing/data";
 import { getUserCount } from "@/features/user/data";
-import { Trans } from "@/i18n/client";
+import { getTranslation } from "@/i18n/server";
 import { isSelfHosted } from "@/lib/constants";
 
 export async function LicenseLimitWarning() {
@@ -21,9 +22,13 @@ export async function LicenseLimitWarning() {
     return null;
   }
 
+  const { t } = await getTranslation();
+
   return (
     <div className="m-1 rounded-md bg-muted p-2 text-center text-muted-foreground text-sm">
       <Trans
+        t={t}
+        ns="app"
         i18nKey="licenseLimitWarning"
         defaults="You have exceeded the limits of your license. Please <a>upgrade</a>."
         components={{

--- a/apps/web/src/features/licensing/components/license-limit-warning.tsx
+++ b/apps/web/src/features/licensing/components/license-limit-warning.tsx
@@ -22,12 +22,13 @@ export async function LicenseLimitWarning() {
     return null;
   }
 
-  const { t } = await getTranslation();
+  const { t, i18n } = await getTranslation();
 
   return (
     <div className="m-1 rounded-md bg-muted p-2 text-center text-muted-foreground text-sm">
       <Trans
         t={t}
+        i18n={i18n}
         ns="app"
         i18nKey="licenseLimitWarning"
         defaults="You have exceeded the limits of your license. Please <a>upgrade</a>."

--- a/apps/web/src/i18n/server.ts
+++ b/apps/web/src/i18n/server.ts
@@ -1,9 +1,10 @@
+import { cache } from "react";
 import { defaultNS } from "@/i18n/settings";
 
 import { initI18next } from "./i18n";
 import { getLocale } from "./server/get-locale";
 
-export async function getTranslation(localeOverride?: string) {
+export const getTranslation = cache(async (localeOverride?: string) => {
   let locale = localeOverride;
 
   if (!locale) {
@@ -17,4 +18,4 @@ export async function getTranslation(localeOverride?: string) {
     t: i18n.getFixedT(locale, defaultNS),
     i18n,
   };
-}
+});


### PR DESCRIPTION
## Summary

Follow-up to #2826. Three server components still rendered the client `Trans` (from `@/i18n/client`) with JSX elements in the `components` prop — the pattern that broke SSR on the forgot password page:

- `control-panel/branding/page.tsx` — `SetEnvironmentVariableAlert` interpolates a `<code>` element; the page always renders dynamically (control panel layout reads the session)
- `(auth)/reset-password/page.tsx` — footer interpolates `LinkWithRedirectTo`, the exact shape from #2826; currently static, so one dynamic API call away from breaking
- `features/licensing/components/license-limit-warning.tsx` — interpolates a `Link`; renders inside dynamic layouts on self-hosted instances over the seat limit

All three now use `Trans` from `react-i18next/TransWithoutContext` with `t` from `getTranslation()`, matching `login/verify` and `forgot-password`. No i18n keys changed.

## Verification

Production build (`next build` + `next start`), curled the rendered HTML:

- `/control-panel/branding` with an authenticated admin session: alert text and env var names present in SSR output, zero `data-dgst` error templates, no "Element type is invalid" in server logs
- `/reset-password`: footer link SSR'd, zero `data-dgst`
- `/forgot-password` (regression check): zero `data-dgst`

**Honest caveat:** I could not reproduce the original corruption locally — a prod build with #2826 reverted also rendered `/forgot-password` clean. Whatever triggers the Flight-stream corruption isn't present in a local `next start` (16.2.6, no PPR/cacheComponents). So for the branding page this is verified pattern alignment, not a locally confirmed bug fix; the deployed environment is where the failure signature was originally observed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Localization**
  - Improved translated text across the password reset and branding pages.
  - Updated headings, descriptions, labels, links, and alerts to display the correct localized content.
  - Improved translation handling for license limit warnings, providing more consistent localized messaging.
  - Enhanced consistency of localized content during page loading and server-rendered experiences.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->