### PR TITLE
♻️ Extract width-stable save button inputs shared by the settings pages

### DIFF
--- a/apps/web/src/app/[locale]/(space)/settings/general/components/space-settings-form.tsx
+++ b/apps/web/src/app/[locale]/(space)/settings/general/components/space-settings-form.tsx
@@ -9,15 +9,7 @@ import {
   FieldLabel,
   FieldTitle,
 } from "@rallly/ui/field";
-import {
-  InputGroup,
-  InputGroupAddon,
-  InputGroupButton,
-  InputGroupInput,
-} from "@rallly/ui/input-group";
 import { toast } from "@rallly/ui/sonner";
-import { Tooltip, TooltipContent, TooltipTrigger } from "@rallly/ui/tooltip";
-import { CheckIcon } from "lucide-react";
 import type React from "react";
 import type { Control } from "react-hook-form";
 import { Controller, useForm } from "react-hook-form";
@@ -27,6 +19,7 @@ import {
   ImageUploadControl,
   ImageUploadPreview,
 } from "@/components/image-upload";
+import { InputWithSaveButton } from "@/components/input-with-save-button";
 import {
   getSpaceImageUploadUrlAction,
   removeSpaceImageAction,
@@ -175,41 +168,17 @@ function SpaceNameField({
         name="name"
         render={({ field, fieldState }) => (
           <>
-            <InputGroup className="w-56">
-              <InputGroupInput
-                {...field}
-                id="space-name"
-                disabled={disabled}
-                placeholder={t("spaceNamePlaceholder", {
-                  defaultValue: "My Team",
-                })}
-                aria-invalid={fieldState.invalid}
-              />
-              {/* Rendered only when there is something to save. A disabled
-                  button here would trip InputGroup's `has-disabled:` styles
-                  and grey out the whole field. */}
-              {isDirty && !disabled ? (
-                <InputGroupAddon align="inline-end">
-                  <Tooltip>
-                    <TooltipTrigger
-                      render={
-                        <InputGroupButton
-                          type="submit"
-                          size="icon-xs"
-                          loading={isSaving}
-                          aria-label={t("save", { defaultValue: "Save" })}
-                        >
-                          <CheckIcon />
-                        </InputGroupButton>
-                      }
-                    />
-                    <TooltipContent>
-                      <Trans i18nKey="save" defaults="Save" />
-                    </TooltipContent>
-                  </Tooltip>
-                </InputGroupAddon>
-              ) : null}
-            </InputGroup>
+            <InputWithSaveButton
+              {...field}
+              id="space-name"
+              disabled={disabled}
+              placeholder={t("spaceNamePlaceholder", {
+                defaultValue: "My Team",
+              })}
+              aria-invalid={fieldState.invalid}
+              isDirty={isDirty}
+              isSaving={isSaving}
+            />
             {fieldState.invalid ? (
               <FieldError className="mt-1.5" errors={[fieldState.error]} />
             ) : null}

--- a/apps/web/src/app/[locale]/control-panel/branding/components/app-name-field.tsx
+++ b/apps/web/src/app/[locale]/control-panel/branding/components/app-name-field.tsx
@@ -2,18 +2,11 @@
 
 import { zodResolver } from "@hookform/resolvers/zod";
 import { FieldError } from "@rallly/ui/field";
-import {
-  InputGroup,
-  InputGroupAddon,
-  InputGroupButton,
-  InputGroupInput,
-} from "@rallly/ui/input-group";
 import { toast } from "@rallly/ui/sonner";
-import { Tooltip, TooltipContent, TooltipTrigger } from "@rallly/ui/tooltip";
-import { CheckIcon } from "lucide-react";
 import { Controller, useForm } from "react-hook-form";
+import { InputWithSaveButton } from "@/components/input-with-save-button";
 import { brandingSettingsSchema } from "@/features/instance-settings/schema";
-import { Trans, useTranslation } from "@/i18n/client";
+import { useTranslation } from "@/i18n/client";
 import { useSafeAction } from "@/lib/safe-action/client";
 import { updateBrandingSettingsAction } from "../actions";
 
@@ -52,38 +45,14 @@ export function AppNameField({
         name="appName"
         render={({ field, fieldState }) => (
           <>
-            <InputGroup className="w-56">
-              <InputGroupInput
-                {...field}
-                id="app-name"
-                disabled={disabled}
-                aria-invalid={fieldState.invalid}
-              />
-              {/* Rendered only when there is something to save. A disabled
-                  button here would trip InputGroup's `has-disabled:` styles
-                  and grey out the whole field. */}
-              {form.formState.isDirty && !disabled ? (
-                <InputGroupAddon align="inline-end">
-                  <Tooltip>
-                    <TooltipTrigger
-                      render={
-                        <InputGroupButton
-                          type="submit"
-                          size="icon-xs"
-                          loading={updateBranding.isExecuting}
-                          aria-label={t("save", { defaultValue: "Save" })}
-                        >
-                          <CheckIcon />
-                        </InputGroupButton>
-                      }
-                    />
-                    <TooltipContent>
-                      <Trans i18nKey="save" defaults="Save" />
-                    </TooltipContent>
-                  </Tooltip>
-                </InputGroupAddon>
-              ) : null}
-            </InputGroup>
+            <InputWithSaveButton
+              {...field}
+              id="app-name"
+              disabled={disabled}
+              aria-invalid={fieldState.invalid}
+              isDirty={form.formState.isDirty}
+              isSaving={updateBranding.isExecuting}
+            />
             {fieldState.invalid ? (
               <FieldError className="mt-1.5" errors={[fieldState.error]} />
             ) : null}

--- a/apps/web/src/components/input-with-save-button.tsx
+++ b/apps/web/src/components/input-with-save-button.tsx
@@ -1,0 +1,63 @@
+"use client";
+
+import { cn } from "@rallly/ui";
+import {
+  InputGroup,
+  InputGroupAddon,
+  InputGroupButton,
+  InputGroupInput,
+} from "@rallly/ui/input-group";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@rallly/ui/tooltip";
+import { CheckIcon } from "lucide-react";
+import type React from "react";
+import { Trans, useTranslation } from "@/i18n/client";
+
+/**
+ * Text input with an inline save button that appears when there are unsaved
+ * changes. Must be rendered inside a form: the save button submits it.
+ */
+export function InputWithSaveButton({
+  isDirty,
+  isSaving,
+  disabled,
+  className,
+  ...inputProps
+}: React.ComponentProps<typeof InputGroupInput> & {
+  isDirty: boolean;
+  isSaving: boolean;
+}) {
+  const { t } = useTranslation();
+  const showSaveButton = isDirty && !disabled;
+
+  return (
+    <InputGroup className={cn("w-56", className)}>
+      <InputGroupInput {...inputProps} disabled={disabled} />
+      {/* Kept mounted so the input width doesn't change when the save button
+          appears; `invisible` also keeps it out of the tab order. It must not
+          be disabled instead — that would trip InputGroup's `has-disabled:`
+          styles and grey out the whole field. */}
+      <InputGroupAddon
+        align="inline-end"
+        className={cn(!showSaveButton && "invisible")}
+      >
+        <Tooltip>
+          <TooltipTrigger
+            render={
+              <InputGroupButton
+                type="submit"
+                size="icon-xs"
+                loading={isSaving}
+                aria-label={t("save", { defaultValue: "Save" })}
+              >
+                <CheckIcon />
+              </InputGroupButton>
+            }
+          />
+          <TooltipContent>
+            <Trans i18nKey="save" defaults="Save" />
+          </TooltipContent>
+        </Tooltip>
+      </InputGroupAddon>
+    </InputGroup>
+  );
+}


### PR DESCRIPTION
Follow-up to #2918, which merged before these landed on the branch.

The inline save pattern (control + check button that appears on unsaved changes) was duplicated between the space settings general page and the control panel branding page, in two flavors: a text input and a color picker. Both lost width the moment their buttons mounted, because the buttons were only rendered when needed.

## Changes

**`components/input-with-save-button.tsx`** (new)
- Text input taking normal input props plus `isDirty`/`isSaving`; expects to be rendered inside a form (the button submits it).
- The save button addon is always mounted and toggled with `invisible`, so the input width no longer changes when edits begin (was 222px → 195px). `visibility: hidden` also keeps the hidden button out of the tab order, and avoids disabling it — a disabled button would trip InputGroup's `has-disabled:` styles and grey out the whole field.
- Used by `space-settings-form.tsx` (space name) and branding `app-name-field.tsx`.

**`components/color-picker-with-save-button.tsx`** (new)
- Color picker with the same always-mounted save button, plus an optional reset-to-default slot (`onReset` reserves it, `showReset` reveals it).
- Fixed at `w-56` to line up with the name input. The width class sits below a wrapper div because Field's `*:w-auto` child selector overrides any width utility on a direct child — which is also why the picker was effectively auto-width before and grew ~70px when buttons appeared.
- Used by the space `custom-branding-section.tsx` and branding `primary-color-field.tsx`.

**`@rallly/ui` ColorPicker**
- Gains a `disabled` prop (disabled hex field via `useColorField`'s `isDisabled` + disabled swatch trigger). Replaces the control panel's static-swatch fallback and fixes the space settings picker staying interactive for members without manage permissions.

## Verification

Measured in the browser on both pages, both components: group and input widths are identical across clean/dirty/saved/reset states (name input 224px group / 195px input; color picker 224px group throughout). Saves verified on both pages; reset-to-default verified on space settings. Type-check and lint pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)