### PR TITLE
🐛 Fix internal server error when re-activating an installed license key

### DIFF
--- a/apps/web/src/features/licensing/actions.ts
+++ b/apps/web/src/features/licensing/actions.ts
@@ -7,7 +7,7 @@ import { INSTANCE_LICENSE_TAG } from "@/features/licensing/constants";
 import { validateLicenseKeyInputSchema } from "@/features/licensing/schema";
 import { AppError } from "@/lib/errors/app-error";
 import { adminActionClient } from "@/lib/safe-action/server";
-import { licenseManager } from "./mutations";
+import { licenseManager, setInstanceLicense } from "./mutations";
 
 const logger = createLogger("licensing/actions");
 
@@ -107,18 +107,7 @@ export const validateLicenseKeyAction = adminActionClient
       });
     }
 
-    await prisma.instanceLicense.create({
-      data: {
-        licenseKey: data.key,
-        licenseeName: data.licenseeName,
-        licenseeEmail: data.licenseeEmail,
-        issuedAt: data.issuedAt,
-        expiresAt: data.expiresAt,
-        seats: data.seats,
-        type: data.type,
-        whiteLabelAddon: data.whiteLabelAddon,
-      },
-    });
+    await setInstanceLicense(data);
 
     updateTag(INSTANCE_LICENSE_TAG);
 

--- a/apps/web/src/features/licensing/mutations.test.ts
+++ b/apps/web/src/features/licensing/mutations.test.ts
@@ -1,0 +1,77 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockTransaction, mockDeleteMany, mockCreate } = vi.hoisted(() => ({
+  mockTransaction: vi.fn(),
+  mockDeleteMany: vi.fn(),
+  mockCreate: vi.fn(),
+}));
+
+vi.mock("@rallly/database", () => ({
+  prisma: {
+    $transaction: mockTransaction,
+    instanceLicense: {
+      deleteMany: mockDeleteMany,
+      create: mockCreate,
+    },
+  },
+}));
+// setInstanceLicense doesn't touch either, but importing the module pulls in
+// LicenseManager (env) and createLicenseCheckoutSession (billing).
+vi.mock("@/env", () => ({ env: {} }));
+vi.mock("@rallly/billing", () => ({}));
+
+const license = {
+  key: "RLYV4-AAAA-BBBB-CCCC-DDDD-00199",
+  licenseeName: "Probe Licensee",
+  licenseeEmail: "probe@example.com",
+  issuedAt: new Date("2026-01-01T00:00:00Z"),
+  expiresAt: null,
+  seats: 5,
+  type: "PLUS" as const,
+  whiteLabelAddon: false,
+};
+
+describe("setInstanceLicense", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  /**
+   * An instance holds exactly one license. Activating a key used to call
+   * create() directly, so re-entering the key already installed hit the
+   * license_key unique index. Prisma's P2002 surfaced through safe-action's
+   * handleServerError as a bare "INTERNAL_SERVER_ERROR" — the control panel
+   * showed an internal-error toast even though the licensing API returned 200.
+   */
+  it("clears the existing license before inserting, so re-activating the same key cannot collide", async () => {
+    const { setInstanceLicense } = await import("./mutations");
+    await setInstanceLicense(license);
+
+    expect(mockDeleteMany).toHaveBeenCalled();
+    expect(mockCreate).toHaveBeenCalledWith({
+      data: expect.objectContaining({ licenseKey: license.key }),
+    });
+
+    // Both operations must be in one transaction, or a failed insert would
+    // leave the instance with no license at all.
+    expect(mockTransaction).toHaveBeenCalledTimes(1);
+    expect(mockTransaction.mock.calls[0][0]).toHaveLength(2);
+  });
+
+  it("replaces a different installed key rather than accumulating rows", async () => {
+    const { setInstanceLicense } = await import("./mutations");
+    await setInstanceLicense({
+      ...license,
+      key: "RLYV4-ZZZZ-YYYY-XXXX-WWWW-99999",
+    });
+
+    // loadInstanceLicense reads the first row by id, so a stale row left
+    // behind here would keep winning over the key just activated.
+    expect(mockDeleteMany).toHaveBeenCalled();
+    expect(mockCreate).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        licenseKey: "RLYV4-ZZZZ-YYYY-XXXX-WWWW-99999",
+      }),
+    });
+  });
+});

