### PR TITLE
💄 Move edit votes out of participant dropdown into an icon button

### DIFF
--- a/apps/web/src/features/poll/components/desktop-poll/participant-row.tsx
+++ b/apps/web/src/features/poll/components/desktop-poll/participant-row.tsx
@@ -77,7 +77,7 @@ export const ParticipantRowView: React.FunctionComponent<{
             />
             <ParticipantName>{name}</ParticipantName>
           </Participant>
-          <div className="flex items-center gap-x-2">
+          <div className="flex items-center gap-x-1">
             {isYou ? (
               <Badge variant="secondary" className="shrink-0">
                 <Trans i18nKey="you" defaults="You" />

--- a/apps/web/src/features/poll/components/desktop-poll/participant-row.tsx
+++ b/apps/web/src/features/poll/components/desktop-poll/participant-row.tsx
@@ -4,7 +4,7 @@ import type { VoteType } from "@rallly/database";
 import { cn } from "@rallly/ui";
 import { Badge } from "@rallly/ui/badge";
 import { Button } from "@rallly/ui/button";
-import { MoreHorizontalIcon } from "lucide-react";
+import { MoreHorizontalIcon, PencilIcon } from "lucide-react";
 import type * as React from "react";
 
 import { OptimizedAvatarImage } from "@/components/optimized-avatar-image";
@@ -155,19 +155,25 @@ const ParticipantRow: React.FunctionComponent<ParticipantRowProps> = ({
       }
       action={
         canEdit ? (
-          <ParticipantDropdown
-            participant={participant}
-            align="start"
-            onEdit={() => onChangeEditMode?.(true)}
-          >
+          <>
             <Button
-              aria-label={t("moreOptions", { defaultValue: "More options" })}
+              aria-label={t("editVotes", { defaultValue: "Edit votes" })}
               size="icon-xs"
               variant="ghost"
+              onClick={() => onChangeEditMode?.(true)}
             >
-              <MoreHorizontalIcon />
+              <PencilIcon />
             </Button>
-          </ParticipantDropdown>
+            <ParticipantDropdown participant={participant} align="start">
+              <Button
+                aria-label={t("moreOptions", { defaultValue: "More options" })}
+                size="icon-xs"
+                variant="ghost"
+              >
+                <MoreHorizontalIcon />
+              </Button>
+            </ParticipantDropdown>
+          </>
         ) : null
       }
       isYou={isYou}

--- a/apps/web/src/features/poll/components/mobile-poll.tsx
+++ b/apps/web/src/features/poll/components/mobile-poll.tsx
@@ -109,7 +109,7 @@ const MobilePoll: React.FunctionComponent = () => {
   return (
     <Card className="overflow-visible">
       <div className="flex flex-col space-y-2 border-b p-2">
-        <div className="flex gap-x-1">
+        <div className="flex gap-x-2">
           {selectedParticipantId || !isEditing ? (
             <Select
               items={participantOptions}

--- a/apps/web/src/features/poll/components/mobile-poll.tsx
+++ b/apps/web/src/features/poll/components/mobile-poll.tsx
@@ -109,7 +109,7 @@ const MobilePoll: React.FunctionComponent = () => {
   return (
     <Card className="overflow-visible">
       <div className="flex flex-col space-y-2 border-b p-2">
-        <div className="flex gap-x-2">
+        <div className="flex gap-x-1">
           {selectedParticipantId || !isEditing ? (
             <Select
               items={participantOptions}

--- a/apps/web/src/features/poll/components/mobile-poll.tsx
+++ b/apps/web/src/features/poll/components/mobile-poll.tsx
@@ -9,7 +9,12 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@rallly/ui/select";
-import { MoreHorizontalIcon, PlusIcon, UsersIcon } from "lucide-react";
+import {
+  MoreHorizontalIcon,
+  PencilIcon,
+  PlusIcon,
+  UsersIcon,
+} from "lucide-react";
 import { AnimatePresence } from "motion/react";
 import * as m from "motion/react-m";
 import type * as React from "react";
@@ -162,6 +167,17 @@ const MobilePoll: React.FunctionComponent = () => {
                   size="icon"
                 />
               ) : null}
+              <Button
+                aria-label={t("editVotes", { defaultValue: "Edit votes" })}
+                variant="ghost"
+                size="icon"
+                disabled={!canEditParticipant(selectedParticipant.id)}
+                onClick={() => {
+                  votingForm.setEditingParticipantId(selectedParticipant.id);
+                }}
+              >
+                <PencilIcon />
+              </Button>
               <ParticipantDropdown
                 align="end"
                 disabled={!canEditParticipant(selectedParticipant.id)}
@@ -170,9 +186,6 @@ const MobilePoll: React.FunctionComponent = () => {
                   userId: selectedParticipant.userId ?? undefined,
                   email: selectedParticipant.email ?? undefined,
                   id: selectedParticipant.id,
-                }}
-                onEdit={() => {
-                  votingForm.setEditingParticipantId(selectedParticipant.id);
                 }}
                 onDelete={() => {
                   votingForm.setValue("participantId", "all");

--- a/apps/web/src/features/poll/components/participant-dropdown.tsx
+++ b/apps/web/src/features/poll/components/participant-dropdown.tsx
@@ -26,7 +26,7 @@ import {
   FormMessage,
 } from "@rallly/ui/form";
 import { Input } from "@rallly/ui/input";
-import { PencilIcon, TagIcon, TrashIcon } from "lucide-react";
+import { TagIcon, TrashIcon } from "lucide-react";
 import React from "react";
 import type { SubmitHandler } from "react-hook-form";
 import { useForm } from "react-hook-form";
@@ -43,7 +43,6 @@ import { trpc } from "@/trpc/client";
 
 export const ParticipantDropdown = ({
   participant,
-  onEdit,
   onDelete,
   children,
   disabled,
@@ -57,7 +56,6 @@ export const ParticipantDropdown = ({
     id: string;
   };
   align?: "start" | "end";
-  onEdit: () => void;
   onDelete?: () => void;
   children: React.ReactElement;
 }) => {
@@ -88,10 +86,6 @@ export const ParticipantDropdown = ({
             </div>
           </DropdownMenuLabel>
           <DropdownMenuSeparator />
-          <DropdownMenuItem onClick={onEdit}>
-            <PencilIcon />
-            <Trans i18nKey="editVotes" defaults="Edit votes" />
-          </DropdownMenuItem>
           <DropdownMenuItem onClick={() => setIsChangeNameModalVisible(true)}>
             <TagIcon />
             <Trans i18nKey="changeName" defaults="Change name" />


### PR DESCRIPTION
## Summary
- The participant dropdown menu now contains only **Change name** and **Delete**
- **Edit votes** is a standalone pencil icon button rendered to the left of the dropdown trigger, in both the desktop participant row and the mobile poll header
- On mobile, the edit button is disabled under the same `canEditParticipant` condition as the dropdown; on desktop both are gated behind `canEdit` as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a dedicated edit-votes button for participants on desktop and mobile.
  * The edit button is disabled when editing is unavailable.
* **UI Improvements**
  * Streamlined participant actions by separating vote editing from the options menu.
  * Reduced spacing between participant action controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->