### PR TITLE
🐛 Reset participant selection when a participant is deleted on mobile poll

### DIFF
--- a/apps/web/src/features/poll/components/mobile-poll.tsx
+++ b/apps/web/src/features/poll/components/mobile-poll.tsx
@@ -59,9 +59,9 @@ const MobilePoll: React.FunctionComponent = () => {
 
   const { canEditParticipant, canAddNewParticipant } = usePermissions();
 
-  const { t } = useTranslation();
-
   const isEditing = votingForm.watch("mode") !== "view";
+
+  const { t } = useTranslation();
 
   const participantOptions = [
     {
@@ -117,7 +117,10 @@ const MobilePoll: React.FunctionComponent = () => {
               }}
               disabled={isEditing}
             >
-              <SelectTrigger className="flex-1">
+              <SelectTrigger
+                className="flex-1"
+                data-testid="participant-selector"
+              >
                 <SelectValue />
               </SelectTrigger>
               <SelectContent>
@@ -169,6 +172,9 @@ const MobilePoll: React.FunctionComponent = () => {
                 }}
                 onEdit={() => {
                   votingForm.setEditingParticipantId(selectedParticipant.id);
+                }}
+                onDelete={() => {
+                  votingForm.setValue("participantId", "all");
                 }}
               >
                 <Button

--- a/apps/web/src/features/poll/components/participant-dropdown.tsx
+++ b/apps/web/src/features/poll/components/participant-dropdown.tsx
@@ -44,6 +44,7 @@ import { trpc } from "@/trpc/client";
 export const ParticipantDropdown = ({
   participant,
   onEdit,
+  onDelete,
   children,
   disabled,
   align,
@@ -57,6 +58,7 @@ export const ParticipantDropdown = ({
   };
   align?: "start" | "end";
   onEdit: () => void;
+  onDelete?: () => void;
   children: React.ReactElement;
 }) => {
   const [isChangeNameModalVisible, setIsChangeNameModalVisible] =
@@ -115,6 +117,7 @@ export const ParticipantDropdown = ({
         onOpenChange={setIsDeleteParticipantModalVisible}
         participantId={participant.id}
         participantName={participant.name}
+        onDelete={onDelete}
       />
     </>
   );
@@ -125,11 +128,13 @@ const DeleteParticipantModal = ({
   onOpenChange,
   participantId,
   participantName,
+  onDelete,
 }: {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   participantId: string;
   participantName: string;
+  onDelete?: () => void;
 }) => {
   const deleteParticipant = useDeleteParticipantMutation();
   const token = useEditToken();
@@ -163,6 +168,7 @@ const DeleteParticipantModal = ({
                 participantId,
                 token,
               });
+              onDelete?.();
               onOpenChange(false);
             }}
           >

--- a/apps/web/tests/mobile-test.spec.ts
+++ b/apps/web/tests/mobile-test.spec.ts
@@ -1,34 +1,51 @@
+import type { Page } from "@playwright/test";
 import { expect, test } from "@playwright/test";
+import { NewPollPage } from "./new-poll-page";
 
-test.skip("should be able to vote and comment on a poll", async ({ page }) => {
-  await page.setViewportSize({ width: 375, height: 667 });
-  await page.goto("/demo");
+test.describe(() => {
+  let inviteUrl: string;
 
-  await expect(page.locator('text="Lunch Meeting"')).toBeVisible();
+  test.beforeAll(async ({ browser }) => {
+    const page = await browser.newPage();
+    const newPollPage = new NewPollPage(page);
+    await newPollPage.goto();
+    const dialog = await newPollPage.create({ name: "Mobile Meetup" });
+    const pollPage = await dialog.goToPollPage();
+    inviteUrl = await pollPage.copyInviteLink();
+    await page.close();
+  });
 
-  await page.click('text="New"');
-  await page.click("data-testid=poll-option >> nth=0");
-  await page.click("data-testid=poll-option >> nth=1");
-  await page.click("data-testid=poll-option >> nth=3");
+  const voteAsNewParticipant = async (page: Page, name: string) => {
+    await page.getByTestId("poll-option").first().click();
+    await page.getByRole("button", { name: "Continue" }).click();
+    await page.getByPlaceholder("Jessie Smith").fill(name);
+    await page.getByRole("button", { name: "Save availability" }).click();
+    await page.getByRole("button", { name: "Back to poll" }).click();
+  };
 
-  await page.getByText("Continue").click();
+  test("deleting a participant resets the participant selector", async ({
+    browser,
+  }) => {
+    const context = await browser.newContext({
+      viewport: { width: 375, height: 667 },
+    });
+    const page = await context.newPage();
+    await page.goto(inviteUrl);
 
-  await page.getByPlaceholder("Jessie Smith").type("Test user");
-  await page.getByText(/^Save availability$/).click();
+    await voteAsNewParticipant(page, "Test user");
 
-  await expect(page.locator("data-testid=user")).toBeVisible();
-  await expect(
-    page.locator("data-testid=participant-selector").locator("text=You"),
-  ).toBeVisible();
+    const selector = page.getByTestId("participant-selector");
+    await expect(selector).toContainText("Test user");
 
-  await page.getByTestId("participant-menu").click();
-  await page.getByText("Edit votes").click();
-  await page.click("data-testid=poll-option >> nth=1");
-  await page.click("text=Save");
+    await page.getByTestId("participant-menu").click();
+    await page.getByRole("menuitem", { name: "Delete" }).click();
+    await page
+      .getByRole("dialog")
+      .getByRole("button", { name: "Delete" })
+      .click();
 
-  await page.getByTestId("participant-menu").click();
-  await page.locator("button", { hasText: "Delete" }).click();
-  const modal = page.getByTestId("modal");
-  await modal.locator("button", { hasText: "Delete" }).click();
-  await expect(page.locator("text='Test user'")).not.toBeVisible();
+    await expect(selector).toContainText("All Participants");
+
+    await context.close();
+  });
 });


### PR DESCRIPTION
## Description

Deleting a participant on the mobile poll left the deleted participant's id in the voting form, so the participant select rendered the raw id (e.g. `cmsel9tvz…`) until the page was refreshed. The delete mutation optimistically removes the participant from the participants cache, but nothing reset the form's `participantId`, leaving the Base UI Select controlled by a value with no matching item — it falls back to rendering the raw value. The stale id was also a latent hazard: a later submit would have targeted a deleted participant.

`ParticipantDropdown` now accepts an optional `onDelete` callback, invoked when the delete is confirmed, and the mobile poll uses it to reset the selection to All Participants. Desktop usage is unchanged (no callback passed).

Also replaces the stale, skipped `mobile-test.spec.ts` (which targeted `/demo`) with a real regression test: vote as a guest on a mobile viewport, delete via the participant menu, and assert the selector resets to All Participants. The red run reproduced the exact bug before the fix. A `data-testid="participant-selector"` was added to the select trigger for the test.

## Checklist

- [x] I have performed a self-review of my code
- [x] My code follows the code style of this project
- [x] I have commented my code, particularly in hard-to-understand areas

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Participant selector now resets to 'All Participants' when a participant is deleted from the poll, ensuring consistent behavior on mobile devices.

* **Tests**
  * Enhanced mobile viewport test coverage for participant management features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->