### PR TITLE
🐛 Close the license dialog when a key is activated

### DIFF
--- a/apps/web/src/app/[locale]/control-panel/license/page.tsx
+++ b/apps/web/src/app/[locale]/control-panel/license/page.tsx
@@ -1,21 +1,8 @@
 import { buttonVariants } from "@rallly/ui";
 import { Badge } from "@rallly/ui/badge";
-import { Button } from "@rallly/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@rallly/ui/card";
-import {
-  Dialog,
-  DialogContent,
-  DialogHeader,
-  DialogTitle,
-  DialogTrigger,
-} from "@rallly/ui/dialog";
 
-import {
-  KeySquareIcon,
-  PaletteIcon,
-  PlusIcon,
-  ShoppingBagIcon,
-} from "lucide-react";
+import { KeySquareIcon, PaletteIcon, ShoppingBagIcon } from "lucide-react";
 import type { Metadata } from "next";
 import {
   DescriptionList,
@@ -37,7 +24,7 @@ import {
   SettingsPageHeader,
   SettingsPageTitle,
 } from "@/components/settings-layout";
-import { LicenseKeyForm } from "@/features/licensing/components/license-key-form";
+import { AddLicenseKeyButton } from "@/features/licensing/components/add-license-key-button";
 import { RefreshLicenseButton } from "@/features/licensing/components/refresh-license-button";
 import { RemoveLicenseButton } from "@/features/licensing/components/remove-license-button";
 import { loadInstanceLicense } from "@/features/licensing/data";
@@ -193,23 +180,7 @@ export default async function LicensePage() {
                 <ShoppingBagIcon data-icon="inline-start" />
                 <Trans i18nKey="purchaseLicense" defaults="Purchase license" />
               </a>
-              <Dialog>
-                <DialogTrigger render={<Button variant="primary" />}>
-                  <PlusIcon data-icon="inline-start" />
-                  <Trans i18nKey="addLicenseKey" defaults="Add license key" />
-                </DialogTrigger>
-                <DialogContent size="sm">
-                  <DialogHeader>
-                    <DialogTitle>
-                      <Trans
-                        i18nKey="addLicenseKey"
-                        defaults="Add license key"
-                      />
-                    </DialogTitle>
-                  </DialogHeader>
-                  <LicenseKeyForm />
-                </DialogContent>
-              </Dialog>
+              <AddLicenseKeyButton />
             </EmptyStateFooter>
           </EmptyState>
         )}

--- a/apps/web/src/features/licensing/components/add-license-key-button.tsx
+++ b/apps/web/src/features/licensing/components/add-license-key-button.tsx
@@ -15,6 +15,18 @@ import { Trans } from "@/i18n/client";
 export function AddLicenseKeyButton() {
   const dialog = useDialog();
 
+  // On success the page swaps to the installed-license view, which unmounts
+  // this trigger, so dismiss()'s focus restore targets a detached node and
+  // focus falls to <body>. Send it to the main content region instead, which
+  // survives the swap. Deferred so it lands after the dialog's own focus
+  // handling rather than being overwritten by it.
+  const handleSuccess = () => {
+    dialog.dismiss();
+    requestAnimationFrame(() => {
+      document.getElementById("main-content")?.focus();
+    });
+  };
+
   return (
     <>
       <Button variant="primary" {...dialog.triggerProps}>
@@ -28,7 +40,7 @@ export function AddLicenseKeyButton() {
               <Trans i18nKey="addLicenseKey" defaults="Add license key" />
             </DialogTitle>
           </DialogHeader>
-          <LicenseKeyForm onSuccess={dialog.dismiss} />
+          <LicenseKeyForm onSuccess={handleSuccess} />
         </DialogContent>
       </Dialog>
     </>

--- a/apps/web/src/features/licensing/components/add-license-key-button.tsx
+++ b/apps/web/src/features/licensing/components/add-license-key-button.tsx
@@ -1,0 +1,36 @@
+"use client";
+
+import { Button } from "@rallly/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  useDialog,
+} from "@rallly/ui/dialog";
+import { PlusIcon } from "lucide-react";
+import { LicenseKeyForm } from "@/features/licensing/components/license-key-form";
+import { Trans } from "@/i18n/client";
+
+export function AddLicenseKeyButton() {
+  const dialog = useDialog();
+
+  return (
+    <>
+      <Button variant="primary" {...dialog.triggerProps}>
+        <PlusIcon data-icon="inline-start" />
+        <Trans i18nKey="addLicenseKey" defaults="Add license key" />
+      </Button>
+      <Dialog {...dialog.dialogProps}>
+        <DialogContent size="sm">
+          <DialogHeader>
+            <DialogTitle>
+              <Trans i18nKey="addLicenseKey" defaults="Add license key" />
+            </DialogTitle>
+          </DialogHeader>
+          <LicenseKeyForm onSuccess={dialog.dismiss} />
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}

--- a/apps/web/src/features/licensing/components/license-key-form.tsx
+++ b/apps/web/src/features/licensing/components/license-key-form.tsx
@@ -25,7 +25,7 @@ const formSchema = z.object({
   }),
 });
 
-export function LicenseKeyForm() {
+export function LicenseKeyForm({ onSuccess }: { onSuccess?: () => void }) {
   const { t } = useTranslation();
   const router = useRouter();
   const form = useForm({
@@ -53,6 +53,7 @@ export function LicenseKeyForm() {
                   defaultValue: "Invalid license key",
                 }),
               });
+              return;
             }
           } catch (_error) {
             form.setError("licenseKey", {
@@ -61,7 +62,13 @@ export function LicenseKeyForm() {
                   "An error occurred while validating the license key",
               }),
             });
