### PR TITLE
💄 Animate landing stats with an odometer count-up on scroll

### DIFF
--- a/apps/landing/package.json
+++ b/apps/landing/package.json
@@ -11,6 +11,7 @@
     "i18n:scan": "i18next-cli extract"
   },
   "dependencies": {
+    "@number-flow/react": "^0.6.2",
     "@prisma/adapter-pg": "^7.8.0",
     "@prisma/client": "^7.8.0",
     "@rallly/billing": "workspace:*",

--- a/apps/landing/public/locales/en/home.json
+++ b/apps/landing/public/locales/en/home.json
@@ -45,7 +45,7 @@
   "new": "New",
   "pcmagQuote": "“Set up a scheduling poll in as little time as possible.”",
   "popsciQuote": "“The perfect pick if you want to keep your RSVPs simple.”",
-  "statsLast30Days": "<b><voters/> {voterCount, plural, one {person} other {people}}</b> voted on <b><polls/> {pollCount, plural, one {poll} other {polls}}</b> in the last 30 days",
+  "statsLast30Days": "<b>{voterCount, plural, one {# person} other {# people}}</b> voted on <b>{pollCount, plural, one {# poll} other {# polls}}</b> in the last 30 days",
   "subheading": "Coordinate group meetings without the back-and-forth emails",
   "viaTrustpilot": "via Trustpilot",
   "when2meetAlternative": "A modern When2Meet alternative",

--- a/apps/landing/public/locales/en/home.json
+++ b/apps/landing/public/locales/en/home.json
@@ -45,7 +45,7 @@
   "new": "New",
   "pcmagQuote": "“Set up a scheduling poll in as little time as possible.”",
   "popsciQuote": "“The perfect pick if you want to keep your RSVPs simple.”",
-  "statsLast30Days": "<b>{voterCount, plural, one {# person} other {# people}}</b> voted on <b>{pollCount, plural, one {# poll} other {# polls}}</b> in the last 30 days",
+  "statsLast30Days": "<b><voters/> {voterCount, plural, one {person} other {people}}</b> voted on <b><polls/> {pollCount, plural, one {poll} other {polls}}</b> in the last 30 days",
   "subheading": "Coordinate group meetings without the back-and-forth emails",
   "viaTrustpilot": "via Trustpilot",
   "when2meetAlternative": "A modern When2Meet alternative",

--- a/apps/landing/src/components/home/animated-number.tsx
+++ b/apps/landing/src/components/home/animated-number.tsx
@@ -48,13 +48,22 @@ export function AnimatedNumber({
   }, [value]);
 
   return (
-    <span ref={ref}>
-      <NumberFlow
-        value={shown}
-        locales={locale}
-        animated={animated}
-        spinTiming={{ duration: 1200, easing: "cubic-bezier(0.16, 1, 0.3, 1)" }}
-      />
+    <span
+      ref={ref}
+      role="img"
+      aria-label={new Intl.NumberFormat(locale).format(value)}
+    >
+      <span aria-hidden="true">
+        <NumberFlow
+          value={shown}
+          locales={locale}
+          animated={animated}
+          spinTiming={{
+            duration: 1200,
+            easing: "cubic-bezier(0.16, 1, 0.3, 1)",
+          }}
+        />
+      </span>
     </span>
   );
 }

--- a/apps/landing/src/components/home/animated-number.tsx
+++ b/apps/landing/src/components/home/animated-number.tsx
@@ -3,11 +3,48 @@
 import NumberFlow from "@number-flow/react";
 import * as React from "react";
 
