### PR TITLE
⏪️ Revert default sender name to "Rallly"

### DIFF
--- a/apps/docs/self-hosting/configuration.mdx
+++ b/apps/docs/self-hosting/configuration.mdx
@@ -32,7 +32,7 @@ All configuration lives in the `.env` file at the root of your self-hosted stack
   Sender address for all transactional emails. Falls back to `SUPPORT_EMAIL` if not set.
 </ParamField>
 
-<ParamField path="NOREPLY_EMAIL_NAME" default="Rallly Notifications">
+<ParamField path="NOREPLY_EMAIL_NAME" default="Rallly">
   Sender name for all transactional emails.
 </ParamField>
 

--- a/apps/web/src/env.ts
+++ b/apps/web/src/env.ts
@@ -71,7 +71,7 @@ export const env = createEnv({
      */
     SUPPORT_EMAIL: z.email(),
     NOREPLY_EMAIL: z.email().optional(),
-    NOREPLY_EMAIL_NAME: z.string().default("Rallly Notifications"),
+    NOREPLY_EMAIL_NAME: z.string().default("Rallly"),
 
     /**
      * S3 Configuration

--- a/packages/emails/src/send.tsx
+++ b/packages/emails/src/send.tsx
@@ -26,7 +26,7 @@ export type SendArgs<P> = {
 function resolveFrom(from?: From): From {
   return (
     from ?? {
-      name: process.env.NOREPLY_EMAIL_NAME ?? "Rallly Notifications",
+      name: process.env.NOREPLY_EMAIL_NAME ?? "Rallly",
       address: process.env.NOREPLY_EMAIL || process.env.SUPPORT_EMAIL || "",
     }
   );


### PR DESCRIPTION
Reverts #2786.

"Rallly Notifications" reads oddly as a sender name — the from name should just be the app name. This restores the previous default `Rallly` for `NOREPLY_EMAIL_NAME` (env default, send fallback, and self-hosting docs). The `NOREPLY_EMAIL_NAME` env var remains available for anyone who wants a custom sender name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Updated the default sender name for email notifications from “Rallly Notifications” to “Rallly.”
  * Updated the self-hosting configuration documentation to reflect the new default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->