### PR TITLE
👷 Skip production deploy and release draft for pre-release tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,9 @@ name: Create Release
 jobs:
   build:
     name: Create Release
+    # Pre-release tags (v4.12.3-rc.1) exist to publish a pinned Docker image
+    # for validation — they must not deploy production or draft a release.
+    if: ${{ !contains(github.ref_name, '-') }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code


### PR DESCRIPTION
## Why

`release.yml` triggers on any `v*` tag and unconditionally fires the production deploy hook and drafts a GitHub release with `makeLatest: true`. That makes pre-release tags unusable: tagging `v4.12.3-rc.1` to publish a pinned Docker image for a self-hoster to validate would also deploy cloud production and draft a "latest" release for an RC.

This adds a job-level guard skipping the workflow for any tag containing `-`. The Docker image workflow needs no change: `docker/metadata-action`'s `type=semver` already skips the `{{major}}.{{minor}}`/`{{major}}` float tags and `latest` for pre-release versions, so an RC tag publishes only the exact pinned image.

Every hyphenated tag in the repo's history (`v3.0.0-rc1`, `v3.9.1-fork.*`) is a pre-release; no stable tag would ever be skipped.

## Context

Immediate use: publishing `v4.12.3-rc.1` so the RAL-1505 proxy fix (#2897) can be validated in the reporter's environment before the official patch. This guard is also the prerequisite step for the planned self-hosted beta channel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prerelease tags are now excluded from production builds and draft release creation, preventing unintended deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->