### PR TITLE
✅ Make login accessibility locators resilient to streamed Suspense reveal

### DIFF
--- a/apps/web/tests/accessibility.spec.ts
+++ b/apps/web/tests/accessibility.spec.ts
@@ -28,15 +28,22 @@ async function scan(page: Page) {
 }
 
 test.describe("accessibility (axe-core, WCAG 2.1 A/AA)", () => {
+  // React 19.2 reveals streamed Suspense content paint-aligned, so during
+  // hydration the page can transiently hold two hidden copies of the heading.
+  // A text locator strict-fails on that window; getByRole ignores hidden
+  // elements and .first() tolerates the duplicate.
+  const welcomeHeading = (page: Page) =>
+    page.getByRole("heading", { name: "Welcome" }).first();
+
   test("login page", async ({ page }) => {
     await page.goto("/login");
-    await page.getByText("Welcome").waitFor();
+    await welcomeHeading(page).waitFor();
     expect(await scan(page)).toEqual([]);
   });
 
   test("login verify page", async ({ page }) => {
     await page.goto("/login");
-    await page.getByText("Welcome").waitFor();
+    await welcomeHeading(page).waitFor();
     await expect(async () => {
       await page
         .getByPlaceholder("jessie.smith@example.com")


### PR DESCRIPTION
## Description

Fixes the flaky `accessibility.spec.ts › login page` test (strict mode violation: `getByText('Welcome')` resolved to 2 hidden elements, e.g. CI run 30847580071 first attempt).

Root cause, traced from that run's Playwright trace artifact: the server HTML contains exactly one `<h1>Welcome</h1>`, inside the hidden out-of-order streaming container (`<div hidden id="S:1">`), with the `(auth)/loading.tsx` spinner in the visible slot. React 19.2's new paint-aligned Suspense reveal means the inline `$RC` no longer swaps streamed content into place synchronously — it queues the swap in `$RB` and defers it to a `requestAnimationFrame`/`setTimeout` batch (~300ms throttle). On a slow CI box, hydration races that deferred reveal and the page transiently holds two hidden copies of the heading. `getByText` enforces strict mode before visibility filtering, so it throws; one frame later there is a single visible heading (confirmed by the trace's final snapshot). Benign framework timing, not an app double render — so the fix is test-side.

Both login tests now wait on `getByRole("heading", { name: "Welcome" }).first()`: role locators never match hidden elements, so the pre-reveal copies are ignored entirely, and `.first()` removes the strict-mode failure mode. The "login verify page" test used the identical pattern and was equally at risk.

Verified locally: both login accessibility tests pass.

## Checklist

- [x] I have performed a self-review of my code
- [x] My code follows the code style of this project
- [x] I have commented my code, particularly in hard-to-understand areas

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved login accessibility test reliability by using a role-based locator for the welcome heading.
  * Updated tests to handle hidden matching elements and consistently select the intended heading.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->