### PR TITLE
✨ Add a final CTA section to the landing home page

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -19,6 +19,21 @@
       "runtimeExecutable": "pnpm",
       "runtimeArgs": ["--filter", "@rallly/docs", "dev", "--port", "3333"],
       "port": 3333
+    },
+    {
+      "name": "landing",
+      "runtimeExecutable": "pnpm",
+      "runtimeArgs": [
+        "--dir",
+        "apps/landing",
+        "exec",
+        "next",
+        "dev",
+        "--turbopack",
+        "--port",
+        "3033"
+      ],
+      "port": 3033
     }
   ]
 }

--- a/apps/landing/public/locales/en/home.json
+++ b/apps/landing/public/locales/en/home.json
@@ -4,6 +4,8 @@
   "createPageLikeThis": "Create a page like this in seconds!",
   "doodleAlternative": "The Best Free Doodle Alternative",
   "doodleAlternativeDescription": "Rallly is the Doodle alternative that everyone is looking for. Thousands of users have already made the switch and are now enjoying professional ad-free meeting polls in an intuitive and easy-to-use interface.        ",
+  "doodleAlternativeFinalCtaDescription": "Create your first poll in seconds and see why so many people left Doodle behind.",
+  "doodleAlternativeFinalCtaTitle": "Ready to make the switch?",
   "doodleAlternativeMetaDescription": "Looking for a Doodle alternative? Try Rallly! It's free, easy to use, and doesn't require an account.",
   "doodleAlternativeMetaTitle": "Best Free Doodle Alternative | Rallly",
   "ericJobTitle": "Executive Assistant at MIT",
@@ -11,6 +13,8 @@
   "finalCtaDescription": "Create a poll, share the link, and let everyone vote on times that work.",
   "finalCtaTitle": "Ready to find the best time to meet?",
   "freeSchedulingPollDescription": "Rallly lets you create beautiful and easy to use scheduling polls so you can find the best time for your next event.",
+  "freeSchedulingPollFinalCtaDescription": "It takes seconds and your group can start voting right away.",
+  "freeSchedulingPollFinalCtaTitle": "Ready to create your scheduling poll?",
   "freeSchedulingPollMetaDescription": "Create a free scheduling poll in seconds. Ideal for organizing meetings, events, conferences, sports teams and more.",
   "freeSchedulingPollMetaTitle": "Create a Free Scheduling Poll Instantly | No Account Required",
   "freeSchedulingPollTitle": "Find a date for your next event",
@@ -29,6 +33,8 @@
   "viaTrustpilot": "via Trustpilot",
   "when2meetAlternative": "A Modern When2Meet Alternative",
   "when2meetAlternativeDescription": "Rallly does everything you use When2Meet for, without the clunky parts. Create clean scheduling polls that work great on mobile, get notified when participants respond, and manage all your polls in one place. Free, without ads, and no account needed to vote. Coming from When2Meet or WhenIsGood? Rallly will feel instantly familiar.",
+  "when2meetAlternativeFinalCtaDescription": "Create a poll in seconds and enjoy a cleaner way to find a time that works.",
+  "when2meetAlternativeFinalCtaTitle": "Ready for a fresh take on When2Meet?",
   "when2meetAlternativeMetaDescription": "Rallly is a free When2Meet alternative with a clean interface, great mobile support, response notifications, and no ads. No account needed to vote.",
   "when2meetAlternativeMetaTitle": "Best Free When2Meet Alternative | Rallly"
 }

--- a/apps/landing/public/locales/en/home.json
+++ b/apps/landing/public/locales/en/home.json
@@ -8,6 +8,8 @@
   "doodleAlternativeMetaTitle": "Best Free Doodle Alternative | Rallly",
   "ericJobTitle": "Executive Assistant at MIT",
   "ericQuote": "“If your scheduling workflow lives in emails, I strongly encourage you to try and let Rallly simplify your scheduling tasks for a more organized and less stressful workday.”",
+  "finalCtaDescription": "Create a poll, share the link, and let everyone vote on times that work.",
+  "finalCtaTitle": "Ready to find the best time to meet?",
   "freeSchedulingPollDescription": "Rallly lets you create beautiful and easy to use scheduling polls so you can find the best time for your next event.",
   "freeSchedulingPollMetaDescription": "Create a free scheduling poll in seconds. Ideal for organizing meetings, events, conferences, sports teams and more.",
   "freeSchedulingPollMetaTitle": "Create a Free Scheduling Poll Instantly | No Account Required",

