### PR TITLE
💄 Add light primary fill to checked duration radio pills

### DIFF
--- a/packages/ui/src/radio-pills.tsx
+++ b/packages/ui/src/radio-pills.tsx
@@ -20,7 +20,7 @@ function RadioPillsItem({ className, ...props }: RadioPrimitive.Root.Props) {
     <RadioPrimitive.Root
       data-slot="radio-pills-item"
       className={cn(
-        "inline-flex h-8 cursor-pointer items-center rounded-full border px-3 font-medium text-muted-foreground text-sm data-checked:border-primary data-checked:text-primary data-unchecked:hover:text-foreground",
+        "inline-flex h-8 cursor-pointer items-center rounded-full border px-3 font-medium text-muted-foreground text-sm data-checked:border-primary data-checked:bg-primary/10 data-checked:text-primary data-unchecked:hover:text-foreground",
         className,
       )}
       {...props}


### PR DESCRIPTION
## Description

The duration selector on the poll options calendar uses the `RadioCards` pills from `packages/ui/src/radio-pills.tsx`. The checked state only changed the border and text color to primary with no background fill, so it looked flatter than the other selection groups in the app.

This adds `data-checked:bg-primary/10` to the checked pill, matching the light primary background used by the theme selector (primary/10 → primary/5 gradient) and the paywall plan selector (`bg-primary/5`). Flat fill at /10 since /5 is barely perceptible on a 32px pill.

Note for reviewers: this styles the shared `RadioPillsItem` primitive, so any future `RadioCards` consumer inherits the fill — consistent with the checked border/text styling already living there. The duration picker is currently the only consumer.

## Checklist

- [x] I have performed a self-review of my code
- [x] My code follows the code style of this project
- [x] I have commented my code, particularly in hard-to-understand areas

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated selected radio pills to display a light primary-color background for clearer visual feedback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->