### PR TITLE
🐛 Reject localhost, dotless hostnames and IPs as the cookie domain

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -98,6 +98,7 @@
     "smoothscroll-polyfill": "^0.4.4",
     "superjson": "^2.0.0",
     "tailwindcss": "^4.1.18",
+    "tldts": "^6.1.86",
     "undici": "^7.29.0",
     "zod": "^4.3.6",
     "zustand": "^5.0.14",

--- a/apps/web/src/env.ts
+++ b/apps/web/src/env.ts
@@ -207,9 +207,9 @@ export const env = createEnv({
      * Domain to attach to server-set cookies (auth session, locale).
      * Set to a parent domain prefixed with a leading dot (e.g. `.rallly.co`)
      * to make these cookies readable across subdomains. When unset, cookies
-     * stay scoped to the apex host of the request. Must be a dotted DNS
+     * stay scoped to the exact request host. Must be a registrable DNS
      * domain: browsers ignore the Domain attribute for localhost, dotless
-     * hostnames, and IP addresses, which breaks sign-in.
+     * hostnames, IP addresses, and public suffixes, which breaks sign-in.
      */
     NEXT_PUBLIC_COOKIE_DOMAIN: cookieDomainSchema.optional(),
   },

--- a/apps/web/src/env.ts
+++ b/apps/web/src/env.ts
@@ -287,7 +287,11 @@ export const env = createEnv({
     API_BASE_URL: process.env.API_BASE_URL,
     NEXT_PUBLIC_TURNSTILE_SITE_KEY: process.env.NEXT_PUBLIC_TURNSTILE_SITE_KEY,
     NEXT_PUBLIC_CDN_BASE_URL: process.env.NEXT_PUBLIC_CDN_BASE_URL,
-    NEXT_PUBLIC_COOKIE_DOMAIN: process.env.NEXT_PUBLIC_COOKIE_DOMAIN,
+    // Empty string means unset: the process env can override an .env file
+    // value but never remove it, so this is the only way a dev server on
+    // plain localhost can neutralize a configured cookie domain.
+    NEXT_PUBLIC_COOKIE_DOMAIN:
+      process.env.NEXT_PUBLIC_COOKIE_DOMAIN || undefined,
   },
   skipValidation: !!process.env.SKIP_ENV_VALIDATION,
 });

--- a/apps/web/src/env.ts
+++ b/apps/web/src/env.ts
@@ -5,6 +5,7 @@
 import "server-only";
 import { createEnv } from "@t3-oss/env-nextjs";
 import * as z from "zod";
+import { cookieDomainSchema } from "@/lib/cookie-domain";
 
 // Base URL fallback on preview deployments, where `NEXT_PUBLIC_BASE_URL` is
 // unset. Prefer the stable branch alias (the URL Vercel links to) over the
