### PR TITLE
💄 Use card background for desktop poll table

### DIFF
--- a/apps/web/src/features/poll/components/desktop-poll.tsx
+++ b/apps/web/src/features/poll/components/desktop-poll.tsx
@@ -271,7 +271,7 @@ const DesktopPoll: React.FunctionComponent = () => {
             className={cn(
               "flex max-h-full flex-col overflow-hidden rounded-2xl",
               {
-                "w-full max-w-7xl border border-popover-border bg-background shadow-2xl":
+                "w-full max-w-7xl border border-popover-border bg-card shadow-2xl":
                   expanded,
               },
             )}

--- a/apps/web/src/features/poll/components/desktop-poll/participant-row-form.tsx
+++ b/apps/web/src/features/poll/components/desktop-poll/participant-row-form.tsx
@@ -116,12 +116,7 @@ const ParticipantRowForm = ({
               control={form.control}
               name={`votes.${i}`}
               render={({ field }) => (
-                <div
-                  className={cn(
-                    "absolute inset-0 flex items-center justify-center transition-colors",
-                    "hover:bg-gray-50 active:bg-gray-100 active:ring-1 active:ring-gray-200 active:ring-inset dark:active:bg-gray-700/50 dark:active:ring-gray-700 dark:active:ring-inset dark:hover:bg-gray-800",
-                  )}
-                >
+                <div className={cn("flex justify-center gap-2")}>
                   <VoteSelector
                     className="after:absolute after:inset-0"
                     optionLabel={

--- a/apps/web/src/features/poll/components/desktop-poll/participant-row-form.tsx
+++ b/apps/web/src/features/poll/components/desktop-poll/participant-row-form.tsx
@@ -56,7 +56,7 @@ const ParticipantRowForm = ({
     <tr className={cn("group", className)}>
       <td
         style={{ minWidth: 235, maxWidth: 235 }}
-        className="sticky left-0 z-10 h-12 border-b border-b-border-muted bg-background px-3 group-[.last-row]:border-b-0"
+        className="sticky left-0 z-10 h-12 border-b border-b-border-muted bg-card px-3 group-[.last-row]:border-b-0"
       >
         <div className="flex items-center justify-between gap-x-2.5">
           <Participant>
@@ -110,7 +110,7 @@ const ParticipantRowForm = ({
         return (
           <td
             key={optionId}
-            className="relative h-12 border-b border-b-border-muted border-l bg-background group-[.last-row]:border-b-0"
+            className="relative h-12 border-b border-b-border-muted border-l bg-card group-[.last-row]:border-b-0"
           >
             <Controller
               control={form.control}

--- a/apps/web/src/features/poll/components/desktop-poll/participant-row.tsx
+++ b/apps/web/src/features/poll/components/desktop-poll/participant-row.tsx
@@ -66,7 +66,7 @@ export const ParticipantRowView: React.FunctionComponent<{
     >
       <td
         style={{ minWidth: 235, maxWidth: 235 }}
-        className="sticky left-0 z-10 h-12 border-border-muted border-b bg-background px-3 group-[.last-row]:border-b-0"
+        className="sticky left-0 z-10 h-12 border-border-muted border-b bg-card px-3 group-[.last-row]:border-b-0"
       >
         <div className="flex max-w-full items-center justify-between gap-x-1">
           <Participant>
@@ -94,7 +94,7 @@ export const ParticipantRowView: React.FunctionComponent<{
             // biome-ignore lint/suspicious/noArrayIndexKey: Fix this later
             key={i}
             className={cn(
-              "h-12 border-b border-b-border-muted border-l bg-background group-[.last-row]:border-b-0",
+              "h-12 border-b border-b-border-muted border-l bg-card group-[.last-row]:border-b-0",
             )}
           >
             <div className={cn("flex items-center justify-center")}>

--- a/apps/web/src/features/poll/components/desktop-poll/poll-header.tsx
+++ b/apps/web/src/features/poll/components/desktop-poll/poll-header.tsx
@@ -44,7 +44,7 @@ const TimelineRow = ({
         <th
           rowSpan={rowSpan}
           style={{ minWidth: 235, width: 235, top }}
-          className={cn("sticky left-0 z-30 border-b bg-background px-4 py-2")}
+          className={cn("sticky left-0 z-30 border-b bg-card px-4 py-2")}
         />
       ) : null}
       {children}
@@ -108,7 +108,7 @@ const PollHeader = () => {
             colSpan={group.count}
             style={{ height: monthRowHeight }}
             className={cn(
-              "sticky top-0 z-10 border-b border-l bg-background text-left",
+              "sticky top-0 z-10 border-b border-l bg-card text-left",
             )}
           >
             <div className="sticky right-0 left-[236px] inline-flex h-5 gap-1 px-2 py-0.5 font-medium text-xs uppercase">
@@ -125,7 +125,7 @@ const PollHeader = () => {
             scope="colgroup"
             colSpan={group.count}
             style={{ height: dayRowHeight, top: monthRowHeight }}
-            className="sticky z-10 border-l bg-background"
+            className="sticky z-10 border-l bg-card"
           >
             <div
               style={{ width: `calc(100% / ${group.count})` }}
@@ -148,7 +148,7 @@ const PollHeader = () => {
               key={option.optionId}
               scope="col"
               style={{ minWidth: 80, top: scoreRowTop }}
-              className="sticky z-20 border-b border-l bg-background px-2 pb-2.5 align-top"
+              className="sticky z-20 border-b border-l bg-card px-2 pb-2.5 align-top"
             >
               <div className="flex flex-col items-center gap-3">
                 {option.type === "timeSlot" ? (

--- a/apps/web/src/features/poll/components/vote-selector.tsx
+++ b/apps/web/src/features/poll/components/vote-selector.tsx
@@ -1,5 +1,5 @@
 import type { VoteType } from "@rallly/database";
-import { cn } from "@rallly/ui";
+import { buttonVariants, cn } from "@rallly/ui";
 import * as React from "react";
 
 import { useTranslation } from "@/i18n/client";
@@ -61,7 +61,13 @@ export const VoteSelector = React.forwardRef<
       onBlur={onBlur}
       onKeyDown={onKeyDown}
       className={cn(
-        "flex size-7 cursor-pointer items-center justify-center rounded-lg border border-input bg-background ring-ring focus-visible:ring-2",
+        buttonVariants({
+          size: "icon-sm",
+        }),
+        // The default variant's backdrop-blur makes this button a containing
+        // block, which would trap the after:inset-0 overlay callers use to
+        // extend the tap target to the whole cell/row.
+        "backdrop-blur-none",
         className,
       )}
       onClick={() => {


### PR DESCRIPTION
Visual pass on the desktop poll table:

- Sweeps `bg-background` → `bg-card` across the desktop poll table surfaces (sticky name column, option cells, header rows, expanded overlay) so the table matches the card it sits in.
- Restyles the vote selector with the shared `buttonVariants` (default variant, `icon-sm`) instead of its custom one-off classes, and drops the form cell's custom hover treatment.

One functional note: the selector opts out of the button variant's `backdrop-blur` — a non-none `backdrop-filter` makes the button the containing block for the `after:inset-0` overlay that extends the tap target to the whole cell (desktop) / row (mobile), which silently shrank the tap target to 28px. Verified with `elementFromPoint` + real clicks at the cell edge and mobile row that the enlarged targets work.

The mobile poll redesign and vote icon redesign that briefly lived on this branch have been split onto their own branches and will come as separate PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)