### PR TITLE
💄 Use an Alert for the comments phase out hint

### DIFF
--- a/apps/web/src/features/poll/components/forms/poll-settings.test.tsx
+++ b/apps/web/src/features/poll/components/forms/poll-settings.test.tsx
@@ -60,4 +60,11 @@ describe("PollSettingsForm comments setting", () => {
       screen.getByText(/comments are being phased out/i),
     ).toBeInTheDocument();
   });
+
+  it("renders the phase out hint as an alert", () => {
+    render(<TestForm enableComments={true} />);
+    expect(screen.getByRole("alert")).toHaveTextContent(
+      /comments are being phased out/i,
+    );
+  });
 });

--- a/apps/web/src/features/poll/components/forms/poll-settings.tsx
+++ b/apps/web/src/features/poll/components/forms/poll-settings.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { posthog } from "@rallly/posthog/client";
+import { Alert, AlertDescription } from "@rallly/ui/alert";
 import { Badge } from "@rallly/ui/badge";
 import { Card, CardContent, CardTitle } from "@rallly/ui/card";
 import {
@@ -166,7 +167,7 @@ export const PollSettingsForm = ({ children }: React.PropsWithChildren) => {
             control={form.control}
             name="enableComments"
             render={({ field }) => (
-              <Field>
+              <div className="flex flex-col gap-3">
                 <Field orientation="horizontal">
                   <div className="@md/field-group:block hidden">
                     <PageIcon size="lg">
@@ -205,17 +206,17 @@ export const PollSettingsForm = ({ children }: React.PropsWithChildren) => {
                   />
                 </Field>
                 {field.value ? (
-                  <FieldDescription className="flex items-start gap-x-1.5">
-                    <InfoIcon className="size-3.5 shrink-0 translate-y-px" />
-                    <span>
+                  <Alert variant="info">
+                    <InfoIcon />
+                    <AlertDescription>
                       <Trans
                         i18nKey="commentsSettingPhaseOutHint"
                         defaults="Comments are being phased out. Participants can include a note with their response instead."
                       />
-                    </span>
-                  </FieldDescription>
+                    </AlertDescription>
+                  </Alert>
                 ) : null}
-              </Field>
+              </div>
             )}
           />
         </FieldGroup>


### PR DESCRIPTION
## Description

Uses the `Alert` component for the hint shown under the Comments setting when the toggle is on.

Previously this was a `FieldDescription` with a hand-rolled icon layout — `flex items-start gap-x-1.5`, an icon nudged into place with `size-3.5 shrink-0 translate-y-px`, and a wrapper `<span>`. `Alert` already handles icon/text alignment via its own `has-[>svg]` grid, so all of that markup goes away.

Beyond the visual, this gives the hint `role="alert"`. The hint appears conditionally when the toggle is switched on, so it should be announced to screen readers rather than rendered as inert text.

Two follow-on changes came out of review:

- **The outer `<Field>` is now a plain `div`.** `Field` renders `role="group"`, so the nesting emitted an unlabelled group inside a group whose only job was stacking two children vertically — a meaningless extra level for anyone navigating by group. The `div` carries the same flex layout with no semantics attached. `FieldGroup` styles its children positionally (`divide-y`, `*:not-first:pt-4`) rather than requiring a `Field` child, so the dividers and padding are unaffected. The other three settings in this file are each a single `Field orientation="horizontal"` — the comments one was the lone nester.
- **Spacing between the toggle row and the alert goes from `gap-2` to `gap-3`.** `Field`'s default gap is tuned for label/description pairs sitting close together and read as cramped under a distinct block.

## Notes for reviewers

**This was not verified visually.** Browser read tools (`screenshot`, `read_page`, `find`) are blocked on the local dev host with a per-action-approval error that couldn't be granted in a non-interactive session. The `variant="info"` choice and the `gap-3` value are judgment calls made from the component source and the Tailwind scale, not from looking at the rendered result. Both are one-line changes if they read wrong in the browser — `variant="warning"` and `gap-4` are the obvious alternatives.

`Alert` was chosen over `warning` styling deliberately: this is informational, not a problem with the user's configuration.

If alerts nested inside fields become a recurring pattern, the better fix is a rule in `Field` itself keying off the alert slot (something like `has-[[data-slot=alert]]:gap-3`) so call sites don't each have to remember. Not worth it for a single instance.

## Verification

- `poll-settings.test.tsx` passes 4/4. Added a test asserting the hint renders with `role="alert"` — it would have failed before this change.
- `tsc --noEmit` reports no errors for the touched file.
- Biome clean; pre-commit hooks passed.

## Checklist

- [x] I have performed a self-review of my code
- [x] My code follows the code style of this project
- [x] I have commented my code, particularly in hard-to-understand areas


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Updated the comments setting to display its phase-out notice as a clear informational alert beneath the toggle.
  * Improved accessibility by ensuring the notice is announced with an alert role.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->