### PR TITLE
💄 Fix icon hover color in space settings sidebar menus

### DIFF
--- a/apps/web/src/app/[locale]/(space)/settings/components/sidebar.tsx
+++ b/apps/web/src/app/[locale]/(space)/settings/components/sidebar.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useFeatureFlagEnabled } from "@rallly/posthog/client";
-import { Icon } from "@rallly/ui/icon";
 import {
   SidebarGroup,
   SidebarGroupContent,
@@ -152,7 +151,7 @@ export function SpaceSidebarMenu() {
             }
             isActive={pathname.startsWith(item.href)}
           >
-            <Icon>{item.icon}</Icon>
+            {item.icon}
             {item.label}
           </SidebarMenuButton>
         </SidebarMenuItem>
@@ -189,9 +188,7 @@ export function DeveloperSidebarMenu() {
               }
               isActive={pathname.startsWith("/settings/api-keys")}
             >
-              <Icon>
-                <KeyIcon />
-              </Icon>
+              <KeyIcon />
               <Trans i18nKey="apiKeys" defaults="API Keys" />
             </SidebarMenuButton>
           </SidebarMenuItem>


### PR DESCRIPTION
## Problem

The space and developer menu items in the settings sidebar looked different from the account menu items: hovering them didn't change the icon color, and the active item's icon stayed muted.

## Cause

`SpaceSidebarMenu` and `DeveloperSidebarMenu` wrapped their icons in the `Icon` component, which hardcodes `text-muted-foreground` on the svg. That overrides the `currentColor` inheritance from `SidebarMenuButton`'s `hover:text-sidebar-accent-foreground` and active state styles.

## Fix

Render bare svgs like `AccountSidebarMenu` and the dashboard sidebar already do — `SidebarMenuButton`'s `[&>svg]:size-4` handles sizing and the icon inherits the button's text color in all states.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified sidebar icon rendering for a cleaner, more consistent interface.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->