### PR TITLE
✅ Harden registration test against dev-server races in full-suite runs

### DIFF
--- a/apps/web/playwright.config.ts
+++ b/apps/web/playwright.config.ts
@@ -13,6 +13,10 @@ const baseURL = `http://localhost:${port}`;
 export default defineConfig({
   // Artifacts folder where screenshots, videos, and traces are stored.
   outputDir: "test-results/",
+  // Local runs use `next dev`, where on-demand route compilation during a
+  // full-suite run can eat most of the default 30s budget before a test's
+  // final assertion. CI runs a production build and keeps the default.
+  timeout: ci ? 30_000 : 60_000,
   projects: [{ name: "chromium", use: { ...devices["Desktop Chrome"] } }],
   use: {
     viewport: { width: 1280, height: 720 },
@@ -22,7 +26,15 @@ export default defineConfig({
   },
   testDir: "./tests",
   webServer: {
-    command: ci ? `next start --port ${port}` : `next dev --port ${port}`,
+    // Local runs clear .next first: Turbopack's persistent dev cache
+    // (default on since Next 16.1) is shared across dev sessions, and a
+    // server killed mid-write — which is how every Playwright run ends —
+    // can leave it in a state that deadlocks on-demand route compiles in
+    // the next run. That surfaces as tests timing out on pages no earlier
+    // test has visited, while already-compiled routes keep working.
+    command: ci
+      ? `next start --port ${port}`
+      : `rm -rf .next && next dev --port ${port}`,
     url: baseURL,
     reuseExistingServer: !ci,
     env: {

--- a/apps/web/tests/create-delete-poll.spec.ts
+++ b/apps/web/tests/create-delete-poll.spec.ts
@@ -33,6 +33,10 @@ test.describe.serial(() => {
 
     await deletePollDialog.getByRole("button", { name: "delete" }).click();
 
-    await expect(page).toHaveURL("/login?redirectTo=%2Fpolls");
+    // Delete → invalidate → navigate to /polls → bounce to /login is a
+    // long chain for the dev server; give it more than the 5s default.
+    await expect(page).toHaveURL("/login?redirectTo=%2Fpolls", {
+      timeout: 15_000,
+    });
   });
 });

--- a/apps/web/tests/register-page.ts
+++ b/apps/web/tests/register-page.ts
@@ -47,10 +47,24 @@ export class RegisterPage {
     await this.page
       .getByRole("heading", { name: "Set Up Your Account" })
       .waitFor();
-    await this.page.getByPlaceholder("Jessie Smith").fill(name);
-    await this.page
-      .getByRole("button", { name: "Continue", exact: true })
-      .click();
+
+    // The setup page is reached via a full page load, so like the login
+    // form it is visible before React hydrates it: a fill can be wiped when
+    // the controlled input hydrates and a click can land before the submit
+    // handler is attached. Retry until we navigate away. The setup action
+    // is idempotent, so re-submitting is safe.
+    await expect(async () => {
+      if (!new URL(this.page.url()).pathname.includes("/setup")) {
+        return;
+      }
+      await this.page.getByPlaceholder("Jessie Smith").fill(name);
+      await this.page
+        .getByRole("button", { name: "Continue", exact: true })
+        .click();
+      await this.page.waitForURL((url) => !url.pathname.includes("/setup"), {
+        timeout: 5000,
+      });
+    }).toPass();
 
     // Verify successful registration
     await expect(this.page.getByText(name)).toBeVisible();


### PR DESCRIPTION
## Description

Follow-up to #2823. The registration test still failed in local full-suite runs, now timing out at the final assertion with hydration noise in the console, while isolated runs passed. Two causes, both specific to running the suite against `next dev`:

1. **The setup step has the same pre-hydration race #2823 fixed at the login step.** After OTP verification the client navigates with `window.location.href = "/setup"` — a full page load — so the setup form is visible and interactable before React hydrates it. A fill can be wiped when the controlled input hydrates and the Continue click can land before the submit handler attaches. The step had no retry protection.
2. **30s test budget starvation.** In a full-suite run dozens of routes compile on demand before registration, and `/setup` compiles only inside that test, so accumulated dev-server latency can exhaust the default 30s and kill the test at whatever line it happens to be on — the final assertion.

Changes:

- `register-page.ts`: wrap the setup-form fill/submit in the same `expect().toPass()` retry used for the login step, exiting once navigation leaves `/setup`. The setup action is idempotent so re-submitting is safe.
- `playwright.config.ts`: 60s test timeout locally, 30s kept in CI (CI runs a production build, where none of this applies).
- `playwright.config.ts`: the local webServer now clears `.next` before `next dev`. Turbopack's persistent dev cache (default on since Next 16.1) can be left wedged by a killed server — which is how every Playwright run ends — and then every new-route compile in the next run hangs forever at 0% CPU while cached routes keep serving.
- `create-delete-poll.spec.ts`: give the post-delete redirect assertion 15s; the delete → invalidate → `/polls` → `/login` chain legitimately exceeds the 5s default on a dev server (trace showed the mutation succeeded and only the final RSC hop was slow).

Verified with two consecutive full-suite runs, both fully green (56 passed, 1 skipped; registration 3.9s/4.0s).

Noted in passing, tracked separately: `/forgot-password` deterministically fails SSR ("Element type is invalid … got: undefined") and falls back to client rendering — this is the console error the failing runs logged — and the poll form's duration RadioPills has a hydration mismatch.

## Checklist

- [x] I have performed a self-review of my code
- [x] My code follows the code style of this project
- [x] I have commented my code, particularly in hard-to-understand areas

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved end-to-end test reliability for poll deletion and registration onboarding.
  * Added retries for account setup when navigation does not complete promptly.
  * Increased local test timeouts and improved local development server startup handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->