### PR TITLE
♻️ Use SettingIcon for the remaining setting rows

### DIFF
--- a/apps/web/src/app/[locale]/(space)/settings/general/page-client.tsx
+++ b/apps/web/src/app/[locale]/(space)/settings/general/page-client.tsx
@@ -10,7 +10,6 @@ import {
   FieldTitle,
 } from "@rallly/ui/field";
 import { EyeIcon, LogOutIcon, TrashIcon } from "lucide-react";
-import { PageIcon } from "@/components/page-icons";
 import {
   PageSection,
   PageSectionContent,
@@ -19,6 +18,7 @@ import {
   PageSectionHeader,
   PageSectionTitle,
 } from "@/components/page-layout";
+import { SettingIcon } from "@/components/setting-icon";
 import {
   SettingsPage,
   SettingsPageContent,
@@ -85,11 +85,9 @@ export function GeneralSettingsPageClient() {
                 <FieldGroup variant="divided">
                   {!isOwner ? (
                     <Field orientation="responsive">
-                      <div className="@md/field-group:block hidden">
-                        <PageIcon size="lg">
-                          <LogOutIcon />
-                        </PageIcon>
-                      </div>
+                      <SettingIcon>
+                        <LogOutIcon />
+                      </SettingIcon>
                       <FieldContent>
                         <FieldTitle>
                           <Trans i18nKey="leaveSpace" defaults="Leave space" />
@@ -109,11 +107,9 @@ export function GeneralSettingsPageClient() {
                   ) : null}
                   {canDeleteSpace ? (
                     <Field orientation="responsive">
-                      <div className="@md/field-group:block hidden">
-                        <PageIcon size="lg">
-                          <TrashIcon />
-                        </PageIcon>
-                      </div>
+                      <SettingIcon>
+                        <TrashIcon />
+                      </SettingIcon>
                       <FieldContent>
                         <FieldTitle>
                           <Trans

--- a/apps/web/src/app/[locale]/(space)/settings/notifications/notifications-page.tsx
+++ b/apps/web/src/app/[locale]/(space)/settings/notifications/notifications-page.tsx
@@ -11,7 +11,6 @@ import { toast } from "@rallly/ui/sonner";
 import { Switch } from "@rallly/ui/switch";
 import { InboxIcon, MessageCircleIcon } from "lucide-react";
 import React from "react";
-import { PageIcon } from "@/components/page-icons";
 import {
   PageSection,
   PageSectionContent,
@@ -20,6 +19,7 @@ import {
   PageSectionHeader,
   PageSectionTitle,
 } from "@/components/page-layout";
+import { SettingIcon } from "@/components/setting-icon";
 import { updateNotificationPreferenceAction } from "@/features/notifications/actions";
 import type {
   ActivityEventType,
@@ -70,11 +70,9 @@ export function NotificationsPage({
         <PageSectionContent>
           <FieldGroup variant="divided">
             <Field orientation="horizontal">
-              <div className="@md/field-group:block hidden">
-                <PageIcon size="lg">
-                  <InboxIcon />
-                </PageIcon>
-              </div>
+              <SettingIcon>
+                <InboxIcon />
+              </SettingIcon>
               <FieldContent>
                 <FieldLabel htmlFor="notify-new-response">
                   <Trans i18nKey="notifyNewResponse" defaults="New response" />
@@ -95,11 +93,9 @@ export function NotificationsPage({
               />
             </Field>
             <Field orientation="horizontal">
-              <div className="@md/field-group:block hidden">
-                <PageIcon size="lg">
-                  <MessageCircleIcon />
-                </PageIcon>
-              </div>
+              <SettingIcon>
+                <MessageCircleIcon />
+              </SettingIcon>
               <FieldContent>
                 <FieldLabel htmlFor="notify-new-comment">
                   <Trans i18nKey="notifyNewComment" defaults="New comment" />

--- a/apps/web/src/app/[locale]/(space)/settings/preferences/components/localization-preferences.tsx
+++ b/apps/web/src/app/[locale]/(space)/settings/preferences/components/localization-preferences.tsx
@@ -26,7 +26,7 @@ import {
 import Link from "next/link";
 import React from "react";
 import { LanguageSelect } from "@/components/language-selector";
-import { PageIcon } from "@/components/page-icons";
+import { SettingIcon } from "@/components/setting-icon";
 import { TimeZoneSelect } from "@/components/time-zone-picker/time-zone-select";
 import { updateLocalizationAction } from "@/features/user/actions";
 import { Trans, useTranslation } from "@/i18n/client";
@@ -94,11 +94,9 @@ export const LocalizationPreferences = ({
     <div>
       <FieldGroup variant="divided">
         <Field orientation="responsive">
-          <div className="@md/field-group:block hidden">
-            <PageIcon size="lg">
-              <LanguagesIcon />
-            </PageIcon>
-          </div>
+          <SettingIcon>
+            <LanguagesIcon />
+          </SettingIcon>
           <FieldContent>
             <FieldLabel htmlFor="language-select">
               <Trans i18nKey="language" defaults="Language" />
@@ -139,11 +137,9 @@ export const LocalizationPreferences = ({
           />
         </Field>
         <Field orientation="responsive">
-          <div className="@md/field-group:block hidden">
-            <PageIcon size="lg">
-              <GlobeIcon />
-            </PageIcon>
-          </div>
+          <SettingIcon>
+            <GlobeIcon />
+          </SettingIcon>
           <FieldContent>
             <FieldLabel htmlFor="time-zone-select">
               <Trans i18nKey="timeZone" defaults="Time zone" />
@@ -172,11 +168,9 @@ export const LocalizationPreferences = ({
           />
         </Field>
         <Field orientation="responsive">
-          <div className="@md/field-group:block hidden">
-            <PageIcon size="lg">
-              <ClockIcon />
-            </PageIcon>
-          </div>
+          <SettingIcon>
+            <ClockIcon />
+          </SettingIcon>
           <FieldContent>
             <FieldLabel htmlFor="time-format-select">
               <Trans i18nKey="timeFormat" defaults="Time format" />
@@ -216,11 +210,9 @@ export const LocalizationPreferences = ({
           </Select>
         </Field>
         <Field orientation="responsive">
-          <div className="@md/field-group:block hidden">
-            <PageIcon size="lg">
-              <CalendarIcon />
-            </PageIcon>
-          </div>
+          <SettingIcon>
+            <CalendarIcon />
+          </SettingIcon>
           <FieldContent>
             <FieldLabel htmlFor="week-start-select">
               <Trans i18nKey="startOfWeek" defaults="Start of week" />

--- a/apps/web/src/app/[locale]/(space)/settings/profile/components/delete-account-setting.tsx
+++ b/apps/web/src/app/[locale]/(space)/settings/profile/components/delete-account-setting.tsx
@@ -6,7 +6,7 @@ import {
   FieldTitle,
 } from "@rallly/ui/field";
 import { TriangleAlertIcon } from "lucide-react";
-import { PageIcon } from "@/components/page-icons";
+import { SettingIcon } from "@/components/setting-icon";
 import { getScheduledDeletionDate } from "@/features/user/account-deletion/utils";
 import { Trans } from "@/i18n/client";
 import { getSession } from "@/lib/auth";
@@ -28,11 +28,9 @@ export async function PendingDeletionSetting({
 
   return (
     <Field orientation="responsive">
-      <div className="@md/field-group:block hidden">
-        <PageIcon size="lg">
-          <TriangleAlertIcon />
-        </PageIcon>
-      </div>
+      <SettingIcon>
+        <TriangleAlertIcon />
+      </SettingIcon>
       <FieldContent>
         <FieldTitle>
           <Trans i18nKey="deleteAccount" defaults="Delete account" />
@@ -57,11 +55,9 @@ export function DeleteAccountSetting({
 }) {
   return (
     <Field orientation="responsive">
-      <div className="@md/field-group:block hidden">
-        <PageIcon size="lg">
-          <TriangleAlertIcon />
-        </PageIcon>
-      </div>
+      <SettingIcon>
+        <TriangleAlertIcon />
+      </SettingIcon>
       <FieldContent>
         <FieldTitle>
           <Trans i18nKey="deleteAccount" defaults="Delete account" />

--- a/apps/web/src/features/poll/components/forms/poll-settings.tsx
+++ b/apps/web/src/features/poll/components/forms/poll-settings.tsx
@@ -21,7 +21,7 @@ import {
   VenetianMaskIcon,
 } from "lucide-react";
 import { useFormContext } from "react-hook-form";
-import { PageIcon } from "@/components/page-icons";
+import { SettingIcon } from "@/components/setting-icon";
 import { showPayWall, useIsFree } from "@/features/billing/client";
 import { ProBadge } from "@/features/billing/components/pro-badge";
 import type { PollSettingsFormData } from "@/features/poll/components/forms/types";
@@ -45,11 +45,9 @@ export const PollSettingsForm = ({ children }: React.PropsWithChildren) => {
             name="requireParticipantEmail"
             render={({ field }) => (
               <Field orientation="horizontal">
-                <div className="@md/field-group:block hidden">
-                  <PageIcon size="lg">
-                    <MailIcon />
-                  </PageIcon>
-                </div>
+                <SettingIcon>
+                  <MailIcon />
+                </SettingIcon>
                 <FieldContent>
                   <FieldLabel htmlFor="require-participant-email">
                     <Trans
@@ -87,11 +85,9 @@ export const PollSettingsForm = ({ children }: React.PropsWithChildren) => {
             name="hideParticipants"
             render={({ field }) => (
               <Field orientation="horizontal">
-                <div className="@md/field-group:block hidden">
-                  <PageIcon size="lg">
-                    <VenetianMaskIcon />
-                  </PageIcon>
-                </div>
+                <SettingIcon>
+                  <VenetianMaskIcon />
+                </SettingIcon>
                 <FieldContent>
                   <FieldLabel htmlFor="hide-participants">
                     <Trans
@@ -129,11 +125,9 @@ export const PollSettingsForm = ({ children }: React.PropsWithChildren) => {
             name="hideScores"
             render={({ field }) => (
               <Field orientation="horizontal">
-                <div className="@md/field-group:block hidden">
-                  <PageIcon size="lg">
-                    <BarChart2Icon />
-                  </PageIcon>
-                </div>
+                <SettingIcon>
+                  <BarChart2Icon />
+                </SettingIcon>
                 <FieldContent>
                   <FieldLabel htmlFor="hide-scores">
                     <Trans i18nKey="hideScoresTitle" defaults="Hide votes" />
@@ -169,11 +163,9 @@ export const PollSettingsForm = ({ children }: React.PropsWithChildren) => {
             render={({ field }) => (
               <div className="flex flex-col gap-3">
                 <Field orientation="horizontal">
-                  <div className="@md/field-group:block hidden">
-                    <PageIcon size="lg">
-                      <MessageCircleIcon />
-                    </PageIcon>
-                  </div>
+                  <SettingIcon>
+                    <MessageCircleIcon />
+                  </SettingIcon>
                   <FieldContent>
                     <FieldLabel htmlFor="enable-comments">
                       <Trans


### PR DESCRIPTION
## Description

`PageIcon` was created to identify a **route** — hence its named exports `HomePageIcon`, `PollPageIcon`, `BillingPageIcon` and friends. Setting rows later borrowed the visual and inherited a name describing a different concept, and the borrowed use came to outnumber the intended one: the named `*PageIcon` exports appear in 3 files, while raw `<PageIcon size="lg">` appeared in 14 setting rows.

`SettingIcon` (added in #2888) is the setting-row concept: fixed styling, no size or color variants, and it owns the `@md/field-group` hide-when-stacked wrapper that every call site was repeating by hand. The security page already used it. This migrates the remaining 14 usages so the settings surface is consistent again.

Each `<div className="@md/field-group:block hidden"><PageIcon size="lg">…</PageIcon></div>` becomes `<SettingIcon>…</SettingIcon>`. The wrapper div goes away since `SettingIcon` provides it. Every row keeps the lucide icon it already had — this is not a redesign.

**14 usages across 5 files:**

- `settings/general/page-client.tsx` (2)
- `settings/notifications/notifications-page.tsx` (2)
- `settings/preferences/components/localization-preferences.tsx` (4)
- `settings/profile/components/delete-account-setting.tsx` (2)
- `features/poll/components/forms/poll-settings.tsx` (4)

### This is a deliberate visual change, not a like-for-like swap

`PageIcon size="lg"` is `size-9` with `[&_svg]:size-4`. `SettingIcon` is `size-10` with `[&_svg]:size-5` plus `pr-2`. Migrated rows therefore get a slightly larger badge, a larger glyph, and more space between icon and text. That sizing was chosen deliberately on the security page (40px roughly matches the ~42px of a single-line title-plus-description block); applying it everywhere is the point of the change. No size variants were added to `SettingIcon` to preserve the old sizing.

### Verification

- `pnpm type-check` — passes (8/8 tasks).
- `pnpm check:fix` — no fixes applied to these files. The one warning in the run is pre-existing in `packages/ui/src/rich-text-editor.tsx` and untouched here.
- No `PageIcon` reference remains in any touched file, and the only remaining `@md/field-group:block hidden` in the codebase is inside `SettingIcon` itself.
- Confirmed on a running dev server against `/settings/preferences`: all 4 rows compute to a 40px badge, 20px glyph and 8px right padding with the correct icons — the intended change, versus 36px/16px/0 before.

⚠️ **Not visually confirmed:** notifications, general, profile and the poll settings form. A client-side navigation raced and the preview dropped before I could re-read them. They are mechanically identical substitutions of the same component, so the risk is low, but since this PR is purely visual please eyeball those four surfaces before merging.

### Left alone deliberately

- The named `*PageIcon` exports and their 3 call sites (command menu, dashboard home, quick-create widget) — that is the route-identity concept and it stays.
- The 5 control-panel usages (`control-panel/page.tsx`, `control-panel/version-tile.tsx`) — tiles at the default `md`, not setting rows.
- `features/billing/components/pay-wall-dialog.tsx` uses `<PageIcon size="sm" color="primary">`. It is neither route identity nor a setting row, so it needs its own decision rather than being swept into `SettingIcon`, which deliberately has no variants.

### On `PageIcon`'s cva surface

Not changed in this PR, but to record the finding: the leftover callers do justify keeping `size`/`color` roughly as-is. Control panel uses the default `md`; the paywall uses `sm` + `primary`. So `size` still needs at least `sm`/`md`, and `color` needs `primary` plus the palette the named exports consume (`gray`, `darkGray`, `indigo`, `lime`, `rose`, `purple`). Only `xs`, `lg`, `xl` and `blue` are now dead — worth trimming separately.

## Checklist

- [x] I have performed a self-review of my code
- [x] My code follows the code style of this project
- [x] I have commented my code, particularly in hard-to-understand areas

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated settings and poll configuration icons to use a consistent visual treatment.
  * Preserved existing icons and field behavior across space settings, notifications, preferences, profile, and polls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->