### PR TITLE
✨ Include user email in moderation notification

### DIFF
--- a/apps/web/src/features/moderation/mutations.ts
+++ b/apps/web/src/features/moderation/mutations.ts
@@ -103,10 +103,12 @@ const safeResult: ModerationResult = {
  */
 export async function moderateContent({
   userId,
+  userEmail,
   content,
   trusted = false,
 }: {
   userId: string;
+  userEmail: string;
   content: Record<string, string>;
   trusted?: boolean;
 }): Promise<ModerationResult> {
@@ -163,6 +165,7 @@ export async function moderateContent({
             subject: `Content ${result.verdict} by moderation`,
             text: [
               `User ID: ${userId}`,
+              `User Email: ${userEmail}`,
               `Trusted: ${trusted ? "Yes" : "No"}`,
               `Verdict: ${result.verdict}`,
               `Reason: ${result.reason}`,

--- a/apps/web/src/trpc/routers/polls.ts
+++ b/apps/web/src/trpc/routers/polls.ts
@@ -127,6 +127,7 @@ export const polls = router({
 
       const moderation = await moderateContent({
         userId: ctx.user.id,
+        userEmail: ctx.user.email,
         content: {
           Title: input.title,
           Description: input.description || "",
@@ -323,6 +324,7 @@ export const polls = router({
 
       const moderation = await moderateContent({
         userId: ctx.user.id,
+        userEmail: ctx.user.email,
         content: {
           Title: input.title || "",
           Description: input.description || "",


### PR DESCRIPTION
## Description

Adds the flagged user's email address to the moderation notification email sent to `SUPPORT_EMAIL`, alongside the existing user ID. This speeds up triage: the email address makes it easy to spot disposable-domain patterns and correlate repeat offenders without a database lookup per flag.

`moderateContent` now takes a required `userEmail` parameter (passed explicitly per the mutations-trust-input convention — no session or DB reads added). Both call sites in the polls router pass `ctx.user.email` from the existing `UserDTO`. For guest users this is the Better-Auth anonymous placeholder address, which doubles as a visible guest marker in the notification.

Processing rests on legitimate interest (abuse prevention, GDPR Recital 47); the notification already contains the flagged content itself, so this adds no new category of data.

## Checklist

- [x] I have performed a self-review of my code
- [x] My code follows the code style of this project
- [x] I have commented my code, particularly in hard-to-understand areas

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Moderation alert emails now include the email address associated with flagged content.
  - Poll creation and editing moderation checks consistently provide the relevant account contact details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->