### PR TITLE
📈 Track hero demo interactions

### DIFF
--- a/apps/landing/src/components/home/hero-demo/mobile-demo.tsx
+++ b/apps/landing/src/components/home/hero-demo/mobile-demo.tsx
@@ -122,6 +122,9 @@ export const MobileDemo = ({ days }: { days: MobileDemoDay[] }) => {
                     label={`${day.label} ${option.time}`}
                     value={votes[option.id]}
                     onChange={(vote) => {
+                      posthog?.capture("landing:hero_demo_vote_change", {
+                        vote,
+                      });
                       setVotes((current) => ({
                         ...current,
                         [option.id]: vote,
@@ -162,7 +165,10 @@ export const MobileDemo = ({ days }: { days: MobileDemoDay[] }) => {
               <button
                 type="button"
                 aria-label={t("heroDemoClose", { defaultValue: "Close" })}
-                onClick={() => setSubmitted(false)}
+                onClick={() => {
+                  posthog?.capture("landing:hero_demo_close_click");
+                  setSubmitted(false);
+                }}
                 className="absolute top-3 right-3 flex size-6 cursor-pointer items-center justify-center rounded-full text-gray-400 hover:bg-gray-100 hover:text-gray-600"
               >
                 <XIcon className="size-4" />


### PR DESCRIPTION
## Description

Follow-up to #2934, which merged before this commit landed. Completes the hero demo's PostHog funnel: `landing:hero_demo_vote_change` (with the chosen vote as a property) and `landing:hero_demo_close_click` join the existing `hero_demo_continue_click` and `hero_demo_modal_cta_click`, so demo engagement is measurable end to end.

## Checklist

- [x] I have performed a self-review of my code
- [x] My code follows the code style of this project
- [x] I have commented my code, particularly in hard-to-understand areas

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Analytics**
  * Added tracking for vote changes in the mobile demo.
  * Added tracking when the submission confirmation modal is closed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->