@@ -206,15 +207,11 @@ export const env = createEnv({
      * Domain to attach to server-set cookies (auth session, locale).
      * Set to a parent domain prefixed with a leading dot (e.g. `.rallly.co`)
      * to make these cookies readable across subdomains. When unset, cookies
-     * stay scoped to the apex host of the request.
+     * stay scoped to the apex host of the request. Must be a dotted DNS
+     * domain: browsers ignore the Domain attribute for localhost, dotless
+     * hostnames, and IP addresses, which breaks sign-in.
      */
-    NEXT_PUBLIC_COOKIE_DOMAIN: z
-      .string()
-      .regex(/^\.?[A-Za-z0-9-]+(\.[A-Za-z0-9-]+)*$/, {
-        message:
-          "must be a hostname or optional leading-dot domain (no protocol/port/path)",
-      })
-      .optional(),
+    NEXT_PUBLIC_COOKIE_DOMAIN: cookieDomainSchema.optional(),
   },
   /*
    * Due to how Next.js bundles environment variables on Edge and Client,

--- a/apps/web/src/lib/cookie-domain.test.ts
+++ b/apps/web/src/lib/cookie-domain.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+
+import { cookieDomainSchema } from "./cookie-domain";
+
+describe("cookieDomainSchema", () => {
+  it.each([
+    ".rallly.co",
+    "rallly.example.com",
+    ".rallly.example.com",
+    "example.com",
+  ])("accepts registrable domain %s", (value) => {
+    expect(cookieDomainSchema.safeParse(value).success).toBe(true);
+  });
+
+  it.each([
+    "https://example.com",
+    "example.com:3000",
+    "example.com/path",
+  ])("rejects non-hostname %s", (value) => {
+    expect(cookieDomainSchema.safeParse(value).success).toBe(false);
+  });
+
+  // Browsers refuse to create a domain cookie for these hosts and silently
+  // store the cookie host-only instead (RFC 6265bis public suffix handling).
+  // The session cookie then collides with hostOnlyCookieCleanup's host-only
+  // deletions and every sign-in destroys its own session.
+  it.each([
+    "localhost",
+    ".localhost",
+    "intranet-host",
+  ])("rejects dotless hostname %s", (value) => {
+    expect(cookieDomainSchema.safeParse(value).success).toBe(false);
+  });
+
+  it.each([
+    "127.0.0.1",
+    "192.168.1.10",
+    ".127.0.0.1",
+  ])("rejects IP address %s", (value) => {
+    expect(cookieDomainSchema.safeParse(value).success).toBe(false);
+  });
+});

--- a/apps/web/src/lib/cookie-domain.test.ts
+++ b/apps/web/src/lib/cookie-domain.test.ts
@@ -39,4 +39,24 @@ describe("cookieDomainSchema", () => {
   ])("rejects IP address %s", (value) => {
     expect(cookieDomainSchema.safeParse(value).success).toBe(false);
   });
+
+  // Browsers also refuse to set a cookie whose Domain is a public suffix:
+  // ignored entirely when it differs from the request host, downgraded to
+  // host-only when it matches. The private section counts too, so a site on
+  // foo.vercel.app cannot share cookies via Domain=.vercel.app.
+  it.each([
+    ".com",
+    "co.uk",
+    ".co.uk",
+    "vercel.app",
+  ])("rejects public suffix %s", (value) => {
+    expect(cookieDomainSchema.safeParse(value).success).toBe(false);
+  });
+
+  // Dotted domains under an unlisted TLD (intranet setups) stay valid.
+  it("accepts a dotted intranet domain", () => {
+    expect(cookieDomainSchema.safeParse(".rallly.corp.internal").success).toBe(
+      true,
+    );
+  });
 });

--- a/apps/web/src/lib/cookie-domain.ts
+++ b/apps/web/src/lib/cookie-domain.ts
@@ -1,0 +1,23 @@
+import * as z from "zod";
+
+export const cookieDomainSchema = z
+  .string()
+  .regex(/^\.?[A-Za-z0-9-]+(\.[A-Za-z0-9-]+)*$/, {
+    message:
+      "must be a hostname or optional leading-dot domain (no protocol/port/path)",
+  })
+  .refine(
+    (value) => {
+      // Browsers ignore the Domain attribute for dotless hostnames and IP
+      // addresses (RFC 6265bis public suffix handling) and store the cookie
+      // host-only instead. The session cookie then shares a store key with
+      // hostOnlyCookieCleanup's host-only deletions, so every sign-in
+      // deletes the session it just set.
+      const host = value.replace(/^\./, "");
+      return host.includes(".") && !/^\d+(\.\d+)*$/.test(host);
+    },
+    {
+      message:
+        "cannot be localhost, a single-label hostname, or an IP address. Browsers ignore the Domain attribute for these hosts, which breaks sign-in. Unset it to scope cookies to the request host instead.",
+    },
+  );

--- a/apps/web/src/lib/cookie-domain.ts
+++ b/apps/web/src/lib/cookie-domain.ts
@@ -1,3 +1,4 @@
+import { getDomain } from "tldts";
 import * as z from "zod";
 
 export const cookieDomainSchema = z
@@ -8,16 +9,18 @@ export const cookieDomainSchema = z
   })
   .refine(
     (value) => {
-      // Browsers ignore the Domain attribute for dotless hostnames and IP
-      // addresses (RFC 6265bis public suffix handling) and store the cookie
-      // host-only instead. The session cookie then shares a store key with
-      // hostOnlyCookieCleanup's host-only deletions, so every sign-in
-      // deletes the session it just set.
+      // Browsers only honor a Domain attribute naming a registrable domain.
+      // For anything else (localhost, single-label hostnames, IP addresses,
+      // public suffixes like co.uk or vercel.app) the cookie is either
+      // dropped or silently stored host-only, where it shares a store key
+      // with hostOnlyCookieCleanup's host-only deletions, so every sign-in
+      // deletes the session it just set. getDomain returns null for exactly
+      // this class; unlisted TLDs (intranet domains) still resolve.
       const host = value.replace(/^\./, "");
-      return host.includes(".") && !/^\d+(\.\d+)*$/.test(host);
+      return getDomain(host, { allowPrivateDomains: true }) !== null;
     },
     {
       message:
-        "cannot be localhost, a single-label hostname, or an IP address. Browsers ignore the Domain attribute for these hosts, which breaks sign-in. Unset it to scope cookies to the request host instead.",
+        "must be a registrable domain. Browsers ignore a Domain attribute naming localhost, an IP address, a single-label hostname, or a public suffix (like .com or .vercel.app), which breaks sign-in. Unset it to scope cookies to the request host instead.",
     },
   );

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -94,7 +94,7 @@ importers:
         version: 8.1.0(typescript@6.0.3)
       '@vercel/analytics':
         specifier: ^1.5.0
-        version: 1.6.1(next@16.3.0(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.1)(@types/node@24.10.11)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)
+        version: 1.6.1(next@16.3.0(@opentelemetry/api@1.9.0)(@playwright/test@1.58.1)(@types/node@24.10.11)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)
       dayjs:
         specifier: ^1.11.13
         version: 1.11.19
@@ -133,7 +133,7 @@ importers:
         version: 6.0.0(@types/react@19.2.13)(react@19.2.6)
       next-seo:
         specifier: ^6.1.0
-        version: 6.8.0(next@16.3.0(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.1)(@types/node@24.10.11)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        version: 6.8.0(next@16.3.0(@opentelemetry/api@1.9.0)(@playwright/test@1.58.1)(@types/node@24.10.11)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       pg:
         specifier: ^8.17.1
         version: 8.18.0
@@ -423,6 +423,9 @@ importers:
       tailwindcss:
         specifier: ^4.1.18
         version: 4.1.18
+      tldts:
+        specifier: ^6.1.86
+        version: 6.1.86
       undici:
         specifier: ^7.29.0
         version: 7.29.0
@@ -18359,7 +18362,7 @@ snapshots:
     dependencies:
       uncrypto: 0.1.3
 
-  '@vercel/analytics@1.6.1(next@16.3.0(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.1)(@types/node@24.10.11)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)':
+  '@vercel/analytics@1.6.1(next@16.3.0(@opentelemetry/api@1.9.0)(@playwright/test@1.58.1)(@types/node@24.10.11)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)':
     optionalDependencies:
       next: 16.3.0(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.1)(@types/node@24.10.11)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react: 19.2.6
@@ -22111,7 +22114,7 @@ snapshots:
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
 
-  next-seo@6.8.0(next@16.3.0(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.1)(@types/node@24.10.11)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
+  next-seo@6.8.0(next@16.3.0(@opentelemetry/api@1.9.0)(@playwright/test@1.58.1)(@types/node@24.10.11)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
     dependencies:
       next: 16.3.0(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.1)(@types/node@24.10.11)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react: 19.2.6


### PR DESCRIPTION
## What changed

`NEXT_PUBLIC_COOKIE_DOMAIN` now rejects values browsers cannot honor as a cookie Domain attribute: `localhost`, any single-label hostname (with or without a leading dot), and IP addresses. The validation lives in a new `cookieDomainSchema` (`apps/web/src/lib/cookie-domain.ts`), extracted from the inline regex in `env.ts` so it is unit testable. The `hostOnlyCookieCleanup` plugin is untouched.

## Why

Browsers ignore the Domain attribute for these hosts (RFC 6265bis public suffix handling) and store the cookie **host-only** instead. The session cookie then shares a store key (name, domain, host-only-flag, path) with `hostOnlyCookieCleanup`'s host-only deletions, so the deletion emitted in the same sign-in response evicts the session that was just set: every sign-in returns 200, `get-session` returns null, and login loops forever.

Verified empirically in Chrome plus RFC 6265bis §5.7:

- `Domain=localhost` and `Domain=127.0.0.1` are stored host-only (`cookieStore` reports `domain: null`) and are clobbered by the host-only deletion.
- Dotted domains (apex `example.com` and exact-host subdomain `en.wikipedia.org`) store a distinct domain cookie; the host-only deletion is a no-op against it. Real self-hosted deployments with `COOKIE_DOMAIN` equal to their dotted host are unaffected.

## Reviewer notes

- Failing at boot breaks nothing that works: sign-in is already impossible with a rejected value, so this converts a silent, undiagnosable login loop into an explicit config error with remediation in the message.
- This footgun has bitten twice before: a lost debugging session with `NEXT_PUBLIC_COOKIE_DOMAIN=localhost` in a dev `.env`, and the `__NEXT_PROCESSED_ENV` workaround in `playwright.config.ts` for the same class of leak.
- Client-side consumers of `process.env.NEXT_PUBLIC_COOKIE_DOMAIN` (datetime cookies) still read the raw value, but the server validates on the first request, so a bad value fails loudly before any client is involved.
- Test discipline: the six dotless/IP rejection cases were written first and observed failing against the old regex-only schema before the refinement was added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cookie domain validation to reject invalid values, including URLs, ports, paths, localhost, dotless hostnames, and IP addresses.
  * Added support for valid registrable domains and optional leading-dot formats.
  * Improved validation feedback for unsupported cookie domain values.

* **Tests**
  * Added coverage for accepted and rejected cookie domain formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->