### PR TITLE
🐛 Never proxy loopback traffic and exempt the container healthcheck

### DIFF
--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -87,6 +87,8 @@ ENV NEXT_PUBLIC_SELF_HOSTED=$SELF_HOSTED
 
 EXPOSE 3000
 
-HEALTHCHECK CMD curl --fail http://localhost:${PORT}/api/status || exit 1
+# --noproxy '*': curl honors http_proxy/no_proxy env, and a probe of our own
+# loopback must never depend on the host's proxy policy.
+HEALTHCHECK CMD curl --fail --noproxy '*' http://localhost:${PORT}/api/status || exit 1
 
 CMD ["./docker-start.sh"]

--- a/apps/web/src/lib/outbound-proxy.test.ts
+++ b/apps/web/src/lib/outbound-proxy.test.ts
@@ -45,10 +45,10 @@ afterEach(async () => {
   );
 });
 
-function listen(server: Server) {
+function listen(server: Server, host = "127.0.0.1") {
   servers.push(server);
   return new Promise<number>((resolve) => {
-    server.listen(0, "127.0.0.1", () => {
+    server.listen(0, host, () => {
       resolve((server.address() as AddressInfo).port);
     });
   });
@@ -84,13 +84,13 @@ async function startProxyServer() {
   return { port: await listen(proxy), targets };
 }
 
-async function startOriginServer() {
+async function startOriginServer(host: string) {
   const origin = createServer((_req, res) => {
     res.setHeader("connection", "close");
     res.end("direct");
   });
 
-  return { port: await listen(origin) };
+  return { port: await listen(origin, host) };
 }
 
 /**
@@ -124,7 +124,7 @@ test.each([
   "127.0.0.1",
 ])("loopback host %s bypasses the proxy even without NO_PROXY", async (host) => {
   const { port: proxyPort, targets } = await startProxyServer();
-  const { port: originPort } = await startOriginServer();
+  const { port: originPort } = await startOriginServer(host);
   process.env.HTTP_PROXY = `http://127.0.0.1:${proxyPort}`;
 
   setupOutboundProxy();

--- a/apps/web/src/lib/outbound-proxy.test.ts
+++ b/apps/web/src/lib/outbound-proxy.test.ts
@@ -20,7 +20,7 @@ const PROXY_ENV_VARS = [
 
 const savedEnv: Record<string, string | undefined> = {};
 const originalDispatcher = getGlobalDispatcher();
-let server: Server | undefined;
+const servers: Server[] = [];
 
 beforeEach(() => {
   for (const name of PROXY_ENV_VARS) {
@@ -38,11 +38,21 @@ afterEach(async () => {
     }
   }
   setGlobalDispatcher(originalDispatcher);
-  if (server) {
-    await new Promise((resolve) => server?.close(resolve));
-    server = undefined;
-  }
+  await Promise.all(
+    servers
+      .splice(0)
+      .map((server) => new Promise((resolve) => server.close(resolve))),
+  );
 });
+
+function listen(server: Server) {
+  servers.push(server);
+  return new Promise<number>((resolve) => {
+    server.listen(0, "127.0.0.1", () => {
+      resolve((server.address() as AddressInfo).port);
+    });
+  });
+}
 
 /**
  * A local server that behaves as a forward proxy for both proxying styles:
@@ -51,7 +61,7 @@ afterEach(async () => {
  * changes mechanics across majors. Every request is answered with "proxied"
  * and the target host is recorded.
  */
-function startProxyServer() {
+async function startProxyServer() {
   const targets: string[] = [];
 
   const proxy = createServer((req, res) => {
@@ -71,13 +81,16 @@ function startProxyServer() {
     clientSocket.on("error", () => {});
   });
 
-  server = proxy;
+  return { port: await listen(proxy), targets };
+}
 
-  return new Promise<{ port: number; targets: string[] }>((resolve) => {
-    proxy.listen(0, "127.0.0.1", () => {
-      resolve({ port: (proxy.address() as AddressInfo).port, targets });
-    });
+async function startOriginServer() {
+  const origin = createServer((_req, res) => {
+    res.setHeader("connection", "close");
+    res.end("direct");
   });
+
+  return { port: await listen(origin) };
 }
 
 /**
@@ -104,6 +117,41 @@ test("Node's global fetch routes through the proxy from HTTP_PROXY", async () =>
   expect(targets).toContainEqual(
     expect.stringContaining("rallly-proxy-contract-check.invalid"),
   );
+});
+
+test.each([
+  "localhost",
+  "127.0.0.1",
+])("loopback host %s bypasses the proxy even without NO_PROXY", async (host) => {
+  const { port: proxyPort, targets } = await startProxyServer();
+  const { port: originPort } = await startOriginServer();
+  process.env.HTTP_PROXY = `http://127.0.0.1:${proxyPort}`;
+
+  setupOutboundProxy();
+
+  const res = await fetch(`http://${host}:${originPort}/ping`, {
+    signal: AbortSignal.timeout(5000),
+  });
+
+  expect(await res.text()).toBe("direct");
+  expect(targets).toEqual([]);
+});
+
+test("lowercase no_proxy entries are honored", async () => {
+  const { port, targets } = await startProxyServer();
+  process.env.http_proxy = `http://127.0.0.1:${port}`;
+  process.env.no_proxy = "proxy-exempt.invalid";
+
+  setupOutboundProxy();
+
+  // Exempt from the proxy, the unresolvable host can only fail DNS — reaching
+  // the proxy would have succeeded, which is what the last assertion rules out.
+  await expect(
+    fetch("http://proxy-exempt.invalid/ping", {
+      signal: AbortSignal.timeout(5000),
+    }),
+  ).rejects.toThrow("fetch failed");
+  expect(targets).toEqual([]);
 });
 
 test("leaves the global dispatcher untouched when no proxy variables are set", () => {

--- a/apps/web/src/lib/outbound-proxy.ts
+++ b/apps/web/src/lib/outbound-proxy.ts
@@ -25,6 +25,17 @@ function sanitize(value: string) {
 }
 
 /**
+ * Loopback traffic is never proxied, regardless of NO_PROXY: a CONNECT to
+ * "localhost" through a remote proxy reaches the proxy's loopback, never this
+ * container's, so proxying it is categorically wrong. Go's
+ * ProxyFromEnvironment applies the same rule. The undici matcher compares
+ * entries literally (no CIDR, no name/IP resolution), so both name and
+ * address forms are listed. "localhost" also covers *.localhost via the
+ * matcher's subdomain rule.
+ */
+const LOOPBACK_NO_PROXY = "localhost,127.0.0.1,[::1]";
+
+/**
  * Node's built-in fetch ignores proxy environment variables, so on networks
  * with no direct egress (self-hosted behind a corporate proxy) outbound calls
  * never reach the proxy at all. EnvHttpProxyAgent honors HTTP_PROXY /
@@ -42,14 +53,21 @@ export function setupOutboundProxy() {
     return;
   }
 
-  setGlobalDispatcher(new EnvHttpProxyAgent());
+  const noProxy = [
+    process.env.no_proxy ?? process.env.NO_PROXY,
+    LOOPBACK_NO_PROXY,
+  ]
+    .filter(Boolean)
+    .join(",");
+
+  setGlobalDispatcher(new EnvHttpProxyAgent({ noProxy }));
 
   logger.info(
     {
       proxies: Object.fromEntries(
         configured.map((name) => [name, sanitize(process.env[name] as string)]),
       ),
-      noProxy: process.env.NO_PROXY ?? process.env.no_proxy ?? null,
+      noProxy,
     },
     "Outbound proxy enabled: fetch will route through the configured proxy",
   );


### PR DESCRIPTION
## Problem

Follow-up to #2897, reported by the same self-hoster: with the proxy dispatcher active, connections to localhost were also being routed to the corporate proxy, and the environment's `no_proxy` didn't prevent it in their setup.

Two distinct paths were affected:

1. **The Docker healthcheck** — `curl http://localhost:${PORT}/api/status` runs inside the container every 30s; curl honors `http_proxy`, and unless `no_proxy` contains the literal name `localhost` (neither curl's nor undici's matcher resolves names against IP/CIDR entries), every probe goes to the proxy.
2. **Any in-app fetch to loopback**, present or future, for the same literal-matching reason.

## Fix

- `setupOutboundProxy` now appends `localhost,127.0.0.1,[::1]` to the environment's `no_proxy` when constructing `EnvHttpProxyAgent`. Loopback is never proxied regardless of configuration — a CONNECT to localhost through a remote proxy reaches the *proxy's* loopback, never the container's, so proxying it is categorically wrong. Go's `ProxyFromEnvironment` hard-codes the same rule. `localhost` also covers `*.localhost` via the matcher's subdomain rule.
- The healthcheck curl gets `--noproxy '*'` — a self-probe must never depend on proxy policy.

## Tests

Two new hermetic tests alongside the existing contract tests: loopback fetches (`localhost` and `127.0.0.1`) reach a local origin server directly while the recording proxy sees nothing — with no `NO_PROXY` set at all — and lowercase `no_proxy` entries are honored for non-loopback hosts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved local health checks so proxy settings no longer interfere with status verification.
  - Ensured requests to local addresses, including `localhost`, IPv4 loopback, and IPv6 loopback, bypass outbound proxies.
  - Improved handling of lowercase `no_proxy` configuration and combined it with built-in local-address exclusions.

- **Tests**
  - Expanded coverage for proxy bypass behavior and improved test server cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->