### PR TITLE
✨ Redesign the mobile poll voting experience

### DIFF
--- a/apps/web/public/locales/en/app.json
+++ b/apps/web/public/locales/en/app.json
@@ -520,6 +520,7 @@
   "optionalLabel": "(Optional)",
   "optionCount": "{count, plural, one {# option} other {# options}}",
   "optionsSelected": "{count, plural, =0 {None selected} one {# option selected} other {# options selected}}",
+  "optionVoteBreakdown": "{yesScore} yes, {ifNeedBeScore} if need be",
   "or": "Or",
   "organizationName": "Organization name",
   "organizationNamePlaceholder": "e.g. Acme Corp",

--- a/apps/web/public/locales/en/app.json
+++ b/apps/web/public/locales/en/app.json
@@ -701,6 +701,7 @@
   "setupPasswordAlertTitle": "Login quicker with a password",
   "setupPasswordButton": "Set up password",
   "share": "Share",
+  "showParticipantVotes": "Show participant votes",
   "showPassword": "Show password",
   "shrink": "Shrink",
   "signedInAs": "You're signed in as:",

--- a/apps/web/src/features/poll/components/mobile-poll.tsx
+++ b/apps/web/src/features/poll/components/mobile-poll.tsx
@@ -223,7 +223,7 @@ const MobilePoll: React.FunctionComponent = () => {
       <AnimatePresence>
         {isEditing ? (
           <m.div
-            className="sticky bottom-0 z-20"
+            className="sticky bottom-0 z-20 px-3 pb-3"
             variants={{
               hidden: { opacity: 0, y: -20, height: 0 },
               visible: { opacity: 1, y: 0, height: "auto" },
@@ -237,9 +237,7 @@ const MobilePoll: React.FunctionComponent = () => {
               transition: { duration: 0.2 },
             }}
           >
-            <div className="p-3">
-              <VotingFooter />
-            </div>
+            <VotingFooter />
           </m.div>
         ) : null}
       </AnimatePresence>

--- a/apps/web/src/features/poll/components/mobile-poll.tsx
+++ b/apps/web/src/features/poll/components/mobile-poll.tsx
@@ -102,7 +102,7 @@ const MobilePoll: React.FunctionComponent = () => {
   ];
 
   return (
-    <Card>
+    <Card className="overflow-visible">
       <div className="flex flex-col space-y-2 border-b p-2">
         <div className="flex gap-x-2">
           {selectedParticipantId || !isEditing ? (
@@ -223,6 +223,7 @@ const MobilePoll: React.FunctionComponent = () => {
       <AnimatePresence>
         {isEditing ? (
           <m.div
+            className="sticky bottom-0 z-20"
             variants={{
               hidden: { opacity: 0, y: -20, height: 0 },
               visible: { opacity: 1, y: 0, height: "auto" },
@@ -236,7 +237,7 @@ const MobilePoll: React.FunctionComponent = () => {
               transition: { duration: 0.2 },
             }}
           >
-            <CardFooter className="border-t">
+            <CardFooter className="rounded-b-2xl border-t bg-card">
               <VotingFooter className="flex-1" />
             </CardFooter>
           </m.div>

--- a/apps/web/src/features/poll/components/mobile-poll.tsx
+++ b/apps/web/src/features/poll/components/mobile-poll.tsx
@@ -104,7 +104,7 @@ const MobilePoll: React.FunctionComponent = () => {
   return (
     <Card>
       <div className="flex flex-col space-y-2 border-b p-2">
-        <div className="flex gap-x-2.5">
+        <div className="flex gap-x-2">
           {selectedParticipantId || !isEditing ? (
             <Select
               items={participantOptions}

--- a/apps/web/src/features/poll/components/mobile-poll.tsx
+++ b/apps/web/src/features/poll/components/mobile-poll.tsx
@@ -1,6 +1,6 @@
 import { Badge } from "@rallly/ui/badge";
 import { Button } from "@rallly/ui/button";
-import { Card, CardFooter } from "@rallly/ui/card";
+import { Card } from "@rallly/ui/card";
 import { Icon } from "@rallly/ui/icon";
 import {
   Select,
@@ -237,9 +237,9 @@ const MobilePoll: React.FunctionComponent = () => {
               transition: { duration: 0.2 },
             }}
           >
-            <CardFooter className="rounded-b-2xl border-t bg-card">
-              <VotingFooter className="flex-1" />
-            </CardFooter>
+            <div className="p-3">
+              <VotingFooter />
+            </div>
           </m.div>
         ) : null}
       </AnimatePresence>

--- a/apps/web/src/features/poll/components/mobile-poll.tsx
+++ b/apps/web/src/features/poll/components/mobile-poll.tsx
@@ -223,7 +223,7 @@ const MobilePoll: React.FunctionComponent = () => {
       <AnimatePresence>
         {isEditing ? (
           <m.div
-            className="sticky bottom-0 z-20 px-3 pb-3"
+            className="sticky bottom-0 z-20"
             variants={{
               hidden: { opacity: 0, y: -20, height: 0 },
               visible: { opacity: 1, y: 0, height: "auto" },
@@ -237,7 +237,7 @@ const MobilePoll: React.FunctionComponent = () => {
               transition: { duration: 0.2 },
             }}
           >
-            <VotingFooter />
+            <VotingFooter className="p-3" />
           </m.div>
         ) : null}
       </AnimatePresence>

--- a/apps/web/src/features/poll/components/mobile-poll.tsx
+++ b/apps/web/src/features/poll/components/mobile-poll.tsx
@@ -108,8 +108,7 @@ const MobilePoll: React.FunctionComponent = () => {
           {selectedParticipantId || !isEditing ? (
             <Select
               items={participantOptions}
-              defaultValue="all"
-              value={selectedParticipantId}
+              value={selectedParticipantId ?? "all"}
               onValueChange={(participantId) => {
                 if (participantId) {
                   votingForm.setValue("participantId", participantId);
@@ -183,6 +182,7 @@ const MobilePoll: React.FunctionComponent = () => {
                   aria-label={t("moreOptions", {
                     defaultValue: "More options",
                   })}
+                  variant="ghost"
                   size="icon"
                 >
                   <MoreHorizontalIcon />

--- a/apps/web/src/features/poll/components/mobile-poll/date-option.tsx
+++ b/apps/web/src/features/poll/components/mobile-poll/date-option.tsx
@@ -21,9 +21,7 @@ const DateOption: React.FunctionComponent<DateOptionProps> = ({
        * until we update this component.
        */}
       <div className="text-sm">
-        <span className="font-semibold">
-          {day} {dow}
-        </span>
+        {day} {dow}
       </div>
     </PollOption>
   );

--- a/apps/web/src/features/poll/components/mobile-poll/grouped-options.tsx
+++ b/apps/web/src/features/poll/components/mobile-poll/grouped-options.tsx
@@ -29,7 +29,7 @@ const GroupedOptions: React.FunctionComponent<GroupedOptionsProps> = ({
           <div key={day}>
             <div
               className={cn(
-                "flex border-b bg-muted px-4 py-2 font-medium text-xs uppercase",
+                "flex border-b bg-muted px-4 py-2 text-sm",
                 groupClassName,
               )}
             >

--- a/apps/web/src/features/poll/components/mobile-poll/grouped-options.tsx
+++ b/apps/web/src/features/poll/components/mobile-poll/grouped-options.tsx
@@ -27,13 +27,10 @@ const GroupedOptions: React.FunctionComponent<GroupedOptionsProps> = ({
       {Object.entries(grouped).map(([day, options]) => {
         return (
           <div key={day}>
-            <div
-              className={cn(
-                "flex border-b bg-muted px-4 py-2 text-sm",
-                groupClassName,
-              )}
-            >
-              {day}
+            <div className={cn("sticky top-0 z-10 p-1", groupClassName)}>
+              <div className="rounded-lg border bg-card/80 p-2 font-semibold text-sm shadow-xs backdrop-blur-lg">
+                {day}
+              </div>
             </div>
             <PollOptions
               options={options}

--- a/apps/web/src/features/poll/components/mobile-poll/grouped-options.tsx
+++ b/apps/web/src/features/poll/components/mobile-poll/grouped-options.tsx
@@ -28,7 +28,7 @@ const GroupedOptions: React.FunctionComponent<GroupedOptionsProps> = ({
         return (
           <div key={day}>
             <div className={cn("sticky top-0 z-10 p-1", groupClassName)}>
-              <div className="rounded-lg border bg-card/80 p-2 font-semibold text-sm shadow-xs backdrop-blur-lg">
+              <div className="rounded-lg border bg-card/80 p-2 font-semibold text-sm shadow-sm backdrop-blur-lg">
                 {day}
               </div>
             </div>

--- a/apps/web/src/features/poll/components/mobile-poll/poll-option.tsx
+++ b/apps/web/src/features/poll/components/mobile-poll/poll-option.tsx
@@ -169,10 +169,7 @@ const PollOption: React.FunctionComponent<PollOptionProps> = ({
   );
 
   return (
-    <div
-      className="flex items-center gap-x-2.5 bg-background p-3"
-      data-testid="poll-option"
-    >
+    <div className="flex items-center gap-x-1" data-testid="poll-option">
       {editable ? (
         <button
           type="button"
@@ -183,13 +180,13 @@ const PollOption: React.FunctionComponent<PollOptionProps> = ({
           }}
           className={cn(
             buttonVariants(),
-            "h-12 min-w-0 flex-1 justify-between px-3",
+            "h-11 min-w-0 flex-1 justify-between px-3",
           )}
         >
           {optionSummary}
         </button>
       ) : (
-        <div className="flex h-12 min-w-0 flex-1 items-center justify-between px-3">
+        <div className="flex h-9 min-w-0 flex-1 items-center justify-between px-3">
           {optionSummary}
         </div>
       )}
@@ -198,8 +195,8 @@ const PollOption: React.FunctionComponent<PollOptionProps> = ({
           defaultValue: "Show participant votes",
         })}
         variant="ghost"
-        size="icon-lg"
-        className="size-12"
+        size={editable ? "icon-lg" : "icon"}
+        className={editable ? "size-11" : undefined}
         onClick={() => {
           dialog.trigger();
         }}

--- a/apps/web/src/features/poll/components/mobile-poll/poll-option.tsx
+++ b/apps/web/src/features/poll/components/mobile-poll/poll-option.tsx
@@ -168,14 +168,7 @@ const PollOption: React.FunctionComponent<PollOptionProps> = ({
 
   return (
     <div className="flex items-center gap-x-2" data-testid="poll-option">
-      <div className={cn(optionGrid, "h-11")}>{optionSummary}</div>
-      {editable ? (
-        <VoteSegmentedControl
-          value={vote}
-          onChange={onChange}
-          optionLabel={optionLabel}
-        />
-      ) : null}
+      <div className={cn(optionGrid)}>{optionSummary}</div>
       <IfScoresVisible>
         <Button
           {...dialog.triggerProps}
@@ -187,7 +180,6 @@ const PollOption: React.FunctionComponent<PollOptionProps> = ({
             defaultValue: "Show participant votes",
           })}`}
           variant="ghost"
-          className="w-14"
         >
           <ConnectedScoreSummary optionId={optionId} />
         </Button>
@@ -203,6 +195,13 @@ const PollOption: React.FunctionComponent<PollOptionProps> = ({
           </DialogContent>
         </Dialog>
       </IfScoresVisible>
+      {editable ? (
+        <VoteSegmentedControl
+          value={vote}
+          onChange={onChange}
+          optionLabel={optionLabel}
+        />
+      ) : null}
     </div>
   );
 };

--- a/apps/web/src/features/poll/components/mobile-poll/poll-option.tsx
+++ b/apps/web/src/features/poll/components/mobile-poll/poll-option.tsx
@@ -151,7 +151,7 @@ const PollOption: React.FunctionComponent<PollOptionProps> = ({
     <div
       className={cn(
         "grid h-14 items-center px-2 text-left transition-[grid-template-columns] duration-300",
-        editable && "grid-cols-[0rem_1fr_3rem_3.5rem_8.375rem]",
+        editable && "grid-cols-[0rem_1fr_3rem_3.5rem_8.875rem]",
         showVote && "grid-cols-[1.875rem_1fr_3rem_3.5rem_0rem]",
         !editable && !showVote && "grid-cols-[0rem_1fr_3rem_3.5rem_0rem]",
       )}

--- a/apps/web/src/features/poll/components/mobile-poll/poll-option.tsx
+++ b/apps/web/src/features/poll/components/mobile-poll/poll-option.tsx
@@ -144,19 +144,26 @@ const PollOption: React.FunctionComponent<PollOptionProps> = ({
   const { t } = useTranslation();
   const dialog = useDialog();
 
+  const showVote = !editable && !!selectedParticipantId;
+
   const optionSummary = (
     <>
-      {!editable && selectedParticipantId ? (
-        <VoteIcon type={vote} />
-      ) : (
-        <span aria-hidden="true" />
-      )}
+      <span
+        aria-hidden={showVote ? undefined : true}
+        className="overflow-hidden"
+      >
+        {showVote ? <VoteIcon type={vote} /> : null}
+      </span>
       {children}
     </>
   );
 
-  const optionGrid =
-    "grid min-w-0 flex-1 grid-cols-[1.25rem_4.5rem_1fr] items-center gap-x-2.5 px-3 text-left";
+  const optionGrid = cn(
+    "grid min-w-0 flex-1 items-center px-2 text-left transition-[grid-template-columns] duration-300",
+    showVote
+      ? "grid-cols-[1.875rem_4.5rem_1fr]"
+      : "grid-cols-[0rem_4.5rem_1fr]",
+  );
 
   return (
     <div className="flex items-center gap-x-1" data-testid="poll-option">

--- a/apps/web/src/features/poll/components/mobile-poll/poll-option.tsx
+++ b/apps/web/src/features/poll/components/mobile-poll/poll-option.tsx
@@ -152,8 +152,8 @@ const PollOption: React.FunctionComponent<PollOptionProps> = ({
       className={cn(
         "grid h-14 items-center px-2 text-left transition-[grid-template-columns] duration-300",
         showVote
-          ? "grid-cols-[1.875rem_4.5rem_3rem_auto_1fr]"
-          : "grid-cols-[0rem_4.5rem_3rem_auto_1fr]",
+          ? "grid-cols-[1.875rem_1fr_3rem_3rem_8.375rem]"
+          : "grid-cols-[0rem_1fr_3rem_3rem_8.375rem]",
       )}
       data-testid="poll-option"
     >
@@ -176,7 +176,7 @@ const PollOption: React.FunctionComponent<PollOptionProps> = ({
           })}`}
           variant="ghost"
           size="lg"
-          className="col-start-4 justify-self-start"
+          className="col-start-4 justify-self-end"
         >
           <ConnectedScoreSummary optionId={optionId} />
         </Button>

--- a/apps/web/src/features/poll/components/mobile-poll/poll-option.tsx
+++ b/apps/web/src/features/poll/components/mobile-poll/poll-option.tsx
@@ -11,7 +11,7 @@ import {
   useDialog,
 } from "@rallly/ui/dialog";
 import { Icon } from "@rallly/ui/icon";
-import { UsersIcon } from "lucide-react";
+import { InfoIcon } from "lucide-react";
 import type * as React from "react";
 
 import { OptimizedAvatarImage } from "@/components/optimized-avatar-image";
@@ -205,7 +205,7 @@ const PollOption: React.FunctionComponent<PollOptionProps> = ({
         }}
       >
         <Icon>
-          <UsersIcon />
+          <InfoIcon />
         </Icon>
       </Button>
       <Dialog {...dialog.dialogProps}>

--- a/apps/web/src/features/poll/components/mobile-poll/poll-option.tsx
+++ b/apps/web/src/features/poll/components/mobile-poll/poll-option.tsx
@@ -19,9 +19,8 @@ import {
   filterParticipantsByVote,
   useParticipants,
 } from "@/features/poll/components/participants-provider";
+import { IfScoresVisible } from "@/features/poll/components/visibility";
 import { Trans, useTranslation } from "@/i18n/client";
-
-import { ConnectedScoreSummary } from "../score-summary";
 import VoteIcon from "../vote-icon";
 import { toggleVote } from "../vote-selector";
 
@@ -133,6 +132,59 @@ const PollOptionVoteSummary: React.FunctionComponent<{ optionId: string }> = ({
   );
 };
 
+const OptionScoreDonut = ({
+  yesScore,
+  ifNeedBeScore,
+}: {
+  yesScore: number;
+  ifNeedBeScore: number;
+}) => {
+  const { t } = useTranslation();
+  const { participants } = useParticipants();
+  const total = participants.length;
+  const stroke = 4;
+  const radius = (20 - stroke) / 2;
+  const circumference = 2 * Math.PI * radius;
+  const yesLength = total > 0 ? (yesScore / total) * circumference : 0;
+  const ifNeedBeLength =
+    total > 0 ? (ifNeedBeScore / total) * circumference : 0;
+  const segment = (className: string, length: number, offset: number) => (
+    <circle
+      cx="10"
+      cy="10"
+      r={radius}
+      fill="none"
+      strokeWidth={stroke}
+      strokeDasharray={`${length} ${circumference}`}
+      strokeDashoffset={-offset}
+      className={className}
+    />
+  );
+  return (
+    <svg
+      role="img"
+      aria-label={t("optionVoteBreakdown", {
+        defaultValue: "{yesScore} yes, {ifNeedBeScore} if need be",
+        yesScore,
+        ifNeedBeScore,
+      })}
+      viewBox="0 0 20 20"
+      className="size-5 -rotate-90"
+    >
+      <circle
+        cx="10"
+        cy="10"
+        r={radius}
+        fill="none"
+        strokeWidth={stroke}
+        className="stroke-muted"
+      />
+      {segment("stroke-[#00C950]", yesLength, 0)}
+      {segment("stroke-[#FFB900]", ifNeedBeLength, yesLength)}
+    </svg>
+  );
+};
+
 const PollOption: React.FunctionComponent<PollOptionProps> = ({
   children,
   selectedParticipantId,
@@ -141,6 +193,8 @@ const PollOption: React.FunctionComponent<PollOptionProps> = ({
   editable = false,
   optionId,
   optionLabel,
+  yesScore,
+  ifNeedBeScore,
 }) => {
   const { t } = useTranslation();
   const dialog = useDialog();
@@ -167,7 +221,9 @@ const PollOption: React.FunctionComponent<PollOptionProps> = ({
       )}
       {children}
       <span className="col-start-4 justify-self-end">
-        <ConnectedScoreSummary optionId={optionId} />
+        <IfScoresVisible>
+          <OptionScoreDonut yesScore={yesScore} ifNeedBeScore={ifNeedBeScore} />
+        </IfScoresVisible>
       </span>
     </>
   );

--- a/apps/web/src/features/poll/components/mobile-poll/poll-option.tsx
+++ b/apps/web/src/features/poll/components/mobile-poll/poll-option.tsx
@@ -17,6 +17,7 @@ import {
   filterParticipantsByVote,
   useParticipants,
 } from "@/features/poll/components/participants-provider";
+import { IfScoresVisible } from "@/features/poll/components/visibility";
 import { Trans, useTranslation } from "@/i18n/client";
 import { ConnectedScoreSummary } from "../score-summary";
 import VoteIcon from "../vote-icon";
@@ -175,33 +176,33 @@ const PollOption: React.FunctionComponent<PollOptionProps> = ({
           optionLabel={optionLabel}
         />
       ) : null}
-      <Button
-        aria-label={`${t("optionVoteBreakdown", {
-          defaultValue: "{yesScore} yes, {ifNeedBeScore} if need be",
-          yesScore,
-          ifNeedBeScore,
-        })}. ${t("showParticipantVotes", {
-          defaultValue: "Show participant votes",
-        })}`}
-        variant="ghost"
-        className="w-14"
-        onClick={() => {
-          dialog.trigger();
-        }}
-      >
-        <ConnectedScoreSummary optionId={optionId} />
-      </Button>
-      <Dialog {...dialog.dialogProps}>
-        <DialogContent size="sm">
-          <DialogHeader>
-            <DialogTitle>
-              <Trans i18nKey="participants" defaults="Participants" />
-            </DialogTitle>
-            <DialogDescription>{optionLabel}</DialogDescription>
-          </DialogHeader>
-          <PollOptionVoteSummary optionId={optionId} />
-        </DialogContent>
-      </Dialog>
+      <IfScoresVisible>
+        <Button
+          {...dialog.triggerProps}
+          aria-label={`${t("optionVoteBreakdown", {
+            defaultValue: "{yesScore} yes, {ifNeedBeScore} if need be",
+            yesScore,
+            ifNeedBeScore,
+          })}. ${t("showParticipantVotes", {
+            defaultValue: "Show participant votes",
+          })}`}
+          variant="ghost"
+          className="w-14"
+        >
+          <ConnectedScoreSummary optionId={optionId} />
+        </Button>
+        <Dialog {...dialog.dialogProps}>
+          <DialogContent size="sm">
+            <DialogHeader>
+              <DialogTitle>
+                <Trans i18nKey="participants" defaults="Participants" />
+              </DialogTitle>
+              <DialogDescription>{optionLabel}</DialogDescription>
+            </DialogHeader>
+            <PollOptionVoteSummary optionId={optionId} />
+          </DialogContent>
+        </Dialog>
+      </IfScoresVisible>
     </div>
   );
 };

--- a/apps/web/src/features/poll/components/mobile-poll/poll-option.tsx
+++ b/apps/web/src/features/poll/components/mobile-poll/poll-option.tsx
@@ -5,6 +5,7 @@ import { Button } from "@rallly/ui/button";
 import {
   Dialog,
   DialogContent,
+  DialogDescription,
   DialogHeader,
   DialogTitle,
   useDialog,
@@ -18,7 +19,7 @@ import {
   filterParticipantsByVote,
   useParticipants,
 } from "@/features/poll/components/participants-provider";
-import { useTranslation } from "@/i18n/client";
+import { Trans, useTranslation } from "@/i18n/client";
 
 import { ConnectedScoreSummary } from "../score-summary";
 import VoteIcon from "../vote-icon";
@@ -196,7 +197,9 @@ const PollOption: React.FunctionComponent<PollOptionProps> = ({
         aria-label={t("showParticipantVotes", {
           defaultValue: "Show participant votes",
         })}
+        variant="ghost"
         size="icon-lg"
+        className="size-12"
         onClick={() => {
           dialog.trigger();
         }}
@@ -208,7 +211,10 @@ const PollOption: React.FunctionComponent<PollOptionProps> = ({
       <Dialog {...dialog.dialogProps}>
         <DialogContent size="sm">
           <DialogHeader>
-            <DialogTitle>{optionLabel}</DialogTitle>
+            <DialogTitle>
+              <Trans i18nKey="participants" defaults="Participants" />
+            </DialogTitle>
+            <DialogDescription>{optionLabel}</DialogDescription>
           </DialogHeader>
           <PollOptionVoteSummary optionId={optionId} />
         </DialogContent>

--- a/apps/web/src/features/poll/components/mobile-poll/poll-option.tsx
+++ b/apps/web/src/features/poll/components/mobile-poll/poll-option.tsx
@@ -151,9 +151,9 @@ const PollOption: React.FunctionComponent<PollOptionProps> = ({
     <div
       className={cn(
         "grid h-14 items-center px-2 text-left transition-[grid-template-columns] duration-300",
-        editable && "grid-cols-[0rem_1fr_3rem_3.5rem_8.875rem]",
-        showVote && "grid-cols-[1.875rem_1fr_3rem_3.5rem_0rem]",
-        !editable && !showVote && "grid-cols-[0rem_1fr_3rem_3.5rem_0rem]",
+        editable && "grid-cols-[0rem_1fr_3.5rem_8.875rem]",
+        showVote && "grid-cols-[1.875rem_1fr_3.5rem_0rem]",
+        !editable && !showVote && "grid-cols-[0rem_1fr_3.5rem_0rem]",
       )}
       data-testid="poll-option"
     >
@@ -176,7 +176,7 @@ const PollOption: React.FunctionComponent<PollOptionProps> = ({
           })}`}
           variant="ghost"
           size="lg"
-          className="col-start-4 justify-self-end"
+          className="col-start-3 justify-self-end"
         >
           <ConnectedScoreSummary optionId={optionId} />
         </Button>
@@ -197,7 +197,7 @@ const PollOption: React.FunctionComponent<PollOptionProps> = ({
           value={vote}
           onChange={onChange}
           optionLabel={optionLabel}
-          className="col-start-5 justify-self-end"
+          className="col-start-4 justify-self-end"
         />
       ) : null}
     </div>

--- a/apps/web/src/features/poll/components/mobile-poll/poll-option.tsx
+++ b/apps/web/src/features/poll/components/mobile-poll/poll-option.tsx
@@ -17,8 +17,8 @@ import {
   filterParticipantsByVote,
   useParticipants,
 } from "@/features/poll/components/participants-provider";
-import { IfScoresVisible } from "@/features/poll/components/visibility";
 import { Trans, useTranslation } from "@/i18n/client";
+import { ConnectedScoreSummary } from "../score-summary";
 import VoteIcon from "../vote-icon";
 import { VoteSegmentedControl } from "../vote-segmented-control";
 
@@ -130,63 +130,6 @@ const PollOptionVoteSummary: React.FunctionComponent<{ optionId: string }> = ({
   );
 };
 
-const OptionScoreDonut = ({
-  yesScore,
-  ifNeedBeScore,
-}: {
-  yesScore: number;
-  ifNeedBeScore: number;
-}) => {
-  const { participants } = useParticipants();
-  const total = participants.length;
-  const score = yesScore + ifNeedBeScore;
-  const stroke = 2.5;
-  const radius = (24 - stroke) / 2;
-  const circumference = 2 * Math.PI * radius;
-  const yesLength = total > 0 ? (yesScore / total) * circumference : 0;
-  const ifNeedBeLength =
-    total > 0 ? (ifNeedBeScore / total) * circumference : 0;
-  const segment = (className: string, length: number, offset: number) => (
-    <circle
-      cx="12"
-      cy="12"
-      r={radius}
-      fill="none"
-      strokeWidth={stroke}
-      strokeDasharray={`${length} ${circumference}`}
-      strokeDashoffset={-offset}
-      className={className}
-    />
-  );
-  return (
-    <svg aria-hidden="true" viewBox="0 0 24 24" className="size-6 opacity-100">
-      {/* Segments start at 12 o'clock; only the ring rotates so the score stays upright. */}
-      <g transform="rotate(-90 12 12)">
-        <circle
-          cx="12"
-          cy="12"
-          r={radius}
-          fill="none"
-          strokeWidth={stroke}
-          className="stroke-muted"
-        />
-        {segment("stroke-[#00C950]", yesLength, 0)}
-        {segment("stroke-[#FFB900]", ifNeedBeLength, yesLength)}
-      </g>
-      <text
-        x="12"
-        y="12.5"
-        textAnchor="middle"
-        dominantBaseline="central"
-        fontSize="9"
-        className="fill-foreground font-medium"
-      >
-        {score}
-      </text>
-    </svg>
-  );
-};
-
 const PollOption: React.FunctionComponent<PollOptionProps> = ({
   children,
   selectedParticipantId,
@@ -234,15 +177,12 @@ const PollOption: React.FunctionComponent<PollOptionProps> = ({
           defaultValue: "Show participant votes",
         })}`}
         variant="ghost"
-        size="icon-lg"
-        className="size-11"
+        className="h-11 min-w-11 px-1.5"
         onClick={() => {
           dialog.trigger();
         }}
       >
-        <IfScoresVisible>
-          <OptionScoreDonut yesScore={yesScore} ifNeedBeScore={ifNeedBeScore} />
-        </IfScoresVisible>
+        <ConnectedScoreSummary optionId={optionId} />
       </Button>
       <Dialog {...dialog.dialogProps}>
         <DialogContent size="sm">

--- a/apps/web/src/features/poll/components/mobile-poll/poll-option.tsx
+++ b/apps/web/src/features/poll/components/mobile-poll/poll-option.tsx
@@ -166,7 +166,7 @@ const PollOption: React.FunctionComponent<PollOptionProps> = ({
   );
 
   return (
-    <div className="flex items-center gap-x-1" data-testid="poll-option">
+    <div className="flex items-center gap-x-2" data-testid="poll-option">
       <div className={cn(optionGrid, "h-11")}>{optionSummary}</div>
       {editable ? (
         <VoteSegmentedControl
@@ -184,7 +184,7 @@ const PollOption: React.FunctionComponent<PollOptionProps> = ({
           defaultValue: "Show participant votes",
         })}`}
         variant="ghost"
-        className="h-11 min-w-11 px-1.5"
+        className="w-14"
         onClick={() => {
           dialog.trigger();
         }}

--- a/apps/web/src/features/poll/components/mobile-poll/poll-option.tsx
+++ b/apps/web/src/features/poll/components/mobile-poll/poll-option.tsx
@@ -198,7 +198,7 @@ const PollOption: React.FunctionComponent<PollOptionProps> = ({
           className="col-start-4 justify-self-end"
           initial={{ opacity: 0, x: 12 }}
           animate={{ opacity: 1, x: 0 }}
-          transition={{ duration: 0.2, ease: "easeOut" }}
+          transition={{ duration: 0.3, ease: [0.4, 0, 0.2, 1] }}
         >
           <VoteSegmentedControl
             value={vote}

--- a/apps/web/src/features/poll/components/mobile-poll/poll-option.tsx
+++ b/apps/web/src/features/poll/components/mobile-poll/poll-option.tsx
@@ -10,6 +10,7 @@ import {
   DialogTitle,
   useDialog,
 } from "@rallly/ui/dialog";
+import * as m from "motion/react-m";
 import type * as React from "react";
 
 import { OptimizedAvatarImage } from "@/components/optimized-avatar-image";
@@ -193,12 +194,18 @@ const PollOption: React.FunctionComponent<PollOptionProps> = ({
         </Dialog>
       </IfScoresVisible>
       {editable ? (
-        <VoteSegmentedControl
-          value={vote}
-          onChange={onChange}
-          optionLabel={optionLabel}
+        <m.div
           className="col-start-4 justify-self-end"
-        />
+          initial={{ opacity: 0, x: 12 }}
+          animate={{ opacity: 1, x: 0 }}
+          transition={{ duration: 0.2, ease: "easeOut" }}
+        >
+          <VoteSegmentedControl
+            value={vote}
+            onChange={onChange}
+            optionLabel={optionLabel}
+          />
+        </m.div>
       ) : null}
     </div>
   );

--- a/apps/web/src/features/poll/components/mobile-poll/poll-option.tsx
+++ b/apps/web/src/features/poll/components/mobile-poll/poll-option.tsx
@@ -152,8 +152,8 @@ const PollOption: React.FunctionComponent<PollOptionProps> = ({
       className={cn(
         "grid h-14 items-center px-2 text-left transition-[grid-template-columns] duration-300",
         showVote
-          ? "grid-cols-[1.875rem_1fr_3rem_3rem_8.375rem]"
-          : "grid-cols-[0rem_1fr_3rem_3rem_8.375rem]",
+          ? "grid-cols-[1.875rem_1fr_3rem_3.5rem_8.375rem]"
+          : "grid-cols-[0rem_1fr_3rem_3.5rem_8.375rem]",
       )}
       data-testid="poll-option"
     >

--- a/apps/web/src/features/poll/components/mobile-poll/poll-option.tsx
+++ b/apps/web/src/features/poll/components/mobile-poll/poll-option.tsx
@@ -1,6 +1,6 @@
 "use client";
 import type { VoteType } from "@rallly/database";
-import { buttonVariants, cn } from "@rallly/ui";
+import { cn } from "@rallly/ui";
 import { Button } from "@rallly/ui/button";
 import {
   Dialog,
@@ -20,7 +20,7 @@ import {
 import { IfScoresVisible } from "@/features/poll/components/visibility";
 import { Trans, useTranslation } from "@/i18n/client";
 import VoteIcon from "../vote-icon";
-import { toggleVote } from "../vote-selector";
+import { VoteSegmentedControl } from "../vote-segmented-control";
 
 export interface PollOptionProps {
   children?: React.ReactNode;
@@ -191,22 +191,9 @@ const PollOption: React.FunctionComponent<PollOptionProps> = ({
   const { t } = useTranslation();
   const dialog = useDialog();
 
-  const voteLabel = (() => {
-    switch (vote) {
-      case "yes":
-        return t("yes", { defaultValue: "Yes" });
-      case "ifNeedBe":
-        return t("ifNeedBe", { defaultValue: "If need be" });
-      case "no":
-        return t("no", { defaultValue: "No" });
-      default:
-        return t("pending", { defaultValue: "Pending" });
-    }
-  })();
-
   const optionSummary = (
     <>
-      {editable || selectedParticipantId ? (
+      {!editable && selectedParticipantId ? (
         <VoteIcon type={vote} />
       ) : (
         <span aria-hidden="true" />
@@ -220,21 +207,14 @@ const PollOption: React.FunctionComponent<PollOptionProps> = ({
 
   return (
     <div className="flex items-center gap-x-1" data-testid="poll-option">
+      <div className={cn(optionGrid, "h-11")}>{optionSummary}</div>
       {editable ? (
-        <button
-          type="button"
-          data-testid="vote-selector"
-          aria-label={`${optionLabel}, ${voteLabel}`}
-          onClick={() => {
-            onChange(toggleVote(vote));
-          }}
-          className={cn(buttonVariants(), optionGrid, "h-11")}
-        >
-          {optionSummary}
-        </button>
-      ) : (
-        <div className={cn(optionGrid, "h-11")}>{optionSummary}</div>
-      )}
+        <VoteSegmentedControl
+          value={vote}
+          onChange={onChange}
+          optionLabel={optionLabel}
+        />
+      ) : null}
       <Button
         aria-label={`${t("optionVoteBreakdown", {
           defaultValue: "{yesScore} yes, {ifNeedBeScore} if need be",

--- a/apps/web/src/features/poll/components/mobile-poll/poll-option.tsx
+++ b/apps/web/src/features/poll/components/mobile-poll/poll-option.tsx
@@ -246,15 +246,15 @@ const PollOption: React.FunctionComponent<PollOptionProps> = ({
           {optionSummary}
         </button>
       ) : (
-        <div className={cn(optionGrid, "h-9")}>{optionSummary}</div>
+        <div className={cn(optionGrid, "h-11")}>{optionSummary}</div>
       )}
       <Button
         aria-label={t("showParticipantVotes", {
           defaultValue: "Show participant votes",
         })}
         variant="ghost"
-        size={editable ? "icon-lg" : "icon"}
-        className={editable ? "size-11" : undefined}
+        size="icon-lg"
+        className="size-11"
         onClick={() => {
           dialog.trigger();
         }}

--- a/apps/web/src/features/poll/components/mobile-poll/poll-option.tsx
+++ b/apps/web/src/features/poll/components/mobile-poll/poll-option.tsx
@@ -147,8 +147,16 @@ const PollOption: React.FunctionComponent<PollOptionProps> = ({
 
   const showVote = !editable && !!selectedParticipantId;
 
-  const optionSummary = (
-    <>
+  return (
+    <div
+      className={cn(
+        "grid h-14 items-center px-2 text-left transition-[grid-template-columns] duration-300",
+        showVote
+          ? "grid-cols-[1.875rem_4.5rem_3rem_auto_1fr]"
+          : "grid-cols-[0rem_4.5rem_3rem_auto_1fr]",
+      )}
+      data-testid="poll-option"
+    >
       <span
         aria-hidden={showVote ? undefined : true}
         className="overflow-hidden"
@@ -156,19 +164,6 @@ const PollOption: React.FunctionComponent<PollOptionProps> = ({
         {showVote ? <VoteIcon type={vote} /> : null}
       </span>
       {children}
-    </>
-  );
-
-  const optionGrid = cn(
-    "grid min-w-0 flex-1 items-center px-2 text-left transition-[grid-template-columns] duration-300",
-    showVote
-      ? "grid-cols-[1.875rem_4.5rem_1fr]"
-      : "grid-cols-[0rem_4.5rem_1fr]",
-  );
-
-  return (
-    <div className="flex items-center gap-x-2" data-testid="poll-option">
-      <div className={cn(optionGrid)}>{optionSummary}</div>
       <IfScoresVisible>
         <Button
           {...dialog.triggerProps}
@@ -180,6 +175,8 @@ const PollOption: React.FunctionComponent<PollOptionProps> = ({
             defaultValue: "Show participant votes",
           })}`}
           variant="ghost"
+          size="lg"
+          className="col-start-4 justify-self-start"
         >
           <ConnectedScoreSummary optionId={optionId} />
         </Button>
@@ -200,6 +197,7 @@ const PollOption: React.FunctionComponent<PollOptionProps> = ({
           value={vote}
           onChange={onChange}
           optionLabel={optionLabel}
+          className="col-start-5 justify-self-end"
         />
       ) : null}
     </div>

--- a/apps/web/src/features/poll/components/mobile-poll/poll-option.tsx
+++ b/apps/web/src/features/poll/components/mobile-poll/poll-option.tsx
@@ -1,11 +1,17 @@
 "use client";
 import type { VoteType } from "@rallly/database";
-import { cn } from "@rallly/ui";
+import { buttonVariants, cn } from "@rallly/ui";
 import { Button } from "@rallly/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  useDialog,
+} from "@rallly/ui/dialog";
 import { Icon } from "@rallly/ui/icon";
-import { ChevronDownIcon, ChevronUpIcon } from "lucide-react";
+import { UsersIcon } from "lucide-react";
 import type * as React from "react";
-import { useToggle } from "react-use";
 
 import { OptimizedAvatarImage } from "@/components/optimized-avatar-image";
 import {
@@ -16,7 +22,7 @@ import { useTranslation } from "@/i18n/client";
 
 import { ConnectedScoreSummary } from "../score-summary";
 import VoteIcon from "../vote-icon";
-import { VoteSelector } from "../vote-selector";
+import { toggleVote } from "../vote-selector";
 
 export interface PollOptionProps {
   children?: React.ReactNode;
@@ -135,51 +141,78 @@ const PollOption: React.FunctionComponent<PollOptionProps> = ({
   optionId,
   optionLabel,
 }) => {
-  const showVotes = !!(selectedParticipantId || editable);
-  const [isExpanded, toggle] = useToggle(false);
+  const { t } = useTranslation();
+  const dialog = useDialog();
+
+  const voteLabel = (() => {
+    switch (vote) {
+      case "yes":
+        return t("yes", { defaultValue: "Yes" });
+      case "ifNeedBe":
+        return t("ifNeedBe", { defaultValue: "If need be" });
+      case "no":
+        return t("no", { defaultValue: "No" });
+      default:
+        return t("pending", { defaultValue: "Pending" });
+    }
+  })();
+
+  const optionSummary = (
+    <>
+      {children}
+      <span className="flex items-center gap-x-2.5">
+        <ConnectedScoreSummary optionId={optionId} />
+        {editable || selectedParticipantId ? <VoteIcon type={vote} /> : null}
+      </span>
+    </>
+  );
+
   return (
     <div
-      className={cn(
-        "relative space-y-4 bg-background p-4 transition-colors",
-        editable && "active:bg-accent/50",
-      )}
+      className="flex items-center gap-x-2.5 bg-background p-3"
       data-testid="poll-option"
     >
-      <div className="flex h-7 items-center justify-between gap-x-4">
-        <div className="shrink-0">{children}</div>
-        <div className="flex items-center gap-x-4">
-          <Button
-            size="sm"
-            variant="ghost"
-            className="relative z-10"
-            onClick={() => toggle()}
-          >
-            <ConnectedScoreSummary optionId={optionId} />
-            <Icon>{isExpanded ? <ChevronUpIcon /> : <ChevronDownIcon />}</Icon>
-          </Button>
-
-          {showVotes ? (
-            <div className="flex size-7 items-center justify-center">
-              {editable ? (
-                <VoteSelector
-                  className="after:absolute after:inset-0"
-                  optionLabel={optionLabel}
-                  value={vote}
-                  onChange={onChange}
-                />
-              ) : (
-                <div
-                  key={vote}
-                  className="flex h-full items-center justify-center"
-                >
-                  <VoteIcon type={vote} />
-                </div>
-              )}
-            </div>
-          ) : null}
+      {editable ? (
+        <button
+          type="button"
+          data-testid="vote-selector"
+          aria-label={`${optionLabel}, ${voteLabel}`}
+          onClick={() => {
+            onChange(toggleVote(vote));
+          }}
+          className={cn(
+            buttonVariants(),
+            "h-12 min-w-0 flex-1 justify-between px-3",
+          )}
+        >
+          {optionSummary}
+        </button>
+      ) : (
+        <div className="flex h-12 min-w-0 flex-1 items-center justify-between px-3">
+          {optionSummary}
         </div>
-      </div>
-      {isExpanded ? <PollOptionVoteSummary optionId={optionId} /> : null}
+      )}
+      <Button
+        aria-label={t("showParticipantVotes", {
+          defaultValue: "Show participant votes",
+        })}
+        size="icon-lg"
+        onClick={() => {
+          dialog.trigger();
+        }}
+      >
+        <Icon>
+          <UsersIcon />
+        </Icon>
+      </Button>
+      <Dialog {...dialog.dialogProps}>
+        <DialogContent size="sm">
+          <DialogHeader>
+            <DialogTitle>{optionLabel}</DialogTitle>
+          </DialogHeader>
+          <PollOptionVoteSummary optionId={optionId} />
+        </DialogContent>
+      </Dialog>
     </div>
   );
 };

--- a/apps/web/src/features/poll/components/mobile-poll/poll-option.tsx
+++ b/apps/web/src/features/poll/components/mobile-poll/poll-option.tsx
@@ -139,16 +139,17 @@ const OptionScoreDonut = ({
 }) => {
   const { participants } = useParticipants();
   const total = participants.length;
-  const stroke = 4;
-  const radius = (20 - stroke) / 2;
+  const score = yesScore + ifNeedBeScore;
+  const stroke = 2.5;
+  const radius = (24 - stroke) / 2;
   const circumference = 2 * Math.PI * radius;
   const yesLength = total > 0 ? (yesScore / total) * circumference : 0;
   const ifNeedBeLength =
     total > 0 ? (ifNeedBeScore / total) * circumference : 0;
   const segment = (className: string, length: number, offset: number) => (
     <circle
-      cx="10"
-      cy="10"
+      cx="12"
+      cy="12"
       r={radius}
       fill="none"
       strokeWidth={stroke}
@@ -158,21 +159,30 @@ const OptionScoreDonut = ({
     />
   );
   return (
-    <svg
-      aria-hidden="true"
-      viewBox="0 0 20 20"
-      className="size-5 -rotate-90 opacity-100"
-    >
-      <circle
-        cx="10"
-        cy="10"
-        r={radius}
-        fill="none"
-        strokeWidth={stroke}
-        className="stroke-muted"
-      />
-      {segment("stroke-[#00C950]", yesLength, 0)}
-      {segment("stroke-[#FFB900]", ifNeedBeLength, yesLength)}
+    <svg aria-hidden="true" viewBox="0 0 24 24" className="size-6 opacity-100">
+      {/* Segments start at 12 o'clock; only the ring rotates so the score stays upright. */}
+      <g transform="rotate(-90 12 12)">
+        <circle
+          cx="12"
+          cy="12"
+          r={radius}
+          fill="none"
+          strokeWidth={stroke}
+          className="stroke-muted"
+        />
+        {segment("stroke-[#00C950]", yesLength, 0)}
+        {segment("stroke-[#FFB900]", ifNeedBeLength, yesLength)}
+      </g>
+      <text
+        x="12"
+        y="12.5"
+        textAnchor="middle"
+        dominantBaseline="central"
+        fontSize="9"
+        className="fill-foreground font-medium"
+      >
+        {score}
+      </text>
     </svg>
   );
 };

--- a/apps/web/src/features/poll/components/mobile-poll/poll-option.tsx
+++ b/apps/web/src/features/poll/components/mobile-poll/poll-option.tsx
@@ -151,9 +151,9 @@ const PollOption: React.FunctionComponent<PollOptionProps> = ({
     <div
       className={cn(
         "grid h-14 items-center px-2 text-left transition-[grid-template-columns] duration-300",
-        showVote
-          ? "grid-cols-[1.875rem_1fr_3rem_3.5rem_8.375rem]"
-          : "grid-cols-[0rem_1fr_3rem_3.5rem_8.375rem]",
+        editable && "grid-cols-[0rem_1fr_3rem_3.5rem_8.375rem]",
+        showVote && "grid-cols-[1.875rem_1fr_3rem_3.5rem_0rem]",
+        !editable && !showVote && "grid-cols-[0rem_1fr_3rem_3.5rem_0rem]",
       )}
       data-testid="poll-option"
     >

--- a/apps/web/src/features/poll/components/mobile-poll/poll-option.tsx
+++ b/apps/web/src/features/poll/components/mobile-poll/poll-option.tsx
@@ -160,11 +160,11 @@ const PollOption: React.FunctionComponent<PollOptionProps> = ({
 
   const optionSummary = (
     <>
-      {children}
-      <span className="flex items-center gap-x-2.5">
-        <ConnectedScoreSummary optionId={optionId} />
+      <span className="flex min-w-0 items-center gap-x-2.5">
         {editable || selectedParticipantId ? <VoteIcon type={vote} /> : null}
+        {children}
       </span>
+      <ConnectedScoreSummary optionId={optionId} />
     </>
   );
 

--- a/apps/web/src/features/poll/components/mobile-poll/poll-option.tsx
+++ b/apps/web/src/features/poll/components/mobile-poll/poll-option.tsx
@@ -10,8 +10,6 @@ import {
   DialogTitle,
   useDialog,
 } from "@rallly/ui/dialog";
-import { Icon } from "@rallly/ui/icon";
-import { InfoIcon } from "lucide-react";
 import type * as React from "react";
 
 import { OptimizedAvatarImage } from "@/components/optimized-avatar-image";
@@ -139,7 +137,6 @@ const OptionScoreDonut = ({
   yesScore: number;
   ifNeedBeScore: number;
 }) => {
-  const { t } = useTranslation();
   const { participants } = useParticipants();
   const total = participants.length;
   const stroke = 4;
@@ -162,14 +159,9 @@ const OptionScoreDonut = ({
   );
   return (
     <svg
-      role="img"
-      aria-label={t("optionVoteBreakdown", {
-        defaultValue: "{yesScore} yes, {ifNeedBeScore} if need be",
-        yesScore,
-        ifNeedBeScore,
-      })}
+      aria-hidden="true"
       viewBox="0 0 20 20"
-      className="size-5 -rotate-90"
+      className="size-5 -rotate-90 opacity-100"
     >
       <circle
         cx="10"
@@ -220,16 +212,11 @@ const PollOption: React.FunctionComponent<PollOptionProps> = ({
         <span aria-hidden="true" />
       )}
       {children}
-      <span className="col-start-4 justify-self-end">
-        <IfScoresVisible>
-          <OptionScoreDonut yesScore={yesScore} ifNeedBeScore={ifNeedBeScore} />
-        </IfScoresVisible>
-      </span>
     </>
   );
 
   const optionGrid =
-    "grid min-w-0 flex-1 grid-cols-[1.25rem_4.5rem_1fr_auto] items-center gap-x-2.5 px-3 text-left";
+    "grid min-w-0 flex-1 grid-cols-[1.25rem_4.5rem_1fr] items-center gap-x-2.5 px-3 text-left";
 
   return (
     <div className="flex items-center gap-x-1" data-testid="poll-option">
@@ -249,9 +236,13 @@ const PollOption: React.FunctionComponent<PollOptionProps> = ({
         <div className={cn(optionGrid, "h-11")}>{optionSummary}</div>
       )}
       <Button
-        aria-label={t("showParticipantVotes", {
+        aria-label={`${t("optionVoteBreakdown", {
+          defaultValue: "{yesScore} yes, {ifNeedBeScore} if need be",
+          yesScore,
+          ifNeedBeScore,
+        })}. ${t("showParticipantVotes", {
           defaultValue: "Show participant votes",
-        })}
+        })}`}
         variant="ghost"
         size="icon-lg"
         className="size-11"
@@ -259,9 +250,9 @@ const PollOption: React.FunctionComponent<PollOptionProps> = ({
           dialog.trigger();
         }}
       >
-        <Icon>
-          <InfoIcon />
-        </Icon>
+        <IfScoresVisible>
+          <OptionScoreDonut yesScore={yesScore} ifNeedBeScore={ifNeedBeScore} />
+        </IfScoresVisible>
       </Button>
       <Dialog {...dialog.dialogProps}>
         <DialogContent size="sm">

--- a/apps/web/src/features/poll/components/mobile-poll/poll-option.tsx
+++ b/apps/web/src/features/poll/components/mobile-poll/poll-option.tsx
@@ -160,13 +160,20 @@ const PollOption: React.FunctionComponent<PollOptionProps> = ({
 
   const optionSummary = (
     <>
-      <span className="flex min-w-0 items-center gap-x-2.5">
-        {editable || selectedParticipantId ? <VoteIcon type={vote} /> : null}
-        {children}
+      {editable || selectedParticipantId ? (
+        <VoteIcon type={vote} />
+      ) : (
+        <span aria-hidden="true" />
+      )}
+      {children}
+      <span className="col-start-4 justify-self-end">
+        <ConnectedScoreSummary optionId={optionId} />
       </span>
-      <ConnectedScoreSummary optionId={optionId} />
     </>
   );
+
+  const optionGrid =
+    "grid min-w-0 flex-1 grid-cols-[1.25rem_4.5rem_1fr_auto] items-center gap-x-2.5 px-3 text-left";
 
   return (
     <div className="flex items-center gap-x-1" data-testid="poll-option">
@@ -178,17 +185,12 @@ const PollOption: React.FunctionComponent<PollOptionProps> = ({
           onClick={() => {
             onChange(toggleVote(vote));
           }}
-          className={cn(
-            buttonVariants(),
-            "h-11 min-w-0 flex-1 justify-between px-3",
-          )}
+          className={cn(buttonVariants(), optionGrid, "h-11")}
         >
           {optionSummary}
         </button>
       ) : (
-        <div className="flex h-9 min-w-0 flex-1 items-center justify-between px-3">
-          {optionSummary}
-        </div>
+        <div className={cn(optionGrid, "h-9")}>{optionSummary}</div>
       )}
       <Button
         aria-label={t("showParticipantVotes", {

--- a/apps/web/src/features/poll/components/mobile-poll/poll-options.tsx
+++ b/apps/web/src/features/poll/components/mobile-poll/poll-options.tsx
@@ -30,66 +30,71 @@ const PollOptions: React.FunctionComponent<PollOptions> = ({
     : undefined;
 
   return (
-    <div className="space-y-1.5 px-2 py-2">
+    <div className="divide-y">
       {options.map((option) => {
         const score = getScore(option.optionId);
         const index = optionIds.indexOf(option.optionId);
         return (
-          <Controller
-            key={option.optionId}
-            control={control}
-            name="votes"
-            render={({ field }) => {
-              const vote =
-                !editable && selectedParticipant
-                  ? getVote(selectedParticipant.id, option.optionId)
-                  : field.value[index]?.type;
+          <div key={option.optionId} className="p-2">
+            <Controller
+              key={option.optionId}
+              control={control}
+              name="votes"
+              render={({ field }) => {
+                const vote =
+                  !editable && selectedParticipant
+                    ? getVote(selectedParticipant.id, option.optionId)
+                    : field.value[index]?.type;
 
-              const handleChange = (newVote: VoteType) => {
-                if (!editable) {
-                  return;
+                const handleChange = (newVote: VoteType) => {
+                  if (!editable) {
+                    return;
+                  }
+                  const newValue = [...field.value];
+                  newValue[index] = {
+                    optionId: option.optionId,
+                    type: newVote,
+                  };
+                  field.onChange(newValue);
+                };
+
+                switch (option.type) {
+                  case "timeSlot":
+                    return (
+                      <TimeSlotOption
+                        onChange={handleChange}
+                        optionId={option.optionId}
+                        optionLabel={getOptionDateTimeLabel(option)}
+                        yesScore={score.yes}
+                        ifNeedBeScore={score.ifNeedBe}
+                        vote={vote}
+                        startTime={option.startTime}
+                        endTime={option.endTime}
+                        duration={option.duration}
+                        editable={editable}
+                        selectedParticipantId={selectedParticipant?.id}
+                      />
+                    );
+                  case "date":
+                    return (
+                      <DateOption
+                        onChange={handleChange}
+                        optionId={option.optionId}
+                        optionLabel={getOptionDateTimeLabel(option)}
+                        yesScore={score.yes}
+                        ifNeedBeScore={score.ifNeedBe}
+                        vote={vote}
+                        dow={option.dow}
+                        day={option.day}
+                        month={option.month}
+                        editable={editable}
+                        selectedParticipantId={selectedParticipant?.id}
+                      />
+                    );
                 }
-                const newValue = [...field.value];
-                newValue[index] = { optionId: option.optionId, type: newVote };
-                field.onChange(newValue);
-              };
-
-              switch (option.type) {
-                case "timeSlot":
-                  return (
-                    <TimeSlotOption
-                      onChange={handleChange}
-                      optionId={option.optionId}
-                      optionLabel={getOptionDateTimeLabel(option)}
-                      yesScore={score.yes}
-                      ifNeedBeScore={score.ifNeedBe}
-                      vote={vote}
-                      startTime={option.startTime}
-                      endTime={option.endTime}
-                      duration={option.duration}
-                      editable={editable}
-                      selectedParticipantId={selectedParticipant?.id}
-                    />
-                  );
-                case "date":
-                  return (
-                    <DateOption
-                      onChange={handleChange}
-                      optionId={option.optionId}
-                      optionLabel={getOptionDateTimeLabel(option)}
-                      yesScore={score.yes}
-                      ifNeedBeScore={score.ifNeedBe}
-                      vote={vote}
-                      dow={option.dow}
-                      day={option.day}
-                      month={option.month}
-                      editable={editable}
-                      selectedParticipantId={selectedParticipant?.id}
-                    />
-                  );
-              }
-            }}
-          />
+              }}
+            />
+          </div>
         );
       })}
     </div>

--- a/apps/web/src/features/poll/components/mobile-poll/poll-options.tsx
+++ b/apps/web/src/features/poll/components/mobile-poll/poll-options.tsx
@@ -1,4 +1,5 @@
 import type { VoteType } from "@rallly/database";
+import { cn } from "@rallly/ui";
 import type * as React from "react";
 import { Controller } from "react-hook-form";
 import { useParticipants } from "@/features/poll/components/participants-provider";
@@ -30,7 +31,7 @@ const PollOptions: React.FunctionComponent<PollOptions> = ({
     : undefined;
 
   return (
-    <div>
+    <div className={cn("px-2 py-2", editable && "space-y-1.5")}>
       {options.map((option) => {
         const score = getScore(option.optionId);
         const index = optionIds.indexOf(option.optionId);

--- a/apps/web/src/features/poll/components/mobile-poll/poll-options.tsx
+++ b/apps/web/src/features/poll/components/mobile-poll/poll-options.tsx
@@ -30,7 +30,7 @@ const PollOptions: React.FunctionComponent<PollOptions> = ({
     : undefined;
 
   return (
-    <div className="divide-y">
+    <div>
       {options.map((option) => {
         const score = getScore(option.optionId);
         const index = optionIds.indexOf(option.optionId);

--- a/apps/web/src/features/poll/components/mobile-poll/poll-options.tsx
+++ b/apps/web/src/features/poll/components/mobile-poll/poll-options.tsx
@@ -1,5 +1,4 @@
 import type { VoteType } from "@rallly/database";
-import { cn } from "@rallly/ui";
 import type * as React from "react";
 import { Controller } from "react-hook-form";
 import { useParticipants } from "@/features/poll/components/participants-provider";
@@ -31,7 +30,7 @@ const PollOptions: React.FunctionComponent<PollOptions> = ({
     : undefined;
 
   return (
-    <div className={cn("px-2 py-2", editable && "space-y-1.5")}>
+    <div className="space-y-1.5 px-2 py-2">
       {options.map((option) => {
         const score = getScore(option.optionId);
         const index = optionIds.indexOf(option.optionId);

--- a/apps/web/src/features/poll/components/mobile-poll/time-slot-option.tsx
+++ b/apps/web/src/features/poll/components/mobile-poll/time-slot-option.tsx
@@ -1,4 +1,3 @@
-import { ClockIcon } from "lucide-react";
 import type * as React from "react";
 
 import type { PollOptionProps } from "./poll-option";
@@ -19,10 +18,7 @@ const TimeSlotOption: React.FunctionComponent<TimeSlotOptionProps> = ({
     <PollOption {...rest}>
       <div className="contents text-sm">
         <div>{startTime}</div>
-        <div className="flex items-center gap-x-1.5 text-muted-foreground">
-          <ClockIcon className="size-4" />
-          {duration}
-        </div>
+        <div className="text-muted-foreground">{duration}</div>
       </div>
     </PollOption>
   );

--- a/apps/web/src/features/poll/components/mobile-poll/time-slot-option.tsx
+++ b/apps/web/src/features/poll/components/mobile-poll/time-slot-option.tsx
@@ -17,7 +17,7 @@ const TimeSlotOption: React.FunctionComponent<TimeSlotOptionProps> = ({
 }) => {
   return (
     <PollOption {...rest}>
-      <div className="flex items-center gap-x-4 text-sm">
+      <div className="contents text-sm">
         <div>{startTime}</div>
         <div className="flex items-center gap-x-1.5 text-muted-foreground">
           <ClockIcon className="size-4" />

--- a/apps/web/src/features/poll/components/mobile-poll/time-slot-option.tsx
+++ b/apps/web/src/features/poll/components/mobile-poll/time-slot-option.tsx
@@ -18,7 +18,7 @@ const TimeSlotOption: React.FunctionComponent<TimeSlotOptionProps> = ({
     <PollOption {...rest}>
       <div className="contents text-sm">
         <div>{startTime}</div>
-        <div className="text-muted-foreground">{duration}</div>
+        <div className="justify-self-end text-muted-foreground">{duration}</div>
       </div>
     </PollOption>
   );

--- a/apps/web/src/features/poll/components/mobile-poll/time-slot-option.tsx
+++ b/apps/web/src/features/poll/components/mobile-poll/time-slot-option.tsx
@@ -9,18 +9,24 @@ export interface TimeSlotOptionProps extends PollOptionProps {
   duration: string;
 }
 
+const meridiem = (time: string) => /(AM|PM)$/.exec(time)?.[0];
+
 const TimeSlotOption: React.FunctionComponent<TimeSlotOptionProps> = ({
   startTime,
-  duration,
+  endTime,
   ...rest
 }) => {
+  // "12:00 – 1:00 PM" reads cleaner than repeating the period; keep it when
+  // the range crosses noon ("11:00 AM – 1:00 PM") or the locale has none.
+  const startLabel =
+    meridiem(startTime) && meridiem(startTime) === meridiem(endTime)
+      ? startTime.replace(/ (AM|PM)$/, "")
+      : startTime;
+
   return (
     <PollOption {...rest}>
-      <div className="contents text-sm">
-        <div>{startTime}</div>
-        <div className="mr-1 justify-self-end text-muted-foreground">
-          {duration}
-        </div>
+      <div className="text-sm">
+        {startLabel} – {endTime}
       </div>
     </PollOption>
   );

--- a/apps/web/src/features/poll/components/mobile-poll/time-slot-option.tsx
+++ b/apps/web/src/features/poll/components/mobile-poll/time-slot-option.tsx
@@ -18,7 +18,7 @@ const TimeSlotOption: React.FunctionComponent<TimeSlotOptionProps> = ({
     <PollOption {...rest}>
       <div className="contents text-sm">
         <div>{startTime}</div>
-        <div className="justify-self-end text-muted-foreground">{duration}</div>
+        <div className="text-muted-foreground">{duration}</div>
       </div>
     </PollOption>
   );

--- a/apps/web/src/features/poll/components/mobile-poll/time-slot-option.tsx
+++ b/apps/web/src/features/poll/components/mobile-poll/time-slot-option.tsx
@@ -18,7 +18,9 @@ const TimeSlotOption: React.FunctionComponent<TimeSlotOptionProps> = ({
     <PollOption {...rest}>
       <div className="contents text-sm">
         <div>{startTime}</div>
-        <div className="justify-self-end text-muted-foreground">{duration}</div>
+        <div className="mr-1 justify-self-end text-muted-foreground">
+          {duration}
+        </div>
       </div>
     </PollOption>
   );

--- a/apps/web/src/features/poll/components/vote-segmented-control.tsx
+++ b/apps/web/src/features/poll/components/vote-segmented-control.tsx
@@ -50,7 +50,7 @@ export const VoteSegmentedControl = ({
           key={type}
           value={type}
           aria-label={voteLabels[type]}
-          className="data-unchecked:opacity-60 data-unchecked:grayscale"
+          className="data-unchecked:[&_path]:fill-gray-400"
         >
           <VoteIcon type={type} />
         </SegmentedControlItem>

--- a/apps/web/src/features/poll/components/vote-segmented-control.tsx
+++ b/apps/web/src/features/poll/components/vote-segmented-control.tsx
@@ -1,4 +1,5 @@
 "use client";
+import { cn } from "@rallly/ui";
 import {
   SegmentedControl,
   SegmentedControlItem,
@@ -16,9 +17,11 @@ export const VoteSegmentedControl = ({
   value,
   onChange,
   optionLabel,
+  className,
 }: {
   value?: VoteType;
   onChange: (value: VoteType) => void;
+  className?: string;
   /**
    * Accessible description of the option being voted on (e.g. "Tue 30 Jun
    * 2026, 1:00 PM – 2:00 PM") so screen readers can tie the vote to its
@@ -38,7 +41,7 @@ export const VoteSegmentedControl = ({
     <SegmentedControl
       data-testid="vote-selector"
       aria-label={optionLabel}
-      className="h-11"
+      className={cn("h-11", className)}
       value={value ?? null}
       onValueChange={(newValue) => {
         if (newValue) {

--- a/apps/web/src/features/poll/components/vote-segmented-control.tsx
+++ b/apps/web/src/features/poll/components/vote-segmented-control.tsx
@@ -50,7 +50,7 @@ export const VoteSegmentedControl = ({
           key={type}
           value={type}
           aria-label={voteLabels[type]}
-          className="data-unchecked:[&_path]:fill-gray-400"
+          className="w-8 data-unchecked:[&_path]:fill-gray-400"
         >
           <VoteIcon type={type} />
         </SegmentedControlItem>

--- a/apps/web/src/features/poll/components/vote-segmented-control.tsx
+++ b/apps/web/src/features/poll/components/vote-segmented-control.tsx
@@ -38,6 +38,7 @@ export const VoteSegmentedControl = ({
     <SegmentedControl
       data-testid="vote-selector"
       aria-label={optionLabel}
+      className="h-11"
       value={value ?? null}
       onValueChange={(newValue) => {
         if (newValue) {
@@ -50,7 +51,7 @@ export const VoteSegmentedControl = ({
           key={type}
           value={type}
           aria-label={voteLabels[type]}
-          className="w-8 data-unchecked:[&_path]:fill-gray-400"
+          className="w-11 data-unchecked:[&_path]:fill-gray-400"
         >
           <VoteIcon type={type} />
         </SegmentedControlItem>

--- a/apps/web/src/features/poll/components/vote-segmented-control.tsx
+++ b/apps/web/src/features/poll/components/vote-segmented-control.tsx
@@ -1,0 +1,60 @@
+"use client";
+import {
+  SegmentedControl,
+  SegmentedControlItem,
+} from "@rallly/ui/segmented-control";
+
+import { useTranslation } from "@/i18n/client";
+
+import VoteIcon from "./vote-icon";
+
+type VoteType = "yes" | "ifNeedBe" | "no";
+
+const voteTypes: VoteType[] = ["yes", "ifNeedBe", "no"];
+
+export const VoteSegmentedControl = ({
+  value,
+  onChange,
+  optionLabel,
+}: {
+  value?: VoteType;
+  onChange: (value: VoteType) => void;
+  /**
+   * Accessible description of the option being voted on (e.g. "Tue 30 Jun
+   * 2026, 1:00 PM – 2:00 PM") so screen readers can tie the vote to its
+   * date/time.
+   */
+  optionLabel?: string;
+}) => {
+  const { t } = useTranslation();
+
+  const voteLabels: Record<VoteType, string> = {
+    yes: t("yes", { defaultValue: "Yes" }),
+    ifNeedBe: t("ifNeedBe", { defaultValue: "If need be" }),
+    no: t("no", { defaultValue: "No" }),
+  };
+
+  return (
+    <SegmentedControl
+      data-testid="vote-selector"
+      aria-label={optionLabel}
+      value={value ?? null}
+      onValueChange={(newValue) => {
+        if (newValue) {
+          onChange(newValue as VoteType);
+        }
+      }}
+    >
+      {voteTypes.map((type) => (
+        <SegmentedControlItem
+          key={type}
+          value={type}
+          aria-label={voteLabels[type]}
+          className="data-unchecked:opacity-60"
+        >
+          <VoteIcon type={type} />
+        </SegmentedControlItem>
+      ))}
+    </SegmentedControl>
+  );
+};

--- a/apps/web/src/features/poll/components/vote-segmented-control.tsx
+++ b/apps/web/src/features/poll/components/vote-segmented-control.tsx
@@ -50,7 +50,7 @@ export const VoteSegmentedControl = ({
           key={type}
           value={type}
           aria-label={voteLabels[type]}
-          className="data-unchecked:opacity-60"
+          className="data-unchecked:opacity-60 data-unchecked:grayscale"
         >
           <VoteIcon type={type} />
         </SegmentedControlItem>

--- a/apps/web/src/features/poll/components/voting-footer.tsx
+++ b/apps/web/src/features/poll/components/voting-footer.tsx
@@ -75,7 +75,7 @@ export const VotingFooter = ({ className }: { className?: string }) => {
         type="submit"
         size="lg"
         variant="primary"
-        className="flex-2 backdrop-blur-lg aria-disabled:opacity-50 md:flex-none"
+        className="flex-2 bg-primary/80 backdrop-blur-lg aria-disabled:opacity-50 md:flex-none"
         aria-disabled={isBlocked}
         loading={votingForm.formState.isSubmitting}
         onClick={(event) => {

--- a/apps/web/src/features/poll/components/voting-footer.tsx
+++ b/apps/web/src/features/poll/components/voting-footer.tsx
@@ -57,6 +57,7 @@ export const VotingFooter = ({ className }: { className?: string }) => {
       </p>
       <Button
         type="button"
+        size="lg"
         className="flex-1 md:flex-none"
         disabled={votingForm.formState.isSubmitting}
         onClick={() => {
@@ -72,8 +73,9 @@ export const VotingFooter = ({ className }: { className?: string }) => {
       <Button
         form="voting-form"
         type="submit"
+        size="lg"
         variant="primary"
-        className="flex-2 aria-disabled:opacity-50 md:flex-none"
+        className="flex-2 backdrop-blur-lg aria-disabled:opacity-50 md:flex-none"
         aria-disabled={isBlocked}
         loading={votingForm.formState.isSubmitting}
         onClick={(event) => {

--- a/apps/web/src/features/poll/components/voting-footer.tsx
+++ b/apps/web/src/features/poll/components/voting-footer.tsx
@@ -73,7 +73,7 @@ export const VotingFooter = ({ className }: { className?: string }) => {
         form="voting-form"
         type="submit"
         variant="primary"
-        className="flex-[2] aria-disabled:opacity-50 md:flex-none"
+        className="flex-2 aria-disabled:opacity-50 md:flex-none"
         aria-disabled={isBlocked}
         loading={votingForm.formState.isSubmitting}
         onClick={(event) => {

--- a/apps/web/tests/mobile-test.spec.ts
+++ b/apps/web/tests/mobile-test.spec.ts
@@ -16,7 +16,11 @@ test.describe(() => {
   });
 
   const voteAsNewParticipant = async (page: Page, name: string) => {
-    await page.getByTestId("poll-option").first().click();
+    await page
+      .getByTestId("vote-selector")
+      .first()
+      .getByRole("radio", { name: "Yes" })
+      .click();
     await page.getByRole("button", { name: "Continue" }).click();
     await page.getByPlaceholder("Jessie Smith").fill(name);
     await page.getByRole("button", { name: "Save availability" }).click();

--- a/packages/ui/src/alert.tsx
+++ b/packages/ui/src/alert.tsx
@@ -5,12 +5,12 @@ import type * as React from "react";
 import { cn } from "./lib/utils";
 
 const alertVariants = cva(
-  "group/alert relative grid w-full items-center gap-0.5 rounded-lg border px-2.5 py-2 text-left text-sm has-[>svg]:has-data-[slot=alert-action]:grid-cols-[auto_1fr_auto] has-[>svg]:grid-cols-[auto_1fr] has-data-[slot=alert-action]:grid-cols-[1fr_auto] has-data-[slot=alert-title]:items-start has-[>svg]:gap-x-2 has-data-[slot=alert-action]:gap-x-2 *:[svg:not([class*='size-'])]:size-4 *:[svg]:text-current has-data-[slot=alert-title]:*:[svg]:row-span-2 has-data-[slot=alert-title]:*:[svg]:translate-y-0.5",
+  "group/alert relative grid w-full items-center gap-0.5 rounded-xl border p-2 text-left text-sm has-[>svg]:has-data-[slot=alert-action]:grid-cols-[auto_1fr_auto] has-[>svg]:grid-cols-[auto_1fr] has-data-[slot=alert-action]:grid-cols-[1fr_auto] has-data-[slot=alert-title]:items-start has-[>svg]:gap-x-2 has-data-[slot=alert-action]:gap-x-2 *:[svg:not([class*='size-'])]:size-4 *:[svg]:text-current has-data-[slot=alert-title]:*:[svg]:row-span-2 has-data-[slot=alert-title]:*:[svg]:translate-y-0.5",
   {
     variants: {
       variant: {
         primary:
-          "border-indigo-500/20 bg-indigo-500/10 text-indigo-900 *:data-[slot=alert-description]:text-indigo-900/90 dark:text-indigo-100 dark:*:data-[slot=alert-description]:text-indigo-100/90 [&>svg]:text-indigo-900/75 dark:[&>svg]:text-indigo-100/75",
+          "border-indigo-500/20 bg-indigo-500/10 text-indigo-900 backdrop-blur-lg *:data-[slot=alert-description]:text-indigo-900/90 dark:text-indigo-100 dark:*:data-[slot=alert-description]:text-indigo-100/90 [&>svg]:text-indigo-900/75 dark:[&>svg]:text-indigo-100/75",
         info: "border-blue-500/20 bg-blue-500/10 text-blue-900 *:data-[slot=alert-description]:text-blue-900/90 dark:text-blue-100 dark:*:data-[slot=alert-description]:text-blue-100/90 [&>svg]:text-blue-900/75 dark:[&>svg]:text-blue-100/75",
         warning:
           "border-yellow-500/20 bg-yellow-500/10 text-yellow-900 *:data-[slot=alert-description]:text-yellow-900/90 dark:text-yellow-100 dark:*:data-[slot=alert-description]:text-yellow-100/90 [&>svg]:text-yellow-900/75 dark:[&>svg]:text-yellow-100/75",

--- a/packages/ui/src/segmented-control.tsx
+++ b/packages/ui/src/segmented-control.tsx
@@ -26,7 +26,7 @@ function SegmentedControlItem({
     <RadioPrimitive.Root
       data-slot="segmented-control-item"
       className={cn(
-        "inline-flex h-full cursor-pointer items-center justify-center rounded-lg ring-offset-background transition-colors focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 data-checked:bg-white data-checked:ring-1 data-checked:ring-gray-200 dark:data-checked:bg-gray-800 dark:data-checked:ring-gray-700",
+        "relative inline-flex h-full cursor-pointer touch-manipulation items-center justify-center rounded-lg ring-offset-background [-webkit-tap-highlight-color:transparent] before:absolute before:inset-x-0 before:-inset-y-1 focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 data-checked:bg-white data-checked:ring-1 data-checked:ring-gray-200 data-unchecked:active:bg-black/5 dark:data-checked:bg-gray-800 dark:data-checked:ring-gray-700 dark:data-unchecked:active:bg-white/5",
         className,
       )}
       {...props}

--- a/packages/ui/src/segmented-control.tsx
+++ b/packages/ui/src/segmented-control.tsx
@@ -10,7 +10,7 @@ function SegmentedControl({ className, ...props }: RadioGroupPrimitive.Props) {
     <RadioGroupPrimitive
       data-slot="segmented-control"
       className={cn(
-        "inline-flex h-8 shrink-0 items-center justify-center rounded-lg border border-input bg-muted dark:bg-gray-900",
+        "inline-flex h-8 shrink-0 items-center justify-center rounded-xl border border-input bg-muted dark:bg-gray-900",
         className,
       )}
       {...props}
@@ -26,7 +26,7 @@ function SegmentedControlItem({
     <RadioPrimitive.Root
       data-slot="segmented-control-item"
       className={cn(
-        "relative inline-flex h-full cursor-pointer touch-manipulation items-center justify-center rounded-lg ring-offset-background [-webkit-tap-highlight-color:transparent] before:absolute before:inset-x-0 before:-inset-y-1 focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 data-checked:bg-white data-checked:ring-1 data-checked:ring-gray-200 data-unchecked:active:bg-black/5 dark:data-checked:bg-gray-800 dark:data-checked:ring-gray-700 dark:data-unchecked:active:bg-white/5",
+        "relative inline-flex h-full cursor-pointer touch-manipulation items-center justify-center rounded-xl ring-offset-background [-webkit-tap-highlight-color:transparent] before:absolute before:inset-x-0 before:-inset-y-1 focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 data-checked:bg-white data-checked:ring-1 data-checked:ring-gray-200 data-unchecked:active:bg-black/5 dark:data-checked:bg-gray-800 dark:data-checked:ring-gray-700 dark:data-unchecked:active:bg-white/5",
         className,
       )}
       {...props}

--- a/packages/ui/src/segmented-control.tsx
+++ b/packages/ui/src/segmented-control.tsx
@@ -10,7 +10,7 @@ function SegmentedControl({ className, ...props }: RadioGroupPrimitive.Props) {
     <RadioGroupPrimitive
       data-slot="segmented-control"
       className={cn(
-        "inline-flex shrink-0 items-center gap-0.5 rounded-lg bg-muted p-0.5",
+        "inline-flex h-8 shrink-0 items-center justify-center rounded-lg border border-input bg-muted dark:bg-gray-900",
         className,
       )}
       {...props}
@@ -26,7 +26,7 @@ function SegmentedControlItem({
     <RadioPrimitive.Root
       data-slot="segmented-control-item"
       className={cn(
-        "inline-flex size-8 cursor-pointer items-center justify-center rounded-md ring-ring transition-colors focus-visible:ring-2 data-checked:bg-card",
+        "inline-flex h-full cursor-pointer items-center justify-center rounded-lg ring-offset-background transition-colors focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 data-checked:bg-white data-checked:ring-1 data-checked:ring-gray-200 dark:data-checked:bg-gray-800 dark:data-checked:ring-gray-700",
         className,
       )}
       {...props}

--- a/packages/ui/src/segmented-control.tsx
+++ b/packages/ui/src/segmented-control.tsx
@@ -1,0 +1,37 @@
+"use client";
+
+import { Radio as RadioPrimitive } from "@base-ui/react/radio";
+import { RadioGroup as RadioGroupPrimitive } from "@base-ui/react/radio-group";
+
+import { cn } from "./lib/utils";
+
+function SegmentedControl({ className, ...props }: RadioGroupPrimitive.Props) {
+  return (
+    <RadioGroupPrimitive
+      data-slot="segmented-control"
+      className={cn(
+        "inline-flex shrink-0 items-center gap-0.5 rounded-lg bg-muted p-0.5",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function SegmentedControlItem({
+  className,
+  ...props
+}: RadioPrimitive.Root.Props) {
+  return (
+    <RadioPrimitive.Root
+      data-slot="segmented-control-item"
+      className={cn(
+        "inline-flex size-9 cursor-pointer items-center justify-center rounded-md ring-ring transition-colors focus-visible:ring-2 data-checked:bg-background data-checked:shadow-sm",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+export { SegmentedControl, SegmentedControlItem };

--- a/packages/ui/src/segmented-control.tsx
+++ b/packages/ui/src/segmented-control.tsx
@@ -26,7 +26,7 @@ function SegmentedControlItem({
     <RadioPrimitive.Root
       data-slot="segmented-control-item"
       className={cn(
-        "inline-flex size-9 cursor-pointer items-center justify-center rounded-md ring-ring transition-colors focus-visible:ring-2 data-checked:bg-background data-checked:shadow-sm",
+        "inline-flex size-8 cursor-pointer items-center justify-center rounded-md ring-ring transition-colors focus-visible:ring-2 data-checked:bg-card",
         className,
       )}
       {...props}


### PR DESCRIPTION
Rebuilds the mobile poll voting experience around explicit, visible, touch friendly controls.

## Option rows

- Each row is a fixed-column grid — **time range · vote count · segmented control** — so values align vertically in every row. Options display as "12:00 – 1:00 PM" (start period dropped when shared); the duration column is gone, with uniform-duration handling tracked separately in RAL-1507.
- The vote count doubles as the trigger for a per-option participants dialog (replacing the inline expanding summary) and sits behind the hidden-scores gate along with the dialog. Dismissing the dialog restores focus to its trigger.
- In view mode the control column collapses so count sits at the row's right edge; entering edit mode animates the count left in lockstep with the control fading in from the right (same 300ms curve). A participant's vote icon column animates open on the left when viewing their response.
- Date group headers are sticky frosted cards that float at the viewport top while their day is in view.

## Three state vote control

- New `SegmentedControl` primitive (Base UI radio group: real radiogroup semantics, `aria-checked`, arrow keys) styled with the `TabsList`/`TabsTrigger` recipe so it matches the app's tab bars, including dark mode.
- Apple HIG touch compliance: 44pt segments with an invisible overlay extending the tappable area, `touch-action: manipulation` (no tap delay), no iOS tap highlight, instant state flip, pressed tint on touch-down.
- Glyph vote icons with a uniform gray for unchecked segments; only the selection is coloured.

## Footer

- The Decline/Continue buttons float at the viewport bottom (sticky, chromeless) while the option list runs long, settling into the card at the end.

## Verification

Verified against the dev server across the whole flow: radiogroup semantics and keyboard selection, hit target measurement (44×50 effective), zero mode-switch layout shift, column alignment measurements across rows and modes, hidden-scores gating, dialog focus restoration, sticky footer float/settle, and integration with the merged voting footer (#2893). `mobile-test.spec.ts` updated to vote via the segmented control. Type check, Biome, unit tests pass; rebased on latest main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)