### PR TITLE
💄 Show the poll invite link as selectable text in the new poll email

### DIFF
--- a/packages/emails/src/components/styled-components.tsx
+++ b/packages/emails/src/components/styled-components.tsx
@@ -148,6 +148,40 @@ export const SmallText = (props: TextProps) => {
   );
 };
 
+export const CopyableUrl = ({ url }: { url: string }) => {
+  // Split before every delimiter and wrap each chunk in its own span so no
+  // single text node matches a URL pattern — this stops mail clients (Gmail,
+  // Outlook) from auto-linking the text. Unlike invisible-character tricks,
+  // span boundaries survive copy/paste with the URL intact.
+  let offset = 0;
+  const segments = url.split(/(?=[/.:])/).map((text) => {
+    const segment = { text, offset };
+    offset += text.length;
+    return segment;
+  });
+  return (
+    <pre
+      style={{
+        margin: "16px 0",
+        padding: "12px 16px",
+        borderRadius: "6px",
+        backgroundColor: "#F9FAFB",
+        border: `1px solid ${borderColor}`,
+        fontFamily:
+          "SFMono-Regular, Consolas, 'Liberation Mono', Menlo, monospace",
+        fontSize: "14px",
+        color: darkTextColor,
+        whiteSpace: "pre-wrap",
+        wordBreak: "break-all",
+      }}
+    >
+      {segments.map((segment) => (
+        <span key={segment.offset}>{segment.text}</span>
+      ))}
+    </pre>
+  );
+};
+
 export const Card = (props: SectionProps) => {
   return (
     <Section

--- a/packages/emails/src/templates/new-poll.test.tsx
+++ b/packages/emails/src/templates/new-poll.test.tsx
@@ -1,0 +1,40 @@
+import { render } from "@react-email/render";
+import { describe, expect, it } from "vitest";
+import { previewChrome } from "../components/preview-chrome";
+import NewPollEmail from "./new-poll";
+
+const baseProps = {
+  title: "Team Meeting",
+  name: "Jane Doe",
+  adminLink: "https://rallly.co/poll/xyz789",
+  participantLink: "https://rallly.co/invite/abc123",
+  chrome: previewChrome,
+};
+
+describe("NewPollEmail", () => {
+  it("renders the participant link as selectable text, not an anchor", async () => {
+    const html = await render(await NewPollEmail(baseProps));
+    expect(html).not.toContain(`href="${baseProps.participantLink}"`);
+    expect(html).toContain("<pre");
+    expect(html).toContain("abc123");
+  });
+
+  it("splits the participant link so clients cannot auto-link it", async () => {
+    const html = await render(await NewPollEmail(baseProps));
+    // No contiguous URL in the markup — every delimiter starts a new span.
+    expect(html).not.toContain(baseProps.participantLink);
+    expect(html).toContain("<span>https</span>");
+  });
+
+  it("keeps the full participant link intact in the plain text part", async () => {
+    const text = await render(await NewPollEmail(baseProps), {
+      plainText: true,
+    });
+    expect(text).toContain(baseProps.participantLink);
+  });
+
+  it("keeps the manage poll button linked to the admin page", async () => {
+    const html = await render(await NewPollEmail(baseProps));
+    expect(html).toContain(`href="${baseProps.adminLink}"`);
+  });
+});

--- a/packages/emails/src/templates/new-poll.tsx
+++ b/packages/emails/src/templates/new-poll.tsx
@@ -8,8 +8,8 @@ import {
   Body,
   Button,
   Container,
+  CopyableUrl,
   Heading,
-  Link,
   Text,
 } from "../components/styled-components";
 import { createEmailI18n } from "../i18n";
@@ -36,7 +36,12 @@ async function NewPollEmail({
   const { t, i18n } = await createEmailI18n(locale);
   return (
     <Html>
-      <Head />
+      <Head>
+        <meta
+          name="format-detection"
+          content="telephone=no, date=no, address=no, email=no, url=no"
+        />
+      </Head>
       <Preview>
         {t("newPoll_preview", {
           defaultValue:
@@ -69,11 +74,7 @@ async function NewPollEmail({
               defaults="Your meeting poll titled <b>{title}</b> is ready! Share it using the link below:"
             />
           </Text>
-          <Text>
-            <Link color={chrome.primaryColor} href={participantLink}>
-              {participantLink}
-            </Link>
-          </Text>
+          <CopyableUrl url={participantLink} />
           <Button href={adminLink} color={chrome.primaryColor}>
             {t("newPoll_button", {
               defaultValue: "Manage Poll",


### PR DESCRIPTION
## Description

The new poll confirmation email showed the participant link as a clickable anchor, and email clients auto-link it anyway. Since this link is meant to be copied and shared (not clicked — the Manage Poll button covers navigation), that made it awkward to select on mobile and exposed the URL to link-rewriting proxies.

Changes:

- New `CopyableUrl` component: renders the URL in a `pre`-styled box (monospace, gray background, `word-break: break-all`) so the whole link is easy to select and copy.
- The URL is split across `<span>`s at every `/`, `.`, and `:` so mail clients' auto-link detection never sees a full URL in one text node. Invisible-character tricks (word joiner, soft hyphen) were deliberately avoided — they get copied with the text and break the URL on paste.
- Added `format-detection` meta to disable Apple Mail's data detectors.
- Tests covering: no anchor around the participant link, no contiguous URL in the HTML, full URL preserved in the plain-text MIME part, admin button still linked.

Known limitation: the plain-text MIME part still contains the raw URL and will be linkified by text-only clients — unavoidable without corrupting the URL.

## Checklist

- [x] I have performed a self-review of my code
- [x] My code follows the code style of this project
- [x] I have commented my code, particularly in hard-to-understand areas

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved participant-link display in new poll emails to prevent email clients from automatically converting URL text into links.
  * Preserved the complete URL for easy copying while retaining the administrator link.

* **Tests**
  * Added coverage for URL rendering, copyable text preservation, and administrator-link behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->