### PR TITLE
🐛 Prevent false success screen when participant submission fails

### DIFF
--- a/apps/web/public/locales/en/app.json
+++ b/apps/web/public/locales/en/app.json
@@ -465,6 +465,7 @@
   "newParticipantFormNoteDescription": "Only the organizer will see this note.",
   "newParticipantFormNoteLabel": "Note for the organizer",
   "newParticipantFormSubmit": "Save availability",
+  "newParticipantFormSubmitError": "Your response could not be saved. Please check your connection and try again.",
   "newPassword": "New Password",
   "newPoll": "New Poll",
   "nextMonth": "Next month",

--- a/apps/web/src/features/poll/components/new-participant-modal.tsx
+++ b/apps/web/src/features/poll/components/new-participant-modal.tsx
@@ -244,11 +244,15 @@ export const NewParticipantForm = (props: NewParticipantModalProps) => {
               });
               props.onSubmit?.(newParticipant);
             } catch (error) {
-              if (error instanceof TRPCClientError) {
-                setError("root", {
-                  message: error.message,
-                });
-              }
+              setError("root", {
+                message:
+                  error instanceof TRPCClientError
+                    ? error.message
+                    : t("newParticipantFormSubmitError", {
+                        defaultValue:
+                          "Your response could not be saved. Please check your connection and try again.",
+                      }),
+              });
             }
           })}
           className="space-y-4"


### PR DESCRIPTION
## Problem

The new participant form shows its success screen based on `formState.isSubmitSuccessful`, but the submit handler's catch block only called `setError` for `TRPCClientError`. Any other exception was silently swallowed, which react-hook-form treats as a successful submission.

Concrete failure path: a first-time visitor with no session fills in the form while their connection drops. `createGuestIfNeeded()` → `authClient.signIn.anonymous()` rejects with a plain `TypeError` (better-fetch does not catch network-level fetch rejections), the participant mutation never runs, and the visitor sees "Your response has been saved" with nothing persisted.

## Fix

Set a root form error for every caught exception: tRPC errors keep their server message, anything else gets a generic "could not be saved" message. With `formState.errors` non-empty, `isSubmitSuccessful` stays false and the success screen cannot render unless the mutation actually completed.

The other `createGuestIfNeeded` call sites (`create-poll.tsx`, `discussion.tsx`) have no try/catch, so errors propagate there and this bug does not apply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error messages when saving a participant’s availability response.
  * Server-provided error details are preserved, with a translated fallback shown for other errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->