### PR TITLE
💄 Float the comments pill above the voting footer on mobile

### DIFF
--- a/apps/web/src/app/[locale]/(optional-space)/poll/[urlId]/admin-page.tsx
+++ b/apps/web/src/app/[locale]/(optional-space)/poll/[urlId]/admin-page.tsx
@@ -14,11 +14,11 @@ export function AdminPage() {
       <VotingForm>
         <ResponsiveResults />
       </VotingForm>
-      <div className="fixed right-4 bottom-4 z-40 lg:right-6 lg:bottom-6">
+      <div className="fixed right-4 bottom-15 z-40 lg:right-6 lg:bottom-6">
         <CommentsSheet className="rounded-full shadow-lg" />
       </div>
       <PollFooter />
-      <div className="h-12 lg:hidden" />
+      <div className="h-24 lg:hidden" />
     </div>
   );
 }

--- a/apps/web/src/app/[locale]/invite/[urlId]/invite-page.tsx
+++ b/apps/web/src/app/[locale]/invite/[urlId]/invite-page.tsx
@@ -59,10 +59,10 @@ export function InvitePage() {
           <ResponsiveResults />
         </VotingForm>
         <PollFooter />
-        <div className="fixed right-4 bottom-4 z-40 lg:right-6 lg:bottom-6">
+        <div className="fixed right-4 bottom-15 z-40 lg:right-6 lg:bottom-6">
           <CommentsSheet className="rounded-full shadow-lg" />
         </div>
-        <div className="h-12 lg:hidden" />
+        <div className="h-24 lg:hidden" />
       </main>
     </div>
   );


### PR DESCRIPTION
The floating comments pill overlapped the sticky Decline/Continue footer introduced in #2903. On mobile the pill now floats with a gap-2 sized space above the Continue button (verified at exactly 8px); desktop keeps the existing bottom corner placement. The mobile scroll-clearance spacer grows to match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Adjusted the floating comments control position for improved mobile visibility.
  * Increased bottom spacing on mobile pages to prevent content from being obscured by the comments control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->