### PR TITLE
💄 Mobile poll style tweaks

### DIFF
--- a/apps/web/src/features/poll/components/mobile-poll.tsx
+++ b/apps/web/src/features/poll/components/mobile-poll.tsx
@@ -237,7 +237,7 @@ const MobilePoll: React.FunctionComponent = () => {
               transition: { duration: 0.2 },
             }}
           >
-            <VotingFooter className="p-3" />
+            <VotingFooter className="px-3 pb-3" />
           </m.div>
         ) : null}
       </AnimatePresence>

--- a/apps/web/src/features/poll/components/mobile-poll/grouped-options.tsx
+++ b/apps/web/src/features/poll/components/mobile-poll/grouped-options.tsx
@@ -27,10 +27,13 @@ const GroupedOptions: React.FunctionComponent<GroupedOptionsProps> = ({
       {Object.entries(grouped).map(([day, options]) => {
         return (
           <div key={day}>
-            <div className={cn("sticky top-0 z-10 p-1", groupClassName)}>
-              <div className="rounded-lg border bg-card/80 p-2 font-semibold text-sm shadow-sm backdrop-blur-lg">
-                {day}
-              </div>
+            <div
+              className={cn(
+                "border-b bg-card/80 px-4 py-3 font-semibold text-sm",
+                groupClassName,
+              )}
+            >
+              {day}
             </div>
             <PollOptions
               options={options}


### PR DESCRIPTION
Follow-up styling on the mobile poll redesign (#2903):

- Date group headers become flat bordered rows instead of sticky frosted cards (drops the sticky float)
- The floating footer keeps only horizontal and bottom padding

The comments button relocation was split into its own PR: #2908.

🤖 Generated with [Claude Code](https://claude.com/claude-code)