--- a/apps/landing/src/app/[locale]/(main)/(seo)/best-doodle-alternative/page.tsx
+++ b/apps/landing/src/app/[locale]/(main)/(seo)/best-doodle-alternative/page.tsx
@@ -4,6 +4,7 @@ import type { Metadata } from "next";
 import { cacheLife } from "next/cache";
 import { Trans } from "react-i18next/TransWithoutContext";
 import Bonus from "@/components/home/bonus";
+import { FinalCta } from "@/components/home/final-cta";
 import { MarketingHero } from "@/components/home/hero";
 import { BigTestimonial, Marketing, MentionedBy } from "@/components/marketing";
 import { getTranslation } from "@/i18n/server";
@@ -28,6 +29,25 @@ export default async function Page(props: {
       <Bonus locale={locale} />
       <BigTestimonial />
       <MentionedBy />
+      <FinalCta
+        title={
+          <Trans
+            t={t}
+            ns="home"
+            i18nKey="doodleAlternativeFinalCtaTitle"
+            defaults="Ready to make the switch?"
+          />
+        }
+        description={
+          <Trans
+            t={t}
+            ns="home"
+            i18nKey="doodleAlternativeFinalCtaDescription"
+            defaults="Create your first poll in seconds and see why so many people left Doodle behind."
+          />
+        }
+        callToAction={<Trans t={t} ns="home" i18nKey="createAPoll" />}
+      />
     </Marketing>
   );
 }

--- a/apps/landing/src/app/[locale]/(main)/(seo)/free-scheduling-poll/page.tsx
+++ b/apps/landing/src/app/[locale]/(main)/(seo)/free-scheduling-poll/page.tsx
@@ -4,6 +4,7 @@ import type { Metadata } from "next";
 import { cacheLife } from "next/cache";
 import { Trans } from "react-i18next/TransWithoutContext";
 import Bonus from "@/components/home/bonus";
+import { FinalCta } from "@/components/home/final-cta";
 import { MarketingHero } from "@/components/home/hero";
 import { BigTestimonial, Marketing, MentionedBy } from "@/components/marketing";
 import { getTranslation } from "@/i18n/server";
@@ -28,6 +29,25 @@ export default async function Page(props: {
       <Bonus locale={locale} />
       <BigTestimonial />
       <MentionedBy />
+      <FinalCta
+        title={
+          <Trans
+            t={t}
+            ns="home"
+            i18nKey="freeSchedulingPollFinalCtaTitle"
+            defaults="Ready to create your scheduling poll?"
+          />
+        }
+        description={
+          <Trans
+            t={t}
+            ns="home"
+            i18nKey="freeSchedulingPollFinalCtaDescription"
+            defaults="It takes seconds and your group can start voting right away."
+          />
+        }
+        callToAction={<Trans t={t} ns="home" i18nKey="createASchedulingPoll" />}
+      />
     </Marketing>
   );
 }

--- a/apps/landing/src/app/[locale]/(main)/(seo)/when2meet-alternative/page.tsx
+++ b/apps/landing/src/app/[locale]/(main)/(seo)/when2meet-alternative/page.tsx
@@ -4,6 +4,7 @@ import type { Metadata } from "next";
 import { cacheLife } from "next/cache";
 import { Trans } from "react-i18next/TransWithoutContext";
 import Bonus from "@/components/home/bonus";
+import { FinalCta } from "@/components/home/final-cta";
 import { MarketingHero } from "@/components/home/hero";
 import { BigTestimonial, Marketing, MentionedBy } from "@/components/marketing";
 import { getTranslation } from "@/i18n/server";
@@ -28,6 +29,25 @@ export default async function Page(props: {
       <Bonus locale={locale} />
       <BigTestimonial />
       <MentionedBy />
+      <FinalCta
+        title={
+          <Trans
+            t={t}
+            ns="home"
+            i18nKey="when2meetAlternativeFinalCtaTitle"
+            defaults="Ready for a fresh take on When2Meet?"
+          />
+        }
+        description={
+          <Trans
+            t={t}
+            ns="home"
+            i18nKey="when2meetAlternativeFinalCtaDescription"
+            defaults="Create a poll in seconds and enjoy a cleaner way to find a time that works."
+          />
+        }
+        callToAction={<Trans t={t} ns="home" i18nKey="createASchedulingPoll" />}
+      />
     </Marketing>
   );
 }

--- a/apps/landing/src/app/[locale]/(main)/page.tsx
+++ b/apps/landing/src/app/[locale]/(main)/page.tsx
@@ -3,6 +3,7 @@
 import type { Metadata } from "next";
 import { cacheLife } from "next/cache";
 import Bonus from "@/components/home/bonus";
