### PR TITLE
⚡️ Preload the landing page hero screenshot

### DIFF
--- a/apps/landing/src/components/home/hero.tsx
+++ b/apps/landing/src/components/home/hero.tsx
@@ -62,7 +62,7 @@ const Screenshot = () => {
           width={1440}
           height={1152}
           quality={100}
-          priority
+          preload
           onLoad={() => {
             setIsLoaded(true);
           }}

--- a/apps/landing/src/components/home/hero.tsx
+++ b/apps/landing/src/components/home/hero.tsx
@@ -62,6 +62,7 @@ const Screenshot = () => {
           width={1440}
           height={1152}
           quality={100}
+          priority
           onLoad={() => {
             setIsLoaded(true);
           }}


### PR DESCRIPTION
## Description

The landing page hero screenshot is the largest in-viewport element but was lazy-loaded (the \`next/image\` default), so the browser deferred fetching it — delaying LCP and the \`onLoad\`-gated entrance animation. This adds the \`priority\` prop, which emits a \`<link rel=\"preload\">\` and \`fetchpriority=\"high\"\` so the fetch starts immediately. This mirrors what Linear does on their landing page: their hero shots are preloaded via \`<link rel=\"preload\" as=\"image\">\` even though the \`<img>\` elements are marked lazy.

Note for reviewer: the entrance animation still holds the image at \`opacity: 0\` until \`onLoad\` fires, so the reveal timing (not the fetch) is now the remaining contributor to when the screenshot paints. Left as is since changing the animation is a design decision.

## Checklist

- [x] I have performed a self-review of my code
- [x] My code follows the code style of this project
- [x] I have commented my code, particularly in hard-to-understand areas

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Performance**
  - Improved loading priority for the hero screenshot image to help it appear sooner on the landing page.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->