+            return;
           }
+
+          // Refreshing swaps the page to the installed-license branch, which
+          // unmounts this form. Notify the owner first so closing the dialog
+          // doesn't depend on that re-render winning a race.
+          onSuccess?.();
           router.refresh();
         })}
       >


### PR DESCRIPTION
## What

The **Add license key** dialog had no close logic at all. It only disappeared as a *side effect*: `router.refresh()` re-rendered the page, `loadInstanceLicense` started returning a license, and the page swapped from the empty state to the installed-license branch — unmounting the `<Dialog>` that lived inside that branch.

That made closing a **race**. `router.refresh()` is fire-and-forget (it returns `void`, so it can't be awaited), and whether the dialog visibly closed depended on the re-render landing — which varies with server timing and the client Router Cache (`experimental.staleTimes.dynamic` is 60s). Same code, different outcome each attempt: sometimes the dialog closed and the license appeared, sometimes it just sat there looking like nothing had happened.

That's how users ended up re-submitting a key that was already installed.

## The fix

Move the trigger and dialog into a new `AddLicenseKeyButton` client component using `useDialog`, and have `LicenseKeyForm` report success through an `onSuccess` callback. The dialog now closes because the action succeeded, not because a re-render happened to win the race.

`useDialog` also restores focus to the trigger on dismiss, which the uncontrolled `<Dialog>` never did.

**Also fixed:** `router.refresh()` ran unconditionally, including when validation failed — so a rejected key refreshed the page while the form was displaying its error. It now returns early on both the invalid-key and thrown-error paths.

## Verification

Both paths driven in a real browser against a self-hosted dev server:

- **Success** — dialog closes, license card renders with all details, no manual refresh, exactly one DB row.
- **Failure** (licensing API returning 404) — dialog **stays open**, inline "Invalid license key" error on the field, no page refresh.

`pnpm type-check`, `pnpm check` and unit tests all pass.

## Note for reviewers

This is a UI fix and is independent of #2883, which fixes the `P2002` crash on the server side. They're causally linked though: this race is what made users retry an activation, and that retry is what hit the unique-constraint error. Worth landing both together.

`experimental.staleTimes.dynamic: 60` in `next.config.ts` is non-default (Next's default is 0) and means any action-then-view flow in the app can show up to 60s of stale client-cached data. Not the cause of this bug, but adjacent and probably worth a separate look.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Enhancements**
  * Added a dedicated “Add License Key” button for streamlined license key management.
  * License keys can now be entered in a focused dialog instead of an inline form.
  * The dialog closes automatically after a license key is successfully added.
  * Improved validation handling keeps errors visible and returns focus to the main content after successful submission.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->