### PR TITLE
🐛 Fix doubled "v" prefix on the control panel version tile

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -87,6 +87,16 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
+      # -----------------------------------------------------------------
+      # Resolve App Version
+      # Purpose: Strip the leading "v" from the release tag so the app
+      #          reports an unprefixed version, matching the value
+      #          produced by scripts/inject-version.js.
+      # -----------------------------------------------------------------
+      - name: Resolve App Version
+        id: version
+        run: echo "app_version=${GITHUB_REF_NAME#v}" | tee -a $GITHUB_OUTPUT
+
       - name: Build and Push Multi-Arch Image
         id: build
         uses: docker/build-push-action@v5
@@ -98,7 +108,7 @@ jobs:
             type=image,"name=${{ env.DOCKER_REGISTRY }}/${{ env.DOCKER_IMAGE_NAME }}",
             push-by-digest=true,name-canonical=true,push=true
           build-args: |
-            APP_VERSION=${{ github.ref_name }}
+            APP_VERSION=${{ steps.version.outputs.app_version }}
             SELF_HOSTED=true
 
       # -----------------------------------------------------------------

--- a/apps/web/src/app/[locale]/control-panel/version-tile.tsx
+++ b/apps/web/src/app/[locale]/control-panel/version-tile.tsx
@@ -43,7 +43,9 @@ export function VersionTile() {
       <PageIcon>
         <DownloadIcon />
       </PageIcon>
-      <TileTitle>{`v${appVersion ?? "unknown"}`}</TileTitle>
+      <TileTitle>
+        {appVersion ? `v${appVersion.replace(/^v/, "")}` : "unknown"}
+      </TileTitle>
       <TileDescription>
         <Suspense fallback={<Skeleton className="h-4 w-24" />}>
           <UpdateStatus />


### PR DESCRIPTION
## Description

The version tile in the control panel renders the app version as `vv4.12.2` on self-hosted (Docker) builds.

Two producers of `NEXT_PUBLIC_APP_VERSION` disagreed on whether the value carries a `v` prefix:

- `scripts/inject-version.js` produces `4.12.0-<hash>` — no prefix. Used by `pnpm build:web` (cloud).
- `.github/workflows/docker-image.yml` passed `APP_VERSION=${{ github.ref_name }}` — the tag name, i.e. `v4.12.2`.

The tile adds its own display `v`, so the Docker path doubled it. Since the control panel is the self-hosted admin surface, this was visible to every self-hosted user, not an edge case.

**The fix treats `appVersion` as data and the `v` as presentation:**

1. **Strip at the producer** (`docker-image.yml`) — a `Resolve App Version` step strips the leading `v` from the ref so both build paths emit the same shape. This also makes `/api/status` consistent across cloud and Docker, which previously reported different formats for the same release. Uses `${GITHUB_REF_NAME#v}` rather than a regex so it strips only the leading character and leaves `workflow_dispatch` branch names untouched (`main` → `main`).
2. **Strip defensively at the point of display** (`version-tile.tsx`) — so existing images that already ship `v4.12.2` render correctly without waiting for a rebuild. Also fixes `vunknown` → `unknown` when the env var is absent.

I considered sourcing the version from root `package.json` instead of the ref, and rejected it: `package.json` is currently `4.12.0` while the latest tag is `v4.12.2` (`v4.12.1` and `v4.12.2` were tagged without a bump commit). An image published as `v4.12.2` would have reported `4.12.0` — a version lie in a self-hosted deployment, and the update check would then flag "update available" against the release the operator is already running. The tag defines the release here; both `docker-image.yml` and `release.yml` trigger on `v*`.

**Not affected:** the update check. `normalizeVersion` in `apps/web/src/features/instance-settings/service.ts` already stripped an optional leading `v` before comparing, so "Up to date" / "Update available" was always correct. That redundant strip is left in place as defence against this class of bug.

**Out of scope, worth a separate look:** root `package.json` has drifted from the release tags, so cloud builds currently report `4.12.0-<hash>` while running post-`4.12.2` code. A CI guard asserting the `package.json` version matches the tag on release would catch it.

### Verification

Biome clean. Render logic checked against `v4.12.2` → `v4.12.2`, `4.12.2` → `v4.12.2`, `4.12.0-abc1234` → `v4.12.0-abc1234`, and undefined/empty → `unknown`; the shell strip checked against both tag and branch ref names.

Not exercised in a running app — the tile requires a self-hosted instance with `NEXT_PUBLIC_APP_VERSION` baked in at build time, which the dev server does not provide, so a preview would only render `unknown`. The workflow change is verifiable only on the next tagged release.

## Checklist

- [x] I have performed a self-review of my code
- [x] My code follows the code style of this project
- [x] I have commented my code, particularly in hard-to-understand areas

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected version displays so release numbers no longer show a duplicated “v” prefix.
  * Improved version handling during application builds to ensure displayed release information is consistent.
  * Preserved the “unknown” label when version information is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->