### PR TITLE
♻️ Remove tRPC prefetching from layouts

### DIFF
--- a/apps/web/src/app/[locale]/(optional-space)/layout.tsx
+++ b/apps/web/src/app/[locale]/(optional-space)/layout.tsx
@@ -1,37 +1,40 @@
-import { dehydrate, HydrationBoundary } from "@tanstack/react-query";
 import { Suspense } from "react";
 import { RouterLoadingIndicator } from "@/components/router-loading-indicator";
 import { SessionRefresher } from "@/components/session-refresher";
+import { TierProvider } from "@/features/billing/client";
 import { PayWall } from "@/features/billing/components/pay-wall";
 import { isQuickCreateEnabled } from "@/features/quick-create/constants";
+import { getActiveSpaceForUser } from "@/features/space/data";
 import { UserProvider } from "@/features/user/client";
+import { requireUser } from "@/features/user/loaders";
 import { getLocale } from "@/i18n/server/get-locale";
 import { getSession } from "@/lib/auth";
+import { isSelfHosted } from "@/lib/constants";
 import { DeviceDateTimeProvider } from "@/lib/datetime/device";
 import { getDeviceDateTimeConfig } from "@/lib/datetime/server";
-import {
-  createPrivateSSRHelper,
-  createPublicSSRHelper,
-} from "@/trpc/server/create-ssr-helper";
 
-// The session and tRPC prefetch awaits sit below the Suspense boundary in
-// the default export so the document shell can flush before they resolve.
+// The session awaits sit below the Suspense boundary in the default export
+// so the document shell can flush before they resolve.
 async function OptionalSpaceGate({ children }: { children: React.ReactNode }) {
-  const helpers = isQuickCreateEnabled
-    ? await createPublicSSRHelper()
-    : await createPrivateSSRHelper();
+  // Guests may only enter when quick create is enabled.
+  if (!isQuickCreateEnabled) {
+    await requireUser();
+  }
 
   const [locale, deviceDateTimeConfig, session] = await Promise.all([
     getLocale(),
     getDeviceDateTimeConfig(),
     getSession(),
-    helpers.billing.getTier.prefetch(),
   ]);
 
   const user = session?.user;
 
+  const space =
+    user && !user.isGuest ? await getActiveSpaceForUser(user.id) : null;
+  const tier = space?.tier ?? (isSelfHosted ? "pro" : "hobby");
+
   return (
-    <HydrationBoundary state={dehydrate(helpers.queryClient)}>
+    <>
       <SessionRefresher />
       <UserProvider user={user ?? null}>
         <DeviceDateTimeProvider
@@ -44,11 +47,13 @@ async function OptionalSpaceGate({ children }: { children: React.ReactNode }) {
           }
           weekStart={user?.weekStart ?? undefined}
         >
-          {children}
-          <PayWall />
+          <TierProvider tier={tier}>
+            {children}
+            <PayWall />
+          </TierProvider>
         </DeviceDateTimeProvider>
       </UserProvider>
-    </HydrationBoundary>
+    </>
   );
 }
 

--- a/apps/web/src/app/[locale]/(space)/(dashboard)/layout.tsx
+++ b/apps/web/src/app/[locale]/(space)/(dashboard)/layout.tsx
@@ -11,17 +11,17 @@ import {
   SidebarMenuItem,
   SidebarSeparator,
 } from "@rallly/ui/sidebar";
-import { dehydrate, HydrationBoundary } from "@tanstack/react-query";
 import { SettingsIcon } from "lucide-react";
 import Link from "next/link";
 import { CustomBrandingPrompt } from "@/features/branding/components/custom-branding-prompt";
 import { LicenseLimitWarning } from "@/features/licensing/components/license-limit-warning";
 import { CommandMenu } from "@/features/navigation/components/command-menu";
 import { SpaceDropdown } from "@/features/space/components/space-dropdown";
+import { listSpacesForUser } from "@/features/space/data";
 import { NavUser } from "@/features/user/components/nav-user";
+import { requireUser } from "@/features/user/loaders";
 import { Trans } from "@/i18n/client";
 import { IfFeatureEnabled } from "@/lib/feature-flags/client";
