### PR TITLE
✨ Logo upload through the branding page

### DIFF
--- a/apps/web/public/locales/en/app.json
+++ b/apps/web/public/locales/en/app.json
@@ -101,6 +101,7 @@
   "brandingPreviewEventTitle": "Team Offsite",
   "brandingPreviewLocation": "The Old Fire Station",
   "brandingSettingsDescription": "Customize your instance branding",
+  "brandingStorageNotConfigured": "Logo uploads require object storage, which has not been configured on this instance.",
   "calendar": "Calendar",
   "calendarDisconnectedError": "Failed to disconnect calendar",
   "calendarDisconnectedSuccess": "Calendar disconnected successfully",

--- a/apps/web/src/app/[locale]/(auth)/components/already-logged-in.tsx
+++ b/apps/web/src/app/[locale]/(auth)/components/already-logged-in.tsx
@@ -18,9 +18,6 @@ import { SignOutButton } from "./sign-out-button";
  * / ↔ /login redirect loop — a loop needs two automated legs,
  * so the user must click to continue. The sign out button is the escape
  * hatch when the session only looks alive (stale cookie cache).
- *
- * Server component: AuthPageContainer renders the async server-only Logo,
- * so this must not be a client module.
  */
 export async function AlreadyLoggedIn({ redirectTo }: { redirectTo?: string }) {
   const { t, i18n } = await getTranslation();

--- a/apps/web/src/app/[locale]/(auth)/components/auth-footer.tsx
+++ b/apps/web/src/app/[locale]/(auth)/components/auth-footer.tsx
@@ -1,0 +1,27 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { LanguageSelect } from "@/components/language-selector";
+import { ThemeSwitcher } from "@/components/theme-switcher";
+import { useTranslation } from "@/i18n/client";
+import { setLocaleCookie, useLocale } from "@/lib/locale/client";
+
+export function AuthFooter() {
+  const { t } = useTranslation();
+  const router = useRouter();
+  const { locale } = useLocale();
+
+  return (
+    <footer className="flex items-center justify-center gap-x-4">
+      <LanguageSelect
+        aria-label={t("language", { defaultValue: "Language" })}
+        value={locale}
+        onChange={(language) => {
+          setLocaleCookie(language);
+          router.refresh();
+        }}
+      />
+      <ThemeSwitcher />
+    </footer>
+  );
+}

--- a/apps/web/src/app/[locale]/(auth)/components/auth-footer.tsx
+++ b/apps/web/src/app/[locale]/(auth)/components/auth-footer.tsx
@@ -12,7 +12,9 @@ export function AuthFooter() {
   const { locale } = useLocale();
 
   return (
-    <footer className="flex items-center justify-center gap-x-4">
+    // h-50 mirrors the header's 200px logo slot so the vertically centered
+    // content sits at the true middle of the page
+    <footer className="flex h-50 items-end justify-center gap-x-4">
       <LanguageSelect
         aria-label={t("language", { defaultValue: "Language" })}
         value={locale}

--- a/apps/web/src/app/[locale]/(auth)/components/auth-footer.tsx
+++ b/apps/web/src/app/[locale]/(auth)/components/auth-footer.tsx
@@ -12,9 +12,9 @@ export function AuthFooter() {
   const { locale } = useLocale();
 
   return (
-    // h-50 mirrors the header's 200px logo slot so the vertically centered
+    // h-40 mirrors the header's 160px logo slot so the vertically centered
     // content sits at the true middle of the page
-    <footer className="flex h-50 items-end justify-center gap-x-4">
+    <footer className="flex h-40 items-end justify-center gap-x-4">
       <LanguageSelect
         aria-label={t("language", { defaultValue: "Language" })}
         value={locale}

--- a/apps/web/src/app/[locale]/(auth)/components/auth-page.tsx
+++ b/apps/web/src/app/[locale]/(auth)/components/auth-page.tsx
@@ -3,8 +3,8 @@ import { Logo } from "@/features/branding/components/logo";
 export function AuthPageContainer({ children }: { children: React.ReactNode }) {
   return (
     <div className="space-y-8">
-      <div className="mb-12 flex justify-center">
-        <Logo />
+      <div className="mb-4 flex justify-center">
+        <Logo size="fit" />
       </div>
       {children}
     </div>

--- a/apps/web/src/app/[locale]/(auth)/components/auth-page.tsx
+++ b/apps/web/src/app/[locale]/(auth)/components/auth-page.tsx
@@ -1,14 +1,5 @@
-import { Logo } from "@/features/branding/components/logo";
-
 export function AuthPageContainer({ children }: { children: React.ReactNode }) {
-  return (
-    <div className="space-y-8">
-      <div className="mb-4 flex justify-center">
-        <Logo size="fit" />
-      </div>
-      {children}
-    </div>
-  );
+  return <div className="space-y-8">{children}</div>;
 }
 
 export function AuthPageHeader({ children }: { children: React.ReactNode }) {

--- a/apps/web/src/app/[locale]/(auth)/layout.tsx
+++ b/apps/web/src/app/[locale]/(auth)/layout.tsx
@@ -1,4 +1,5 @@
 import { AuthFooter } from "@/app/[locale]/(auth)/components/auth-footer";
+import { Logo } from "@/features/branding/components/logo";
 import { QuickCreateButton } from "@/features/quick-create/components/quick-create-button";
 import { QuickCreateWidget } from "@/features/quick-create/components/quick-create-widget";
 import { isQuickCreateEnabled } from "@/features/quick-create/constants";
@@ -25,6 +26,9 @@ export default async function Layout({
       <div className="relative flex min-h-dvh flex-col items-center justify-center bg-background">
         <div className="z-10 flex w-full flex-1 lg:p-4">
           <div className="flex flex-1 flex-col gap-4 p-6">
+            <header className="flex justify-center">
+              <Logo size="fit" />
+            </header>
             <div className="my-auto">
               <main
                 id="main-content"

--- a/apps/web/src/app/[locale]/(auth)/layout.tsx
+++ b/apps/web/src/app/[locale]/(auth)/layout.tsx
@@ -1,3 +1,4 @@
+import { AuthFooter } from "@/app/[locale]/(auth)/components/auth-footer";
 import { QuickCreateButton } from "@/features/quick-create/components/quick-create-button";
 import { QuickCreateWidget } from "@/features/quick-create/components/quick-create-widget";
 import { isQuickCreateEnabled } from "@/features/quick-create/constants";
@@ -38,6 +39,7 @@ export default async function Layout({
                 <QuickCreateButton />
               </div>
             ) : null}
+            <AuthFooter />
           </div>
           {isQuickCreateEnabled ? (
             <div className="relative hidden flex-1 flex-col justify-center rounded-lg border bg-muted/50 lg:flex lg:p-16">

--- a/apps/web/src/app/[locale]/control-panel/branding/actions.ts
+++ b/apps/web/src/app/[locale]/control-panel/branding/actions.ts
@@ -1,10 +1,31 @@
 "use server";
 
-import { updateInstanceSettings } from "@/features/instance-settings/mutations";
-import { brandingSettingsSchema } from "@/features/instance-settings/schema";
+import {
+  updateInstanceLogo,
+  updateInstanceSettings,
+} from "@/features/instance-settings/mutations";
+import type { BrandingLogoType } from "@/features/instance-settings/schema";
+import {
+  brandingLogoUploadSchema,
+  brandingSettingsSchema,
+  removeBrandingLogoSchema,
+  updateBrandingLogoSchema,
+} from "@/features/instance-settings/schema";
 import { getWhiteLabelAddon } from "@/features/licensing/data";
 import { AppError } from "@/lib/errors/app-error";
 import { adminActionClient } from "@/lib/safe-action/server";
+import { getImageUploadUrl } from "@/lib/storage/image-upload";
+
+async function requireWhiteLabelAddon() {
+  const hasWhiteLabelAddon = await getWhiteLabelAddon();
+
+  if (!hasWhiteLabelAddon) {
+    throw new AppError({
+      code: "PAYMENT_REQUIRED",
+      message: "Custom branding requires the white label add-on.",
+    });
+  }
+}
 
 export const updateBrandingSettingsAction = adminActionClient
   .metadata({
@@ -12,14 +33,64 @@ export const updateBrandingSettingsAction = adminActionClient
   })
   .inputSchema(brandingSettingsSchema.partial())
   .action(async ({ parsedInput }) => {
-    const hasWhiteLabelAddon = await getWhiteLabelAddon();
+    await requireWhiteLabelAddon();
 
-    if (!hasWhiteLabelAddon) {
+    await updateInstanceSettings(parsedInput);
+  });
+
+const logoEntityIds: Record<BrandingLogoType, string> = {
+  logo: "logo",
+  logoDark: "logo-dark",
+  logoIcon: "logo-icon",
+};
+
+export const getBrandingLogoUploadUrlAction = adminActionClient
+  .metadata({
+    actionName: "get_branding_logo_upload_url",
+  })
+  .inputSchema(brandingLogoUploadSchema)
+  .action(async ({ parsedInput }) => {
+    await requireWhiteLabelAddon();
+
+    return await getImageUploadUrl({
+      keyPrefix: "branding",
+      entityId: logoEntityIds[parsedInput.logoType],
+      fileType: parsedInput.fileType,
+      fileSize: parsedInput.fileSize,
+    });
+  });
+
+export const updateBrandingLogoAction = adminActionClient
+  .metadata({
+    actionName: "update_branding_logo",
+  })
+  .inputSchema(updateBrandingLogoSchema)
+  .action(async ({ parsedInput }) => {
+    await requireWhiteLabelAddon();
+
+    if (!parsedInput.imageKey.startsWith("branding/")) {
       throw new AppError({
-        code: "PAYMENT_REQUIRED",
-        message: "Custom branding requires the white label add-on.",
+        code: "FORBIDDEN",
+        message: "Invalid image key",
       });
     }
 
-    await updateInstanceSettings(parsedInput);
+    await updateInstanceLogo({
+      logoType: parsedInput.logoType,
+      imageKey: parsedInput.imageKey,
+    });
+  });
+
+export const removeBrandingLogoAction = adminActionClient
+  .metadata({
+    actionName: "remove_branding_logo",
+  })
+  .inputSchema(removeBrandingLogoSchema)
+  .action(async ({ parsedInput }) => {
+    await requireWhiteLabelAddon();
+
+    await updateInstanceLogo({
+      logoType: parsedInput.logoType,
+      imageKey: null,
+    });
   });

--- a/apps/web/src/app/[locale]/control-panel/branding/components/branding-settings.tsx
+++ b/apps/web/src/app/[locale]/control-panel/branding/components/branding-settings.tsx
@@ -298,7 +298,7 @@ export async function BrandingSettings() {
             {!isStorageEnabled ? <StorageNotConfiguredAlert /> : null}
             <FieldGroup variant="divided">
               <Field>
-                <Field orientation="responsive">
+                <Field>
                   <FieldContent>
                     <FieldTitle>
                       <Trans
@@ -325,7 +325,7 @@ export async function BrandingSettings() {
                 ) : null}
               </Field>
               <Field>
-                <Field orientation="responsive">
+                <Field>
                   <FieldContent>
                     <FieldTitle>
                       <Trans
@@ -355,7 +355,7 @@ export async function BrandingSettings() {
                 ) : null}
               </Field>
               <Field>
-                <Field orientation="responsive">
+                <Field>
                   <FieldContent>
                     <FieldTitle>
                       <Trans

--- a/apps/web/src/app/[locale]/control-panel/branding/components/branding-settings.tsx
+++ b/apps/web/src/app/[locale]/control-panel/branding/components/branding-settings.tsx
@@ -6,7 +6,7 @@ import {
   FieldLabel,
   FieldTitle,
 } from "@rallly/ui/field";
-import { CodeIcon, ContainerIcon, GemIcon } from "lucide-react";
+import { CodeIcon, ContainerIcon, GemIcon, HardDriveIcon } from "lucide-react";
 import { Trans } from "react-i18next/TransWithoutContext";
 import {
   PageSection,
@@ -18,8 +18,10 @@ import {
 } from "@/components/page-layout";
 import { loadBrandingSettings } from "@/features/branding/loaders";
 import { getTranslation } from "@/i18n/server";
+import { isStorageEnabled } from "@/lib/storage/constants";
 import { AppNameField } from "./app-name-field";
 import { HideAttributionField } from "./hide-attribution-field";
+import { LogoUploadField } from "./logo-upload-field";
 import { PrimaryColorField } from "./primary-color-field";
 
 async function ConfiguredByEnvironmentVariableAlert() {
@@ -35,6 +37,42 @@ async function ConfiguredByEnvironmentVariableAlert() {
           i18nKey="configuredByEnvironmentVariable"
           defaults="This setting has been configured by environment variable."
         />
+      </AlertDescription>
+    </Alert>
+  );
+}
+
+async function StorageNotConfiguredAlert() {
+  const { t, i18n } = await getTranslation();
+  return (
+    <Alert>
+      <HardDriveIcon />
+      <AlertDescription className="flex gap-2">
+        <p className="flex-1">
+          <Trans
+            t={t}
+            i18n={i18n}
+            ns="app"
+            i18nKey="brandingStorageNotConfigured"
+            defaults="Logo uploads require object storage, which has not been configured on this instance."
+          />
+        </p>
+        <p>
+          <a
+            href="https://support.rallly.co/self-hosting/configuration#external-object-storage"
+            target="_blank"
+            className="underline"
+            rel="noreferrer"
+          >
+            <Trans
+              t={t}
+              i18n={i18n}
+              ns="app"
+              i18nKey="learnMore"
+              defaults="Learn more"
+            />
+          </a>
+        </p>
       </AlertDescription>
     </Alert>
   );
@@ -73,6 +111,7 @@ export async function BrandingSettings() {
     logoUrlLight,
     logoUrlDark,
     logoIconUrl,
+    logoConfigured,
     envConfigured,
   } = await loadBrandingSettings();
   const { t, i18n } = await getTranslation();
@@ -256,6 +295,7 @@ export async function BrandingSettings() {
             </PageSectionDescription>
           </PageSectionHeader>
           <PageSectionContent>
+            {!isStorageEnabled ? <StorageNotConfiguredAlert /> : null}
             <FieldGroup variant="divided">
               <Field>
                 <Field orientation="responsive">
@@ -270,18 +310,19 @@ export async function BrandingSettings() {
                       />
                     </FieldTitle>
                   </FieldContent>
-                  <div className="flex items-center">
-                    <div className="flex w-48 items-center justify-center overflow-hidden rounded border bg-white">
-                      {/* biome-ignore lint/performance/noImgElement: external URLs may not work with Next.js Image */}
-                      <img
-                        src={logoUrlLight}
-                        alt={t("logo", { ns: "app", defaultValue: "Logo" })}
-                        className="max-h-full max-w-full object-contain p-2"
-                      />
-                    </div>
-                  </div>
+                  <LogoUploadField
+                    logoType="logo"
+                    previewUrl={logoUrlLight}
+                    previewAlt={t("logo", { ns: "app", defaultValue: "Logo" })}
+                    hasCustomLogo={logoConfigured.logo}
+                    disabled={!hasWhiteLabelAddon}
+                  />
                 </Field>
-                <SetEnvironmentVariableAlert variable="LOGO_URL" />
+                {envConfigured.logo ? (
+                  <ConfiguredByEnvironmentVariableAlert />
+                ) : !isStorageEnabled ? (
+                  <SetEnvironmentVariableAlert variable="LOGO_URL" />
+                ) : null}
               </Field>
               <Field>
                 <Field orientation="responsive">
@@ -296,21 +337,22 @@ export async function BrandingSettings() {
                       />
                     </FieldTitle>
                   </FieldContent>
-                  <div className="flex items-center">
-                    <div className="flex w-48 items-center justify-center overflow-hidden rounded border bg-gray-900">
-                      {/* biome-ignore lint/performance/noImgElement: external URLs may not work with Next.js Image */}
-                      <img
-                        src={logoUrlDark}
-                        alt={t("logoDark", {
-                          ns: "app",
-                          defaultValue: "Logo (dark mode)",
-                        })}
-                        className="max-h-full max-w-full object-contain p-2"
-                      />
-                    </div>
-                  </div>
+                  <LogoUploadField
+                    logoType="logoDark"
+                    previewUrl={logoUrlDark}
+                    previewAlt={t("logoDark", {
+                      ns: "app",
+                      defaultValue: "Logo (dark mode)",
+                    })}
+                    hasCustomLogo={logoConfigured.logoDark}
+                    disabled={!hasWhiteLabelAddon}
+                  />
                 </Field>
-                <SetEnvironmentVariableAlert variable="LOGO_URL_DARK" />
+                {envConfigured.logoDark ? (
+                  <ConfiguredByEnvironmentVariableAlert />
+                ) : !isStorageEnabled ? (
+                  <SetEnvironmentVariableAlert variable="LOGO_URL_DARK" />
+                ) : null}
               </Field>
               <Field>
                 <Field orientation="responsive">
@@ -325,21 +367,22 @@ export async function BrandingSettings() {
                       />
                     </FieldTitle>
                   </FieldContent>
-                  <div className="flex items-center">
-                    <div className="flex size-16 items-center justify-center overflow-hidden rounded border bg-white">
-                      {/* biome-ignore lint/performance/noImgElement: external URLs may not work with Next.js Image */}
-                      <img
-                        src={logoIconUrl}
-                        alt={t("logoIcon", {
-                          ns: "app",
-                          defaultValue: "Logo icon",
-                        })}
-                        className="max-h-full max-w-full object-contain p-2"
-                      />
-                    </div>
-                  </div>
+                  <LogoUploadField
+                    logoType="logoIcon"
+                    previewUrl={logoIconUrl}
+                    previewAlt={t("logoIcon", {
+                      ns: "app",
+                      defaultValue: "Logo icon",
+                    })}
+                    hasCustomLogo={logoConfigured.logoIcon}
+                    disabled={!hasWhiteLabelAddon}
+                  />
                 </Field>
-                <SetEnvironmentVariableAlert variable="LOGO_ICON_URL" />
+                {envConfigured.logoIcon ? (
+                  <ConfiguredByEnvironmentVariableAlert />
+                ) : !isStorageEnabled ? (
+                  <SetEnvironmentVariableAlert variable="LOGO_ICON_URL" />
+                ) : null}
               </Field>
             </FieldGroup>
           </PageSectionContent>

--- a/apps/web/src/app/[locale]/control-panel/branding/components/logo-upload-field.tsx
+++ b/apps/web/src/app/[locale]/control-panel/branding/components/logo-upload-field.tsx
@@ -10,10 +10,25 @@ import {
   updateBrandingLogoAction,
 } from "../actions";
 
-const previewVariants: Record<BrandingLogoType, string> = {
-  logo: "bg-white",
-  logoDark: "bg-gray-900",
-  logoIcon: "bg-white",
+const previewVariants: Record<
+  BrandingLogoType,
+  { container: string; line: string; label: string }
+> = {
+  logo: {
+    container: "bg-white",
+    line: "border-gray-200",
+    label: "text-gray-400",
+  },
+  logoDark: {
+    container: "bg-gray-900",
+    line: "border-gray-700",
+    label: "text-gray-500",
+  },
+  logoIcon: {
+    container: "bg-white",
+    line: "border-gray-200",
+    label: "text-gray-400",
+  },
 };
 
 export function LogoUploadField({
@@ -50,14 +65,62 @@ export function LogoUploadField({
 
   return (
     <div className="w-full space-y-3">
-      {/* Full-width preview of the 200x160 slot the logo renders in */}
+      {/* Full-width preview of the 200x160 slot the logo renders in. The
+          cell's guide lines are oversized and clipped by the strip, so they
+          run edge to edge. */}
       <div
         className={cn(
-          "flex w-full items-center justify-center overflow-hidden rounded-lg border",
-          previewVariants[logoType],
+          "flex w-full items-center justify-center overflow-hidden rounded-lg border py-10",
+          previewVariants[logoType].container,
         )}
       >
-        <div className="flex h-40 w-50 items-center justify-center">
+        <div className="relative flex h-40 w-50 items-center justify-center">
+          <div
+            aria-hidden="true"
+            className={cn(
+              "absolute -inset-x-[100vw] top-0 border-t border-dashed",
+              previewVariants[logoType].line,
+            )}
+          />
+          <div
+            aria-hidden="true"
+            className={cn(
+              "absolute -inset-x-[100vw] bottom-0 border-t border-dashed",
+              previewVariants[logoType].line,
+            )}
+          />
+          <div
+            aria-hidden="true"
+            className={cn(
+              "absolute -inset-y-[100vh] left-0 border-l border-dashed",
+              previewVariants[logoType].line,
+            )}
+          />
+          <div
+            aria-hidden="true"
+            className={cn(
+              "absolute -inset-y-[100vh] right-0 border-l border-dashed",
+              previewVariants[logoType].line,
+            )}
+          />
+          <span
+            aria-hidden="true"
+            className={cn(
+              "absolute top-full left-1/2 mt-1.5 -translate-x-1/2 text-[10px] tabular-nums",
+              previewVariants[logoType].label,
+            )}
+          >
+            200px
+          </span>
+          <span
+            aria-hidden="true"
+            className={cn(
+              "absolute top-1/2 left-full ml-1.5 -translate-y-1/2 text-[10px] tabular-nums",
+              previewVariants[logoType].label,
+            )}
+          >
+            160px
+          </span>
           {/* biome-ignore lint/performance/noImgElement: external URLs may not work with Next.js Image */}
           <img
             src={previewUrl}

--- a/apps/web/src/app/[locale]/control-panel/branding/components/logo-upload-field.tsx
+++ b/apps/web/src/app/[locale]/control-panel/branding/components/logo-upload-field.tsx
@@ -50,14 +50,14 @@ export function LogoUploadField({
 
   return (
     <div className="w-full space-y-3">
-      {/* Full-width preview of the 160x160 slot the logo renders in */}
+      {/* Full-width preview of the 200x160 slot the logo renders in */}
       <div
         className={cn(
           "flex w-full items-center justify-center overflow-hidden rounded-lg border",
           previewVariants[logoType],
         )}
       >
-        <div className="flex size-40 items-center justify-center">
+        <div className="flex h-40 w-50 items-center justify-center">
           {/* biome-ignore lint/performance/noImgElement: external URLs may not work with Next.js Image */}
           <img
             src={previewUrl}

--- a/apps/web/src/app/[locale]/control-panel/branding/components/logo-upload-field.tsx
+++ b/apps/web/src/app/[locale]/control-panel/branding/components/logo-upload-field.tsx
@@ -71,7 +71,12 @@ export function LogoUploadField({
         disabled={disabled}
         getUploadUrl={handleGetUploadUrl}
         onUploadSuccess={async (imageKey) => {
-          await updateLogo.executeAsync({ logoType, imageKey });
+          const result = await updateLogo.executeAsync({ logoType, imageKey });
+          // executeAsync resolves on server errors; throw so the control
+          // reports the failure instead of completing
+          if (result?.serverError || result?.validationErrors) {
+            throw new Error("Failed to save logo");
+          }
         }}
         onRemoveSuccess={async () => {
           await removeLogo.executeAsync({ logoType });

--- a/apps/web/src/app/[locale]/control-panel/branding/components/logo-upload-field.tsx
+++ b/apps/web/src/app/[locale]/control-panel/branding/components/logo-upload-field.tsx
@@ -15,9 +15,9 @@ import {
 } from "../actions";
 
 const previewVariants: Record<BrandingLogoType, string> = {
-  logo: "w-48 bg-white",
-  logoDark: "w-48 bg-gray-900",
-  logoIcon: "size-16 bg-white",
+  logo: "bg-white",
+  logoDark: "bg-gray-900",
+  logoIcon: "bg-white",
 };
 
 export function LogoUploadField({
@@ -57,7 +57,7 @@ export function LogoUploadField({
       <ImageUploadPreview>
         <div
           className={cn(
-            "flex items-center justify-center overflow-hidden rounded border",
+            "flex size-50 items-center justify-center overflow-hidden rounded border",
             previewVariants[logoType],
           )}
         >
@@ -65,7 +65,7 @@ export function LogoUploadField({
           <img
             src={previewUrl}
             alt={previewAlt}
-            className="max-h-full max-w-full object-contain p-2"
+            className="max-h-full max-w-full object-contain p-4"
           />
         </div>
       </ImageUploadPreview>

--- a/apps/web/src/app/[locale]/control-panel/branding/components/logo-upload-field.tsx
+++ b/apps/web/src/app/[locale]/control-panel/branding/components/logo-upload-field.tsx
@@ -50,14 +50,14 @@ export function LogoUploadField({
 
   return (
     <div className="w-full space-y-3">
-      {/* Full-width preview of the 200x200 slot the logo renders in */}
+      {/* Full-width preview of the 160x160 slot the logo renders in */}
       <div
         className={cn(
           "flex w-full items-center justify-center overflow-hidden rounded-lg border",
           previewVariants[logoType],
         )}
       >
-        <div className="flex size-50 items-center justify-center">
+        <div className="flex size-40 items-center justify-center">
           {/* biome-ignore lint/performance/noImgElement: external URLs may not work with Next.js Image */}
           <img
             src={previewUrl}

--- a/apps/web/src/app/[locale]/control-panel/branding/components/logo-upload-field.tsx
+++ b/apps/web/src/app/[locale]/control-panel/branding/components/logo-upload-field.tsx
@@ -1,11 +1,7 @@
 "use client";
 
 import { cn } from "@rallly/ui";
-import {
-  ImageUpload,
-  ImageUploadControl,
-  ImageUploadPreview,
-} from "@/components/image-upload";
+import { ImageUploadControl } from "@/components/image-upload";
 import type { BrandingLogoType } from "@/features/instance-settings/schema";
 import { useSafeAction } from "@/lib/safe-action/client";
 import {
@@ -53,22 +49,23 @@ export function LogoUploadField({
   };
 
   return (
-    <ImageUpload>
-      <ImageUploadPreview>
-        <div
-          className={cn(
-            "flex size-50 items-center justify-center overflow-hidden rounded border",
-            previewVariants[logoType],
-          )}
-        >
+    <div className="w-full space-y-3">
+      {/* Full-width preview of the 200x200 slot the logo renders in */}
+      <div
+        className={cn(
+          "flex w-full items-center justify-center overflow-hidden rounded-lg border",
+          previewVariants[logoType],
+        )}
+      >
+        <div className="flex size-50 items-center justify-center">
           {/* biome-ignore lint/performance/noImgElement: external URLs may not work with Next.js Image */}
           <img
             src={previewUrl}
             alt={previewAlt}
-            className="max-h-full max-w-full object-contain p-4"
+            className="max-h-full max-w-full object-contain"
           />
         </div>
-      </ImageUploadPreview>
+      </div>
       <ImageUploadControl
         crop={false}
         disabled={disabled}
@@ -81,6 +78,6 @@ export function LogoUploadField({
         }}
         hasCurrentImage={hasCustomLogo}
       />
-    </ImageUpload>
+    </div>
   );
 }

--- a/apps/web/src/app/[locale]/control-panel/branding/components/logo-upload-field.tsx
+++ b/apps/web/src/app/[locale]/control-panel/branding/components/logo-upload-field.tsx
@@ -1,0 +1,86 @@
+"use client";
+
+import { cn } from "@rallly/ui";
+import {
+  ImageUpload,
+  ImageUploadControl,
+  ImageUploadPreview,
+} from "@/components/image-upload";
+import type { BrandingLogoType } from "@/features/instance-settings/schema";
+import { useSafeAction } from "@/lib/safe-action/client";
+import {
+  getBrandingLogoUploadUrlAction,
+  removeBrandingLogoAction,
+  updateBrandingLogoAction,
+} from "../actions";
+
+const previewVariants: Record<BrandingLogoType, string> = {
+  logo: "w-48 bg-white",
+  logoDark: "w-48 bg-gray-900",
+  logoIcon: "size-16 bg-white",
+};
+
+export function LogoUploadField({
+  logoType,
+  previewUrl,
+  previewAlt,
+  hasCustomLogo,
+  disabled = false,
+}: {
+  logoType: BrandingLogoType;
+  previewUrl: string;
+  previewAlt: string;
+  hasCustomLogo: boolean;
+  disabled?: boolean;
+}) {
+  const updateLogo = useSafeAction(updateBrandingLogoAction);
+  const removeLogo = useSafeAction(removeBrandingLogoAction);
+
+  const handleGetUploadUrl = async (input: {
+    fileType: "image/jpeg" | "image/png";
+    fileSize: number;
+  }) => {
+    const result = await getBrandingLogoUploadUrlAction({
+      logoType,
+      ...input,
+    });
+
+    if (!result?.data) {
+      throw new Error("Failed to get upload URL");
+    }
+
+    return result.data;
+  };
+
+  return (
+    <ImageUpload>
+      <ImageUploadPreview>
+        <div
+          className={cn(
+            "flex items-center justify-center overflow-hidden rounded border",
+            previewVariants[logoType],
+          )}
+        >
+          {/* biome-ignore lint/performance/noImgElement: external URLs may not work with Next.js Image */}
+          <img
+            src={previewUrl}
+            alt={previewAlt}
+            className="max-h-full max-w-full object-contain p-2"
+          />
+        </div>
+      </ImageUploadPreview>
+      <ImageUploadControl
+        crop={false}
+        disabled={disabled}
+        getUploadUrl={handleGetUploadUrl}
+        onUploadSuccess={async (imageKey) => {
+          await updateLogo.executeAsync({ logoType, imageKey });
+        }}
+        onRemoveSuccess={async () => {
+          await removeLogo.executeAsync({ logoType });
+        }}
+        hasCurrentImage={hasCustomLogo}
+      />
+    </ImageUpload>
+  );
+}

--- a/apps/web/src/app/[locale]/control-panel/branding/components/logo-upload-field.tsx
+++ b/apps/web/src/app/[locale]/control-panel/branding/components/logo-upload-field.tsx
@@ -75,52 +75,56 @@ export function LogoUploadField({
         )}
       >
         <div className="relative flex h-40 w-50 items-center justify-center">
-          <div
-            aria-hidden="true"
-            className={cn(
-              "absolute -inset-x-[100vw] top-0 border-t border-dashed",
-              previewVariants[logoType].line,
-            )}
-          />
-          <div
-            aria-hidden="true"
-            className={cn(
-              "absolute -inset-x-[100vw] bottom-0 border-t border-dashed",
-              previewVariants[logoType].line,
-            )}
-          />
-          <div
-            aria-hidden="true"
-            className={cn(
-              "absolute -inset-y-[100vh] left-0 border-l border-dashed",
-              previewVariants[logoType].line,
-            )}
-          />
-          <div
-            aria-hidden="true"
-            className={cn(
-              "absolute -inset-y-[100vh] right-0 border-l border-dashed",
-              previewVariants[logoType].line,
-            )}
-          />
-          <span
-            aria-hidden="true"
-            className={cn(
-              "absolute top-full left-1/2 mt-1.5 -translate-x-1/2 text-[10px] tabular-nums",
-              previewVariants[logoType].label,
-            )}
-          >
-            200px
-          </span>
-          <span
-            aria-hidden="true"
-            className={cn(
-              "absolute top-1/2 left-full ml-1.5 -translate-y-1/2 text-[10px] tabular-nums",
-              previewVariants[logoType].label,
-            )}
-          >
-            160px
-          </span>
+          {logoType !== "logoIcon" ? (
+            <>
+              <div
+                aria-hidden="true"
+                className={cn(
+                  "absolute -inset-x-[100vw] top-0 border-t border-dashed",
+                  previewVariants[logoType].line,
+                )}
+              />
+              <div
+                aria-hidden="true"
+                className={cn(
+                  "absolute -inset-x-[100vw] bottom-0 border-t border-dashed",
+                  previewVariants[logoType].line,
+                )}
+              />
+              <div
+                aria-hidden="true"
+                className={cn(
+                  "absolute -inset-y-[100vh] left-0 border-l border-dashed",
+                  previewVariants[logoType].line,
+                )}
+              />
+              <div
+                aria-hidden="true"
+                className={cn(
+                  "absolute -inset-y-[100vh] right-0 border-l border-dashed",
+                  previewVariants[logoType].line,
+                )}
+              />
+              <span
+                aria-hidden="true"
+                className={cn(
+                  "absolute top-full left-1/2 mt-1.5 -translate-x-1/2 text-[10px] tabular-nums",
+                  previewVariants[logoType].label,
+                )}
+              >
+                200px
+              </span>
+              <span
+                aria-hidden="true"
+                className={cn(
+                  "absolute top-1/2 left-full ml-1.5 -translate-y-1/2 text-[10px] tabular-nums",
+                  previewVariants[logoType].label,
+                )}
+              >
+                160px
+              </span>
+            </>
+          ) : null}
           {/* biome-ignore lint/performance/noImgElement: external URLs may not work with Next.js Image */}
           <img
             src={previewUrl}

--- a/apps/web/src/components/image-upload/image-upload.tsx
+++ b/apps/web/src/components/image-upload/image-upload.tsx
@@ -30,6 +30,8 @@ export function ImageUploadControl({
   onUploadSuccess,
   onRemoveSuccess,
   hasCurrentImage = false,
+  crop = true,
+  disabled = false,
 }: ImageUploadControlProps) {
   const isStorageEnabled = useFeatureFlag("storage");
 
@@ -91,6 +93,12 @@ export function ImageUploadControl({
       return;
     }
 
+    if (!crop) {
+      startUpload(file);
+      event.target.value = "";
+      return;
+    }
+
     // Create preview URL and show cropping dialog
     const { url, cleanup } = createImagePreviewUrl(file);
     setOriginalFile(file);
@@ -102,26 +110,24 @@ export function ImageUploadControl({
     event.target.value = "";
   };
 
-  const handleCropComplete = async (croppedFile: File) => {
-    if (!originalFile) return;
-
-    const parsedFileType = allowedMimeTypes.parse(croppedFile.type);
+  const startUpload = (file: File, onUploaded?: () => void) => {
+    const parsedFileType = allowedMimeTypes.parse(file.type);
 
     startUploading(async () => {
       try {
         const { url, fields } = await getUploadUrl({
           fileType: parsedFileType,
-          fileSize: croppedFile.size,
+          fileSize: file.size,
         });
 
         await uploadImage({
-          file: croppedFile,
+          file,
           url,
           fileType: parsedFileType,
         });
 
         onUploadSuccess(fields.key);
-        handleCloseCropDialog();
+        onUploaded?.();
       } catch {
         toast.error(
           t("errorUploadPicture", {
@@ -136,6 +142,12 @@ export function ImageUploadControl({
         );
       }
     });
+  };
+
+  const handleCropComplete = async (croppedFile: File) => {
+    if (!originalFile) return;
+
+    startUpload(croppedFile, handleCloseCropDialog);
   };
 
   const handleCloseCropDialog = () => {
@@ -162,7 +174,7 @@ export function ImageUploadControl({
         <div className="flex gap-2">
           <Button
             loading={isUploading}
-            disabled={!isStorageEnabled}
+            disabled={disabled || !isStorageEnabled}
             onClick={() => {
               fileInputRef.current?.click();
             }}
@@ -170,7 +182,12 @@ export function ImageUploadControl({
             <Trans i18nKey="chooseImage" defaults="Choose…" />
           </Button>
           {hasCurrentImage ? (
-            <Button loading={isRemoving} variant="ghost" onClick={handleRemove}>
+            <Button
+              loading={isRemoving}
+              disabled={disabled}
+              variant="ghost"
+              onClick={handleRemove}
+            >
               <Trans i18nKey="removeImage" defaults="Remove" />
             </Button>
           ) : null}

--- a/apps/web/src/components/image-upload/image-upload.tsx
+++ b/apps/web/src/components/image-upload/image-upload.tsx
@@ -126,7 +126,7 @@ export function ImageUploadControl({
           fileType: parsedFileType,
         });
 
-        onUploadSuccess(fields.key);
+        await onUploadSuccess(fields.key);
         onUploaded?.();
       } catch {
         toast.error(

--- a/apps/web/src/components/image-upload/types.ts
+++ b/apps/web/src/components/image-upload/types.ts
@@ -11,6 +11,12 @@ export interface ImageUploadControlProps {
   onUploadSuccess: (imageKey: string) => Promise<void> | void;
   onRemoveSuccess: () => Promise<void> | void;
   hasCurrentImage?: boolean;
+  /**
+   * When false, the selected file is uploaded as-is instead of going through
+   * the 1:1 crop dialog. Use for images with a free aspect ratio (e.g. logos).
+   */
+  crop?: boolean;
+  disabled?: boolean;
 }
 
 export interface ImageUploadPreviewProps {

--- a/apps/web/src/components/language-selector.tsx
+++ b/apps/web/src/components/language-selector.tsx
@@ -14,6 +14,7 @@ export const LanguageSelect: React.FunctionComponent<{
   className?: string;
   value?: string;
   onChange?: (language: string) => void;
+  "aria-label"?: string;
   "aria-labelledby"?: string;
   "aria-describedby"?: string;
 }> = ({ id, className, value, onChange, ...ariaProps }) => {

--- a/apps/web/src/features/branding/components/logo.tsx
+++ b/apps/web/src/features/branding/components/logo.tsx
@@ -23,7 +23,7 @@ export const Logo = async ({
   if (size === "fit") {
     return (
       <div
-        className={cn("flex size-40 items-center justify-center", className)}
+        className={cn("flex h-40 w-50 items-center justify-center", className)}
       >
         {/* biome-ignore lint/performance/noImgElement: we don't need Image component here */}
         <img

--- a/apps/web/src/features/branding/components/logo.tsx
+++ b/apps/web/src/features/branding/components/logo.tsx
@@ -23,7 +23,7 @@ export const Logo = async ({
   if (size === "fit") {
     return (
       <div
-        className={cn("flex size-50 items-center justify-center", className)}
+        className={cn("flex size-40 items-center justify-center", className)}
       >
         {/* biome-ignore lint/performance/noImgElement: we don't need Image component here */}
         <img

--- a/apps/web/src/features/branding/components/logo.tsx
+++ b/apps/web/src/features/branding/components/logo.tsx
@@ -16,9 +16,30 @@ export const Logo = async ({
   size = "md",
 }: {
   className?: string;
-  size?: keyof typeof sizes;
+  size?: keyof typeof sizes | "fit";
 }) => {
   const { logo } = await getInstanceBrandingConfig();
+
+  if (size === "fit") {
+    return (
+      <div
+        className={cn("flex size-50 items-center justify-center", className)}
+      >
+        {/* biome-ignore lint/performance/noImgElement: we don't need Image component here */}
+        <img
+          src={logo.light}
+          alt={env.APP_NAME}
+          className="block max-h-full max-w-full object-contain dark:hidden"
+        />
+        {/* biome-ignore lint/performance/noImgElement: we don't need Image component here */}
+        <img
+          src={logo.dark}
+          alt={env.APP_NAME}
+          className="hidden max-h-full max-w-full object-contain dark:block"
+        />
+      </div>
+    );
+  }
 
   return (
     <div

--- a/apps/web/src/features/branding/loaders.ts
+++ b/apps/web/src/features/branding/loaders.ts
@@ -38,6 +38,12 @@ export const loadBrandingSettings = cache(async () => {
     logoUrlLight: resolved.logo.light,
     logoUrlDark: resolved.logo.dark,
     logoIconUrl: resolved.logoIcon,
+    // A stored value exists that can be removed to fall back to env/default
+    logoConfigured: {
+      logo: db.logo !== null,
+      logoDark: db.logoDark !== null,
+      logoIcon: db.logoIcon !== null,
+    },
     // Checked against process.env because the parsed env applies defaults
     // (APP_NAME, HIDE_ATTRIBUTION), which would read as operator-set
     envConfigured: {
@@ -48,6 +54,9 @@ export const loadBrandingSettings = cache(async () => {
         db.primaryColorDark === null && Boolean(process.env.PRIMARY_COLOR_DARK),
       hideAttribution:
         db.hideAttribution === null && Boolean(process.env.HIDE_ATTRIBUTION),
+      logo: db.logo === null && Boolean(process.env.LOGO_URL),
+      logoDark: db.logoDark === null && Boolean(process.env.LOGO_URL_DARK),
+      logoIcon: db.logoIcon === null && Boolean(process.env.LOGO_ICON_URL),
     },
   };
 });

--- a/apps/web/src/features/instance-settings/mutations.ts
+++ b/apps/web/src/features/instance-settings/mutations.ts
@@ -57,8 +57,9 @@ export async function updateInstanceLogo({
 
   updateTag(instanceSettingsTag);
 
-  // Only delete objects we own; a URL value points at externally hosted media
-  if (oldValue && isStorageKey(oldValue)) {
+  // Only delete objects we own; a URL value points at externally hosted
+  // media, and a retry can resubmit the key that is now stored
+  if (oldValue && oldValue !== imageKey && isStorageKey(oldValue)) {
     after(() => deleteImageFromS3(oldValue));
   }
 }

--- a/apps/web/src/features/instance-settings/mutations.ts
+++ b/apps/web/src/features/instance-settings/mutations.ts
@@ -2,7 +2,11 @@ import "server-only";
 
 import { prisma } from "@rallly/database";
 import { updateTag } from "next/cache";
+import { after } from "next/server";
+import { deleteImageFromS3 } from "@/lib/storage/image-upload";
+import { isStorageKey } from "@/lib/storage/resolve-storage-url";
 import { instanceSettingsTag } from "./constants";
+import type { BrandingLogoType } from "./schema";
 
 export async function updateInstanceSettings(data: {
   disableUserRegistration?: boolean;
@@ -20,4 +24,41 @@ export async function updateInstanceSettings(data: {
   });
 
   updateTag(instanceSettingsTag);
+}
+
+export async function updateInstanceLogo({
+  logoType,
+  imageKey,
+}: {
+  logoType: BrandingLogoType;
+  imageKey: string | null;
+}) {
+  const instanceSettings = await prisma.instanceSettings.findUnique({
+    where: {
+      id: 1,
+    },
+    select: {
+      logo: true,
+      logoDark: true,
+      logoIcon: true,
+    },
+  });
+
+  const oldValue = instanceSettings?.[logoType];
+
+  await prisma.instanceSettings.update({
+    where: {
+      id: 1,
+    },
+    data: {
+      [logoType]: imageKey,
+    },
+  });
+
+  updateTag(instanceSettingsTag);
+
+  // Only delete objects we own; a URL value points at externally hosted media
+  if (oldValue && isStorageKey(oldValue)) {
+    after(() => deleteImageFromS3(oldValue));
+  }
 }

--- a/apps/web/src/features/instance-settings/schema.ts
+++ b/apps/web/src/features/instance-settings/schema.ts
@@ -14,3 +14,22 @@ export const brandingSettingsSchema = z.object({
 });
 
 export type BrandingSettings = z.infer<typeof brandingSettingsSchema>;
+
+export const brandingLogoTypeSchema = z.enum(["logo", "logoDark", "logoIcon"]);
+
+export type BrandingLogoType = z.infer<typeof brandingLogoTypeSchema>;
+
+export const brandingLogoUploadSchema = z.object({
+  logoType: brandingLogoTypeSchema,
+  fileType: z.enum(["image/jpeg", "image/png"]),
+  fileSize: z.number(),
+});
+
+export const updateBrandingLogoSchema = z.object({
+  logoType: brandingLogoTypeSchema,
+  imageKey: z.string().max(255),
+});
+
+export const removeBrandingLogoSchema = z.object({
+  logoType: brandingLogoTypeSchema,
+});

--- a/apps/web/src/features/instance-settings/schema.ts
+++ b/apps/web/src/features/instance-settings/schema.ts
@@ -22,7 +22,11 @@ export type BrandingLogoType = z.infer<typeof brandingLogoTypeSchema>;
 export const brandingLogoUploadSchema = z.object({
   logoType: brandingLogoTypeSchema,
   fileType: z.enum(["image/jpeg", "image/png"]),
-  fileSize: z.number(),
+  fileSize: z
+    .number()
+    .int()
+    .positive()
+    .max(2 * 1024 * 1024),
 });
 
 export const updateBrandingLogoSchema = z.object({

--- a/apps/web/src/lib/storage/resolve-storage-url.ts
+++ b/apps/web/src/lib/storage/resolve-storage-url.ts
@@ -13,12 +13,20 @@ import { absoluteUrl } from "@rallly/utils/absolute-url";
  * bundle, which crashes self-hosted builds where `NEXT_PUBLIC_BASE_URL` is set
  * at runtime and is therefore absent on the client.
  */
+/**
+ * Whether a stored image value is a key in our storage bucket, as opposed to
+ * an external URL or data URI.
+ */
+export function isStorageKey(value: string): boolean {
+  return !(
+    value.startsWith("https://") ||
+    value.startsWith("http://") ||
+    value.startsWith("data:")
+  );
+}
+
 export function resolveStorageUrl(key: string): string {
-  if (
-    key.startsWith("https://") ||
-    key.startsWith("http://") ||
-    key.startsWith("data:")
-  ) {
+  if (!isStorageKey(key)) {
     return key;
   }
 


### PR DESCRIPTION
Adds upload controls for the three branding logos (light, dark, icon) to the control panel branding page, so no external hosting is needed. Closes [RAL-1510](https://linear.app/rallly/issue/RAL-1510).

## What's in here

- **Admin-gated upload actions** in the branding route wrapping `getImageUploadUrl` with key prefix `branding/`, all behind the white label add-on check. The update action rejects keys outside `branding/`.
- **Client reuses the existing upload pipeline** (same as space icons): PNG/JPEG only, 2MB cap. The shared `ImageUploadControl` gains a `crop` prop — logos upload as-is instead of going through the 1:1 crop dialog, which would destroy wide logos. SVG stays deferred (XSS vector without sanitization).
- **Previews on the appropriate background** (light/dark/icon slot sizes preserved from the read-only page), with a remove button whenever a stored value exists.
- **Old object cleanup**: `updateInstanceLogo` deletes the previous storage object on replace/remove — only when the old value is a storage key (`isStorageKey`, extracted from `resolveStorageUrl`), never when it's a URL.
- **Without S3 configured**: the Logos section shows a storage-not-configured alert linking to the storage docs, upload buttons disable via the existing `storage` feature flag, and the per-field env var hints remain as the escape hatch for URL-based logos. Fields driven by an env var show the existing "configured by environment variable" note.

## Verified locally (self-hosted mode, Garage S3)

- Upload → `branding/logo-<ts>.png` stored in `instance_settings.logo`, preview refreshes, object served via `/api/storage/`
- Replace → new key stored, old object deleted from the bucket
- Remove → column cleared, object deleted, preview falls back to default
- Dark logo preview correctly falls back to the light logo on the dark swatch
- S3 vars unset + `LOGO_URL` set → storage alert with docs link, env-configured note on the logo field, escape-hatch hints on the others; rest of the form still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added branding logo management for light, dark, and icon logos, including upload, preview, replacement, and removal.
  - Added language selection and theme switching to authentication pages.
  - Added support for uploads without forced cropping.

- **Improvements**
  - Branding settings show storage and environment configuration status with setup guidance.
  - Upload controls can be disabled when unavailable or restricted.
  - Authentication pages now display configured branding consistently.

- **Bug Fixes**
  - Improved handling of stored logo files when replaced or removed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->