### PR TITLE
✏️ Sync landing i18n code defaults with shipped locale values

### DIFF
--- a/apps/landing/public/locales/en/common.json
+++ b/apps/landing/public/locales/en/common.json
@@ -24,7 +24,7 @@
   "notFoundTitle": "404 not found",
   "pricing": "Pricing",
   "privacyPolicy": "Privacy Policy",
-  "signUp": "Sign Up",
+  "signUp": "Sign up",
   "solutions": "Solutions",
   "status": "Status",
   "support": "Support",

--- a/apps/landing/src/app/[locale]/(main)/blog/page.tsx
+++ b/apps/landing/src/app/[locale]/(main)/blog/page.tsx
@@ -62,7 +62,7 @@ export async function generateMetadata(props: {
     }),
     description: t("blogDescription", {
       ns: "blog",
-      defaultValue: "News, updates and announcement about Rallly.",
+      defaultValue: "News, updates and announcements about Rallly.",
     }),
   };
 }

--- a/apps/landing/src/app/[locale]/(main)/page.tsx
+++ b/apps/landing/src/app/[locale]/(main)/page.tsx
@@ -46,13 +46,13 @@ export async function generateMetadata(props: {
   const { t } = await getTranslation(locale, "home");
   return {
     title: t("metaTitle", {
-      defaultValue: "Rallly: Group Scheduling Tool",
+      defaultValue: "Rallly: Free Group Meeting Scheduling Tool",
       ns: "home",
     }),
     description: t("metaDescription", {
       ns: "home",
       defaultValue:
-        "Create polls and vote to find the best day or time. A free alternative to Doodle.",
+        "Rallly is the fastest and easiest scheduling and collaboration tool. Create a meeting poll in seconds, no login required.",
     }),
   };
 }

--- a/apps/landing/src/app/[locale]/(main)/pricing/page.tsx
+++ b/apps/landing/src/app/[locale]/(main)/pricing/page.tsx
@@ -67,7 +67,7 @@ const FAQ = async (props: { locale: string }) => {
           t={t}
           ns="pricing"
           i18nKey="whenPollInactiveAnswer"
-          defaults="Polls become inactive when all date options are in the past AND the poll has not been accessed for over 30 days. Inactive polls are automatically deleted if you do not have a paid subscription."
+          defaults="Polls become inactive when all date options are in the past AND there has been no activity for over 30 days. Activity includes new votes, comments, or changes to the poll. Inactive polls are automatically deleted if you do not have a paid subscription."
         />
       </p>
       <h3 className="mt-6 mb-2 font-bold text-lg">

--- a/apps/landing/src/app/[locale]/(main)/pricing/pricing-table.tsx
+++ b/apps/landing/src/app/[locale]/(main)/pricing/pricing-table.tsx
@@ -123,7 +123,7 @@ export function PriceTables() {
                   t={t}
                   ns="pricing"
                   i18nKey="annualBenefit"
-                  defaults="{count} months free!"
+                  defaults="{count} months free"
                   values={{
                     count: 4,
                   }}
@@ -160,12 +160,7 @@ export function PriceTables() {
               className: "w-full",
             })}
           >
-            <Trans
-              t={t}
-              ns="pricing"
-              i18nKey="upgrade"
-              defaults="Go to billing"
-            />
+            <Trans t={t} ns="pricing" i18nKey="upgrade" defaults="Upgrade" />
           </Link>
           <BillingPlanPerks>
             <BillingPlanPerk pro={true}>


### PR DESCRIPTION
## What changed

The `defaults` props in apps/landing had drifted from the shipped values in `public/locales/en/*.json`, so any `i18next-cli extract --sync-primary` run would clobber curated copy with stale code defaults. This syncs the two sides so the extract runs clean (verified: no diff after running it).

Direction was decided per key from git history of both sides:

**Code updated to match JSON (JSON was the deliberate later edit):**
- `blog.json` `blogDescription` — code had the "announcement" typo that was fixed in the JSON by #2413
- `home.json` `metaTitle` / `metaDescription` — code still carried pre-2024 SEO copy; JSON was updated in the Sept 2024 title/meta commit
- `pricing.json` `annualBenefit` — JSON dropped the trailing "!" in #1289
- `pricing.json` `whenPollInactiveAnswer` — JSON was rewritten in #2469 alongside the activity-based poll cleanup change, so the old code default was also factually wrong about how cleanup works
- `pricing.json` `upgrade` — code said "Go to billing" (written in #884 but never shipped, since the scanner never overwrote the existing key); users have seen "Upgrade" since #734 and it's the better label for the button

**JSON updated to match code (code was the intended copy):**
- `common.json` `signUp` — "Sign Up" → "Sign up". This drift was born in a single commit (#1648) that wrote sentence case in code but title case in JSON; sentence case is the copy standard.

## Reviewer notes

- Runtime behavior is almost entirely unchanged: the JSON wins at runtime, and code defaults are only fallbacks. The one user-visible change is the header/nav button now reading "Sign up" instead of "Sign Up".
- Landing only tracks `en` in-repo, so no checked-in translations are affected; if landing strings sync to Crowdin, the `signUp` source change will reset that key's translations on upload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Content Updates**
  * Improved homepage and blog metadata to more clearly describe Rallly and its announcements.
  * Clarified when polls are considered active in the pricing FAQ.
  * Updated pricing labels, including the Pro-plan action now displayed as “Upgrade.”
  * Standardized capitalization and punctuation in English translations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->