### PR TITLE
💄 Make primary button translucent at rest and opaque on hover

### DIFF
--- a/packages/ui/src/button-variants.ts
+++ b/packages/ui/src/button-variants.ts
@@ -10,7 +10,7 @@ export const buttonVariants = cva(
     variants: {
       variant: {
         primary:
-          "bg-primary text-primary-foreground ring-1 ring-button-outline ring-inset hover:bg-primary/90 dark:bg-primary/80",
+          "bg-primary/90 text-primary-foreground ring-1 ring-button-outline ring-inset hover:bg-primary dark:bg-primary/80 dark:hover:bg-primary",
         destructive:
           "bg-destructive text-destructive-foreground ring-1 ring-button-outline ring-inset hover:bg-destructive/90 dark:bg-destructive/80",
         default:


### PR DESCRIPTION
## Description

Inverts the opacity behavior of the `primary` button variant in `packages/ui/src/button-variants.ts`. It previously rendered fully opaque and dropped to 90% opacity on hover; it now rests at `bg-primary/90` (80% in dark mode, unchanged from before) and becomes fully opaque on hover, so hover reads as emphasis instead of the button receding.

Notes for review:

- `dark:hover:bg-primary` is declared explicitly: without it, `dark:bg-primary/80` and the plain `hover:bg-primary` rule compete in the dark-mode cascade. Verified in the running app that the hover rule wins in both schemes (computed alpha 0.9 → 1 light, 0.8 → 1 dark).
- The `destructive` variant still uses the old pattern (opaque at rest, `/90` on hover). Left untouched; happy to match it in a follow-up if wanted.

## Checklist

- [x] I have performed a self-review of my code
- [x] My code follows the code style of this project
- [x] I have commented my code, particularly in hard-to-understand areas

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the primary button appearance with a partially transparent background.
  * Added a distinct inset background effect when hovering over primary buttons.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->