-export function AnimatedNumber({
+const DURATION_MS = 1200;
+
+// Locates the first localized integer (any Unicode numbering system, with
+// locale grouping separators) so the surrounding translation stays untouched.
+function parseLocalizedInteger(text: string, locale: string) {
+  const digitFor = new Map<string, number>();
+  const plainFormat = new Intl.NumberFormat(locale, { useGrouping: false });
+  for (let digit = 0; digit <= 9; digit++) {
+    digitFor.set(plainFormat.format(digit), digit);
+  }
+  const separators = new Intl.NumberFormat(locale)
+    .formatToParts(1234567)
+    .filter((part) => part.type === "group")
+    .map((part) => part.value)
+    .join("");
+  const digits = [...digitFor.keys()].join("");
+  const pattern = new RegExp(
+    `[${digits}](?:[${digits}${separators}.,\\s\\u00A0\\u202F]*[${digits}])?`,
+    "u",
+  );
+  const match = pattern.exec(text);
+  if (!match) {
+    return null;
+  }
+  const token = match[0];
+  let value = 0;
+  for (const char of token) {
+    const digit = digitFor.get(char);
+    if (digit !== undefined) {
+      value = value * 10 + digit;
+    }
+  }
+  return { value, token, start: match.index };
+}
+
+function AnimatedNumber({
   value,
+  display,
   locale,
 }: {
   value: number;
+  display: string;
   locale: string;
 }) {
   const [shown, setShown] = React.useState(value);
@@ -48,22 +85,48 @@ export function AnimatedNumber({
   }, [value]);
 
   return (
-    <span
-      ref={ref}
-      role="img"
-      aria-label={new Intl.NumberFormat(locale).format(value)}
-    >
+    <span ref={ref} role="img" aria-label={display}>
       <span aria-hidden="true">
         <NumberFlow
           value={shown}
           locales={locale}
           animated={animated}
           spinTiming={{
-            duration: 1200,
+            duration: DURATION_MS,
             easing: "cubic-bezier(0.16, 1, 0.3, 1)",
           }}
         />
       </span>
     </span>
+  );
+}
+
+export function AnimatedStat({
+  locale,
+  children,
+}: {
+  locale: string;
+  children?: React.ReactNode;
+}) {
+  const text = React.Children.toArray(children)
+    .filter((child): child is string => typeof child === "string")
+    .join("");
+  const parsed = parseLocalizedInteger(text, locale);
+  return (
+    <strong className="font-semibold text-gray-800">
+      {parsed ? (
+        <>
+          {text.slice(0, parsed.start)}
+          <AnimatedNumber
+            value={parsed.value}
+            display={parsed.token}
+            locale={locale}
+          />
+          {text.slice(parsed.start + parsed.token.length)}
+        </>
+      ) : (
+        children
+      )}
+    </strong>
   );
 }

--- a/apps/landing/src/components/home/animated-number.tsx
+++ b/apps/landing/src/components/home/animated-number.tsx
@@ -1,0 +1,60 @@
+"use client";
+
+import NumberFlow from "@number-flow/react";
+import * as React from "react";
+
+export function AnimatedNumber({
+  value,
+  locale,
+}: {
+  value: number;
+  locale: string;
+}) {
+  const [shown, setShown] = React.useState(value);
+  const [animated, setAnimated] = React.useState(false);
+  const ref = React.useRef<HTMLSpanElement>(null);
+
+  React.useEffect(() => {
+    const el = ref.current;
+    if (!el) {
+      return;
+    }
+    if (window.matchMedia("(prefers-reduced-motion: reduce)").matches) {
+      return;
+    }
+    let frame: number;
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (!entry.isIntersecting) {
+          return;
+        }
+        observer.disconnect();
+        // Two committed renders: drop to 0 without animation, then roll up.
+        setShown(0);
+        frame = requestAnimationFrame(() => {
+          frame = requestAnimationFrame(() => {
+            setAnimated(true);
+            setShown(value);
+          });
+        });
+      },
+      { threshold: 0.5 },
+    );
+    observer.observe(el);
+    return () => {
+      observer.disconnect();
+      cancelAnimationFrame(frame);
+    };
+  }, [value]);
+
+  return (
+    <span ref={ref}>
+      <NumberFlow
+        value={shown}
+        locales={locale}
+        animated={animated}
+        spinTiming={{ duration: 1200, easing: "cubic-bezier(0.16, 1, 0.3, 1)" }}
+      />
+    </span>
+  );
+}

--- a/apps/landing/src/components/home/bonus.tsx
+++ b/apps/landing/src/components/home/bonus.tsx
@@ -1,4 +1,5 @@
 import { Trans } from "react-i18next/TransWithoutContext";
+import { AnimatedNumber } from "@/components/home/animated-number";
 import { getTranslation } from "@/i18n/server";
 import { getMonthlyPollCount, getMonthlyVoterCount } from "@/lib/data";
 
