### PR TITLE
⚡️ Stream document shell before session gates resolve

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -162,6 +162,12 @@ Always use gitmoji prefixes in commit messages. Follow the gitmoji convention (h
 - Keep component props minimal — pass only the bare minimum information needed
 - Add `"use client"` directive to the top of any `.tsx` file that requires client-side JavaScript
 
+### Streaming & Server Data Access
+These rules prepare the app for Next.js `cacheComponents` (static shell + streamed dynamic content). Follow them in all new and touched server code:
+- Never await runtime data (session, `cookies()`, `headers()`, tRPC prefetches) at the top of a layout or page. Extract the awaits into a private async component rendered under a `<Suspense>` boundary (see the gate pattern in `app/[locale]/(space)/layout.tsx`) so the shell streams immediately.
+- Pass `params`/`searchParams` promises down into Suspense-wrapped children and await them there, instead of awaiting at the top of the page.
+- Don't call argless `dayjs()`, `new Date()`, `Date.now()`, or `Math.random()` during server render outside request-bound components — synchronous IO fails prerendering once `cacheComponents` is enabled. Compute "now" on the client or behind a Suspense boundary after `connection()`.
+
 ### File Organization
 - Route handlers follow Next.js App Router conventions
 - Always use kebab-case for file names

--- a/apps/web/src/app/[locale]/(optional-space)/layout.tsx
+++ b/apps/web/src/app/[locale]/(optional-space)/layout.tsx
@@ -1,4 +1,6 @@
 import { dehydrate, HydrationBoundary } from "@tanstack/react-query";
+import { Suspense } from "react";
+import { RouterLoadingIndicator } from "@/components/router-loading-indicator";
 import { SessionRefresher } from "@/components/session-refresher";
 import { PayWall } from "@/features/billing/components/pay-wall";
 import { isQuickCreateEnabled } from "@/features/quick-create/constants";
@@ -12,11 +14,9 @@ import {
   createPublicSSRHelper,
 } from "@/trpc/server/create-ssr-helper";
 
-export default async function Layout({
-  children,
-}: {
-  children: React.ReactNode;
-}) {
+// The session and tRPC prefetch awaits sit below the Suspense boundary in
+// the default export so the document shell can flush before they resolve.
+async function OptionalSpaceGate({ children }: { children: React.ReactNode }) {
   const helpers = isQuickCreateEnabled
     ? await createPublicSSRHelper()
     : await createPrivateSSRHelper();
@@ -49,5 +49,13 @@ export default async function Layout({
         </DeviceDateTimeProvider>
       </UserProvider>
     </HydrationBoundary>
+  );
+}
+
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return (
+    <Suspense fallback={<RouterLoadingIndicator />}>
+      <OptionalSpaceGate>{children}</OptionalSpaceGate>
+    </Suspense>
   );
 }

--- a/apps/web/src/app/[locale]/(space)/layout.tsx
+++ b/apps/web/src/app/[locale]/(space)/layout.tsx
@@ -1,3 +1,5 @@
+import { Suspense } from "react";
+import { RouterLoadingIndicator } from "@/components/router-loading-indicator";
 import { SessionRefresher } from "@/components/session-refresher";
 import { PayWall } from "@/features/billing/components/pay-wall";
 import { SpaceProvider } from "@/features/space/client";
@@ -8,11 +10,10 @@ import { getLocale } from "@/i18n/server/get-locale";
 import { getSession } from "@/lib/auth";
 import { DateTimeProvider } from "@/lib/datetime/client";
 
-export default async function Layout({
-  children,
-}: {
-  children: React.ReactNode;
-}) {
+// The session gate awaits below this boundary so the document shell can
+// flush before the session store responds; without it, every hard load of
+// a space route streams nothing until getActiveSpace resolves.
+async function SpaceGate({ children }: { children: React.ReactNode }) {
   const [locale, session, space] = await Promise.all([
     getLocale(),
     getSession(),
@@ -39,5 +40,13 @@ export default async function Layout({
         </DateTimeProvider>
       </UserProvider>
     </>
+  );
+}
+
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return (
+    <Suspense fallback={<RouterLoadingIndicator />}>
+      <SpaceGate>{children}</SpaceGate>
+    </Suspense>
   );
 }

--- a/apps/web/src/app/[locale]/control-panel/layout.tsx
+++ b/apps/web/src/app/[locale]/control-panel/layout.tsx
@@ -2,6 +2,8 @@ import { Icon } from "@rallly/ui/icon";
 import { SidebarInset, SidebarTrigger } from "@rallly/ui/sidebar";
 import { GaugeIcon } from "lucide-react";
 import type { Metadata } from "next";
+import { Suspense } from "react";
+import { RouterLoadingIndicator } from "@/components/router-loading-indicator";
 import { LicenseLimitWarning } from "@/features/licensing/components/license-limit-warning";
 import { CommandMenu } from "@/features/navigation/components/command-menu";
 import { UserProvider } from "@/features/user/client";
@@ -13,11 +15,9 @@ import { createAdminSSRHelper } from "@/trpc/server/create-ssr-helper";
 import { ControlPanelSidebarProvider } from "./control-panel-sidebar-provider";
 import { ControlPanelSidebar } from "./sidebar";
 
-export default async function AdminLayout({
-  children,
-}: {
-  children: React.ReactNode;
-}) {
+// The admin gate awaits below the Suspense boundary in the default export
+// so the document shell can flush before the session store responds.
+async function AdminGate({ children }: { children: React.ReactNode }) {
   const [locale, { user }] = await Promise.all([
     getLocale(),
     createAdminSSRHelper(),
@@ -56,6 +56,18 @@ export default async function AdminLayout({
         </ControlPanelSidebarProvider>
       </DateTimeProvider>
     </UserProvider>
+  );
+}
+
+export default function AdminLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <Suspense fallback={<RouterLoadingIndicator />}>
+      <AdminGate>{children}</AdminGate>
+    </Suspense>
   );
 }
 


### PR DESCRIPTION
Phase 0 of the cacheComponents adoption plan: make layouts stream instead of blocking the entire response on session reads.

The `(space)`, `(optional-space)`, and `control-panel` layouts awaited session, active space, and tRPC prefetches at the top level. Nothing below the root layout could flush until the session store responded — on a hard load the user stares at a blank page for the full session roundtrip.

Each layout now extracts those awaits into a private async gate component rendered under a `<Suspense>` boundary with `RouterLoadingIndicator` as the fallback (same loading treatment as `[locale]/loading.tsx`). The document shell and progress bar flush immediately; the gated content streams in when the session resolves. Redirects (`getActiveSpace` → `/login`) now fire inside the streamed boundary, which Next handles via its client-side redirect mechanism — covered by the existing auth integration tests.

Also documents the streaming conventions in CLAUDE.md (no runtime-data awaits at the top of layouts/pages, push `params`/`searchParams` down, no sync IO in prerenderable positions) so future refactors keep moving toward `cacheComponents`.

Verified: `type-check`, `build`, and the `authentication`, `create-delete-poll`, and `control-panel` Playwright specs (21 passed) covering all three refactored layouts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved page transitions by displaying a loading indicator while session and space data are retrieved.
  * Added smoother Suspense-based loading across space, optional-space, and control-panel pages.

* **Documentation**
  * Documented best practices for streaming server data and handling runtime values during server rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->