### PR TITLE
🐛 Pass i18n to server-side Trans to prevent cross-request language leaks

### DIFF
--- a/apps/web/src/app/[locale]/(auth)/components/already-logged-in.tsx
+++ b/apps/web/src/app/[locale]/(auth)/components/already-logged-in.tsx
@@ -23,7 +23,7 @@ import { SignOutButton } from "./sign-out-button";
  * so this must not be a client module.
  */
 export async function AlreadyLoggedIn({ redirectTo }: { redirectTo?: string }) {
-  const { t } = await getTranslation();
+  const { t, i18n } = await getTranslation();
 
   return (
     <AuthPageContainer>
@@ -32,6 +32,7 @@ export async function AlreadyLoggedIn({ redirectTo }: { redirectTo?: string }) {
         <AuthPageTitle>
           <Trans
             t={t}
+            i18n={i18n}
             ns="app"
             i18nKey="alreadyLoggedInTitle"
             defaults="You're already signed in"
@@ -40,6 +41,7 @@ export async function AlreadyLoggedIn({ redirectTo }: { redirectTo?: string }) {
         <AuthPageDescription>
           <Trans
             t={t}
+            i18n={i18n}
             ns="app"
             i18nKey="alreadyLoggedInDescription"
             defaults="Continue to your dashboard or sign out to use a different account."
@@ -59,6 +61,7 @@ export async function AlreadyLoggedIn({ redirectTo }: { redirectTo?: string }) {
           >
             <Trans
               t={t}
+              i18n={i18n}
               ns="app"
               i18nKey="alreadyLoggedInContinue"
               defaults="Continue"

--- a/apps/web/src/app/[locale]/(auth)/forgot-password/page.tsx
+++ b/apps/web/src/app/[locale]/(auth)/forgot-password/page.tsx
@@ -20,7 +20,7 @@ export default async function ForgotPasswordPage() {
     notFound();
   }
   await redirectIfLoggedIn();
-  const { t } = await getTranslation();
+  const { t, i18n } = await getTranslation();
 
   return (
     <AuthPageContainer>
@@ -28,6 +28,7 @@ export default async function ForgotPasswordPage() {
         <AuthPageTitle>
           <Trans
             t={t}
+            i18n={i18n}
             ns="app"
             i18nKey="forgotPasswordTitle"
             defaults="Forgot Password"
@@ -36,6 +37,7 @@ export default async function ForgotPasswordPage() {
         <AuthPageDescription>
           <Trans
             t={t}
+            i18n={i18n}
             ns="app"
             i18nKey="forgotPasswordDescription"
             defaults="Enter your email address and we'll send you a link to reset your password."
@@ -48,6 +50,7 @@ export default async function ForgotPasswordPage() {
       <AuthPageExternal>
         <Trans
           t={t}
+          i18n={i18n}
           ns="app"
           i18nKey="forgotPasswordFooter"
           defaults="Remember your password? <a>Back to login</a>"

--- a/apps/web/src/app/[locale]/(auth)/login/page.tsx
+++ b/apps/web/src/app/[locale]/(auth)/login/page.tsx
@@ -21,7 +21,7 @@ import { AuthErrors } from "./components/auth-errors";
 import { LoginWithEmailForm } from "./components/login-email-form";
 
 async function loadData() {
-  const [isRegistrationEnabled, { t }] = await Promise.all([
+  const [isRegistrationEnabled, { t, i18n }] = await Promise.all([
     getRegistrationEnabled(),
     getTranslation(),
   ]);
@@ -29,6 +29,7 @@ async function loadData() {
   return {
     isRegistrationEnabled,
     t,
+    i18n,
   };
 }
 
@@ -52,7 +53,7 @@ export default async function LoginPage(props: {
     return <AlreadyLoggedIn redirectTo={searchParams?.redirectTo} />;
   }
 
-  const { isRegistrationEnabled, t } = await loadData();
+  const { isRegistrationEnabled, t, i18n } = await loadData();
   const isEmailLoginEnabled = isFeatureEnabled("emailLogin");
 
   const hasGoogleProvider = !!authLib.options.socialProviders.google;
@@ -80,12 +81,19 @@ export default async function LoginPage(props: {
     <AuthPageContainer>
       <AuthPageHeader>
         <AuthPageTitle>
-          <Trans t={t} ns="app" i18nKey="loginTitle" defaults="Welcome" />
+          <Trans
+            t={t}
+            i18n={i18n}
+            ns="app"
+            i18nKey="loginTitle"
+            defaults="Welcome"
+          />
         </AuthPageTitle>
         <AuthPageDescription>
           {!isEmailLoginEnabled && !hasAlternateLoginMethods ? (
             <Trans
               t={t}
+              i18n={i18n}
               ns="app"
               i18nKey="loginNotConfigured"
               defaults="Login is currently not configured."
@@ -93,6 +101,7 @@ export default async function LoginPage(props: {
           ) : isRegistrationEnabled ? (
             <Trans
               t={t}
+              i18n={i18n}
               ns="app"
               i18nKey="loginOrSignUpDescription"
               defaults="Log in to your account or create a new one"
@@ -100,6 +109,7 @@ export default async function LoginPage(props: {
           ) : (
             <Trans
               t={t}
+              i18n={i18n}
               ns="app"
               i18nKey="loginDescription"
               defaults="Login to your account to continue"

--- a/apps/web/src/app/[locale]/(auth)/login/verify/page.tsx
+++ b/apps/web/src/app/[locale]/(auth)/login/verify/page.tsx
@@ -19,7 +19,7 @@ import { OTPForm } from "./components/otp-form";
 
 export default async function VerifyPage() {
   await redirectIfLoggedIn();
-  const { t } = await getTranslation();
+  const { t, i18n } = await getTranslation();
   const email = (await cookies()).get("verification-email")?.value;
   if (!email) {
     redirect("/login");
@@ -34,6 +34,7 @@ export default async function VerifyPage() {
           {isRegistrationEnabled ? (
             <Trans
               t={t}
+              i18n={i18n}
               ns="app"
               i18nKey="verifyEmailTitle"
               defaults="Verify Your Email"
@@ -41,6 +42,7 @@ export default async function VerifyPage() {
           ) : (
             <Trans
               t={t}
+              i18n={i18n}
               ns="app"
               i18nKey="loginVerifyTitle"
               defaults="Finish Logging In"
@@ -51,6 +53,7 @@ export default async function VerifyPage() {
           {isRegistrationEnabled ? (
             <Trans
               t={t}
+              i18n={i18n}
               ns="app"
               i18nKey="verifyEmailDescription"
               defaults="Enter the 6-digit code we sent to <b>{email}</b>"
@@ -62,6 +65,7 @@ export default async function VerifyPage() {
           ) : (
             <Trans
               t={t}
+              i18n={i18n}
               ns="app"
               i18nKey="loginVerifyCheckEmail"
               defaults="If an account exists with this email, you will receive a verification code at <b>{email}</b>"
@@ -86,7 +90,7 @@ export default async function VerifyPage() {
             className: "w-full",
           })}
         >
-          <Trans t={t} ns="app" i18nKey="back" defaults="Back" />
+          <Trans t={t} i18n={i18n} ns="app" i18nKey="back" defaults="Back" />
         </LinkWithRedirectTo>
       </AuthPageContent>
     </AuthPageContainer>

--- a/apps/web/src/features/quick-create/components/quick-create-button.tsx
+++ b/apps/web/src/features/quick-create/components/quick-create-button.tsx
@@ -7,7 +7,7 @@ import { Trans } from "react-i18next/TransWithoutContext";
 import { getTranslation } from "@/i18n/server";
 
 export async function QuickCreateButton() {
-  const { t } = await getTranslation();
+  const { t, i18n } = await getTranslation();
   return (
     <Link
       href="/quick-create"
@@ -16,7 +16,13 @@ export async function QuickCreateButton() {
       <Icon>
         <ZapIcon className="size-4" />
       </Icon>
-      <Trans t={t} ns="app" i18nKey="quickCreate" defaults="Quick Create" />
+      <Trans
+        t={t}
+        i18n={i18n}
+        ns="app"
+        i18nKey="quickCreate"
+        defaults="Quick Create"
+      />
     </Link>
   );
 }

--- a/apps/web/src/features/quick-create/components/quick-create-widget.tsx
+++ b/apps/web/src/features/quick-create/components/quick-create-widget.tsx
@@ -11,7 +11,7 @@ import { RelativeDate } from "./relative-date";
 
 export async function QuickCreateWidget() {
   const polls = await getGuestPolls();
-  const { t } = await getTranslation();
+  const { t, i18n } = await getTranslation();
   return (
     <div className="space-y-8">
       <div className="space-y-6">
@@ -20,6 +20,7 @@ export async function QuickCreateWidget() {
           <h2>
             <Trans
               t={t}
+              i18n={i18n}
               ns="app"
               i18nKey="quickCreate"
               defaults="Quick Create"
@@ -29,6 +30,7 @@ export async function QuickCreateWidget() {
         <p className="text-pretty text-muted-foreground">
           <Trans
             t={t}
+            i18n={i18n}
             ns="app"
             i18nKey="quickActionsDescription"
             defaults="Create a group poll without signing in. Login later to link it to your account."
@@ -39,6 +41,7 @@ export async function QuickCreateWidget() {
             <h3 className="font-semibold">
               <Trans
                 t={t}
+                i18n={i18n}
                 ns="app"
                 i18nKey="quickCreateRecentlyCreated"
                 defaults="Recently Created"
@@ -74,6 +77,7 @@ export async function QuickCreateWidget() {
             <PlusIcon data-icon="inline-start" />
             <Trans
               t={t}
+              i18n={i18n}
               ns="app"
               i18nKey="quickCreateGroupPoll"
               defaults="Create Group Poll"
@@ -86,6 +90,7 @@ export async function QuickCreateWidget() {
           <h3 className="font-semibold">
             <Trans
               t={t}
+              i18n={i18n}
               ns="app"
               i18nKey="quickCreateWhyCreateAnAccount"
               defaults="Why create an account?"
@@ -97,6 +102,7 @@ export async function QuickCreateWidget() {
             <CheckIcon className="size-5 text-green-600 dark:text-green-500" />
             <Trans
               t={t}
+              i18n={i18n}
               ns="app"
               i18nKey="quickCreateSecurePolls"
               defaults="Store polls securely in your account"
@@ -106,6 +112,7 @@ export async function QuickCreateWidget() {
             <CheckIcon className="size-5 text-green-600 dark:text-green-500" />
             <Trans
               t={t}
+              i18n={i18n}
               ns="app"
               i18nKey="quickCreateGetNotifications"
               defaults="Get email notifications"
@@ -115,6 +122,7 @@ export async function QuickCreateWidget() {
             <CheckIcon className="size-5 text-green-600 dark:text-green-500" />
             <Trans
               t={t}
+              i18n={i18n}
               ns="app"
               i18nKey="quickCreateManagePollsFromAnyDevice"
               defaults="Manage your polls from any device"


### PR DESCRIPTION
## Summary

Server components rendering `Trans` from `react-i18next/TransWithoutContext` must pass **both** `t` and `i18n` from `getTranslation()`. When `i18n` is omitted, `TransWithoutContext` falls back to the module-global `getI18n()` (TransWithoutContext.js:367), which can carry another request's language under concurrent requests. Same class of bug fixed for the dashboard in #2864 — this covers the remaining non-compliant usages.

## Changes

Added `i18n={i18n}` (and destructured `i18n` from `getTranslation()`) in:

- `app/[locale]/(auth)/login/page.tsx`
- `app/[locale]/(auth)/login/verify/page.tsx`
- `app/[locale]/(auth)/forgot-password/page.tsx`
- `app/[locale]/(auth)/components/already-logged-in.tsx`
- `features/quick-create/components/quick-create-widget.tsx`
- `features/quick-create/components/quick-create-button.tsx`

## Audit

Checked every file importing `TransWithoutContext`:
- **apps/web**: all compliant after this PR (branding, reset-password, license-limit-warning were already correct)
- **packages/emails**: compliant — per-render `createInstance()` with `t` + `i18n` passed
- **apps/landing**: 9 files / ~57 usages pass only `t` — left out of scope here, flagged as a follow-up

## Verification

- `pnpm type-check` ✅
- `pnpm check` ✅ (one pre-existing unrelated warning)

🤖 Generated with [Claude Code](https://claude.com/claude-code)