--- a/apps/web/src/features/licensing/mutations.ts
+++ b/apps/web/src/features/licensing/mutations.ts
@@ -214,6 +214,43 @@ export async function createLicenseCheckoutSession({
   }
 }
 
+/**
+ * Installs a validated license as the instance's license.
+ *
+ * An instance holds exactly one license, so this replaces whatever is
+ * currently installed rather than inserting alongside it. A plain create
+ * fails with a unique-constraint violation when the same key is re-entered,
+ * and silently accumulates rows when a different one is — loadInstanceLicense
+ * only ever reads the first by id, so the extras would be invisible but
+ * authoritative.
+ */
+export async function setInstanceLicense(license: {
+  key: string;
+  licenseeName: string | null;
+  licenseeEmail: string | null;
+  issuedAt: Date;
+  expiresAt: Date | null;
+  seats: number | null;
+  type: LicenseType;
+  whiteLabelAddon: boolean;
+}) {
+  await prisma.$transaction([
+    prisma.instanceLicense.deleteMany(),
+    prisma.instanceLicense.create({
+      data: {
+        licenseKey: license.key,
+        licenseeName: license.licenseeName,
+        licenseeEmail: license.licenseeEmail,
+        issuedAt: license.issuedAt,
+        expiresAt: license.expiresAt,
+        seats: license.seats,
+        type: license.type,
+        whiteLabelAddon: license.whiteLabelAddon,
+      },
+    }),
+  ]);
+}
+
 export async function validateLicenseKey({
   key,
   fingerprint,


### PR DESCRIPTION
## What

Activating a license key called `prisma.instanceLicense.create` directly. An instance holds exactly one license, so **re-entering the key already installed** violated the `license_key` unique index. Prisma's `P2002` reached safe-action's `handleServerError`, which flattens any non-`AppError` to a bare `"INTERNAL_SERVER_ERROR"` — the control panel showed an internal error toast **even though the licensing API returned 200**.

A second defect surfaced from the same test: activating a *different* key doesn't collide, so the row was appended rather than replacing the old one. `loadInstanceLicense` only reads the first row by `id`, so a stale license stayed authoritative while the UI reported success. Repeated activations left multiple rows.

## The fix

Moved the write into `setInstanceLicense` in `mutations.ts` as a `deleteMany` + `create` inside one `$transaction`, so activating replaces whatever is installed. The transaction matters: a bare delete-then-insert would leave the instance with no license at all if the insert failed.

This also puts the write where the feature vocabulary expects it (`mutations.ts` owns writes), leaving `validateLicenseKeyAction` a thin wrapper.

## Verification

Reproduced end-to-end against a local self-hosted dev server with a stubbed licensing endpoint returning 200:

- **Before** — same key already installed → action returns `"INTERNAL_SERVER_ERROR"`, deterministically.
- **After** — same request succeeds, and `instance_licenses` holds exactly one row.

The regression test was confirmed to actually fail without the fix — reverting `setInstanceLicense` to `create`-only fails both cases; restoring the transaction passes them. `pnpm type-check`, `pnpm check` and all 334 unit tests pass.

## Note for reviewers

The bug only reproduces when a license is **already installed** — on an empty `instance_licenses` table the old code succeeds. That's worth knowing if you try to reproduce it locally.

Two adjacent issues left out of scope, happy to take either as a follow-up:

- `handleServerError` discards the underlying error. The `P2002` appeared in no log, only Sentry, which made this hard to trace from the symptom alone.
- `refreshInstanceLicenseAction` has the inverse problem: its catch block swallows every error and rethrows a generic `INTERNAL_SERVER_ERROR`, discarding the real cause — including the legitimate "No license found" case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved license activation and replacement reliability.
  * Replacing a license now consistently removes the previous license and applies the new one as a single operation, reducing the risk of incomplete or conflicting license updates.
* **Tests**
  * Added coverage for activating, replacing, and reactivating licenses to help ensure consistent licensing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->