### PR TITLE
🚸 Gate primary color saves behind the paywall for hobby spaces

### DIFF
--- a/apps/web/src/app/[locale]/(space)/settings/general/components/custom-branding-section.tsx
+++ b/apps/web/src/app/[locale]/(space)/settings/general/components/custom-branding-section.tsx
@@ -87,7 +87,14 @@ export function CustomBrandingSection({
     }
   };
 
-  const handleSave = () => persistColor(isDefault ? null : hexColor);
+  const handleSave = () => {
+    if (isFree) {
+      showPayWall({ from: "custom-branding", setting: "primary_color" });
+      return;
+    }
+
+    return persistColor(isDefault ? null : hexColor);
+  };
 
   // Clearing the column is what "default" means in the database, so reset
   // writes null rather than storing the default value literally.

--- a/apps/web/src/features/space/actions.ts
+++ b/apps/web/src/features/space/actions.ts
@@ -181,6 +181,13 @@ export const updateSpaceAction = authActionClient
   .action(async ({ ctx, parsedInput }) => {
     const { space } = ctx;
 
+    if (parsedInput.primaryColor && space.tier !== "pro") {
+      throw new AppError({
+        code: "PAYMENT_REQUIRED",
+        message: "You need a Pro subscription to set a primary color",
+      });
+    }
+
     await updateSpace({
       spaceId: space.id,
       name: parsedInput.name,


### PR DESCRIPTION
## Description

Saving a primary color on a hobby space previously persisted the color even though it's a Pro branding feature. Now:

- **Client**: the color picker's Save button opens the paywall dialog (`showPayWall({ from: "custom-branding", setting: "primary_color" })`) for hobby spaces, mirroring the existing custom-branding toggle behavior.
- **Server**: `updateSpaceAction` throws `PAYMENT_REQUIRED` when a non-null `primaryColor` arrives for a non-pro space, same pattern as `updateSpaceShowBrandingAction`.

Reset stays allowed for hobby spaces — it writes `null`, which is how a downgraded space clears a leftover color. Self-hosted is unaffected (spaces report as `pro`), and the name-only save from `SpaceSettingsForm` doesn't send `primaryColor`, so renaming still works on hobby spaces.

Verified in the browser as a hobby user: changing the color and clicking Save opens the upgrade dialog and the database row stays untouched.

## Checklist

- [x] I have performed a self-review of my code
- [x] My code follows the code style of this project
- [x] I have commented my code, particularly in hard-to-understand areas

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a paywall for custom branding when free-plan users attempt to set a primary color.
  * Paid-plan users can continue saving primary color customizations as before.
  * Enforced subscription requirements when updating primary color settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->