-import { createPrivateSSRHelper } from "@/trpc/server/create-ssr-helper";
 import { ControlPanelMenuItem } from "./components/control-panel-menu-item";
 import { FeedbackMenuItem } from "./components/feedback-menu-item";
 import { SpaceSidebarMenu } from "./components/space-sidebar-menu";
@@ -33,56 +33,54 @@ export default async function Layout({
 }: {
   children: React.ReactNode;
 }) {
-  const helpers = await createPrivateSSRHelper();
-
-  await Promise.all([
-    helpers.billing.getTier.prefetch(),
-    helpers.spaces.list.prefetch(),
-  ]);
+  const user = await requireUser();
+  const spaces = await listSpacesForUser(user.id);
 
   return (
-    <HydrationBoundary state={dehydrate(helpers.queryClient)}>
-      <SpaceSidebarProvider>
-        <CommandMenu />
-        <Sidebar>
-          <SidebarHeader>
-            <SpaceDropdown />
-          </SidebarHeader>
-          <SidebarContent>
-            <SpaceSidebarMenu />
-          </SidebarContent>
-          <SidebarFooter>
-            <SidebarGroup>
-              <SidebarGroupContent>
-                <SidebarMenu>
-                  <UpgradeMenuItem />
-                  <IfFeatureEnabled feature="feedback">
-                    <FeedbackMenuItem />
-                  </IfFeatureEnabled>
-                  <ControlPanelMenuItem />
-                  <SidebarMenuItem>
-                    <SidebarMenuButton
-                      render={<Link href="/settings/profile" />}
-                    >
-                      <SettingsIcon />
-                      <Trans i18nKey="settings" defaults="Settings" />
-                    </SidebarMenuButton>
-                  </SidebarMenuItem>
-                </SidebarMenu>
-              </SidebarGroupContent>
-            </SidebarGroup>
-            <SidebarSeparator className="my-1" />
-            <NavUser />
-          </SidebarFooter>
-        </Sidebar>
-        <SidebarInset id="main-content" tabIndex={-1} className="min-w-0">
-          <LicenseLimitWarning />
-          <CustomBrandingPrompt />
-          <div className="flex flex-1 flex-col">
-            <div className="flex flex-1 flex-col">{children}</div>
-          </div>
-        </SidebarInset>
-      </SpaceSidebarProvider>
-    </HydrationBoundary>
+    <SpaceSidebarProvider>
+      <CommandMenu />
+      <Sidebar>
+        <SidebarHeader>
+          <SpaceDropdown
+            spaces={spaces.map((space) => ({
+              id: space.id,
+              name: space.name,
+              image: space.image,
+            }))}
+          />
+        </SidebarHeader>
+        <SidebarContent>
+          <SpaceSidebarMenu />
+        </SidebarContent>
+        <SidebarFooter>
+          <SidebarGroup>
+            <SidebarGroupContent>
+              <SidebarMenu>
+                <UpgradeMenuItem />
+                <IfFeatureEnabled feature="feedback">
+                  <FeedbackMenuItem />
+                </IfFeatureEnabled>
+                <ControlPanelMenuItem />
+                <SidebarMenuItem>
+                  <SidebarMenuButton render={<Link href="/settings/profile" />}>
+                    <SettingsIcon />
+                    <Trans i18nKey="settings" defaults="Settings" />
+                  </SidebarMenuButton>
+                </SidebarMenuItem>
+              </SidebarMenu>
+            </SidebarGroupContent>
+          </SidebarGroup>
+          <SidebarSeparator className="my-1" />
+          <NavUser />
+        </SidebarFooter>
+      </Sidebar>
+      <SidebarInset id="main-content" tabIndex={-1} className="min-w-0">
+        <LicenseLimitWarning />
+        <CustomBrandingPrompt />
+        <div className="flex flex-1 flex-col">
+          <div className="flex flex-1 flex-col">{children}</div>
+        </div>
+      </SidebarInset>
+    </SpaceSidebarProvider>
   );
 }

--- a/apps/web/src/app/[locale]/(space)/layout.tsx
+++ b/apps/web/src/app/[locale]/(space)/layout.tsx
@@ -1,6 +1,7 @@
 import { Suspense } from "react";
 import { RouterLoadingIndicator } from "@/components/router-loading-indicator";
 import { SessionRefresher } from "@/components/session-refresher";
