### PR TITLE
✅ Make space-members locators resilient to streamed Suspense staging copy

### DIFF
--- a/apps/web/tests/space-members.spec.ts
+++ b/apps/web/tests/space-members.spec.ts
@@ -60,6 +60,14 @@ function memberRow(page: Page, text: string) {
   return page.getByRole("listitem").filter({ hasText: text });
 }
 
+// After a page load, React briefly keeps a second hidden copy of the
+// streamed page content in a staging <div hidden> under <body>. Text
+// locators strict-fail against it, so page text assertions scope to
+// #main-content, which only ever holds the live copy.
+function mainContent(page: Page) {
+  return page.locator("#main-content");
+}
+
 async function gotoMembersSettings(page: Page, email: string) {
   await loginWithEmail(page, { email });
   await page.goto("/settings/members");
@@ -88,7 +96,9 @@ test.describe("Space members", () => {
     const inviteeEmail = `invitee-${runId}@example.com`;
 
     await gotoMembersSettings(page, owner.email);
-    await expect(page.getByText("1 of 3 seats used")).toBeVisible();
+    await expect(
+      mainContent(page).getByText("1 of 3 seats used"),
+    ).toBeVisible();
 
     await page.getByRole("button", { name: "Invite member" }).click();
     const dialog = page.getByRole("dialog");
@@ -126,7 +136,9 @@ test.describe("Space members", () => {
     await expect(
       memberRow(page, inviteeEmail).getByText(`Invited by ${owner.user.name}`),
     ).toBeHidden();
-    await expect(page.getByText("2 of 3 seats used")).toBeVisible();
+    await expect(
+      mainContent(page).getByText("2 of 3 seats used"),
+    ).toBeVisible();
   });
 
   test("admin can cancel a pending invite", async ({ page }) => {
@@ -180,7 +192,9 @@ test.describe("Space members", () => {
     });
 
     await gotoMembersSettings(page, owner.email);
-    await expect(page.getByText("2 of 3 seats used")).toBeVisible();
+    await expect(
+      mainContent(page).getByText("2 of 3 seats used"),
+    ).toBeVisible();
 
     const row = memberRow(page, member.email);
     await row.getByRole("button", { name: "More options" }).click();
@@ -190,7 +204,9 @@ test.describe("Space members", () => {
     await expect(page.getByText("Member removed successfully")).toBeVisible();
     await expect(row).toBeHidden();
 
-    await expect(page.getByText("1 of 3 seats used")).toBeVisible();
+    await expect(
+      mainContent(page).getByText("1 of 3 seats used"),
+    ).toBeVisible();
   });
 
   test("invite button is disabled when all seats are used", async ({
@@ -200,12 +216,14 @@ test.describe("Space members", () => {
 
     await gotoMembersSettings(page, owner.email);
 
-    await expect(page.getByText("1 of 1 seats used")).toBeVisible();
+    await expect(
+      mainContent(page).getByText("1 of 1 seats used"),
+    ).toBeVisible();
     await expect(
       page.getByRole("button", { name: "Invite member" }),
     ).toBeDisabled();
     await expect(
-      page.getByText(
+      mainContent(page).getByText(
         "Increase the number of seats in this space from the billing page.",
       ),
     ).toBeVisible();

--- a/packages/test-helpers/src/login.ts
+++ b/packages/test-helpers/src/login.ts
@@ -8,7 +8,11 @@ export async function loginWithEmail(
   { email, password }: { email: string; password?: string },
 ) {
   await page.goto("/login");
-  await page.getByText("Welcome").waitFor();
+  // React reveals streamed Suspense content paint-aligned, so the page can
+  // briefly hold a second hidden copy of the heading. A text locator
+  // strict-fails on that window; getByRole ignores hidden elements and
+  // .first() tolerates the duplicate.
+  await page.getByRole("heading", { name: "Welcome" }).first().waitFor();
 
   // The login form is visible before React has hydrated it, so input that
   // lands too early can be silently lost. Retry until the next screen


### PR DESCRIPTION
## Problem

`space-members.spec.ts` fails on main since the Next.js 16.3.0 upgrade (#2855): `getByText('2 of 3 seats used')` resolves to two identical elements — one inside `#main-content`, one outside — a Playwright strict-mode violation (runs 30900257905, 30900418163).

## Root cause

Next 16.3 vendors React 19.3.0-canary-cbb046ab. With its paint-aligned Suspense reveal, the hidden streaming staging container (`<div hidden id="S:N">` under `<body>`) is removed only well after the streamed content is revealed in place. Instrumenting a cold production-server load of `/login` shows the window:

- t=25ms: content arrives in `body > div#S:1[hidden]`
- t=183ms: **two copies** — revealed copy in `main#main-content` and the staged copy still in `body > div#S:0[hidden]`
- t=353ms: staging copy removed

Raw text locators count hidden elements for strict mode, so any page-level `getByText` on streamed content can fail fast in that ~200ms window after every full page load. Role-based locators are unaffected (hidden nodes are outside the accessibility tree), which is why only the seat-usage `<p>` assertions died. Same mechanism as #2851; the duplicate is invisible to users and not app-fixable.

## Fix

- Scope page-level text assertions in `space-members.spec.ts` to `#main-content` via a `mainContent()` helper (toast assertions stay page-level — they render in a portal and are never streamed).
- `loginWithEmail` in `@rallly/test-helpers` had the same vulnerable pattern (`page.getByText("Welcome").waitFor()`) and strict-failed in local production-mode runs; switched to the role-based locator from #2851.

## Verification

- Reproduced the CI failure locally against a production build (`CI=true`) before the fix.
- After the fix: members spec passed 5/5 across 4 consecutive production-mode runs (including cold server start), and the full integration suite passes 56/56 (+1 skipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved end-to-end test reliability when hidden or streamed page content is present.
  * Updated login readiness checks to recognize the visible Welcome heading consistently.
  * Refined member-management seat-count checks to target the active page content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->