### PR TITLE
⬆️ Upgrade tailwind-merge to v3 and remove text-wrap workaround

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -49,7 +49,7 @@
     "rehype-sanitize": "^6.0.0",
     "remark-breaks": "^4.0.0",
     "sonner": "^2.0.6",
-    "tailwind-merge": "^1.12.0"
+    "tailwind-merge": "^3.6.0"
   },
   "devDependencies": {
     "@rallly/tsconfig": "workspace:*",

--- a/packages/ui/src/lib/utils.test.ts
+++ b/packages/ui/src/lib/utils.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+import { cn } from "./utils";
+
+describe("cn", () => {
+  it("resolves conflicts between viewport-unit and standard sizing utilities", () => {
+    expect(cn("min-h-svh", "min-h-full")).toBe("min-h-full");
+  });
+
+  it("does not treat text-wrap utilities as text colors", () => {
+    expect(cn("text-pretty", "text-muted-foreground")).toBe(
+      "text-pretty text-muted-foreground",
+    );
+  });
+
+  it("resolves conflicts within the same class group", () => {
+    expect(cn("text-balance", "text-pretty")).toBe("text-pretty");
+    expect(cn("text-sm", "text-base")).toBe("text-base");
+  });
+});

--- a/packages/ui/src/lib/utils.ts
+++ b/packages/ui/src/lib/utils.ts
@@ -1,15 +1,6 @@
 import type { ClassValue } from "clsx";
 import clsx from "clsx";
-import { extendTailwindMerge } from "tailwind-merge";
-
-// tailwind-merge v1 predates the text-wrap utilities and misclassifies them
-// as text colors, so `cn("text-pretty text-muted-foreground")` would drop
-// `text-pretty`. Remove this once tailwind-merge is upgraded to v2+.
-const twMerge = extendTailwindMerge({
-  classGroups: {
-    "text-wrap": [{ text: ["wrap", "nowrap", "balance", "pretty"] }],
-  },
-});
+import { twMerge } from "tailwind-merge";
 
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -94,7 +94,7 @@ importers:
         version: 8.1.0(typescript@6.0.3)
       '@vercel/analytics':
         specifier: ^1.5.0
-        version: 1.6.1(next@16.3.0(@opentelemetry/api@1.9.0)(@playwright/test@1.58.1)(@types/node@24.10.11)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)
+        version: 1.6.1(next@16.3.0(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.1)(@types/node@24.10.11)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)
       dayjs:
         specifier: ^1.11.13
         version: 1.11.19
@@ -133,7 +133,7 @@ importers:
         version: 6.0.0(@types/react@19.2.13)(react@19.2.6)
       next-seo:
         specifier: ^6.1.0
-        version: 6.8.0(next@16.3.0(@opentelemetry/api@1.9.0)(@playwright/test@1.58.1)(@types/node@24.10.11)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        version: 6.8.0(next@16.3.0(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.1)(@types/node@24.10.11)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       pg:
         specifier: ^8.17.1
         version: 8.18.0
@@ -858,8 +858,8 @@ importers:
         specifier: ^2.0.6
         version: 2.0.7(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       tailwind-merge:
-        specifier: ^1.12.0
-        version: 1.14.0
+        specifier: ^3.6.0
+        version: 3.6.0
     devDependencies:
       '@rallly/tsconfig':
         specifier: workspace:*
@@ -10950,8 +10950,8 @@ packages:
     resolution: {integrity: sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==}
     engines: {node: '>=20'}
 
-  tailwind-merge@1.14.0:
-    resolution: {integrity: sha512-3mFKyCo/MBcgyOTlrY8T7odzZFx+w+qKSMAmdFzRvqBfLlSigU6TZnlFHK0lkMwj9Bj8OYU+9yW9lmGuS0QEnQ==}
+  tailwind-merge@3.6.0:
+    resolution: {integrity: sha512-uxL7qAVQriqRQPAyK3pj66VqskWqoZ37PW94jwOTwNfq/z9oyu1V+eqrZqtR2+fCiXdYOZe/Modt8GtvqNzu+w==}
 
   tailwind-scrollbar@4.0.2:
     resolution: {integrity: sha512-wAQiIxAPqk0MNTPptVe/xoyWi27y+NRGnTwvn4PQnbvB9kp8QUBiGl/wsfoVBHnQxTmhXJSNt9NHTmcz9EivFA==}
@@ -18359,7 +18359,7 @@ snapshots:
     dependencies:
       uncrypto: 0.1.3
 
-  '@vercel/analytics@1.6.1(next@16.3.0(@opentelemetry/api@1.9.0)(@playwright/test@1.58.1)(@types/node@24.10.11)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)':
+  '@vercel/analytics@1.6.1(next@16.3.0(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.1)(@types/node@24.10.11)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)':
     optionalDependencies:
       next: 16.3.0(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.1)(@types/node@24.10.11)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react: 19.2.6
@@ -22111,7 +22111,7 @@ snapshots:
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
 
-  next-seo@6.8.0(next@16.3.0(@opentelemetry/api@1.9.0)(@playwright/test@1.58.1)(@types/node@24.10.11)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
+  next-seo@6.8.0(next@16.3.0(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.1)(@types/node@24.10.11)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
     dependencies:
       next: 16.3.0(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.1)(@types/node@24.10.11)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react: 19.2.6
@@ -24138,7 +24138,7 @@ snapshots:
 
   tagged-tag@1.0.0: {}
 
-  tailwind-merge@1.14.0: {}
+  tailwind-merge@3.6.0: {}
 
   tailwind-scrollbar@4.0.2(react@19.2.6)(tailwindcss@4.1.18):
     dependencies:


### PR DESCRIPTION
## What changed

- Upgraded `tailwind-merge` from `^1.12.0` to `^3.6.0` in `packages/ui` (the only package in the monorepo that depends on it). The v3 line matches Tailwind CSS 4.x, which the repo is on.
- Removed the `extendTailwindMerge` workaround in `cn()` that manually taught v1 about text-wrap utilities — v3 classifies them natively, so `cn` is now plain `twMerge(clsx(inputs))`.
- Added unit tests for `cn()` (`packages/ui/src/lib/utils.test.ts`).

## Why

tailwind-merge v1 had two classification gaps that made `className` overrides silently fail:

1. Text-wrap utilities (`text-pretty`, `text-balance`, …) were misclassified as text colors, so `cn("text-pretty", "text-muted-foreground")` dropped `text-pretty`. This was patched with the `extendTailwindMerge` workaround, with a comment to remove it after upgrading.
2. Viewport-unit sizing utilities (`svh`/`dvh`) weren't grouped with standard sizing, so `min-h-svh` and `min-h-full` weren't treated as conflicting — overriding `SidebarProvider`'s `min-h-svh` via `className` had no effect.

v3 fixes both natively; the new tests pin the exact failure modes.

## Notes for review

- v1 → v3 is two major versions, so merge behavior improves beyond the two cases above (arbitrary values, important modifiers, etc.). If any component accidentally relied on v1 *failing* to merge two conflicting classes, its rendered class list changes — nothing in the test suite or type-check flags such a case.
- Test classes are passed as separate arguments (`cn("min-h-svh", "min-h-full")`) rather than one string because Biome's `useSortedClasses` auto-sorts multi-class string literals, which would reorder the conflicting classes and invert what the test exercises.
- `pnpm check` and `pnpm type-check` pass; the 3 new tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved utility class conflict resolution, including sizing and text-related classes.
  * Ensured text wrapping and text color utilities are handled independently.

* **Tests**
  * Added coverage for utility class merging scenarios.

* **Chores**
  * Updated the Tailwind utility merging dependency to improve compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->