+import { TierProvider } from "@/features/billing/client";
 import { PayWall } from "@/features/billing/components/pay-wall";
 import { SpaceProvider } from "@/features/space/client";
 import { getActiveSpace } from "@/features/space/loaders";
@@ -33,10 +34,12 @@ async function SpaceGate({ children }: { children: React.ReactNode }) {
           timeFormat={user?.timeFormat}
           weekStart={user?.weekStart}
         >
-          <SpaceProvider space={space}>
-            {children}
-            <PayWall />
-          </SpaceProvider>
+          <TierProvider tier={space.tier}>
+            <SpaceProvider space={space}>
+              {children}
+              <PayWall />
+            </SpaceProvider>
+          </TierProvider>
         </DateTimeProvider>
       </UserProvider>
     </>

--- a/apps/web/src/app/[locale]/(space)/settings/spaces/page.tsx
+++ b/apps/web/src/app/[locale]/(space)/settings/spaces/page.tsx
@@ -9,18 +9,15 @@ import {
   SettingsPageHeader,
   SettingsPageTitle,
 } from "@/components/settings-layout";
+import { listSpacesForUser } from "@/features/space/data";
 import { requireUser } from "@/features/user/loaders";
 import { Trans } from "@/i18n/client";
 import { getTranslation } from "@/i18n/server";
-import { createPrivateSSRHelper } from "@/trpc/server/create-ssr-helper";
 import { SpacesList } from "./components/spaces-list";
 
 export default async function Page() {
-  const helpers = await createPrivateSSRHelper();
-  const [user, spaces] = await Promise.all([
-    requireUser(),
-    helpers.spaces.list.fetch(),
-  ]);
+  const user = await requireUser();
+  const spaces = await listSpacesForUser(user.id);
 
   return (
     <SettingsPage>

--- a/apps/web/src/app/[locale]/control-panel/layout.tsx
+++ b/apps/web/src/app/[locale]/control-panel/layout.tsx
@@ -7,21 +7,18 @@ import { RouterLoadingIndicator } from "@/components/router-loading-indicator";
 import { LicenseLimitWarning } from "@/features/licensing/components/license-limit-warning";
 import { CommandMenu } from "@/features/navigation/components/command-menu";
 import { UserProvider } from "@/features/user/client";
+import { requireAdmin } from "@/features/user/loaders";
 import { Trans } from "@/i18n/client";
 import { getTranslation } from "@/i18n/server";
 import { getLocale } from "@/i18n/server/get-locale";
 import { DateTimeProvider } from "@/lib/datetime/client";
-import { createAdminSSRHelper } from "@/trpc/server/create-ssr-helper";
 import { ControlPanelSidebarProvider } from "./control-panel-sidebar-provider";
 import { ControlPanelSidebar } from "./sidebar";
 
 // The admin gate awaits below the Suspense boundary in the default export
 // so the document shell can flush before the session store responds.
 async function AdminGate({ children }: { children: React.ReactNode }) {
-  const [locale, { user }] = await Promise.all([
-    getLocale(),
-    createAdminSSRHelper(),
-  ]);
+  const [locale, user] = await Promise.all([getLocale(), requireAdmin()]);
 
   return (
     <UserProvider user={user}>

--- a/apps/web/src/app/[locale]/control-panel/users/page.tsx
+++ b/apps/web/src/app/[locale]/control-panel/users/page.tsx
@@ -20,9 +20,9 @@ import {
 } from "@/components/settings-layout";
 import { StackedList } from "@/components/stacked-list";
 import { defineAbilityFor } from "@/features/user/ability";
+import { requireAdmin } from "@/features/user/loaders";
 import { Trans } from "@/i18n/client";
 import { getTranslation } from "@/i18n/server";
-import { createAdminSSRHelper } from "@/trpc/server/create-ssr-helper";
 import { UserRow } from "./user-row";
 import { UserSearchInput } from "./user-search-input";
 import { UsersTabbedView } from "./users-tabbed-view";
@@ -38,7 +38,7 @@ async function loadData({
   q?: string;
   role?: "admin" | "user";
 }) {
-  const { user } = await createAdminSSRHelper();
+  const user = await requireAdmin();
 
   const where: Prisma.UserWhereInput = {
     isAnonymous: false,

--- a/apps/web/src/features/billing/client.tsx
+++ b/apps/web/src/features/billing/client.tsx
@@ -1,14 +1,30 @@
 "use client";
 
 import { posthog } from "@rallly/posthog/client";
+import React from "react";
 import { create } from "zustand";
 import type { SpaceTier } from "@/features/space/schema";
-import { trpc } from "@/trpc/client";
+
+const TierContext = React.createContext<SpaceTier | null>(null);
+
+export function TierProvider({
+  tier,
+  children,
+}: {
+  tier: SpaceTier;
+  children: React.ReactNode;
+}) {
+  return <TierContext.Provider value={tier}>{children}</TierContext.Provider>;
+}
 
 export function useTier(): SpaceTier {
-  const { data: tier } = trpc.billing.getTier.useQuery();
+  const tier = React.useContext(TierContext);
 
-  return tier ?? "hobby";
+  if (tier === null) {
+    throw new Error("useTier must be used within a TierProvider");
+  }
+
+  return tier;
 }
 
 export function useIsFree() {

--- a/apps/web/src/features/space/components/space-dropdown.tsx
+++ b/apps/web/src/features/space/components/space-dropdown.tsx
@@ -26,12 +26,14 @@ import { useSpace } from "@/features/space/client";
 import { SpaceTierLabel } from "@/features/space/components/space-tier";
 import { Trans } from "@/i18n/client";
 import { useSafeAction } from "@/lib/safe-action/client";
-import { trpc } from "@/trpc/client";
 import { CreateSpaceDialog } from "./create-space-dialog";
 import { SpaceIcon } from "./space-icon";
 
-export function SpaceDropdown() {
-  const { data: spaces = [] } = trpc.spaces.list.useQuery();
+export function SpaceDropdown({
+  spaces,
+}: {
+  spaces: { id: string; name: string; image?: string }[];
+}) {
   const { data: activeSpace } = useSpace();
 
   const setActiveSpace = useSafeAction(setActiveSpaceAction);

--- a/apps/web/src/features/space/data.ts
+++ b/apps/web/src/features/space/data.ts
@@ -205,6 +205,41 @@ export const getOwnedSpace = cache(async (userId: string) => {
   });
 });
 
+export const listSpacesForUser = cache(async (userId: string) => {
+  const result = await prisma.spaceMember.findMany({
+    where: effectiveSpaceMemberWhere({ userId }),
+    select: {
+      role: true,
+      space: {
+        select: {
+          id: true,
+          name: true,
+          image: true,
+          ownerId: true,
+          tier: true,
+          primaryColor: true,
+          showBranding: true,
+          _count: { select: { members: true } },
+          subscriptions: {
+            where: { active: true },
+            select: { quantity: true },
+            take: 1,
+          },
+        },
+      },
+    },
+  });
+
+  return result.map((spaceMember) =>
+    createSpaceDTO({
+      ...spaceMember.space,
+      role: spaceMember.role,
+      memberCount: spaceMember.space._count.members,
+      seatCount: spaceMember.space.subscriptions[0]?.quantity ?? 1,
+    }),
+  );
+});
+
 export const getActiveSpaceForUser = cache(async (userId: string) => {
   const spaceMember = await prisma.spaceMember.findFirst({
     where: effectiveSpaceMemberWhere({ userId }),

--- a/apps/web/src/features/user/loaders.ts
+++ b/apps/web/src/features/user/loaders.ts
@@ -1,7 +1,8 @@
 import "server-only";
 
-import { redirect } from "next/navigation";
+import { notFound, redirect } from "next/navigation";
 import { cache } from "react";
+import { isInitialAdmin } from "@/features/instance-settings/utils";
 import { getUser } from "@/features/user/data";
 import type { UserDTO } from "@/features/user/schema";
 import { getSession, getSessionState } from "@/lib/auth";
@@ -58,6 +59,34 @@ export const requireUser = cache(async (): Promise<UserDTO> => {
 
   if (user.banned) {
     throw new InvalidSessionError();
+  }
+
+  return user;
+});
+
+/**
+ * Gate for server pages that require an admin user. Authorized against
+ * the database — the session cookie cache can hold a stale role.
+ * Redirects to /login when unauthenticated, to /admin-setup when the
+ * user is the initial admin but not yet promoted, and returns 404 for
+ * everyone else.
+ */
+export const requireAdmin = cache(async () => {
+  const user = await getCurrentUser();
+
+  if (!user) {
+    const pathname = await getPathname();
+    redirect(
+      buildSafeRedirectUrl({ destination: "/login", returnUrl: pathname }),
+    );
+  }
+
+  if (user.role !== "admin") {
+    if (isInitialAdmin(user.email)) {
+      redirect("/admin-setup");
+    }
+
+    notFound();
   }
 
   return user;

--- a/apps/web/src/trpc/routers/billing.ts
+++ b/apps/web/src/trpc/routers/billing.ts
@@ -3,27 +3,10 @@ import * as z from "zod";
 
 import { getSpaceSubscription } from "@/features/billing/data";
 import { createStripeSubscriptionUpdateConfirmation } from "@/features/billing/mutations";
-import {
-  getActiveSpaceForUser,
-  getSpaceSeatCount,
-} from "@/features/space/data";
-import { isSelfHosted } from "@/lib/constants";
-import { publicProcedure, router, spaceOwnerProcedure } from "../trpc";
+import { getSpaceSeatCount } from "@/features/space/data";
+import { router, spaceOwnerProcedure } from "../trpc";
 
 export const billing = router({
-  getTier: publicProcedure.query(async ({ ctx }) => {
-    if (isSelfHosted) {
-      return "pro" as const;
-    }
-
-    if (!ctx.user || ctx.user.isGuest) {
-      return "hobby" as const;
-    }
-
-    const space = await getActiveSpaceForUser(ctx.user.id);
-
-    return space?.tier ?? ("hobby" as const);
-  }),
   updateSeats: spaceOwnerProcedure
     .input(z.object({ seatDelta: z.int() }))
     .mutation(async ({ ctx, input }) => {

--- a/apps/web/src/trpc/routers/spaces.ts
+++ b/apps/web/src/trpc/routers/spaces.ts
@@ -1,55 +1,12 @@
 import { prisma } from "@rallly/database";
 import { TRPCError } from "@trpc/server";
 import * as z from "zod";
-import { createSpaceDTO } from "@/features/space/data";
-import { effectiveSpaceMemberWhere } from "@/features/space/member/utils";
-import type { SpaceDTO } from "@/features/space/types";
 import { fromDBRole } from "@/features/space/utils";
 import { identifyGroup, track } from "@/lib/posthog";
 import { privateProcedure, router, spaceProcedure } from "../trpc";
 
 export const spaces = router({
   // ── Queries ──────────────────────────────────────────────────────────
-  list: privateProcedure.query(async ({ ctx }) => {
-    const { user } = ctx;
-
-    if (!user) {
-      return [];
-    }
-
-    const result = await prisma.spaceMember.findMany({
-      where: effectiveSpaceMemberWhere({ userId: user.id }),
-      select: {
-        role: true,
-        space: {
-          select: {
-            id: true,
-            name: true,
-            image: true,
-            ownerId: true,
-            tier: true,
-            primaryColor: true,
-            showBranding: true,
-            _count: { select: { members: true } },
-            subscriptions: {
-              where: { active: true },
-              select: { quantity: true },
-              take: 1,
-            },
-          },
-        },
-      },
-    });
-
-    return result.map<SpaceDTO>((spaceMember) =>
-      createSpaceDTO({
-        ...spaceMember.space,
-        role: spaceMember.role,
-        memberCount: spaceMember.space._count.members,
-        seatCount: spaceMember.space.subscriptions[0]?.quantity ?? 1,
-      }),
-    );
-  }),
   listMembers: spaceProcedure.query(async ({ ctx }) => {
     const [members, totalCount] = await Promise.all([
       prisma.spaceMember.findMany({

--- a/apps/web/src/trpc/server/create-ssr-helper.ts
+++ b/apps/web/src/trpc/server/create-ssr-helper.ts
@@ -1,12 +1,8 @@
 import { createServerSideHelpers } from "@trpc/react-query/server";
-import { notFound, redirect } from "next/navigation";
 import { cache } from "react";
 import superjson from "superjson";
-import { isInitialAdmin } from "@/features/instance-settings/utils";
-import { getCurrentUser, requireUser } from "@/features/user/loaders";
+import { requireUser } from "@/features/user/loaders";
 import { getSession } from "@/lib/auth";
-import { getPathname } from "@/lib/pathname";
-import { buildSafeRedirectUrl } from "@/lib/utils/redirect";
 import type { TRPCContext } from "../context";
 import { appRouter } from "../routers";
 
@@ -44,45 +40,4 @@ export const createPrivateSSRHelper = cache(async () => {
     } satisfies TRPCContext,
     transformer: superjson,
   });
-});
-
-/**
- * Admin Server-Side Helper
- * @description Use for prefetching data that requires an admin user.
- * Redirects to /login if not authenticated, to /admin-setup if the user
- * is the initial admin but not yet promoted, or returns 404 if the user
- * is not an admin.
- */
-export const createAdminSSRHelper = cache(async () => {
-  // Admin access must be authorized against the database — the session
-  // cookie cache can hold a stale role. getCurrentUser also rejects
-  // banned users and returns null for guests.
-  const user = await getCurrentUser();
-
-  if (!user) {
-    redirect(
-      buildSafeRedirectUrl({
-        destination: "/login",
-        returnUrl: await getPathname(),
-      }),
-    );
-  }
-
-  if (user.role !== "admin") {
-    if (isInitialAdmin(user.email)) {
-      redirect("/admin-setup");
-    }
-
-    notFound();
-  }
-
-  const helpers = createServerSideHelpers({
-    router: appRouter,
-    ctx: {
-      user,
-    } satisfies TRPCContext,
-    transformer: superjson,
-  });
-
-  return { helpers, user };
 });


### PR DESCRIPTION
Removes all layout-level tRPC prefetching. Follow-up to #2858 and the next step toward `cacheComponents` — the session gates now await only the session, so no layout depends on hydrated queries.

**What changed:**

- **`billing.getTier` deleted.** `SpaceDTO.tier` already carries the exact same value (`createSpaceDTO` applies the self-hosted override), so the query was a second network path to data the layout had loaded. `useTier()`/`useIsFree()` now read from a `TierProvider` fed by the layout gates: the `(space)` gate passes `space.tier`; the `(optional-space)` gate computes it server-side (guests → hobby, self-hosted → pro, otherwise active space tier).
- **`spaces.list` deleted.** The query moved to `listSpacesForUser` in `features/space/data.ts`. The dashboard layout passes the list to `SpaceDropdown` as a prop; the settings/spaces page calls the data read directly.
- **`createAdminSSRHelper` deleted.** Its tRPC helper half was unused — both call sites only wanted the auth gate, which is now `requireAdmin()` in `features/user/loaders.ts` (same DB-verified role check, login/admin-setup redirects, 404 for non-admins).
- **`(optional-space)` keeps its auth semantics**: `createPrivateSSRHelper` was doubling as the login gate when quick create is disabled, so the gate now calls `requireUser()` explicitly in that mode.
- `HydrationBoundary`/`dehydrate` removed from both layouts.

**Bug fixed in passing:** the space list now refreshes after creating or switching a space — `useSafeAction` triggers `router.refresh()`, which re-renders the server-provided prop. The old tRPC query cache was never invalidated, so newly created spaces didn't appear in the dropdown until a reload.

Verified: `type-check`, `build`, and the `authentication`, `create-delete-poll`, `control-panel`, and `space-members` Playwright specs (26 passed) — covering the login gate, `/new` + poll admin under `(optional-space)`, the dashboard sidebar, and the admin gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added consistent billing-tier handling across spaces, including support for self-hosted environments and paywalls.
  * Space navigation now loads available spaces reliably and displays them in the space selector.
  * Added clearer access enforcement for guests, members, and administrators.
* **Bug Fixes**
  * Improved redirects and access checks for protected spaces, settings, and administration pages.
  * Prevented unauthorized users from accessing administrative areas.
* **Refactor**
  * Simplified page loading and authentication flows for more reliable navigation and rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->