### PR TITLE
👷 Fail CI on unbalanced braces in locale JSON strings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,9 @@ jobs:
       - name: Check feature folder structure
         run: pnpm check:structure
 
+      - name: Check locale files for unbalanced braces
+        run: pnpm check:locales
+
   unit-tests:
     name: Unit tests
     runs-on: ubuntu-latest

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "test:unit": "turbo test:unit",
     "check": "biome check .",
     "check:fix": "biome check . --write",
+    "check:locales": "node scripts/check-locale-braces.mjs",
     "check:structure": "node scripts/check-feature-structure.mjs && node scripts/check-feature-cycles.mjs",
     "i18n:scan": "turbo i18n:scan",
     "type-check": "turbo type-check",

--- a/scripts/check-locale-braces.mjs
+++ b/scripts/check-locale-braces.mjs
@@ -90,9 +90,7 @@ if (offenderCount > 0) {
   console.error(
     "These are usually Crowdin machine-translation artifacts (stray `},{` or `}]` fragments).",
   );
-  console.error(
-    "Fix the string in Crowdin and re-sync, or correct the JSON value directly.",
-  );
+  console.error("Fix the string in Crowdin and re-sync.");
   process.exit(1);
 }
 

--- a/scripts/check-locale-braces.mjs
+++ b/scripts/check-locale-braces.mjs
@@ -1,0 +1,99 @@
+#!/usr/bin/env node
+/**
+ * Fails when a locale JSON string has unbalanced braces.
+ *
+ * Crowdin's machine translation batches occasionally bleed ICU plural join
+ * tokens onto neighboring strings, leaving artifacts like `},{`, `}]}{` or a
+ * trailing `}]` in translated values. Balanced-brace counting catches every
+ * observed artifact shape without false-positiving on valid ICU messages
+ * (none of our locales use ICU apostrophe-escaped literal braces).
+ */
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+
+const LOCALE_DIRS = [
+  "apps/web/public/locales",
+  "apps/landing/public/locales",
+  "packages/emails/locales",
+];
+
+function hasUnbalancedBraces(value) {
+  let depth = 0;
+  for (const char of value) {
+    if (char === "{") {
+      depth++;
+    } else if (char === "}") {
+      depth--;
+      if (depth < 0) {
+        return true;
+      }
+    }
+  }
+  return depth !== 0;
+}
+
+function collectOffenders(node, keyPath, offenders) {
+  if (typeof node === "string") {
+    if (hasUnbalancedBraces(node)) {
+      offenders.push({ keyPath, value: node });
+    }
+  } else if (node !== null && typeof node === "object") {
+    for (const [key, child] of Object.entries(node)) {
+      collectOffenders(child, keyPath ? `${keyPath}.${key}` : key, offenders);
+    }
+  }
+}
+
+function* walkJsonFiles(dir) {
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const absolutePath = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      yield* walkJsonFiles(absolutePath);
+    } else if (entry.name.endsWith(".json")) {
+      yield absolutePath;
+    }
+  }
+}
+
+let offenderCount = 0;
+
+for (const localeDir of LOCALE_DIRS) {
+  for (const filePath of walkJsonFiles(path.join(ROOT, localeDir))) {
+    const relativePath = path
+      .relative(ROOT, filePath)
+      .split(path.sep)
+      .join("/");
+    let parsed;
+    try {
+      parsed = JSON.parse(fs.readFileSync(filePath, "utf8"));
+    } catch (error) {
+      offenderCount++;
+      console.error(`${relativePath}: invalid JSON (${error.message})`);
+      continue;
+    }
+    const offenders = [];
+    collectOffenders(parsed, "", offenders);
+    for (const { keyPath, value } of offenders) {
+      offenderCount++;
+      console.error(`${relativePath} → ${keyPath}: ${JSON.stringify(value)}`);
+    }
+  }
+}
+
+if (offenderCount > 0) {
+  console.error(
+    `\nFound ${offenderCount} locale string(s) with unbalanced braces.`,
+  );
+  console.error(
+    "These are usually Crowdin machine-translation artifacts (stray `},{` or `}]` fragments).",
+  );
+  console.error(
+    "Fix the string in Crowdin and re-sync, or correct the JSON value directly.",
+  );
+  process.exit(1);
+}
+
+console.log("Locale brace balance OK");


### PR DESCRIPTION
## What
Adds `scripts/check-locale-braces.mjs`, a zero-dependency node script that walks every string value in `apps/web/public/locales`, `apps/landing/public/locales`, and `packages/emails/locales`, counting `{`/`}` depth. Any value where depth goes negative or ends nonzero fails the check. Wired into the CI linting job as `pnpm check:locales`, following the `check:structure` pattern.

## Why
Crowdin's batch MT recurringly bleeds ICU plural join tokens onto short neighboring strings, leaving artifacts like `},{`, `}]}{`, or repeated `}]` in translated values. This has been fixed at least 4 times (e911c69f0, 4af09ace7, c4c7f75ad, #2944) with no guard, so detection depended on users noticing broken copy in production. Balanced-brace counting catches every observed artifact shape with no false positives on valid ICU messages — no locale uses ICU apostrophe-escaped literal braces (verified by grep).

## Verification
- `pnpm check:locales` passes on this branch (rebased on main, which carries the #2944 fixes via the Crowdin sync)
- Before the sync landed, the script flagged exactly the 35 known artifacts — a real-world positive test
- Negative test: injecting a `},{` suffix into one value makes it exit 1 with the file, key, and offending value printed

🤖 Generated with [Claude Code](https://claude.com/claude-code)