### PR TITLE
💄 Restyle the mobile vote segmented control to match the landing demo

### DIFF
--- a/apps/web/src/features/poll/components/vote-segmented-control.tsx
+++ b/apps/web/src/features/poll/components/vote-segmented-control.tsx
@@ -1,5 +1,4 @@
 "use client";
-import { cn } from "@rallly/ui";
 import {
   SegmentedControl,
   SegmentedControlItem,
@@ -41,7 +40,7 @@ export const VoteSegmentedControl = ({
     <SegmentedControl
       data-testid="vote-selector"
       aria-label={optionLabel}
-      className={cn("h-11", className)}
+      className={className}
       value={value ?? null}
       onValueChange={(newValue) => {
         if (newValue) {

--- a/packages/ui/src/segmented-control.tsx
+++ b/packages/ui/src/segmented-control.tsx
@@ -10,7 +10,7 @@ function SegmentedControl({ className, ...props }: RadioGroupPrimitive.Props) {
     <RadioGroupPrimitive
       data-slot="segmented-control"
       className={cn(
-        "inline-flex h-8 shrink-0 items-center justify-center rounded-xl border border-input bg-muted dark:bg-gray-900",
+        "inline-flex h-8 shrink-0 items-center justify-center rounded-lg border border-input/60 bg-muted p-0.5",
         className,
       )}
       {...props}
@@ -26,7 +26,7 @@ function SegmentedControlItem({
     <RadioPrimitive.Root
       data-slot="segmented-control-item"
       className={cn(
-        "relative inline-flex h-full cursor-pointer touch-manipulation items-center justify-center rounded-xl ring-offset-background [-webkit-tap-highlight-color:transparent] before:absolute before:inset-x-0 before:-inset-y-1 focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 data-checked:bg-white data-checked:ring-1 data-checked:ring-gray-200 data-unchecked:active:bg-black/5 dark:data-checked:bg-gray-800 dark:data-checked:ring-gray-700 dark:data-unchecked:active:bg-white/5",
+        "relative inline-flex h-full cursor-pointer touch-manipulation items-center justify-center rounded-md ring-offset-background [-webkit-tap-highlight-color:transparent] before:absolute before:inset-x-0 before:-inset-y-1 focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 data-checked:bg-white data-checked:shadow-sm data-unchecked:active:bg-black/5 data-unchecked:hover:bg-white/50 dark:data-checked:bg-gray-700 dark:data-checked:ring-1 dark:data-checked:ring-gray-600 dark:data-unchecked:active:bg-white/10 dark:data-unchecked:hover:bg-white/5",
         className,
       )}
       {...props}


### PR DESCRIPTION
Fixes RAL-1546

Restyles `VoteSegmentedControl` (via the shared `SegmentedControl` in `@rallly/ui`, which has no other consumers) to match the landing hero demo's tri-state selector:

* Track: `rounded-lg`, muted surface, `border-input/60`, `p-0.5`, `h-8`
* Selected segment: raised pill — white + `shadow-sm` in light mode, `gray-700` with a hairline `gray-600` ring in dark mode (shadows don't read on dark surfaces), icon in its vote color
* Unselected segments: icon in `gray-400`, `hover:bg-white/50` (`white/5` in dark)
* Selection is carried by the pill shape, not color alone

Radio semantics, touch behavior, focus ring, and the `data-testid`/aria contract are unchanged — verified on the invite page in both themes and via the mobile Playwright spec (one pre-existing failure in poll-creation setup, reproduced on a clean tree).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined segmented control styling with updated corner radii, borders, shadows, colors, and hover states.
  * Improved checked and unchecked item appearance across light and dark themes.
  * Simplified styling behavior for the voting control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->