### PR TITLE
🐛 Fix hydration error on the control panel home page

### DIFF
--- a/packages/ui/src/tile.tsx
+++ b/packages/ui/src/tile.tsx
@@ -38,10 +38,10 @@ const TileTitle = React.forwardRef<
 TileTitle.displayName = "TileTitle";
 
 const TileDescription = React.forwardRef<
-  HTMLParagraphElement,
-  React.HTMLAttributes<HTMLParagraphElement>
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
 >(({ className, ...props }, ref) => (
-  <p
+  <div
     ref={ref}
     className={cn(
       "pointer-events-none absolute top-3 right-3 text-muted-foreground text-sm",


### PR DESCRIPTION
## Description

Fixes a React hydration error on `/control-panel`: `In HTML, <div> cannot be a descendant of <p>`, followed by a full hydration failure.

The version tile renders a `Suspense` boundary inside `TileDescription`, whose fallback is a `Skeleton` (a `div`). `TileDescription` rendered a `p`, and a `div` is invalid inside `p`. The error was intermittent because it only fires when the update check is slow enough for the fallback to still be in the SSR stream at hydration time — with a warm GitHub response the `span` content replaces the fallback before hydration and nothing is logged.

Fix: `TileDescription` renders a `div` instead of a `p` (ref types updated to match). It's an absolutely positioned badge, not prose, so no semantics are lost. All other usages pass plain text and are unaffected.

Verified in dev by forcing a 5s delay in `UpdateStatus`: the original code reproduces the exact error deterministically; with this change the streamed skeleton sits inside the `div` wrapper and the console stays clean. `type-check` passes for `@rallly/ui` and `@rallly/web`.

## Checklist

- [x] I have performed a self-review of my code
- [x] My code follows the code style of this project
- [x] I have commented my code, particularly in hard-to-understand areas

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tile description compatibility by rendering it as a `<div>`.
  * Updated ref handling and HTML attributes to match the new element type.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->