+import { FinalCta } from "@/components/home/final-cta";
 import { MarketingHero } from "@/components/home/hero";
 import { BigTestimonial, Marketing, MentionedBy } from "@/components/marketing";
 import { getTranslation } from "@/i18n/server";
@@ -34,6 +35,7 @@ export default async function Page(props: {
         <BigTestimonial />
       </div>
       <MentionedBy />
+      <FinalCta />
     </Marketing>
   );
 }

--- a/apps/landing/src/components/home/final-cta.tsx
+++ b/apps/landing/src/components/home/final-cta.tsx
@@ -3,6 +3,7 @@ import { posthog } from "@rallly/posthog/client";
 import { buttonVariants, cn } from "@rallly/ui";
 import * as m from "motion/react-m";
 import Link from "next/link";
+import type React from "react";
 import { handwritten } from "@/fonts/handwritten";
 import { Trans } from "@/i18n/client/trans";
 import { linkToApp } from "@/lib/linkToApp";

--- a/apps/landing/src/components/home/final-cta.tsx
+++ b/apps/landing/src/components/home/final-cta.tsx
@@ -1,0 +1,70 @@
+"use client";
+import { buttonVariants, cn } from "@rallly/ui";
+import * as m from "motion/react-m";
+import Link from "next/link";
+import { handwritten } from "@/fonts/handwritten";
+import { Trans } from "@/i18n/client/trans";
+import { linkToApp } from "@/lib/linkToApp";
+
+export const FinalCta = () => {
+  return (
+    <m.div
+      transition={{
+        duration: 1,
+        type: "spring",
+        bounce: 0.3,
+      }}
+      initial={{ opacity: 0, y: 20 }}
+      whileInView={{ opacity: 1, y: 0 }}
+      viewport={{ once: true }}
+    >
+      <section className="space-y-8 py-8 text-center sm:py-24">
+        <div className="space-y-4">
+          <h2 className="text-pretty font-bold text-2xl tracking-tight sm:text-4xl">
+            <Trans
+              ns="home"
+              i18nKey="finalCtaTitle"
+              defaults="Ready to find the best time to meet?"
+            />
+          </h2>
+          <p className="mx-auto max-w-2xl text-pretty text-base text-gray-500 sm:text-lg">
+            <Trans
+              ns="home"
+              i18nKey="finalCtaDescription"
+              defaults="Create a poll, share the link, and let everyone vote on times that work."
+            />
+          </p>
+        </div>
+        <div className="flex flex-col items-center gap-4">
+          <Link
+            href={linkToApp("/new")}
+            className={buttonVariants({
+              size: "xl",
+              variant: "primary",
+              className: "shadow-md transition-all active:shadow-none",
+            })}
+          >
+            <Trans
+              ns="home"
+              i18nKey="createAPoll"
+              defaults="Create a Meeting Poll"
+            />
+          </Link>
+          <p
+            className={cn(
+              "whitespace-nowrap text-center text-gray-600 text-xs",
+              handwritten.className,
+              "decoration underline decoration-2 decoration-gray-300 underline-offset-8",
+            )}
+          >
+            <Trans
+              ns="home"
+              i18nKey="hint"
+              defaults="It's free! No login required."
+            />
+          </p>
+        </div>
+      </section>
+    </m.div>
+  );
+};

--- a/apps/landing/src/components/home/final-cta.tsx
+++ b/apps/landing/src/components/home/final-cta.tsx
@@ -1,4 +1,5 @@
 "use client";
+import { posthog } from "@rallly/posthog/client";
 import { buttonVariants, cn } from "@rallly/ui";
 import * as m from "motion/react-m";
 import Link from "next/link";
@@ -6,7 +7,15 @@ import { handwritten } from "@/fonts/handwritten";
 import { Trans } from "@/i18n/client/trans";
 import { linkToApp } from "@/lib/linkToApp";
 
