### PR TITLE
💄 Use ghost variant for the new-participant modal cancel button

### DIFF
--- a/apps/web/src/features/poll/components/new-participant-modal.tsx
+++ b/apps/web/src/features/poll/components/new-participant-modal.tsx
@@ -415,7 +415,7 @@ export const NewParticipantForm = (props: NewParticipantModalProps) => {
         </form>
       </Form>
       <DialogFooter>
-        <Button type="button" onClick={props.onCancel}>
+        <Button type="button" variant="ghost" onClick={props.onCancel}>
           {t("back")}
         </Button>
         <Button


### PR DESCRIPTION
## Description

The Back/cancel button in the new-participant modal footer used the default (secondary) button variant, giving it a filled background that competed with the primary "Save availability" button. It now uses the ghost variant so the primary action stands alone.

Verified in the browser on the invite page voting flow: the button renders with a transparent background below the primary button in the modal footer.

## Checklist

- [x] I have performed a self-review of my code
- [x] My code follows the code style of this project
- [x] I have commented my code, particularly in hard-to-understand areas

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the form’s Back/Cancel button to use a lighter ghost style.
  * Button behavior and label remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->