### PR TITLE
🐛 Fix local Playwright runs blocked by the dev tools indicator

### DIFF
--- a/apps/web/.env.test
+++ b/apps/web/.env.test
@@ -1,5 +1,9 @@
 CRON_SECRET=1234567890abcdef1234567890abcdef1234
 DATABASE_URL=postgres://postgres:postgres@localhost:5450/rallly
+# The dev tools indicator is pinned bottom-right (next.config.ts) where it
+# covers controls like the comment sheet's submit button, so Playwright's
+# actionability check refuses the click. CI is unaffected (next start).
+HIDE_DEV_INDICATOR=true
 INITIAL_ADMIN_EMAIL=initial.admin@rallly.co
 NEXT_PUBLIC_BASE_URL=http://localhost:3002
 NODE_ENV=test

--- a/apps/web/tests/new-poll-page.ts
+++ b/apps/web/tests/new-poll-page.ts
@@ -1,4 +1,5 @@
 import type { Locator, Page } from "@playwright/test";
+import { expect } from "@playwright/test";
 import { PollPage } from "./poll-page";
 
 export class CreatePollSuccessDialog {
@@ -37,8 +38,15 @@ export class NewPollPage {
 
     // The description is a rich text editor revealed on demand, so open it, then
     // type into its contenteditable (fill() doesn't work on contenteditable).
-    await page.getByRole("button", { name: /add description/i }).click();
+    // A click that lands before React hydrates focuses the button natively but
+    // drops the onClick, so retry until the editor actually mounts.
     const description = page.locator('#description[contenteditable="true"]');
+    await expect(async () => {
+      await page
+        .getByRole("button", { name: /add description/i })
+        .click({ timeout: 2000 });
+      await expect(description).toBeVisible({ timeout: 2000 });
+    }).toPass();
     await description.click();
     await description.pressSequentially(
       "Hey everyone, what time can you meet?",


### PR DESCRIPTION
## Problem

The local Playwright integration suite was failing (CI was unaffected — it runs `next start`). Two independent dev-mode failure modes:

1. **Dev tools indicator covers controls.** `next.config.ts` pins the indicator to `bottom-right`, which at the 1280x720 test viewport lands exactly on the comment sheet's "Add comment" button. Playwright's actionability check sees `<nextjs-portal>` intercepting pointer events and retries the click until the 60s timeout.
2. **Pre-hydration click on "Add description".** A click that lands before React hydrates focuses the button natively but drops the `onClick`, so the rich text editor never mounts and `NewPollPage.create` times out waiting for the contenteditable. The `rm -rf .next && next dev` test server compiles `/new` on first visit, widening the window.

## Fix

- Set `HIDE_DEV_INDICATOR=true` in `apps/web/.env.test` — the escape hatch already existed in `next.config.ts`.
- Retry the "Add description" click in the test helper until the editor mounts.

No app code changes — the form, lazy editor, and tiptap wiring behave correctly once hydrated.

## Verification

Full local integration suite: **57 passed** (previously `vote-and-comment.spec.ts` failed deterministically with 115 blocked click retries).

🤖 Generated with [Claude Code](https://claude.com/claude-code)