### PR TITLE
♻️ Convert the members page to server components and loaders

### DIFF
--- a/apps/web/src/app/[locale]/(space)/(dashboard)/members/components/cancel-invite-button.tsx
+++ b/apps/web/src/app/[locale]/(space)/(dashboard)/members/components/cancel-invite-button.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { subject } from "@casl/ability";
 import { Button } from "@rallly/ui/button";
 import {
   Dialog,
@@ -13,19 +12,19 @@ import {
   useDialog,
 } from "@rallly/ui/dialog";
 import { toast } from "@rallly/ui/sonner";
-import { useSpace } from "@/features/space/client";
 import { cancelInviteAction } from "@/features/space/member/actions";
 import { Trans, useTranslation } from "@/i18n/client";
 import { useSafeAction } from "@/lib/safe-action/client";
 
-type SpaceMemberInvite = {
-  id: string;
-  email: string;
-  spaceId: string;
-};
-
-export function CancelInviteButton({ invite }: { invite: SpaceMemberInvite }) {
-  const space = useSpace();
+export function CancelInviteButton({
+  inviteId,
+  inviteEmail,
+  disabled,
+}: {
+  inviteId: string;
+  inviteEmail: string;
+  disabled?: boolean;
+}) {
   const cancelInviteDialog = useDialog();
   const { t } = useTranslation();
   const cancelInvite = useSafeAction(cancelInviteAction, {
@@ -41,15 +40,11 @@ export function CancelInviteButton({ invite }: { invite: SpaceMemberInvite }) {
     },
   });
 
-  const canCancelInvite = space
-    .getMemberAbility()
-    .can("delete", subject("SpaceMemberInvite", invite));
-
   return (
     <>
       <Button
         size="sm"
-        disabled={!canCancelInvite}
+        disabled={disabled}
         onClick={() => {
           cancelInviteDialog.trigger();
         }}
@@ -66,7 +61,7 @@ export function CancelInviteButton({ invite }: { invite: SpaceMemberInvite }) {
               <Trans
                 i18nKey="cancelInviteConfirmation"
                 defaults="Are you sure you want to cancel the invite for {email}?"
-                values={{ email: invite.email }}
+                values={{ email: inviteEmail }}
               />
             </DialogDescription>
           </DialogHeader>
@@ -75,7 +70,7 @@ export function CancelInviteButton({ invite }: { invite: SpaceMemberInvite }) {
               variant="destructive"
               loading={cancelInvite.isExecuting}
               onClick={() => {
-                cancelInvite.execute({ inviteId: invite.id });
+                cancelInvite.execute({ inviteId });
               }}
             >
               <Trans i18nKey="confirm" defaults="Confirm" />

--- a/apps/web/src/app/[locale]/(space)/(dashboard)/members/components/invite-member-button.tsx
+++ b/apps/web/src/app/[locale]/(space)/(dashboard)/members/components/invite-member-button.tsx
@@ -5,36 +5,30 @@ import { useDialog } from "@rallly/ui/dialog";
 import { Icon } from "@rallly/ui/icon";
 import { toast } from "@rallly/ui/sonner";
 import { UserPlusIcon } from "lucide-react";
-import { showPayWall } from "@/features/billing/client";
-import { useSpace } from "@/features/space/client";
 import { Trans, useTranslation } from "@/i18n/client";
 import { InviteMemberDialog } from "./invite-member-dialog";
 
 export function InviteMemberButton({
-  usedSeats,
-  totalSeats,
+  disabled,
+  canCreateInvite,
 }: {
-  usedSeats: number;
-  totalSeats: number;
+  disabled?: boolean;
+  canCreateInvite: boolean;
 }) {
   const { t } = useTranslation();
   const inviteMemberDialog = useDialog();
-  const space = useSpace();
-  const availableSeats = Math.max(totalSeats - usedSeats, 0);
   return (
     <>
       <Button
         variant="primary"
-        disabled={availableSeats <= 0}
+        disabled={disabled}
         onClick={() => {
-          if (space.getMemberAbility().cannot("create", "SpaceMemberInvite")) {
+          if (!canCreateInvite) {
             toast.error(
               t("adminRoleRequired", {
                 defaultValue: "You need to be an admin to perform this action",
               }),
             );
-          } else if (space.getAbility().cannot("invite", "Member")) {
-            showPayWall({ from: "space-members", action: "invite" });
           } else {
             inviteMemberDialog.trigger();
           }

--- a/apps/web/src/app/[locale]/(space)/(dashboard)/members/components/member-dropdown-menu.tsx
+++ b/apps/web/src/app/[locale]/(space)/(dashboard)/members/components/member-dropdown-menu.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { subject } from "@casl/ability";
 import { Button } from "@rallly/ui/button";
 import {
   Dialog,
@@ -22,7 +21,6 @@ import {
 import { Icon } from "@rallly/ui/icon";
 import { toast } from "@rallly/ui/sonner";
 import { MoreVerticalIcon, ShieldIcon, UserIcon, XIcon } from "lucide-react";
-import { useSpace } from "@/features/space/client";
 import {
   changeMemberRoleAction,
   removeMemberAction,
@@ -32,8 +30,15 @@ import type { MemberRole } from "@/features/space/schema";
 import { Trans, useTranslation } from "@/i18n/client";
 import { useSafeAction } from "@/lib/safe-action/client";
 
-export function MemberDropdownMenu({ member }: { member: MemberDTO }) {
-  const space = useSpace();
+export function MemberDropdownMenu({
+  member,
+  canUpdate,
+  canDelete,
+}: {
+  member: MemberDTO;
+  canUpdate: boolean;
+  canDelete: boolean;
+}) {
   const removeMemberDialog = useDialog();
   const { t } = useTranslation();
   const removeMember = useSafeAction(removeMemberAction, {
@@ -57,14 +62,6 @@ export function MemberDropdownMenu({ member }: { member: MemberDTO }) {
       );
     },
   });
-
-  const canUpdateMember = space
-    .getMemberAbility()
-    .can("update", subject("SpaceMember", member));
-
-  const canDeleteMember = space
-    .getMemberAbility()
-    .can("delete", subject("SpaceMember", member));
 
   const handleRoleChange = (newRole: MemberRole) => {
     changeMemberRole.execute({
@@ -93,7 +90,7 @@ export function MemberDropdownMenu({ member }: { member: MemberDTO }) {
           {member.role === "member" ? (
             <DropdownMenuItem
               onClick={() => handleRoleChange("admin")}
-              disabled={!canUpdateMember}
+              disabled={!canUpdate}
             >
               <Icon>
                 <ShieldIcon className="size-4" />
@@ -103,7 +100,7 @@ export function MemberDropdownMenu({ member }: { member: MemberDTO }) {
           ) : (
             <DropdownMenuItem
               onClick={() => handleRoleChange("member")}
-              disabled={!canUpdateMember}
+              disabled={!canUpdate}
             >
               <Icon>
                 <UserIcon />
@@ -116,7 +113,7 @@ export function MemberDropdownMenu({ member }: { member: MemberDTO }) {
             onClick={() => {
               removeMemberDialog.trigger();
             }}
-            disabled={!canDeleteMember}
+            disabled={!canDelete}
             variant="destructive"
           >
             <XIcon />

--- a/apps/web/src/app/[locale]/(space)/(dashboard)/members/components/pending-invites-dialog.tsx
+++ b/apps/web/src/app/[locale]/(space)/(dashboard)/members/components/pending-invites-dialog.tsx
@@ -9,21 +9,17 @@ import {
 } from "@rallly/ui/dialog";
 import { StackedList, StackedListItem } from "@/components/stacked-list";
 import { SpaceRole } from "@/features/space/components/space-role";
-import type { MemberRole } from "@/features/space/schema";
+import type { MemberInviteDTO } from "@/features/space/member/types";
 import { Trans } from "@/i18n/client";
 import { CancelInviteButton } from "./cancel-invite-button";
 
 export function PendingInvitesDialog({
   invites,
+  canCancelInvite,
   ...dialogProps
 }: {
-  invites: {
-    id: string;
-    email: string;
-    spaceId: string;
-    role: MemberRole;
-    invitedBy: { name: string };
-  }[];
+  invites: MemberInviteDTO[];
+  canCancelInvite: boolean;
 } & DialogProps) {
   return (
     <Dialog {...dialogProps}>
@@ -49,7 +45,11 @@ export function PendingInvitesDialog({
               <div className="text-sm">
                 <SpaceRole role={invite.role} />
               </div>
-              <CancelInviteButton invite={invite} />
+              <CancelInviteButton
+                inviteId={invite.id}
+                inviteEmail={invite.email}
+                disabled={!canCancelInvite}
+              />
             </StackedListItem>
           ))}
         </StackedList>

--- a/apps/web/src/app/[locale]/(space)/(dashboard)/members/components/pending-invites.tsx
+++ b/apps/web/src/app/[locale]/(space)/(dashboard)/members/components/pending-invites.tsx
@@ -1,0 +1,59 @@
+"use client";
+
+import { Alert, AlertAction, AlertDescription } from "@rallly/ui/alert";
+import { Button } from "@rallly/ui/button";
+import { useDialog } from "@rallly/ui/dialog";
+import { MailIcon } from "lucide-react";
+import React from "react";
+import type { MemberInviteDTO } from "@/features/space/member/types";
+import { Trans } from "@/i18n/client";
+import { PendingInvitesDialog } from "./pending-invites-dialog";
+
+export function PendingInvites({
+  invites,
+  canCancelInvite,
+}: {
+  invites: MemberInviteDTO[];
+  canCancelInvite: boolean;
+}) {
+  const pendingInvitesDialog = useDialog();
+  const { dismiss: dismissPendingInvitesDialog } = pendingInvitesDialog;
+
+  React.useEffect(() => {
+    if (invites.length === 0) {
+      dismissPendingInvitesDialog();
+    }
+  }, [invites.length, dismissPendingInvitesDialog]);
+
+  return (
+    <>
+      {invites.length > 0 ? (
+        <Alert variant="primary">
+          <MailIcon />
+          <AlertDescription>
+            <Trans
+              i18nKey="pendingInvitesAlertDescription"
+              defaults="{count, plural, one {There is # pending invite} other {There are # pending invites}}"
+              values={{ count: invites.length }}
+            />
+          </AlertDescription>
+          <AlertAction>
+            <Button
+              size="sm"
+              onClick={() => {
+                pendingInvitesDialog.trigger();
+              }}
+            >
+              <Trans i18nKey="viewInvites" defaults="View invites" />
+            </Button>
+          </AlertAction>
+        </Alert>
+      ) : null}
+      <PendingInvitesDialog
+        invites={invites}
+        canCancelInvite={canCancelInvite}
+        {...pendingInvitesDialog.dialogProps}
+      />
+    </>
+  );
+}

--- a/apps/web/src/app/[locale]/(space)/(dashboard)/members/components/upgrade-to-pro-button.tsx
+++ b/apps/web/src/app/[locale]/(space)/(dashboard)/members/components/upgrade-to-pro-button.tsx
@@ -1,0 +1,25 @@
+"use client";
+
+import { Button } from "@rallly/ui/button";
+import { showPayWall } from "@/features/billing/client";
+import { Trans } from "@/i18n/client";
+
+export function UpgradeToProButton({
+  action,
+  variant,
+}: {
+  action: "invite" | "reactivate";
+  variant?: "link";
+}) {
+  return (
+    <Button
+      size="sm"
+      variant={variant}
+      onClick={() => {
+        showPayWall({ from: "space-members", action });
+      }}
+    >
+      <Trans i18nKey="upgradeToPro" defaults="Upgrade to Pro" />
+    </Button>
+  );
+}

--- a/apps/web/src/app/[locale]/(space)/(dashboard)/members/members-page.tsx
+++ b/apps/web/src/app/[locale]/(space)/(dashboard)/members/members-page.tsx
@@ -1,5 +1,4 @@
-"use client";
-
+import { subject } from "@casl/ability";
 import {
   Alert,
   AlertAction,
@@ -7,239 +6,216 @@ import {
   AlertTitle,
 } from "@rallly/ui/alert";
 import { Badge } from "@rallly/ui/badge";
-import { Button } from "@rallly/ui/button";
-import { useDialog } from "@rallly/ui/dialog";
-import { InfoIcon, MailIcon, SparklesIcon } from "lucide-react";
+import { InfoIcon, SparklesIcon } from "lucide-react";
 import Link from "next/link";
-import React from "react";
 import { IfCloudHosted, IfSelfHosted } from "@/components/environment";
 import { OptimizedAvatarImage } from "@/components/optimized-avatar-image";
-import {
-  PageContainer,
-  PageContent,
-  PageHeader,
-  PageHeaderActions,
-  PageHeaderContent,
-  PageTitle,
-} from "@/components/page-layout";
+import { PageHeaderActions } from "@/components/page-layout";
 import { StackedList, StackedListItem } from "@/components/stacked-list";
-import { showPayWall } from "@/features/billing/client";
-import { useSpace } from "@/features/space/client";
+import { defineAbilityForSpace } from "@/features/space/ability";
 import { SpaceRole } from "@/features/space/components/space-role";
+import { getActiveSpace, getSeatUsage } from "@/features/space/loaders";
+import { defineAbilityForMember } from "@/features/space/member/ability";
+import {
+  loadPendingInvites,
+  loadSpaceMembers,
+} from "@/features/space/member/loaders";
+import { requireUser } from "@/features/user/loaders";
 import { Trans } from "@/i18n/client";
 import { IfFeatureEnabled } from "@/lib/feature-flags/client";
-import { trpc } from "@/trpc/client";
 import { InviteMemberButton } from "./components/invite-member-button";
 import { MemberDropdownMenu } from "./components/member-dropdown-menu";
-import { PendingInvitesDialog } from "./components/pending-invites-dialog";
+import { PendingInvites } from "./components/pending-invites";
+import { UpgradeToProButton } from "./components/upgrade-to-pro-button";
 
-export function MembersPage({
-  totalSeats,
-  usedSeats,
-}: {
-  totalSeats: number;
-  usedSeats: number;
-}) {
-  const space = useSpace();
-  const [members] = trpc.spaces.listMembers.useSuspenseQuery();
-  const [invites] = trpc.spaces.listInvites.useSuspenseQuery();
-  const canInviteMembers = space.getAbility().can("invite", "Member");
-  const hasInactiveMembers = space.data.tier === "hobby" && members.total > 1;
-  const availableSeats = Math.max(totalSeats - usedSeats, 0);
-  const pendingInvitesDialog = useDialog();
-  const { dismiss: dismissPendingInvitesDialog } = pendingInvitesDialog;
+async function getMemberAbility() {
+  const [user, space] = await Promise.all([requireUser(), getActiveSpace()]);
 
-  React.useEffect(() => {
-    if (invites.length === 0) {
-      dismissPendingInvitesDialog();
-    }
-  }, [invites.length, dismissPendingInvitesDialog]);
+  return defineAbilityForMember({
+    user: { id: user.id },
+    space: { id: space.id, ownerId: space.ownerId, role: space.role },
+  });
+}
+
+export async function MembersPageActions() {
+  const space = await getActiveSpace();
+
+  if (defineAbilityForSpace(space).cannot("invite", "Member")) {
+    return null;
+  }
+
+  const [seatUsage, memberAbility] = await Promise.all([
+    getSeatUsage(),
+    getMemberAbility(),
+  ]);
+  const availableSeats = Math.max(seatUsage.total - seatUsage.used, 0);
 
   return (
-    <PageContainer>
-      <PageHeader>
-        <PageHeaderContent>
-          <PageTitle>
-            <Trans i18nKey="members" defaults="Members" />
-          </PageTitle>
-        </PageHeaderContent>
-        {canInviteMembers ? (
-          <PageHeaderActions>
-            <p className="mr-2 text-muted-foreground text-sm">
-              <Trans
-                i18nKey="seatsAvailable"
-                defaults="{count, plural, =0 {No seats available} one {# seat available} other {# seats available}}"
-                values={{ count: availableSeats }}
-              />
-            </p>
-            <InviteMemberButton usedSeats={usedSeats} totalSeats={totalSeats} />
-          </PageHeaderActions>
-        ) : null}
-      </PageHeader>
-      <PageContent className="space-y-4">
-        {canInviteMembers && invites.length > 0 ? (
-          <Alert variant="primary">
-            <MailIcon />
-            <AlertDescription>
-              <Trans
-                i18nKey="pendingInvitesAlertDescription"
-                defaults="{count, plural, one {There is # pending invite} other {There are # pending invites}}"
-                values={{ count: invites.length }}
-              />
-            </AlertDescription>
-            <AlertAction>
-              <Button
-                size="sm"
-                onClick={() => {
-                  pendingInvitesDialog.trigger();
-                }}
-              >
-                <Trans i18nKey="viewInvites" defaults="View invites" />
-              </Button>
-            </AlertAction>
-          </Alert>
-        ) : null}
-        {canInviteMembers && availableSeats <= 0 ? (
-          <Alert variant="info">
-            <InfoIcon />
-            <AlertDescription>
-              <IfCloudHosted>
-                <p>
-                  <Trans
-                    i18nKey="noSeatsAvailableAlertBillingDescription"
-                    defaults="Increase the number of seats in this space from the <a>billing page</a>."
-                    components={{
-                      a: (
-                        <Link
-                          className="underline hover:text-foreground"
-                          href="/settings/billing"
-                        />
-                      ),
-                    }}
-                  />
-                </p>
-              </IfCloudHosted>
-              <IfSelfHosted>
-                <p>
-                  <Trans
-                    i18nKey="noSeatsAvailableAlertSelfHostedDescription"
-                    defaults="You will need to <a>upgrade</a> to increase the number of seats in this space."
-                    components={{
-                      a: (
-                        <Link
-                          className="underline hover:text-foreground"
-                          prefetch={false}
-                          href="https://support.rallly.co/self-hosting/licensing"
-                        />
-                      ),
-                    }}
-                  />
-                </p>
-              </IfSelfHosted>
-            </AlertDescription>
-          </Alert>
-        ) : null}
-        <IfFeatureEnabled feature="billing">
-          {hasInactiveMembers ? (
-            <Alert>
-              <InfoIcon />
-              <AlertTitle>
+    <PageHeaderActions>
+      <p className="mr-2 text-muted-foreground text-sm">
+        <Trans
+          i18nKey="seatsAvailable"
+          defaults="{count, plural, =0 {No seats available} one {# seat available} other {# seats available}}"
+          values={{ count: availableSeats }}
+        />
+      </p>
+      <InviteMemberButton
+        disabled={availableSeats <= 0}
+        canCreateInvite={memberAbility.can("create", "SpaceMemberInvite")}
+      />
+    </PageHeaderActions>
+  );
+}
+
+export async function MembersPageContent() {
+  const [space, members, seatUsage, memberAbility] = await Promise.all([
+    getActiveSpace(),
+    loadSpaceMembers(),
+    getSeatUsage(),
+    getMemberAbility(),
+  ]);
+
+  const canInviteMembers = defineAbilityForSpace(space).can("invite", "Member");
+  const invites = canInviteMembers ? await loadPendingInvites() : [];
+  const availableSeats = Math.max(seatUsage.total - seatUsage.used, 0);
+  const hasInactiveMembers = space.tier === "hobby" && members.length > 1;
+
+  return (
+    <>
+      {canInviteMembers ? (
+        <PendingInvites
+          invites={invites}
+          canCancelInvite={memberAbility.can("delete", "SpaceMemberInvite")}
+        />
+      ) : null}
+      {canInviteMembers && availableSeats <= 0 ? (
+        <Alert variant="info">
+          <InfoIcon />
+          <AlertDescription>
+            <IfCloudHosted>
+              <p>
                 <Trans
-                  i18nKey="membersInactiveAlertTitle"
-                  defaults="Members are inactive"
-                />
-              </AlertTitle>
-              <AlertDescription>
-                <Trans
-                  i18nKey="membersInactiveAlertDescription"
-                  defaults="These members lost access when this space's Pro subscription ended. Their seats are kept and access is restored when the space is upgraded again."
-                />
-              </AlertDescription>
-              <AlertAction>
-                <Button
-                  size="sm"
-                  onClick={() => {
-                    showPayWall({
-                      from: "space-members",
-                      action: "reactivate",
-                    });
+                  i18nKey="noSeatsAvailableAlertBillingDescription"
+                  defaults="Increase the number of seats in this space from the <a>billing page</a>."
+                  components={{
+                    a: (
+                      <Link
+                        className="underline hover:text-foreground"
+                        href="/settings/billing"
+                      />
+                    ),
                   }}
-                >
-                  <Trans i18nKey="upgradeToPro" defaults="Upgrade to Pro" />
-                </Button>
-              </AlertAction>
-            </Alert>
-          ) : null}
-        </IfFeatureEnabled>
-        {!canInviteMembers && !hasInactiveMembers ? (
-          <Alert variant="primary">
-            <SparklesIcon />
+                />
+              </p>
+            </IfCloudHosted>
+            <IfSelfHosted>
+              <p>
+                <Trans
+                  i18nKey="noSeatsAvailableAlertSelfHostedDescription"
+                  defaults="You will need to <a>upgrade</a> to increase the number of seats in this space."
+                  components={{
+                    a: (
+                      <Link
+                        className="underline hover:text-foreground"
+                        prefetch={false}
+                        href="https://support.rallly.co/self-hosting/licensing"
+                      />
+                    ),
+                  }}
+                />
+              </p>
+            </IfSelfHosted>
+          </AlertDescription>
+        </Alert>
+      ) : null}
+      <IfFeatureEnabled feature="billing">
+        {hasInactiveMembers ? (
+          <Alert>
+            <InfoIcon />
+            <AlertTitle>
+              <Trans
+                i18nKey="membersInactiveAlertTitle"
+                defaults="Members are inactive"
+              />
+            </AlertTitle>
             <AlertDescription>
               <Trans
-                i18nKey="inviteMembersUpsellDescription"
-                defaults="Invite members to manage polls and events together in this space."
+                i18nKey="membersInactiveAlertDescription"
+                defaults="These members lost access when this space's Pro subscription ended. Their seats are kept and access is restored when the space is upgraded again."
               />
             </AlertDescription>
             <AlertAction>
-              <Button
-                size="sm"
-                variant="link"
-                onClick={() => {
-                  showPayWall({ from: "space-members", action: "invite" });
-                }}
-              >
-                <Trans i18nKey="upgradeToPro" defaults="Upgrade to Pro" />
-              </Button>
+              <UpgradeToProButton action="reactivate" />
             </AlertAction>
           </Alert>
         ) : null}
-        <StackedList>
-          {members.data.map((member) => (
-            <StackedListItem key={member.id}>
-              <div className="flex flex-1 items-center gap-4">
-                <OptimizedAvatarImage
-                  src={member.image ?? undefined}
-                  name={member.name}
-                  size="xl"
-                />
-                <div>
-                  <div className="flex items-center gap-x-2">
-                    <div className="font-semibold text-sm">{member.name}</div>
-                    <div>
-                      {member.isOwner ? (
+      </IfFeatureEnabled>
+      {!canInviteMembers && !hasInactiveMembers ? (
+        <Alert variant="primary">
+          <SparklesIcon />
+          <AlertDescription>
+            <Trans
+              i18nKey="inviteMembersUpsellDescription"
+              defaults="Invite members to manage polls and events together in this space."
+            />
+          </AlertDescription>
+          <AlertAction>
+            <UpgradeToProButton action="invite" variant="link" />
+          </AlertAction>
+        </Alert>
+      ) : null}
+      <StackedList>
+        {members.map((member) => (
+          <StackedListItem key={member.id}>
+            <div className="flex flex-1 items-center gap-4">
+              <OptimizedAvatarImage
+                src={member.image}
+                name={member.name}
+                size="xl"
+              />
+              <div>
+                <div className="flex items-center gap-x-2">
+                  <div className="font-semibold text-sm">{member.name}</div>
+                  <div>
+                    {member.isOwner ? (
+                      <Badge>
+                        <Trans i18nKey="owner" defaults="Owner" />
+                      </Badge>
+                    ) : null}
+                    <IfFeatureEnabled feature="billing">
+                      {space.tier === "hobby" && !member.isOwner ? (
                         <Badge>
-                          <Trans i18nKey="owner" defaults="Owner" />
+                          <Trans i18nKey="memberInactive" defaults="Inactive" />
                         </Badge>
                       ) : null}
-                      <IfFeatureEnabled feature="billing">
-                        {space.data.tier === "hobby" && !member.isOwner ? (
-                          <Badge>
-                            <Trans
-                              i18nKey="memberInactive"
-                              defaults="Inactive"
-                            />
-                          </Badge>
-                        ) : null}
-                      </IfFeatureEnabled>
-                    </div>
-                  </div>
-                  <div className="text-muted-foreground text-sm">
-                    {member.email}
+                    </IfFeatureEnabled>
                   </div>
                 </div>
+                <div className="text-muted-foreground text-sm">
+                  {member.email}
+                </div>
               </div>
-              <div className="text-sm">
-                <SpaceRole role={member.role} />
-              </div>
-              <MemberDropdownMenu member={member} />
-            </StackedListItem>
-          ))}
-        </StackedList>
-      </PageContent>
-      <PendingInvitesDialog
-        invites={invites}
-        {...pendingInvitesDialog.dialogProps}
-      />
-    </PageContainer>
+            </div>
+            <div className="text-sm">
+              <SpaceRole role={member.role} />
+            </div>
+            <MemberDropdownMenu
+              member={member}
+              // subject() brands the object it's given in place, which would
+              // make `member` fail React's plain-object check when serialized
+              // as a client component prop — hence the copies.
+              canUpdate={memberAbility.can(
+                "update",
+                subject("SpaceMember", { ...member }),
+              )}
+              canDelete={memberAbility.can(
+                "delete",
+                subject("SpaceMember", { ...member }),
+              )}
+            />
+          </StackedListItem>
+        ))}
+      </StackedList>
+    </>
   );
 }

--- a/apps/web/src/app/[locale]/(space)/(dashboard)/members/page.tsx
+++ b/apps/web/src/app/[locale]/(space)/(dashboard)/members/page.tsx
@@ -1,25 +1,44 @@
-import { dehydrate, HydrationBoundary } from "@tanstack/react-query";
+import { Skeleton } from "@rallly/ui/skeleton";
 import type { Metadata } from "next";
-import { getSeatUsage } from "@/features/space/loaders";
+import { Suspense } from "react";
+import {
+  PageContainer,
+  PageContent,
+  PageHeader,
+  PageHeaderContent,
+  PageTitle,
+} from "@/components/page-layout";
+import { Trans } from "@/i18n/client";
 import { getTranslation } from "@/i18n/server";
-import { createPrivateSSRHelper } from "@/trpc/server/create-ssr-helper";
-import { MembersPage } from "./members-page";
+import { MembersPageActions, MembersPageContent } from "./members-page";
 
-export default async function Page() {
-  const [seatUsage, helpers] = await Promise.all([
-    getSeatUsage(),
-    createPrivateSSRHelper(),
-  ]);
-
-  await Promise.all([
-    helpers.spaces.listMembers.prefetch(),
-    helpers.spaces.listInvites.prefetch(),
-  ]);
-
+export default function Page() {
   return (
-    <HydrationBoundary state={dehydrate(helpers.queryClient)}>
-      <MembersPage totalSeats={seatUsage.total} usedSeats={seatUsage.used} />
-    </HydrationBoundary>
+    <PageContainer>
+      <PageHeader>
+        <PageHeaderContent>
+          <PageTitle>
+            <Trans i18nKey="members" defaults="Members" />
+          </PageTitle>
+        </PageHeaderContent>
+        <Suspense>
+          <MembersPageActions />
+        </Suspense>
+      </PageHeader>
+      <PageContent className="space-y-4">
+        <Suspense
+          fallback={
+            <div className="space-y-4">
+              <Skeleton className="h-7 w-full" />
+              <Skeleton className="h-7 w-full" />
+              <Skeleton className="h-7 w-1/2" />
+            </div>
+          }
+        >
+          <MembersPageContent />
+        </Suspense>
+      </PageContent>
+    </PageContainer>
   );
 }
 

--- a/apps/web/src/features/space/member/data.ts
+++ b/apps/web/src/features/space/member/data.ts
@@ -1,6 +1,9 @@
 import "server-only";
 
 import { prisma } from "@rallly/database";
+import type { MemberDTO, MemberInviteDTO } from "@/features/space/member/types";
+import type { AuthorizedSpaceId } from "@/features/space/types";
+import { fromDBRole } from "@/features/space/utils";
 
 export async function getInvite(inviteId: string) {
   return prisma.spaceMemberInvite.findUnique({
@@ -10,4 +13,85 @@ export async function getInvite(inviteId: string) {
       spaceId: true,
     },
   });
+}
+
+export async function listSpaceMembers({
+  spaceId,
+}: {
+  spaceId: AuthorizedSpaceId;
+}) {
+  const members = await prisma.spaceMember.findMany({
+    where: {
+      spaceId,
+    },
+    select: {
+      id: true,
+      userId: true,
+      role: true,
+      spaceId: true,
+      space: {
+        select: {
+          ownerId: true,
+        },
+      },
+      user: {
+        select: {
+          name: true,
+          email: true,
+          image: true,
+        },
+      },
+    },
+    orderBy: {
+      createdAt: "asc",
+    },
+  });
+
+  return members.map(
+    (member) =>
+      ({
+        id: member.id,
+        userId: member.userId,
+        spaceId: member.spaceId,
+        name: member.user.name,
+        email: member.user.email,
+        image: member.user.image ?? undefined,
+        role: fromDBRole(member.role),
+        isOwner: member.userId === member.space.ownerId,
+      }) satisfies MemberDTO,
+  );
+}
+
+export async function listSpaceInvites({
+  spaceId,
+}: {
+  spaceId: AuthorizedSpaceId;
+}) {
+  const invites = await prisma.spaceMemberInvite.findMany({
+    where: {
+      spaceId,
+    },
+    select: {
+      id: true,
+      email: true,
+      spaceId: true,
+      role: true,
+      invitedBy: {
+        select: {
+          name: true,
+        },
+      },
+    },
+    orderBy: {
+      createdAt: "desc",
+    },
+  });
+
+  return invites.map(
+    (invite) =>
+      ({
+        ...invite,
+        role: fromDBRole(invite.role),
+      }) satisfies MemberInviteDTO,
+  );
 }

--- a/apps/web/src/features/space/member/loaders.ts
+++ b/apps/web/src/features/space/member/loaders.ts
@@ -1,0 +1,18 @@
+import "server-only";
+
+import { cache } from "react";
+import { getActiveSpace } from "@/features/space/loaders";
+import {
+  listSpaceInvites,
+  listSpaceMembers,
+} from "@/features/space/member/data";
+
+export const loadSpaceMembers = cache(async () => {
+  const space = await getActiveSpace();
+  return listSpaceMembers({ spaceId: space.id });
+});
+
+export const loadPendingInvites = cache(async () => {
+  const space = await getActiveSpace();
+  return listSpaceInvites({ spaceId: space.id });
+});

--- a/apps/web/src/features/space/member/mutations.ts
+++ b/apps/web/src/features/space/member/mutations.ts
@@ -4,6 +4,7 @@ import { prisma } from "@rallly/database";
 import { sendSpaceInviteEmail } from "@rallly/emails/templates/space-invite";
 import { createLogger } from "@rallly/logger";
 import { absoluteUrl } from "@rallly/utils/absolute-url";
+import { revalidatePath } from "next/cache";
 import { getInstanceBranding } from "@/emails/branding";
 import { getTotalSeatsForSpace } from "@/features/space/data";
 import type { MemberRole } from "@/features/space/schema";
@@ -11,6 +12,10 @@ import { toDBRole } from "@/features/space/utils";
 import { setActiveSpace } from "@/features/user/mutations";
 
 const logger = createLogger("space/member/mutations");
+
+function revalidateMembersPage() {
+  revalidatePath("/[locale]/(space)/(dashboard)/members", "page");
+}
 
 export async function inviteMember({
   spaceId,
@@ -50,6 +55,8 @@ export async function inviteMember({
         where: { id: existingInvite.id },
         data: { role: toDBRole(role) },
       });
+
+      revalidateMembersPage();
 
       return { ok: true as const, code: "INVITE_UPDATED" as const };
     }
@@ -92,6 +99,8 @@ export async function inviteMember({
     await prisma.spaceMemberInvite.delete({ where: { id: invite.id } });
     return { ok: false as const, reason: "INVITE_FAILED" as const };
   }
+
+  revalidateMembersPage();
 
   return { ok: true as const, code: "INVITE_SENT" as const };
 }
@@ -148,6 +157,8 @@ export async function acceptInvite({
     logger.warn({ error }, "Failed to update user's active space");
   }
 
+  revalidateMembersPage();
+
   return result;
 }
 
@@ -155,6 +166,8 @@ export async function cancelInvite({ inviteId }: { inviteId: string }) {
   await prisma.spaceMemberInvite.delete({
     where: { id: inviteId },
   });
+
+  revalidateMembersPage();
 }
 
 export async function removeMember({ memberId }: { memberId: string }) {
@@ -165,6 +178,8 @@ export async function removeMember({ memberId }: { memberId: string }) {
   const memberCount = await prisma.spaceMember.count({
     where: { spaceId: removedMember.spaceId },
   });
+
+  revalidateMembersPage();
 
   return { removedUserId: removedMember.userId, memberCount };
 }
@@ -180,4 +195,6 @@ export async function changeMemberRole({
     where: { id: memberId },
     data: { role: toDBRole(role) },
   });
+
+  revalidateMembersPage();
 }

--- a/apps/web/src/features/space/member/types.ts
+++ b/apps/web/src/features/space/member/types.ts
@@ -10,3 +10,11 @@ export type MemberDTO = {
   role: MemberRole;
   isOwner: boolean;
 };
+
+export type MemberInviteDTO = {
+  id: string;
+  email: string;
+  spaceId: string;
+  role: MemberRole;
+  invitedBy: { name: string };
+};

--- a/apps/web/src/trpc/routers/spaces.ts
+++ b/apps/web/src/trpc/routers/spaces.ts
@@ -51,30 +51,6 @@ export const spaces = router({
       })),
     };
   }),
-  listInvites: spaceProcedure.query(async ({ ctx }) => {
-    const invites = await prisma.spaceMemberInvite.findMany({
-      where: {
-        spaceId: ctx.space.id,
-      },
-      include: {
-        invitedBy: {
-          select: {
-            id: true,
-            name: true,
-            email: true,
-          },
-        },
-      },
-      orderBy: {
-        createdAt: "desc",
-      },
-    });
-
-    return invites.map((invite) => ({
-      ...invite,
-      role: fromDBRole(invite.role),
-    }));
-  }),
   // ── Mutations ────────────────────────────────────────────────────────
   leave: spaceProcedure.mutation(async ({ ctx }) => {
     if (ctx.space.ownerId === ctx.user.id) {


### PR DESCRIPTION
Moves the members page off tRPC reads onto the standard loaders/data architecture (RAL-1544, follow-up to #2929). No visible UI change.

## What changed

**Reads**
- The inline Prisma queries from `spaces.listMembers`/`spaces.listInvites` now live in `features/space/member/data.ts` as `listSpaceMembers`/`listSpaceInvites` (tenant scope as `AuthorizedSpaceId`, `import "server-only"`).
- New `features/space/member/loaders.ts` with `loadSpaceMembers`/`loadPendingInvites` (React `cache()` + `getActiveSpace()`).
- The page is a sync shell; the awaits happen in two Suspense-wrapped async server components (`MembersPageActions`, `MembersPageContent`) per the streaming gate pattern. `createPrivateSSRHelper`/`HydrationBoundary`/`useSuspenseQuery` are gone from this page.
- Pending invites are only fetched when the space ability allows inviting.

**Abilities**
- Computed server side and passed as plain props: the member dropdown takes `canUpdate`/`canDelete`, the cancel button `disabled`, the invite button `canCreateInvite` + `disabled`. `useSpace()` is no longer used by these leaves.
- The paywall branch inside `InviteMemberButton` was unreachable (the button only renders when the space ability allows inviting) and is removed.

**Writes**
- Member mutations (`inviteMember`, `acceptInvite`, `cancelInvite`, `removeMember`, `changeMemberRole`) now call `revalidatePath` on the members page after successful writes, so the server-rendered list refreshes after invite/cancel/role-change/remove.

**tRPC**
- `spaces.listInvites` removed — this page was its only consumer. `spaces.listMembers` stays; the polls and events member filter dropdowns still use it.

## Behavior preserved

- Pending invites alert count, and the dialog auto-dismisses when the last invite is canceled — the effect now watches the server-passed `invites` prop emptying.
- Seat availability text and the disabled invite button when full.

## Notes for review

- CASL's `subject()` brands the object it's given in place, which made `member` fail React's plain-object check when also passed as a client component prop — the server component passes copies to `subject()`.

## Verification

- `apps/web/tests/space-members.spec.ts` passes unchanged (all 5 tests).
- `pnpm type-check`, `pnpm check`, `pnpm test:unit` clean.
- Manually verified the hobby-tier path in the browser: identical rendering, no console errors, owner-row dropdown items correctly disabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a pending-invites alert and dialog with invite counts and cancellation controls.
  * Added upgrade prompts when inviting or reactivating members requires a Pro plan.
  * Member actions now clearly reflect available permissions, including inviting, editing roles, and removing members.
  * Members and pending invitations refresh automatically after changes.

* **Improvements**
  * Improved members page loading with dedicated loading states for actions and content.
  * Invitation controls now display seat availability and prevent unavailable actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->