### PR TITLE
💄 Restyle sheets as floating rounded popover panels

### DIFF
--- a/apps/web/src/features/poll/components/comments-sheet.tsx
+++ b/apps/web/src/features/poll/components/comments-sheet.tsx
@@ -228,7 +228,7 @@ function CommentsSheetInner({ className }: { className?: string }) {
         {count > 0 ? <Badge>{count}</Badge> : null}
       </Button>
       <Sheet {...dialog.dialogProps}>
-        <SheetContent className="flex w-full flex-col sm:max-w-md">
+        <SheetContent className="flex flex-col sm:max-w-md">
           <SheetHeader>
             <div className="flex items-center gap-2">
               <SheetTitle>

--- a/packages/ui/src/sheet.tsx
+++ b/packages/ui/src/sheet.tsx
@@ -37,16 +37,16 @@ function SheetOverlay({ className, ...props }: SheetPrimitive.Backdrop.Props) {
 }
 
 const sheetVariants = cva(
-  "fixed z-50 gap-4 bg-background p-6 shadow-lg transition ease-in-out data-closed:animate-out data-open:animate-in data-closed:duration-200 data-open:duration-200",
+  "fixed z-50 gap-4 rounded-xl bg-popover p-6 text-popover-foreground shadow-lg ring-1 ring-foreground/10 transition ease-in-out data-closed:animate-out data-open:animate-in data-closed:duration-200 data-open:duration-200",
   {
     variants: {
       side: {
-        top: "data-closed:slide-out-to-top data-open:slide-in-from-top inset-x-0 top-0 border-b",
+        top: "data-closed:slide-out-to-top data-open:slide-in-from-top inset-x-2 top-2",
         bottom:
-          "data-closed:slide-out-to-bottom data-open:slide-in-from-bottom inset-x-0 bottom-0 border-t",
-        left: "data-closed:slide-out-to-left data-open:slide-in-from-left inset-y-0 left-0 h-full w-3/4 border-r sm:max-w-sm",
+          "data-closed:slide-out-to-bottom data-open:slide-in-from-bottom inset-x-2 bottom-2",
+        left: "data-closed:slide-out-to-left data-open:slide-in-from-left inset-y-2 left-2 w-[calc(100%-1rem)] sm:max-w-sm",
         right:
-          "data-closed:slide-out-to-right data-open:slide-in-from-right inset-y-0 right-0 h-full w-3/4 border-l sm:max-w-sm",
+          "data-closed:slide-out-to-right data-open:slide-in-from-right inset-y-2 right-2 w-[calc(100%-1rem)] sm:max-w-sm",
       },
     },
     defaultVariants: {


### PR DESCRIPTION
## Description

Restyles the shared `Sheet` component as a floating popover panel instead of an edge-anchored drawer:

- `SheetContent` in `packages/ui/src/sheet.tsx` floats with an 8px inset on every side (`inset-y-2 right-2` etc.), `rounded-xl`, popover colors (`bg-popover text-popover-foreground`) and the same `ring-1 ring-foreground/10` treatment as `PopoverContent`. The per-side borders are gone since the panel no longer touches the viewport.
- Left/right sheets cap their mobile width at `calc(100%-1rem)` so they stay inside the insets.
- The poll comments sheet drops its `w-full` override, which would have pushed the floating panel past the left edge on small screens.

Brings sheets in line with the popover surface treatment so overlay panels share one visual language. The mobile sidebar (`packages/ui/src/sidebar.tsx`) uses `SheetContent` and inherits the float; it keeps its own `bg-sidebar` background override.

Verified live on the invite page comments sheet at desktop and narrow widths: measured 8px gaps, 12px radius, popover background, no console errors.

## Checklist

- [x] I have performed a self-review of my code
- [x] My code follows the code style of this project
- [x] I have commented my code, particularly in hard-to-understand areas

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated panels and comment sheets with a more polished inset appearance, including rounded corners, spacing, and visual emphasis.
  * Improved responsive sizing and positioning for left- and right-sided panels.
  * Refined comment sheet layout across screen sizes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->