### PR TITLE
✨ Optimistic space switching with loading indicator

### DIFF
--- a/apps/web/src/app/[locale]/(space)/(dashboard)/layout.tsx
+++ b/apps/web/src/app/[locale]/(space)/(dashboard)/layout.tsx
@@ -46,6 +46,7 @@ export default async function Layout({
               id: space.id,
               name: space.name,
               image: space.image,
+              tier: space.tier,
             }))}
           />
         </SidebarHeader>

--- a/apps/web/src/features/space/components/space-dropdown.tsx
+++ b/apps/web/src/features/space/components/space-dropdown.tsx
@@ -21,9 +21,12 @@ import {
   UserPlusIcon,
 } from "lucide-react";
 import Link from "next/link";
+import React from "react";
+import { RouterLoadingIndicator } from "@/components/router-loading-indicator";
 import { setActiveSpaceAction } from "@/features/space/actions";
 import { useSpace } from "@/features/space/client";
 import { SpaceTierLabel } from "@/features/space/components/space-tier";
+import type { SpaceTier } from "@/features/space/schema";
 import { Trans } from "@/i18n/client";
 import { useSafeAction } from "@/lib/safe-action/client";
 import { CreateSpaceDialog } from "./create-space-dialog";
@@ -32,14 +35,20 @@ import { SpaceIcon } from "./space-icon";
 export function SpaceDropdown({
   spaces,
 }: {
-  spaces: { id: string; name: string; image?: string }[];
+  spaces: { id: string; name: string; image?: string; tier: SpaceTier }[];
 }) {
   const { data: activeSpace } = useSpace();
+  const [pendingSpaceId, setPendingSpaceId] = React.useState<string>();
 
-  const setActiveSpace = useSafeAction(setActiveSpaceAction);
+  const setActiveSpace = useSafeAction(setActiveSpaceAction, {
+    onError: () => setPendingSpaceId(undefined),
+  });
   const newSpaceDialog = useDialog();
 
-  const selectedSpaceId = activeSpace.id;
+  const pendingSpace = spaces.find((space) => space.id === pendingSpaceId);
+  const isSwitching = !!pendingSpace && pendingSpace.id !== activeSpace.id;
+  const displayedSpace = isSwitching ? pendingSpace : activeSpace;
+  const selectedSpaceId = displayedSpace.id;
 
   return (
     <>
@@ -48,23 +57,23 @@ export function SpaceDropdown({
           render={
             <Button
               className={cn("flex h-auto w-full gap-2.5 p-2", {
-                "pointer-events-none animate-pulse": setActiveSpace.isExecuting,
+                "pointer-events-none": isSwitching,
               })}
               variant="ghost"
             />
           }
         >
           <SpaceIcon
-            src={activeSpace.image}
-            name={activeSpace.name}
+            src={displayedSpace.image}
+            name={displayedSpace.name}
             size="lg"
           />
           <div className="min-w-0 flex-1 px-0.5 text-left">
             <div className="truncate font-medium text-sm">
-              {activeSpace.name}
+              {displayedSpace.name}
             </div>
             <div className="text-muted-foreground text-xs">
-              <SpaceTierLabel tier={activeSpace.tier} />
+              <SpaceTierLabel tier={displayedSpace.tier} />
             </div>
           </div>
           <Icon>
@@ -82,6 +91,7 @@ export function SpaceDropdown({
             value={selectedSpaceId}
             onValueChange={(value) => {
               if (value === selectedSpaceId) return;
+              setPendingSpaceId(value);
               setActiveSpace.execute({ spaceId: value });
             }}
           >
@@ -118,6 +128,7 @@ export function SpaceDropdown({
         </DropdownMenuContent>
       </DropdownMenu>
       <CreateSpaceDialog {...newSpaceDialog.dialogProps} />
+      {isSwitching ? <RouterLoadingIndicator /> : null}
     </>
   );
 }

--- a/apps/web/src/lib/safe-action/client.ts
+++ b/apps/web/src/lib/safe-action/client.ts
@@ -14,7 +14,8 @@ export const useSafeAction: typeof useAction = (action, options) => {
       router.refresh();
       options?.onSuccess?.(args);
     },
-    onError: ({ error }) => {
+    onError: (args) => {
+      const { error } = args;
       if (error.serverError) {
         let translatedDescription = "An unexpected error occurred";
 
@@ -65,6 +66,7 @@ export const useSafeAction: typeof useAction = (action, options) => {
 
         toast.error(translatedDescription);
       }
+      options?.onError?.(args);
     },
   });
 };


### PR DESCRIPTION
## Description

Switching spaces from the space dropdown previously gave no feedback until `setActiveSpaceAction` completed and `router.refresh()` delivered the new RSC payload — the trigger just pulsed with the old space name. The dropdown now updates optimistically and shows the `RouterLoadingIndicator` while the switch is in flight.

- **`space-dropdown.tsx`** — tracks a `pendingSpaceId` when a space is selected. The trigger and radio group render the pending space immediately; the pending state self-resolves once the refreshed `activeSpace` from context matches it, and rolls back on action error. While switching, the `RouterLoadingIndicator` is mounted (it is built around mount/unmount) and the trigger is `pointer-events-none` to block concurrent switches. Dropped `animate-pulse` — the progress bar is the busy signal now.
- **`(dashboard)/layout.tsx`** — passes `tier` in the spaces prop so the optimistic trigger shows the target space's plan label instead of the previous space's.
- **`lib/safe-action/client.ts`** — `useSafeAction` spread the caller's options but then overrode `onError` without delegating (unlike `onSuccess`), silently swallowing every caller's error callback. It now forwards `options.onError` after showing the toast; the dropdown relies on this for optimistic rollback.

Verified with a headless Playwright run against a dev server with the server-action POST artificially delayed by 2s: the trigger showed the new space name and tier within 300ms of clicking, the progress bar was visible during the switch, unmounted after settle, and a fresh reload confirmed the switch persisted.

## Checklist

- [x] I have performed a self-review of my code
- [x] My code follows the code style of this project
- [x] I have commented my code, particularly in hard-to-understand areas

🤖 Generated with [Claude Code](https://claude.com/claude-code)