### PR TITLE
📝 Document why the invite page is deliberately client-only

### DIFF
--- a/apps/web/src/app/[locale]/invite/[urlId]/invite-page-loader.tsx
+++ b/apps/web/src/app/[locale]/invite/[urlId]/invite-page-loader.tsx
@@ -2,6 +2,11 @@
 import dynamic from "next/dynamic";
 import { PollBrandingFromContext } from "@/features/poll/components/poll-branding";
 
+// Deliberately client-only: the page is built around Intl-formatted dates
+// and the viewer's timezone, neither of which can be rendered on the server
+// (no zone cookie on first visit, and Intl output differs across engines).
+// The page's tRPC prefetches still matter — they seed the client query cache
+// via HydrationBoundary so useSuspenseQuery resolves without a round-trip.
 const InvitePage = dynamic(
   () => import("./invite-page").then((mod) => mod.InvitePage),
   { ssr: false },


### PR DESCRIPTION
## Investigation: why HydrationBoundary + prefetch doesn't SSR the invite page

**TLDR: the SSR wiring is not broken — the page opts out of SSR on purpose, and this PR documents that at the opt-out site.**

### Findings

1. **The tRPC SSR pipeline works end to end.** During the server render pass, `usePoll()`'s `useSuspenseQuery` resolves synchronously from the hydrated cache — proven by the dev-mode error template in the streamed HTML, whose component stack shows the render proceeding through `LegacyPollContextProvider` → `PollContextProvider` → `OptionsProvider` all the way into `InvitePageLoader` without suspending. There is no provider-position, query-key, or superjson mismatch.

2. **The sole reason no content materializes is `dynamic(..., { ssr: false })` in `invite-page-loader.tsx`.** The bailout (`BAILOUT_TO_CLIENT_SIDE_RENDERING`, reason `next/dynamic`) discards the boundary content, and since every visible element of the page lives inside `InvitePage`, the server HTML is just the route-level spinner. Flipping the flag to `ssr: true` produced full server HTML (poll options, vote selectors, formatted times) with zero code changes elsewhere.

3. **Client cache seeding works.** A headless Chromium load of `/invite/seed-0053` issued **zero** `/api/trpc` requests — the dehydrated state serves all three prefetched queries (`polls.get`, `participants.list`, `comments.list`). So the prefetches are not dead weight; they eliminate the client round-trip.

4. **Enabling SSR without gating would reintroduce the layout-shift bug that `ssr: false` fixed (00387ba49).** Empirically, with SSR forced on for a `America/New_York` poll requested with `Accept-Language: de` and no cookies, the server baked its own system zone (11:00/15:00 London time where a NY viewer renders 6:00/10:00) and rendered `1h` where Chromium renders `1 Std.` — text-level hydration mismatches on the page's core content. The codebase convention (`use-hydrated.ts`, `Time`/`TimeRange`) is that Intl output is never SSR'd; applying that gate to `OptionsProvider` would make the SSR output a skeleton with blank dates anyway, which is not worth the audit surface for a page whose content *is* dates.

### Decision

Keep the invite page client-only and document the intent (and the reason the prefetches remain) at the `ssr: false` site, so the pattern doesn't read as broken SSR to the next person.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added documentation clarifying why the invitation page runs exclusively in the browser.
  * Documented that invitation data remains available through client-side prefetching and hydration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->