### PR TITLE
🐛 Honor HTTP_PROXY/HTTPS_PROXY for outbound fetch

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -98,6 +98,7 @@
     "smoothscroll-polyfill": "^0.4.4",
     "superjson": "^2.0.0",
     "tailwindcss": "^4.1.18",
+    "undici": "^7.29.0",
     "zod": "^4.3.6",
     "zustand": "^5.0.14",
     "zxcvbn": "^4.4.2"

--- a/apps/web/src/instrumentation.ts
+++ b/apps/web/src/instrumentation.ts
@@ -4,22 +4,11 @@ export const onRequestError = Sentry.captureRequestError;
 
 export async function register() {
   if (process.env.NEXT_RUNTIME === "nodejs") {
-    // Node's built-in fetch ignores proxy environment variables, so on
-    // networks with no direct egress (self-hosted behind a corporate proxy)
-    // outbound calls never reach the proxy at all. EnvHttpProxyAgent honors
-    // HTTP_PROXY / HTTPS_PROXY / NO_PROXY in both cases. This must run before
-    // the first fetch — including Sentry's — and the import must stay dynamic:
-    // a top-level import would be hoisted into the Edge bundle, where undici
-    // doesn't exist.
-    if (
-      process.env.HTTP_PROXY ||
-      process.env.HTTPS_PROXY ||
-      process.env.http_proxy ||
-      process.env.https_proxy
-    ) {
-      const { EnvHttpProxyAgent, setGlobalDispatcher } = await import("undici");
-      setGlobalDispatcher(new EnvHttpProxyAgent());
-    }
+    // Before Sentry, so its outbound traffic is proxied too. The import must
+    // stay dynamic: a top-level import would be hoisted into the Edge bundle,
+    // where undici doesn't exist.
+    const { setupOutboundProxy } = await import("@/lib/outbound-proxy");
+    setupOutboundProxy();
 
     await import("../sentry.server.config");
   }

--- a/apps/web/src/instrumentation.ts
+++ b/apps/web/src/instrumentation.ts
@@ -4,6 +4,23 @@ export const onRequestError = Sentry.captureRequestError;
 
 export async function register() {
   if (process.env.NEXT_RUNTIME === "nodejs") {
+    // Node's built-in fetch ignores proxy environment variables, so on
+    // networks with no direct egress (self-hosted behind a corporate proxy)
+    // outbound calls never reach the proxy at all. EnvHttpProxyAgent honors
+    // HTTP_PROXY / HTTPS_PROXY / NO_PROXY in both cases. This must run before
+    // the first fetch — including Sentry's — and the import must stay dynamic:
+    // a top-level import would be hoisted into the Edge bundle, where undici
+    // doesn't exist.
+    if (
+      process.env.HTTP_PROXY ||
+      process.env.HTTPS_PROXY ||
+      process.env.http_proxy ||
+      process.env.https_proxy
+    ) {
+      const { EnvHttpProxyAgent, setGlobalDispatcher } = await import("undici");
+      setGlobalDispatcher(new EnvHttpProxyAgent());
+    }
+
     await import("../sentry.server.config");
   }
 

--- a/apps/web/src/lib/outbound-proxy.test.ts
+++ b/apps/web/src/lib/outbound-proxy.test.ts
@@ -1,0 +1,115 @@
+import type { Server } from "node:http";
+import { createServer } from "node:http";
+import type { AddressInfo } from "node:net";
+import { getGlobalDispatcher, setGlobalDispatcher } from "undici";
+import { afterEach, beforeEach, expect, test, vi } from "vitest";
+import { setupOutboundProxy } from "./outbound-proxy";
+
+vi.mock("@rallly/logger", () => ({
+  createLogger: () => ({ info: vi.fn() }),
+}));
+
+const PROXY_ENV_VARS = [
+  "HTTP_PROXY",
+  "HTTPS_PROXY",
+  "http_proxy",
+  "https_proxy",
+  "NO_PROXY",
+  "no_proxy",
+];
+
+const savedEnv: Record<string, string | undefined> = {};
+const originalDispatcher = getGlobalDispatcher();
+let server: Server | undefined;
+
+beforeEach(() => {
+  for (const name of PROXY_ENV_VARS) {
+    savedEnv[name] = process.env[name];
+    delete process.env[name];
+  }
+});
+
+afterEach(async () => {
+  for (const name of PROXY_ENV_VARS) {
+    if (savedEnv[name] === undefined) {
+      delete process.env[name];
+    } else {
+      process.env[name] = savedEnv[name];
+    }
+  }
+  setGlobalDispatcher(originalDispatcher);
+  if (server) {
+    await new Promise((resolve) => server?.close(resolve));
+    server = undefined;
+  }
+});
+
+/**
+ * A local server that behaves as a forward proxy for both proxying styles:
+ * CONNECT tunneling (what undici uses today) and absolute-form requests
+ * (what curl uses for plain HTTP), so the test doesn't break if undici
+ * changes mechanics across majors. Every request is answered with "proxied"
+ * and the target host is recorded.
+ */
+function startProxyServer() {
+  const targets: string[] = [];
+
+  const proxy = createServer((req, res) => {
+    targets.push(new URL(req.url as string).host);
+    res.setHeader("connection", "close");
+    res.end("proxied");
+  });
+
+  proxy.on("connect", (req, clientSocket) => {
+    targets.push(req.url as string);
+    clientSocket.write("HTTP/1.1 200 Connection Established\r\n\r\n");
+    clientSocket.once("data", () => {
+      clientSocket.end(
+        "HTTP/1.1 200 OK\r\ncontent-length: 7\r\nconnection: close\r\n\r\nproxied",
+      );
+    });
+    clientSocket.on("error", () => {});
+  });
+
+  server = proxy;
+
+  return new Promise<{ port: number; targets: string[] }>((resolve) => {
+    proxy.listen(0, "127.0.0.1", () => {
+      resolve({ port: (proxy.address() as AddressInfo).port, targets });
+    });
+  });
+}
+
+/**
+ * The load-bearing assumption behind setupOutboundProxy is that the INSTALLED
+ * undici package's setGlobalDispatcher registers the dispatcher that Node's
+ * BUNDLED undici (global fetch) consults — they share a Symbol.for-registered
+ * global. If a Node upgrade ships an undici whose global-dispatcher symbol
+ * version no longer matches the installed package's, the proxy setup becomes
+ * a silent no-op. The target host is unresolvable (.invalid), so this fetch
+ * can only succeed by going through the proxy.
+ */
+test("Node's global fetch routes through the proxy from HTTP_PROXY", async () => {
+  const { port, targets } = await startProxyServer();
+  process.env.HTTP_PROXY = `http://127.0.0.1:${port}`;
+
+  setupOutboundProxy();
+
+  const res = await fetch("http://rallly-proxy-contract-check.invalid/ping", {
+    signal: AbortSignal.timeout(5000),
+  });
+
+  expect(res.status).toBe(200);
+  expect(await res.text()).toBe("proxied");
+  expect(targets).toContainEqual(
+    expect.stringContaining("rallly-proxy-contract-check.invalid"),
+  );
+});
+
+test("leaves the global dispatcher untouched when no proxy variables are set", () => {
+  const before = getGlobalDispatcher();
+
+  setupOutboundProxy();
+
+  expect(getGlobalDispatcher()).toBe(before);
+});

--- a/apps/web/src/lib/outbound-proxy.ts
+++ b/apps/web/src/lib/outbound-proxy.ts
@@ -1,0 +1,56 @@
+import "server-only";
+
+import { createLogger } from "@rallly/logger";
+import { EnvHttpProxyAgent, setGlobalDispatcher } from "undici";
+
+const logger = createLogger("outbound-proxy");
+
+const PROXY_ENV_VARS = [
+  "HTTP_PROXY",
+  "HTTPS_PROXY",
+  "http_proxy",
+  "https_proxy",
+] as const;
+
+// Proxy URLs may carry credentials (http://user:pass@proxy) — never log them.
+function sanitize(value: string) {
+  try {
+    const url = new URL(value);
+    url.username = "";
+    url.password = "";
+    return url.href;
+  } catch {
+    return "<invalid URL>";
+  }
+}
+
+/**
+ * Node's built-in fetch ignores proxy environment variables, so on networks
+ * with no direct egress (self-hosted behind a corporate proxy) outbound calls
+ * never reach the proxy at all. EnvHttpProxyAgent honors HTTP_PROXY /
+ * HTTPS_PROXY / NO_PROXY in both cases. Node consults the global dispatcher
+ * on every fetch, but anything fetched before this runs goes direct — call it
+ * first at boot.
+ *
+ * Node 24's experimental NODE_USE_ENV_PROXY does the same thing natively;
+ * when it stabilizes, this module can be deleted in its favor.
+ */
+export function setupOutboundProxy() {
+  const configured = PROXY_ENV_VARS.filter((name) => process.env[name]);
+
+  if (configured.length === 0) {
+    return;
+  }
+
+  setGlobalDispatcher(new EnvHttpProxyAgent());
+
+  logger.info(
+    {
+      proxies: Object.fromEntries(
+        configured.map((name) => [name, sanitize(process.env[name] as string)]),
+      ),
+      noProxy: process.env.NO_PROXY ?? process.env.no_proxy ?? null,
+    },
+    "Outbound proxy enabled: fetch will route through the configured proxy",
+  );
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -94,7 +94,7 @@ importers:
         version: 8.1.0(typescript@6.0.3)
       '@vercel/analytics':
         specifier: ^1.5.0
-        version: 1.6.1(next@16.3.0(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.1)(@types/node@24.10.11)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)
+        version: 1.6.1(next@16.3.0(@opentelemetry/api@1.9.0)(@playwright/test@1.58.1)(@types/node@24.10.11)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)
       dayjs:
         specifier: ^1.11.13
         version: 1.11.19
@@ -133,7 +133,7 @@ importers:
         version: 6.0.0(@types/react@19.2.13)(react@19.2.6)
       next-seo:
         specifier: ^6.1.0
-        version: 6.8.0(next@16.3.0(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.1)(@types/node@24.10.11)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        version: 6.8.0(next@16.3.0(@opentelemetry/api@1.9.0)(@playwright/test@1.58.1)(@types/node@24.10.11)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       pg:
         specifier: ^8.17.1
         version: 8.18.0
@@ -423,6 +423,9 @@ importers:
       tailwindcss:
         specifier: ^4.1.18
         version: 4.1.18
+      undici:
+        specifier: ^7.29.0
+        version: 7.29.0
       zod:
         specifier: ^4.3.6
         version: 4.3.6
@@ -11224,8 +11227,8 @@ packages:
   undici-types@7.16.0:
     resolution: {integrity: sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==}
 
-  undici@7.20.0:
-    resolution: {integrity: sha512-MJZrkjyd7DeC+uPZh+5/YaMDxFiiEEaDgbUSVMXayofAkDWF1088CDo+2RPg7B1BuS1qf1vgNE7xqwPxE0DuSQ==}
+  undici@7.29.0:
+    resolution: {integrity: sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==}
     engines: {node: '>=20.18.1'}
 
   unicode-canonical-property-names-ecmascript@2.0.1:
@@ -18356,7 +18359,7 @@ snapshots:
     dependencies:
       uncrypto: 0.1.3
 
-  '@vercel/analytics@1.6.1(next@16.3.0(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.1)(@types/node@24.10.11)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)':
+  '@vercel/analytics@1.6.1(next@16.3.0(@opentelemetry/api@1.9.0)(@playwright/test@1.58.1)(@types/node@24.10.11)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)':
     optionalDependencies:
       next: 16.3.0(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.1)(@types/node@24.10.11)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react: 19.2.6
@@ -19017,7 +19020,7 @@ snapshots:
       parse5: 7.3.0
       parse5-htmlparser2-tree-adapter: 7.1.0
       parse5-parser-stream: 7.1.2
-      undici: 7.20.0
+      undici: 7.29.0
       whatwg-mimetype: 4.0.0
 
   chokidar@3.5.3:
@@ -22108,7 +22111,7 @@ snapshots:
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
 
-  next-seo@6.8.0(next@16.3.0(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.1)(@types/node@24.10.11)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
+  next-seo@6.8.0(next@16.3.0(@opentelemetry/api@1.9.0)(@playwright/test@1.58.1)(@types/node@24.10.11)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
     dependencies:
       next: 16.3.0(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.1)(@types/node@24.10.11)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react: 19.2.6
@@ -24428,7 +24431,7 @@ snapshots:
 
   undici-types@7.16.0: {}
 
-  undici@7.20.0: {}
+  undici@7.29.0: {}
 
   unicode-canonical-property-names-ecmascript@2.0.1: {}
 


### PR DESCRIPTION
## Problem

Node's built-in `fetch` (undici) ignores `HTTP_PROXY` / `HTTPS_PROXY` / `NO_PROXY`, unlike `curl`. On networks with no direct egress (self-hosted behind a corporate proxy that doesn't NAT or allow external DNS), outbound calls — including license key activation against `licensing.rallly.co` — fail with a DNS error and never attempt to reach the proxy at all.

Fixes RAL-1505.

## Fix

`lib/outbound-proxy.ts` installs undici's `EnvHttpProxyAgent` as the global dispatcher when any of the four proxy variables (both cases — the agent reads both, so the guard must too) is set, and logs a structured boot event (credentials stripped from proxy URLs) so operators can confirm from logs alone that proxying engaged. `instrumentation.ts` calls it at boot, before the Sentry import so Sentry's own outbound traffic is proxied too, guarded on `NEXT_RUNTIME === "nodejs"` with a dynamic import — a static import would be hoisted into the Edge bundle, where undici doesn't exist.

`undici` becomes a direct dependency of `apps/web`: Node's bundled copy is not importable (`MODULE_NOT_FOUND`). Pinned `^7`, matching what `node:24` (the Docker base image) ships.

## The contract test

The load-bearing assumption is that the installed undici's `setGlobalDispatcher` registers the `Symbol.for`-keyed global that Node's bundled undici (global `fetch`) consults. If a future base-image bump ships an undici whose symbol version no longer matches, the setup becomes a **silent no-op — indistinguishable from the original bug**. `outbound-proxy.test.ts` locks this in CI hermetically: a local server acts as a forward proxy (handling both CONNECT tunneling and absolute-form requests, so the test survives undici changing proxy mechanics), `HTTP_PROXY` points at it, and Node's global `fetch` targets an unresolvable `.invalid` host — the request can only succeed by going through the proxy.

## Answers to the issue's open questions

- **Does the licensing call go through global `fetch`?** Yes — `LicenseManager.validateLicenseKey` in `features/licensing/mutations.ts` uses plain `fetch`, called from a server action (Node runtime).
- **Does anything run on Edge?** No `export const runtime = "edge"` anywhere in `app/`. The middleware (`proxy.ts`) is Edge but makes no licensing calls.
- **Is the dispatcher actually picked up inside Next.js?** Verified end-to-end: ran a local logging CONNECT proxy, booted the dev server with `HTTPS_PROXY=http://127.0.0.1:8899` and `NO_PROXY=localhost,127.0.0.1`, and hit a temporary route handler fetching `https://example.com`. The proxy logged `CONNECT example.com:443`, the route returned 200, localhost traffic bypassed the proxy via `NO_PROXY`, and the `Outbound proxy enabled` boot event appeared in the server log. Without proxy variables set, nothing is installed, so there is no effect on anyone not behind a proxy.

## Not covered (by design)

SDKs with their own HTTP stacks (Stripe uses `node:http`) don't go through the global dispatcher — irrelevant for self-hosted, which is the population behind proxies. SMTP (nodemailer) is not HTTP and proxy variables don't apply. Node 24's experimental `NODE_USE_ENV_PROXY` does this natively; when it stabilizes, `lib/outbound-proxy.ts` can be deleted in its favor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved network connectivity for web requests when proxy settings are configured.
  * Ensured proxy support is applied consistently before error monitoring initializes.
  * Added support for HTTP and HTTPS outbound proxy settings.
  * Improved handling of proxy credentials and invalid proxy URLs in diagnostic logs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->