-export const FinalCta = () => {
+export const FinalCta = ({
+  title,
+  description,
+  callToAction,
+}: {
+  title?: React.ReactNode;
+  description?: React.ReactNode;
+  callToAction?: React.ReactNode;
+}) => {
   return (
     <m.div
       transition={{
@@ -17,22 +26,29 @@ export const FinalCta = () => {
       initial={{ opacity: 0, y: 20 }}
       whileInView={{ opacity: 1, y: 0 }}
       viewport={{ once: true }}
+      onViewportEnter={() => {
+        posthog.capture("landing:final_cta_view");
+      }}
     >
       <section className="space-y-8 py-8 text-center sm:py-24">
         <div className="space-y-4">
           <h2 className="text-pretty font-bold text-2xl tracking-tight sm:text-4xl">
-            <Trans
-              ns="home"
-              i18nKey="finalCtaTitle"
-              defaults="Ready to find the best time to meet?"
-            />
+            {title ?? (
+              <Trans
+                ns="home"
+                i18nKey="finalCtaTitle"
+                defaults="Ready to find the best time to meet?"
+              />
+            )}
           </h2>
           <p className="mx-auto max-w-2xl text-pretty text-base text-gray-500 sm:text-lg">
-            <Trans
-              ns="home"
-              i18nKey="finalCtaDescription"
-              defaults="Create a poll, share the link, and let everyone vote on times that work."
-            />
+            {description ?? (
+              <Trans
+                ns="home"
+                i18nKey="finalCtaDescription"
+                defaults="Create a poll, share the link, and let everyone vote on times that work."
+              />
+            )}
           </p>
         </div>
         <div className="flex flex-col items-center gap-4">
@@ -43,12 +59,17 @@ export const FinalCta = () => {
               variant: "primary",
               className: "shadow-md transition-all active:shadow-none",
             })}
+            onClick={() => {
+              posthog.capture("landing:final_cta_click");
+            }}
           >
-            <Trans
-              ns="home"
-              i18nKey="createAPoll"
-              defaults="Create a Meeting Poll"
-            />
+            {callToAction ?? (
+              <Trans
+                ns="home"
+                i18nKey="createAPoll"
+                defaults="Create a Meeting Poll"
+              />
+            )}
           </Link>
           <p
             className={cn(

--- a/apps/landing/src/components/home/hero.tsx
+++ b/apps/landing/src/components/home/hero.tsx
@@ -1,4 +1,5 @@
 "use client";
+import { posthog } from "@rallly/posthog/client";
 import { buttonVariants, cn } from "@rallly/ui";
 import { Badge } from "@rallly/ui/badge";
 import { ChevronRightIcon } from "lucide-react";
@@ -118,6 +119,9 @@ export const MarketingHero = ({
               variant: "primary",
               className: "shadow-md transition-all active:shadow-none",
             })}
+            onClick={() => {
+              posthog.capture("landing:hero_cta_click");
+            }}
           >
             {callToAction}
           </Link>


### PR DESCRIPTION
## Description

Adds a closing call to action at the bottom of the landing home page and the three SEO pages, between the press mentions and the footer, so visitors who scroll the whole page get a final prompt to create a poll instead of dead-ending at the footer.

The section mirrors the hero: headline, supporting line, primary button linking to the app's `/new` page, and the handwritten "It's free! No login required." hint, with the same scroll-in animation as neighboring sections and generous vertical padding.

- **Home page** — "Ready to find the best time to meet?" with the standard `createAPoll` button.
- **SEO pages** — `FinalCta` takes optional `title`/`description`/`callToAction` props, so each page closes with copy matched to its search intent ("Ready to make the switch?" on the Doodle page, "Ready for a fresh take on When2Meet?", "Ready to create your scheduling poll?"). These render server-side via `TransWithoutContext`, so they localize correctly.
- **Instrumentation** — new PostHog events `landing:hero_cta_click`, `landing:final_cta_click` and `landing:final_cta_view` (fired once when the section scrolls into view). Pathname is captured automatically, so per-page click-through and a fair view-based rate for the below-the-fold CTA can be compared in PostHog without further work.

Notes for review:

- Copy keys were added via `pnpm i18n:scan`.
- Client-side `Trans` on these pages currently renders `defaults` because the client i18n store only carries the default namespace — a pre-existing issue affecting the other home page sections equally, being addressed separately.
- Also adds a `landing` dev server entry to `.claude/launch.json` (dev tooling only).

Verified in the browser on all four pages at desktop and mobile widths with a clean console; type check and Biome pass. The capture calls follow the same pattern as the existing `landing:sign_up_button_click`; event delivery couldn't be observed in the embedded dev browser because PostHog opts out under Global Privacy Control there, which also suppresses the pre-existing pageview events.

## Checklist

- [x] I have performed a self-review of my code
- [x] My code follows the code style of this project
- [x] I have commented my code, particularly in hard-to-understand areas

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a final call-to-action section to the main landing page and scheduling-related pages.
  * Visitors can start creating a meeting poll directly from the new section.
  * Added animated entrance effects and a clear indication that no login is required.

* **Localization**
  * Added English translations for call-to-action titles and descriptions across supported landing pages.

* **Analytics**
  * Added tracking for landing-page call-to-action interactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->