### PR TITLE
🚸 Label the image picker button "Choose…" instead of "Upload"

### DIFF
--- a/apps/web/public/locales/en/app.json
+++ b/apps/web/public/locales/en/app.json
@@ -118,6 +118,7 @@
   "changeRole": "Change role",
   "charactersRemaining": "{count, plural, one {# character remaining} other {# characters remaining}}",
   "checkForConflicts": "Toggle which calendars to check for conflicts",
+  "chooseImage": "Choose…",
   "cityTime": "{city} Time",
   "clockPreferences": "Clock Preferences",
   "clockPreferencesDescription": "Set your preferred time zone and time format.",

--- a/apps/web/src/components/image-upload/image-upload.tsx
+++ b/apps/web/src/components/image-upload/image-upload.tsx
@@ -167,7 +167,7 @@ export function ImageUploadControl({
               fileInputRef.current?.click();
             }}
           >
-            <Trans i18nKey="uploadImage" defaults="Upload" />
+            <Trans i18nKey="chooseImage" defaults="Choose…" />
           </Button>
           {hasCurrentImage ? (
             <Button loading={isRemoving} variant="ghost" onClick={handleRemove}>


### PR DESCRIPTION
## Description

The image picker button on the **General** settings page said "Upload", but clicking it only opens the OS file picker. The actual upload happens later, after the crop dialog is confirmed. The label named the wrong action at the wrong moment, so it now reads "Choose…".

This uses a **new `chooseImage` key** rather than editing the existing `uploadImage` string, because changing a source string clears that key's existing Crowdin translations across all locales.

### Reviewer notes

**This affects two pages, not just General.** `ImageUploadControl` is shared, so the change applies to both the space logo (General settings) and the avatar (Profile settings). That seemed right — both buttons open a file picker — but it's worth a conscious look. If the two should diverge, the component needs a label prop.

**Pre-existing issue left untouched.** `uploadImage` is still in use, in the crop dialog's confirm button:

https://github.com/lukevella/rallly/blob/main/apps/web/src/components/image-upload/image-crop-dialog.tsx#L134

That call site passes `defaults="Crop & Upload"`, but `app.json` has `"uploadImage": "Upload"` — so the dialog's confirm button renders "Upload", and its `Crop & Upload` default is dead. The key was previously bound to two different source strings and the scanner resolved the collision in favour of one of them.

After this PR, `uploadImage` has exactly one call site, so the value *could* be corrected to "Crop & Upload". I did not do it here: `pnpm i18n:scan` preserves the existing value rather than updating it, so the fix requires hand-editing `app.json` (against project convention) and would clear that key's Crowdin translations. Flagging it as a follow-up decision rather than making the call in a copy-tweak PR.

## Checklist

- [x] I have performed a self-review of my code
- [x] My code follows the code style of this project
- [x] I have commented my code, particularly in hard-to-understand areas

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Improvements**
  * Updated the image upload button label from “Upload” to the localized “Choose…” text.
  * Added English localization for the new label.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->