@@ -15,10 +16,12 @@ export async function Bonus(props: { locale: string }) {
         t={t}
         ns="home"
         i18nKey="statsLast30Days"
-        defaults="<b>{voterCount, plural, one {# person} other {# people}}</b> voted on <b>{pollCount, plural, one {# poll} other {# polls}}</b> in the last 30 days"
+        defaults="<b><voters/> {voterCount, plural, one {person} other {people}}</b> voted on <b><polls/> {pollCount, plural, one {poll} other {polls}}</b> in the last 30 days"
         values={{ voterCount, pollCount }}
         components={{
           b: <strong className="font-semibold text-gray-800" />,
+          voters: <AnimatedNumber value={voterCount} locale={props.locale} />,
+          polls: <AnimatedNumber value={pollCount} locale={props.locale} />,
         }}
       />
     </p>

--- a/apps/landing/src/components/home/bonus.tsx
+++ b/apps/landing/src/components/home/bonus.tsx
@@ -1,5 +1,5 @@
 import { Trans } from "react-i18next/TransWithoutContext";
-import { AnimatedNumber } from "@/components/home/animated-number";
+import { AnimatedStat } from "@/components/home/animated-number";
 import { getTranslation } from "@/i18n/server";
 import { getMonthlyPollCount, getMonthlyVoterCount } from "@/lib/data";
 
@@ -16,12 +16,10 @@ export async function Bonus(props: { locale: string }) {
         t={t}
         ns="home"
         i18nKey="statsLast30Days"
-        defaults="<b><voters/> {voterCount, plural, one {person} other {people}}</b> voted on <b><polls/> {pollCount, plural, one {poll} other {polls}}</b> in the last 30 days"
+        defaults="<b>{voterCount, plural, one {# person} other {# people}}</b> voted on <b>{pollCount, plural, one {# poll} other {# polls}}</b> in the last 30 days"
         values={{ voterCount, pollCount }}
         components={{
-          b: <strong className="font-semibold text-gray-800" />,
-          voters: <AnimatedNumber value={voterCount} locale={props.locale} />,
-          polls: <AnimatedNumber value={pollCount} locale={props.locale} />,
+          b: <AnimatedStat locale={props.locale} />,
         }}
       />
     </p>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -62,6 +62,9 @@ importers:
 
   apps/landing:
     dependencies:
+      '@number-flow/react':
+        specifier: ^0.6.2
+        version: 0.6.2(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@prisma/adapter-pg':
         specifier: ^7.8.0
         version: 7.8.0
@@ -614,7 +617,7 @@ importers:
         version: link:../tsconfig
       '@react-email/ui':
         specifier: ^6.6.3
-        version: 6.6.3(@opentelemetry/api@1.9.0)(@playwright/test@1.58.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        version: 6.6.3(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@types/nodemailer':
         specifier: ^6.4.14
         version: 6.4.22
@@ -3412,6 +3415,12 @@ packages:
   '@nodelib/fs.walk@1.2.8':
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
+
+  '@number-flow/react@0.6.2':
+    resolution: {integrity: sha512-WjZuV4aA+vhRCgCF+adGLgFVVAJ8vdvq6EchRT2FiBIgElTXtDOA3YgkcMr9UHpvpS9v4H70AB5wZv0D9jc3QA==}
+    peerDependencies:
+      react: ^18 || ^19
+      react-dom: ^18 || ^19
 
   '@openapi-contrib/openapi-schema-to-json-schema@3.2.0':
     resolution: {integrity: sha512-Gj6C0JwCr8arj0sYuslWXUBSP/KnUlEGnPW4qxlXvAl543oaNQgMgIgkQUA6vs5BCCvwTEiL8m/wdWzfl4UvSw==}
@@ -7661,6 +7670,9 @@ packages:
     resolution: {integrity: sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==}
     engines: {node: '>=8.0.0'}
 
+  esm-env@1.2.2:
+    resolution: {integrity: sha512-Epxrv+Nr/CaL4ZcFGPJIYLWFom+YeV1DqMLHJoEd9SYRxNbaFruBwfEX/kkHUJf55j2+TUbmDcmuilbP1TmXHA==}
+
   esprima@4.0.1:
     resolution: {integrity: sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==}
     engines: {node: '>=4'}
@@ -9525,6 +9537,9 @@ packages:
 
   nth-check@2.1.1:
     resolution: {integrity: sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==}
+
+  number-flow@0.6.2:
+    resolution: {integrity: sha512-MCnImG4Q5vPwhSXnov56nOuyyKn6LC+Qd7II1UiKc+ACRtug5iAtn0+CwXNxM38AC5lSowEY+oYEtZX2qMnUyw==}
 
   nwsapi@2.2.23:
     resolution: {integrity: sha512-7wfH4sLbt4M0gCDzGE6vzQBo0bfTKjU7Sfpqy/7gs1qBfYz2vEJH6vXcBKpO3+6Yu1telwd0t9HpyOoLEQQbIQ==}
@@ -14802,6 +14817,13 @@ snapshots:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.20.1
 
+  '@number-flow/react@0.6.2(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
+    dependencies:
+      esm-env: 1.2.2
+      number-flow: 0.6.2
+      react: 19.2.6
+      react-dom: 19.2.6(react@19.2.6)
+
   '@openapi-contrib/openapi-schema-to-json-schema@3.2.0':
     dependencies:
       fast-deep-equal: 3.1.3
@@ -16239,10 +16261,10 @@ snapshots:
     dependencies:
       react: 19.2.6
 
-  '@react-email/ui@6.6.3(@opentelemetry/api@1.9.0)(@playwright/test@1.58.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
+  '@react-email/ui@6.6.3(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
     dependencies:
       esbuild: 0.28.0
-      next: 16.2.6(@opentelemetry/api@1.9.0)(@playwright/test@1.58.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      next: 16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
     transitivePeerDependencies:
       - '@babel/core'
       - '@opentelemetry/api'
@@ -19828,6 +19850,8 @@ snapshots:
       esrecurse: 4.3.0
       estraverse: 4.3.0
 
+  esm-env@1.2.2: {}
+
   esprima@4.0.1: {}
 
   esrecurse@4.3.0:
@@ -22122,7 +22146,7 @@ snapshots:
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
 
-  next@16.2.6(@opentelemetry/api@1.9.0)(@playwright/test@1.58.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
+  next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
     dependencies:
       '@next/env': 16.2.6
       '@swc/helpers': 0.5.15
@@ -22226,6 +22250,10 @@ snapshots:
   nth-check@2.1.1:
     dependencies:
       boolbase: 1.0.0
+
+  number-flow@0.6.2:
+    dependencies:
+      esm-env: 1.2.2
 
   nwsapi@2.2.23: {}
 


### PR DESCRIPTION
## Summary

Animates the live 30-day stats on the landing page (from #2917) with a Stripe-style odometer roll: when the stat scrolls into view, each digit column spins up from 0 to the real value over 1.2s with an expo-out ease.

- The `statsLast30Days` source string is **unchanged** — no Crowdin churn, existing translations animate immediately
- The `<b>` component mapping is now `AnimatedStat`, a client component that parses the localized number out of its rendered children (any Unicode numbering system + locale grouping separators, via `Intl.NumberFormat`-derived digit maps) and swaps it for a `@number-flow/react` odometer, leaving the surrounding translated text untouched
- If no number is found in a translation, it falls back to rendering the text unanimated
- Trigger is IntersectionObserver at 50% visibility; the reset-to-0 happens un-animated one frame before the roll

## Accessibility & SEO

- `prefers-reduced-motion` skips the choreography entirely (and number-flow also respects it internally)
- The animated slot exposes `role="img"` with the original localized number token as a stable accessible name; number-flow internals are `aria-hidden`
- Raw HTML (no JS) still contains the real numbers — verified via curl: the SSR payload carries the full sentence with digits

## Test plan

- [x] Type-check and Biome pass
- [x] `git diff main -- apps/landing/public/locales/` is empty — zero locale changes
- [x] SSR HTML carries real values and stable aria-labels (curl)
- [x] Clean browser load: shadow roots attach, sentence renders, no server errors
- [x] Count-up triggers on scroll-into-view in the browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)