### PR TITLE
🐛 Assemble calendar dates from formatToParts for small-ICU builds

### DIFF
--- a/apps/web/src/lib/datetime/utils.test.ts
+++ b/apps/web/src/lib/datetime/utils.test.ts
@@ -41,6 +41,21 @@ describe("getCalendarDate", () => {
       getCalendarDate(new Date("2025-07-01T20:00:00Z"), "Asia/Tokyo"),
     ).toBe("2025-07-02");
   });
+
+  it("returns an ISO date on ICU builds without the requested locale", () => {
+    // Small-ICU Node builds (e.g. Alpine's icu-data-en) silently resolve any
+    // requested locale to "en", whose date pattern is MM/DD/YYYY.
+    const RealDateTimeFormat = Intl.DateTimeFormat;
+    Intl.DateTimeFormat = ((
+      _locale?: string | string[],
+      options?: Intl.DateTimeFormatOptions,
+    ) => new RealDateTimeFormat("en", options)) as typeof Intl.DateTimeFormat;
+    try {
+      expect(getCalendarDate(instant, "UTC")).toBe("2025-07-02");
+    } finally {
+      Intl.DateTimeFormat = RealDateTimeFormat;
+    }
+  });
 });
 
 describe("calendarDateToUTCMidnight", () => {

--- a/apps/web/src/lib/datetime/utils.test.ts
+++ b/apps/web/src/lib/datetime/utils.test.ts
@@ -46,10 +46,15 @@ describe("getCalendarDate", () => {
     // Small-ICU Node builds (e.g. Alpine's icu-data-en) silently resolve any
     // requested locale to "en", whose date pattern is MM/DD/YYYY.
     const RealDateTimeFormat = Intl.DateTimeFormat;
-    Intl.DateTimeFormat = ((
-      _locale?: string | string[],
-      options?: Intl.DateTimeFormatOptions,
-    ) => new RealDateTimeFormat("en", options)) as typeof Intl.DateTimeFormat;
+    class EnOnlyDateTimeFormat extends RealDateTimeFormat {
+      constructor(
+        _locales?: string | string[],
+        options?: Intl.DateTimeFormatOptions,
+      ) {
+        super("en", options);
+      }
+    }
+    Intl.DateTimeFormat = EnOnlyDateTimeFormat as typeof Intl.DateTimeFormat;
     try {
       expect(getCalendarDate(instant, "UTC")).toBe("2025-07-02");
     } finally {

--- a/apps/web/src/lib/datetime/utils.ts
+++ b/apps/web/src/lib/datetime/utils.ts
@@ -14,15 +14,20 @@ export function toISODate(value: DateInput) {
 
 /**
  * The calendar date (YYYY-MM-DD) at the given instant in the given zone.
- * en-CA is the locale whose date format is ISO 8601.
+ * Assembled from formatToParts rather than a locale's date pattern: small-ICU
+ * Node builds (e.g. Alpine's icu-data-en) resolve unavailable locales to "en",
+ * whose pattern is MM/DD/YYYY, so no locale can be trusted to format ISO 8601.
  */
 export function getCalendarDate(now: Date, timeZone: string): string {
-  return new Intl.DateTimeFormat("en-CA", {
+  const parts = new Intl.DateTimeFormat("en-CA", {
     timeZone,
     year: "numeric",
     month: "2-digit",
     day: "2-digit",
-  }).format(now);
+  }).formatToParts(now);
+  const get = (type: Intl.DateTimeFormatPartTypes) =>
+    parts.find((part) => part.type === type)?.value;
+  return `${get("year")}-${get("month")}-${get("day")}`;
 }
 
 /**


### PR DESCRIPTION
## Problem

Fixes #2896.

On Node builds with limited ICU locale data (e.g. Alpine's `nodejs` package, whose default data dependency `icu-data-en` ships only the root `en` locale), `Intl.DateTimeFormat` silently resolves `en-CA` to `en`, whose date pattern is `MM/DD/YYYY` rather than ISO 8601.

`getCalendarDate` relied on `en-CA` formatting ISO, so on those builds it returned `08/09/2026`. `calendarDateToUTCMidnight` then produced `new Date("08/09/2026T00:00:00Z")` → Invalid Date, which Prisma rejects in the all-day arm of the upcoming events predicate. Result: `dashboard.stats` 500s and the homepage shows the error page. Official images are unaffected (Node's Docker images bundle full-icu); custom from-source installs on Alpine hit it.

## Fix

Assemble the ISO string from `formatToParts` instead of trusting a locale's date pattern — part types (`year`/`month`/`day`) are locale-independent, so the result is correct regardless of which locale ICU resolves. Time zone conversion works fine under small ICU (the timed arm always produced correct dates), so no ICU data requirement changes.

## Testing

- New unit test simulates the small-ICU fallback by stubbing `Intl.DateTimeFormat` to resolve every locale to `en`; it reproduced the exact `07/02/2025` failure before the fix and passes after.
- Full unit suite (345 tests) and type-check pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed calendar date formatting in environments with limited locale support.
  * Dates now consistently return the expected `YYYY-MM-DD` format regardless of locale fallback behavior.

* **Tests**
  * Added coverage for date formatting when requested locales fall back to English.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->