### PR TITLE
🐛 Fix landing hero demo hydration mismatch

### DIFF
--- a/apps/landing/src/components/home/hero-demo/demo-data.ts
+++ b/apps/landing/src/components/home/hero-demo/demo-data.ts
@@ -35,21 +35,28 @@ const HOUR_MS = 60 * 60 * 1000;
 const DAY_MS = 24 * HOUR_MS;
 const SLOT_HOURS = [12, 18];
 
-// The demo dates are floating wall times constructed in UTC and always
-// formatted with timeZone: "UTC", so the rendered clock times don't depend
-// on the server's time zone.
-export function getDemoDays(now: Date): DemoDay[] {
+// The first Thursday at least a week out, as a plain YYYY-MM-DD string. This is
+// the only thing about the demo that depends on the current time, so it is the
+// cache key for the rendered demo: everything below is a pure function of it.
+// Keying on the value rather than on a duration means the HTML and the RSC
+// payload can never be generated on opposite sides of a rollover, which would
+// otherwise surface as a hydration mismatch.
+export function getDemoAnchor(now: Date) {
   let day = new Date(now.getTime() + 7 * DAY_MS);
   while (day.getUTCDay() !== 4) {
     day = new Date(day.getTime() + DAY_MS);
   }
+  return day.toISOString().slice(0, 10);
+}
+
+// The demo dates are floating wall times constructed in UTC and always
+// formatted with timeZone: "UTC", so the rendered clock times don't depend
+// on the server's time zone.
+export function getDemoDays(anchor: string): DemoDay[] {
+  const [year, month, day] = anchor.split("-").map(Number);
+  const firstThursday = Date.UTC(year, month - 1, day);
   return [0, 1, 2, 3].map((week) => {
-    const thursday = new Date(day.getTime() + week * 7 * DAY_MS);
-    const midnight = Date.UTC(
-      thursday.getUTCFullYear(),
-      thursday.getUTCMonth(),
-      thursday.getUTCDate(),
-    );
+    const midnight = firstThursday + week * 7 * DAY_MS;
     return {
       date: new Date(midnight),
       options: SLOT_HOURS.map((hour) => ({

--- a/apps/landing/src/components/home/hero-demo/hero-demo.tsx
+++ b/apps/landing/src/components/home/hero-demo/hero-demo.tsx
@@ -1,37 +1,36 @@
+import { cacheLife } from "next/cache";
 import { getTranslation } from "@/i18n/server";
-import { formatDemoParts, getDemoDays, getScores } from "./demo-data";
+import { getDemoAnchor, getDemoDays, getScores } from "./demo-data";
 import { DesktopDemo } from "./desktop-demo";
 import { MobileDemo } from "./mobile-demo";
 import { TryItPrompt } from "./try-it-prompt";
 
 // A presentational replica of the poll screens, deliberately decoupled from
-// apps/web so the landing page can't be broken by app changes. Dates are
-// computed at render time and cached with the page (cacheLife on the pages
-// that use this), so they refresh with the page cache instead of going stale
-// like a screenshot.
+// apps/web so the landing page can't be broken by app changes.
 //
-// The desktop shot is decoration (aria-hidden, no interactive elements); the
-// phone is a working demo, so date and time strings are pre-formatted here on
-// the server and passed down as plain props — client-side Intl could disagree
-// with the server and cause hydration mismatches.
+// The dates are derived from an anchor — the first Thursday at least a week
+// out — and the whole demo is a pure function of it. Deriving the anchor first
+// and passing it in as the cache key is what keeps hydration deterministic:
+// the HTML and the RSC payload are produced from the same key, so they cannot
+// be generated on opposite sides of the weekly rollover and disagree. Revalidating
+// hourly keeps the rendered dates from trailing the rollover for long.
 export const HeroDemo = async ({ locale }: { locale: string }) => {
-  const { t } = await getTranslation<"home">(locale, "home");
-  const days = getDemoDays(new Date());
-  const scores = getScores(days);
-  const format = formatDemoParts(locale);
+  "use cache";
+  cacheLife("hours");
+  return <CachedDemo locale={locale} anchor={getDemoAnchor(new Date())} />;
+};
 
-  let optionIndex = -1;
-  const mobileDays = days.map((day) => ({
-    label: format.fullDay.format(day.date),
-    options: day.options.map((option) => {
-      optionIndex += 1;
-      return {
-        id: option.start.toISOString(),
-        time: format.time.formatRange(option.start, option.end),
-        score: scores[optionIndex],
-      };
-    }),
-  }));
+const CachedDemo = async ({
+  locale,
+  anchor,
+}: {
+  locale: string;
+  anchor: string;
+}) => {
+  "use cache";
+  const { t } = await getTranslation<"home">(locale, "home");
+  const days = getDemoDays(anchor);
+  const scores = getScores(days);
 
   return (
     <div className="relative z-10 mb-12 md:mx-auto md:w-fit md:max-w-full">
@@ -50,7 +49,7 @@ export const HeroDemo = async ({ locale }: { locale: string }) => {
             defaultValue: "Go ahead, try voting!",
           })}
         />
-        <MobileDemo days={mobileDays} />
+        <MobileDemo locale={locale} days={days} scores={scores} t={t} />
       </div>
     </div>
   );

--- a/apps/landing/src/components/home/hero-demo/mobile-demo.tsx
+++ b/apps/landing/src/components/home/hero-demo/mobile-demo.tsx
@@ -1,91 +1,30 @@
-"use client";
-import { posthog } from "@rallly/posthog/client";
-import { cn } from "@rallly/ui";
-import { CircleCheckIcon, UserIcon, XIcon } from "lucide-react";
-import * as m from "motion/react-m";
-import Link from "next/link";
-import * as React from "react";
-import { Trans } from "@/i18n/client/trans";
-import { useTranslation } from "@/i18n/client/use-translation";
-import { linkToApp } from "@/lib/linkToApp";
-import type { DemoVote } from "./demo-data";
+import type { TFunction } from "i18next";
+import { UserIcon } from "lucide-react";
+import type { DemoDay, DemoVote } from "./demo-data";
+import { formatDemoParts } from "./demo-data";
 import { DemoFrame, DemoScreen } from "./demo-frame";
+import { VoteButton } from "./vote-button";
 import { VoteCount } from "./vote-count";
-import { VoteIcon } from "./vote-icon";
+import { VoteSelector } from "./vote-selector";
 
-export type MobileDemoDay = {
-  label: string;
-  options: { id: string; time: string; score: number }[];
-};
-
+// Pre-selected votes for the first few options, so the demo opens looking
+// like a poll someone has already started filling in.
 const initialVotes: (DemoVote | undefined)[] = ["yes", "yes", "ifNeedBe"];
 
-const TriState = ({
-  label,
-  value,
-  onChange,
+export const MobileDemo = ({
+  locale,
+  days,
+  scores,
+  t,
 }: {
-  label: string;
-  value?: DemoVote;
-  onChange: (vote: DemoVote) => void;
+  locale: string;
+  days: DemoDay[];
+  scores: number[];
+  t: TFunction<"home">;
 }) => {
-  const { t } = useTranslation("home");
-  const voteLabels: Record<DemoVote, string> = {
-    yes: t("heroDemoYes", { defaultValue: "Yes" }),
-    ifNeedBe: t("heroDemoIfNeedBe", { defaultValue: "If need be" }),
-    no: t("heroDemoNo", { defaultValue: "No" }),
-  };
-  return (
-    <div className="flex h-8 w-24 shrink-0 items-center rounded-lg border border-gray-200/60 bg-gray-100 p-0.5">
-      {(["yes", "ifNeedBe", "no"] as const).map((vote) => {
-        const isSelected = vote === value;
-        return (
-          <label
-            key={vote}
-            className={cn(
-              "group flex h-full flex-1 cursor-pointer items-center justify-center rounded-md has-[:focus-visible]:ring-2 has-[:focus-visible]:ring-indigo-500",
-              isSelected && "bg-white shadow-sm",
-            )}
-          >
-            <input
-              type="radio"
-              name={label}
-              checked={isSelected}
-              onChange={() => onChange(vote)}
-              aria-label={voteLabels[vote]}
-              className="sr-only"
-            />
-            <VoteIcon
-              vote={vote}
-              className={cn(
-                !isSelected &&
-                  "text-gray-400 opacity-50 transition-opacity group-hover:opacity-100",
-              )}
-            />
-          </label>
-        );
-      })}
-    </div>
-  );
-};
-
-export const MobileDemo = ({ days }: { days: MobileDemoDay[] }) => {
-  const { t } = useTranslation("home");
-  const [submitted, setSubmitted] = React.useState(false);
-  const topScore = Math.max(
-    ...days.flatMap((day) => day.options.map((option) => option.score)),
-  );
-  const [votes, setVotes] = React.useState<
-    Record<string, DemoVote | undefined>
-  >(() => {
-    const entries: Record<string, DemoVote | undefined> = {};
-    days
-      .flatMap((day) => day.options)
-      .forEach((option, index) => {
-        entries[option.id] = initialVotes[index];
-      });
-    return entries;
-  });
+  const format = formatDemoParts(locale);
+  const topScore = Math.max(...scores);
+  let optionIndex = -1;
 
   return (
     <DemoFrame className="rounded-[1.8rem]">
@@ -95,153 +34,57 @@ export const MobileDemo = ({ days }: { days: MobileDemoDay[] }) => {
             <span className="flex size-6 items-center justify-center rounded-full bg-gray-100">
               <UserIcon className="size-3.5 text-gray-500" />
             </span>
-            <Trans ns="home" i18nKey="heroDemoYou" defaults="You" />
+            {t("heroDemoYou", { ns: "home", defaultValue: "You" })}
           </span>
         </div>
         <div className="min-h-0 flex-1 overflow-hidden">
-          {days.map((day) => (
-            <div key={day.label}>
-              <div className="border-gray-100 border-b bg-gray-50/60 px-3 py-2 font-semibold text-gray-900 text-xs">
-                {day.label}
-              </div>
-              {day.options.map((option) => (
-                <div
-                  key={option.id}
-                  className="flex items-center justify-between gap-2 border-gray-100 border-b px-3 py-3"
-                >
-                  <div className="min-w-0 flex-1 text-gray-800 text-xs">
-                    {option.time}
-                  </div>
-                  <VoteCount
-                    count={option.score}
-                    highlight={option.score === topScore}
-                    className="mr-2 shrink-0"
-                  />
-                  <TriState
-                    label={`${day.label} ${option.time}`}
-                    value={votes[option.id]}
-                    onChange={(vote) => {
-                      posthog?.capture("landing:hero_demo_vote_change", {
-                        vote,
-                      });
-                      setVotes((current) => ({
-                        ...current,
-                        [option.id]: vote,
-                      }));
-                    }}
-                  />
+          {days.map((day) => {
+            const label = format.fullDay.format(day.date);
+            return (
+              <div key={label}>
+                <div className="border-gray-100 border-b bg-gray-50/60 px-3 py-2 font-semibold text-gray-900 text-xs">
+                  {label}
                 </div>
-              ))}
-            </div>
-          ))}
+                {day.options.map((option) => {
+                  optionIndex += 1;
+                  const time = format.time.formatRange(
+                    option.start,
+                    option.end,
+                  );
+                  const score = scores[optionIndex];
+                  return (
+                    <div
+                      key={option.start.toISOString()}
+                      className="flex items-center justify-between gap-2 border-gray-100 border-b px-3 py-3"
+                    >
+                      <div className="min-w-0 flex-1 text-gray-800 text-xs">
+                        {time}
+                      </div>
+                      <VoteCount
+                        count={score}
+                        highlight={score === topScore}
+                        className="mr-2 shrink-0"
+                      />
+                      <VoteSelector
+                        label={`${label} ${time}`}
+                        defaultValue={initialVotes[optionIndex]}
+                      />
+                    </div>
+                  );
+                })}
+              </div>
+            );
+          })}
         </div>
         <div className="absolute inset-x-0 bottom-0 flex items-center gap-2 bg-gradient-to-t from-55% from-white via-85% via-white/70 to-transparent p-3 pt-10">
           <span
             aria-hidden="true"
             className="flex-1 rounded-xl border border-white/60 bg-white/70 py-2.5 text-center font-medium text-gray-800 text-sm shadow-sm backdrop-blur-md"
           >
-            <Trans ns="home" i18nKey="heroDemoDecline" defaults="Decline" />
+            {t("heroDemoDecline", { ns: "home", defaultValue: "Decline" })}
           </span>
-          <button
-            type="button"
-            onClick={() => {
-              posthog?.capture("landing:hero_demo_continue_click");
-              setSubmitted(true);
-            }}
-            className="flex-[2] cursor-pointer rounded-xl bg-indigo-500/90 py-2.5 text-center font-medium text-sm text-white shadow-sm backdrop-blur-md hover:bg-indigo-500"
-          >
-            <Trans ns="home" i18nKey="heroDemoVote" defaults="Vote" />
-          </button>
+          <VoteButton />
         </div>
-        {submitted && (
-          <div className="absolute inset-0 z-10 flex items-center justify-center bg-gray-900/20 p-4">
-            <m.div
-              initial={{ scale: 0.92, opacity: 0, y: 8 }}
-              animate={{ scale: 1, opacity: 1, y: 0 }}
-              transition={{ type: "spring", duration: 0.5, bounce: 0.35 }}
-              className="relative flex aspect-[4/3] w-full flex-col items-center justify-center rounded-2xl border border-white/60 bg-white/85 p-4 text-center shadow-lg backdrop-blur-xl"
-            >
-              <button
-                type="button"
-                aria-label={t("heroDemoClose", { defaultValue: "Close" })}
-                onClick={() => {
-                  posthog?.capture("landing:hero_demo_close_click");
-                  setSubmitted(false);
-                }}
-                className="absolute top-3 right-3 flex size-6 cursor-pointer items-center justify-center rounded-full text-gray-400 hover:bg-gray-100 hover:text-gray-600"
-              >
-                <XIcon className="size-4" />
-              </button>
-              <m.div
-                initial={{ scale: 0, opacity: 0 }}
-                animate={{ scale: 1, opacity: 1 }}
-                transition={{
-                  type: "spring",
-                  duration: 0.6,
-                  bounce: 0.45,
-                  delay: 0.1,
-                }}
-                className="relative mb-3 inline-block"
-              >
-                <div className="absolute top-0 right-0 bottom-2 -left-1.5 origin-bottom -rotate-12 scale-95 rounded-xl bg-white opacity-75 shadow-xs ring-1 ring-gray-200 ring-inset" />
-                <div className="absolute top-0 -right-1.5 bottom-2 left-0 origin-bottom rotate-12 scale-95 rounded-xl bg-white opacity-75 shadow-xs ring-1 ring-gray-200 ring-inset" />
-                <div className="relative inline-flex rounded-xl bg-white p-2.5 shadow-xs ring-1 ring-gray-200 ring-inset">
-                  <CircleCheckIcon className="size-5 text-green-500" />
-                </div>
-              </m.div>
-              <m.div
-                initial={{ opacity: 0, y: 6 }}
-                animate={{ opacity: 1, y: 0 }}
-                transition={{
-                  type: "spring",
-                  duration: 0.6,
-                  bounce: 0.3,
-                  delay: 0.2,
-                }}
-              >
-                <p className="font-semibold text-gray-900 text-sm">
-                  <Trans
-                    ns="home"
-                    i18nKey="heroDemoThatWasEasy"
-                    defaults="That was easy!"
-                  />
-                </p>
-                <p className="mt-1.5 text-gray-500 text-xs">
-                  <Trans
-                    ns="home"
-                    i18nKey="heroDemoEasyDescription"
-                    defaults="That's all it takes to respond to a poll."
-                  />
-                </p>
-              </m.div>
-              <m.div
-                initial={{ opacity: 0, y: 6 }}
-                animate={{ opacity: 1, y: 0 }}
-                transition={{
-                  type: "spring",
-                  duration: 0.6,
-                  bounce: 0.3,
-                  delay: 0.3,
-                }}
-                className="mt-4"
-              >
-                <Link
-                  href={linkToApp("/new")}
-                  onClick={() => {
-                    posthog?.capture("landing:hero_demo_modal_cta_click");
-                  }}
-                  className="font-medium text-indigo-600 text-xs hover:underline"
-                >
-                  <Trans
-                    ns="home"
-                    i18nKey="heroDemoCreatePoll"
-                    defaults="Create your own poll"
-                  />
-                </Link>
-              </m.div>
-            </m.div>
-          </div>
-        )}
       </DemoScreen>
     </DemoFrame>
   );

--- a/apps/landing/src/components/home/hero-demo/vote-button.tsx
+++ b/apps/landing/src/components/home/hero-demo/vote-button.tsx
@@ -1,0 +1,120 @@
+"use client";
+import { posthog } from "@rallly/posthog/client";
+import { CircleCheckIcon, XIcon } from "lucide-react";
+import * as m from "motion/react-m";
+import Link from "next/link";
+import * as React from "react";
+import { Trans } from "@/i18n/client/trans";
+import { useTranslation } from "@/i18n/client/use-translation";
+import { linkToApp } from "@/lib/linkToApp";
+
+// The submit action of the phone demo, plus the confirmation it opens. The
+// surrounding poll layout stays on the server.
+export const VoteButton = () => {
+  const { t } = useTranslation("home");
+  const [submitted, setSubmitted] = React.useState(false);
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={() => {
+          posthog?.capture("landing:hero_demo_continue_click");
+          setSubmitted(true);
+        }}
+        className="flex-[2] cursor-pointer rounded-xl bg-indigo-500/90 py-2.5 text-center font-medium text-sm text-white shadow-sm backdrop-blur-md hover:bg-indigo-500"
+      >
+        <Trans ns="home" i18nKey="heroDemoVote" defaults="Vote" />
+      </button>
+      {submitted && (
+        <div className="absolute inset-0 z-10 flex items-center justify-center bg-gray-900/20 p-4">
+          <m.div
+            initial={{ scale: 0.92, opacity: 0, y: 8 }}
+            animate={{ scale: 1, opacity: 1, y: 0 }}
+            transition={{ type: "spring", duration: 0.5, bounce: 0.35 }}
+            className="relative flex aspect-[4/3] w-full flex-col items-center justify-center rounded-2xl border border-white/60 bg-white/85 p-4 text-center shadow-lg backdrop-blur-xl"
+          >
+            <button
+              type="button"
+              aria-label={t("heroDemoClose", { defaultValue: "Close" })}
+              onClick={() => {
+                posthog?.capture("landing:hero_demo_close_click");
+                setSubmitted(false);
+              }}
+              className="absolute top-3 right-3 flex size-6 cursor-pointer items-center justify-center rounded-full text-gray-400 hover:bg-gray-100 hover:text-gray-600"
+            >
+              <XIcon className="size-4" />
+            </button>
+            <m.div
+              initial={{ scale: 0, opacity: 0 }}
+              animate={{ scale: 1, opacity: 1 }}
+              transition={{
+                type: "spring",
+                duration: 0.6,
+                bounce: 0.45,
+                delay: 0.1,
+              }}
+              className="relative mb-3 inline-block"
+            >
+              <div className="absolute top-0 right-0 bottom-2 -left-1.5 origin-bottom -rotate-12 scale-95 rounded-xl bg-white opacity-75 shadow-xs ring-1 ring-gray-200 ring-inset" />
+              <div className="absolute top-0 -right-1.5 bottom-2 left-0 origin-bottom rotate-12 scale-95 rounded-xl bg-white opacity-75 shadow-xs ring-1 ring-gray-200 ring-inset" />
+              <div className="relative inline-flex rounded-xl bg-white p-2.5 shadow-xs ring-1 ring-gray-200 ring-inset">
+                <CircleCheckIcon className="size-5 text-green-500" />
+              </div>
+            </m.div>
+            <m.div
+              initial={{ opacity: 0, y: 6 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{
+                type: "spring",
+                duration: 0.6,
+                bounce: 0.3,
+                delay: 0.2,
+              }}
+            >
+              <p className="font-semibold text-gray-900 text-sm">
+                <Trans
+                  ns="home"
+                  i18nKey="heroDemoThatWasEasy"
+                  defaults="That was easy!"
+                />
+              </p>
+              <p className="mt-1.5 text-gray-500 text-xs">
+                <Trans
+                  ns="home"
+                  i18nKey="heroDemoEasyDescription"
+                  defaults="That's all it takes to respond to a poll."
+                />
+              </p>
+            </m.div>
+            <m.div
+              initial={{ opacity: 0, y: 6 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{
+                type: "spring",
+                duration: 0.6,
+                bounce: 0.3,
+                delay: 0.3,
+              }}
+              className="mt-4"
+            >
+              <Link
+                href={linkToApp("/new")}
+                onClick={() => {
+                  posthog?.capture("landing:hero_demo_modal_cta_click");
+                }}
+                className="font-medium text-indigo-600 text-xs hover:underline"
+              >
+                <Trans
+                  ns="home"
+                  i18nKey="heroDemoCreatePoll"
+                  defaults="Create your own poll"
+                />
+              </Link>
+            </m.div>
+          </m.div>
+        </div>
+      )}
+    </>
+  );
+};

--- a/apps/landing/src/components/home/hero-demo/vote-selector.tsx
+++ b/apps/landing/src/components/home/hero-demo/vote-selector.tsx
@@ -1,0 +1,60 @@
+"use client";
+import { posthog } from "@rallly/posthog/client";
+import { cn } from "@rallly/ui";
+import * as React from "react";
+import { useTranslation } from "@/i18n/client/use-translation";
+import type { DemoVote } from "./demo-data";
+import { VoteIcon } from "./vote-icon";
+
+// The one piece of the phone demo that holds state: a tri-state vote control
+// per option. Everything around it is server rendered.
+export const VoteSelector = ({
+  label,
+  defaultValue,
+}: {
+  label: string;
+  defaultValue?: DemoVote;
+}) => {
+  const { t } = useTranslation("home");
+  const [value, setValue] = React.useState(defaultValue);
+  const voteLabels: Record<DemoVote, string> = {
+    yes: t("heroDemoYes", { defaultValue: "Yes" }),
+    ifNeedBe: t("heroDemoIfNeedBe", { defaultValue: "If need be" }),
+    no: t("heroDemoNo", { defaultValue: "No" }),
+  };
+  return (
+    <div className="flex h-8 w-24 shrink-0 items-center rounded-lg border border-gray-200/60 bg-gray-100 p-0.5">
+      {(["yes", "ifNeedBe", "no"] as const).map((vote) => {
+        const isSelected = vote === value;
+        return (
+          <label
+            key={vote}
+            className={cn(
+              "group flex h-full flex-1 cursor-pointer items-center justify-center rounded-md has-[:focus-visible]:ring-2 has-[:focus-visible]:ring-indigo-500",
+              isSelected && "bg-white shadow-sm",
+            )}
+          >
+            <input
+              type="radio"
+              name={label}
+              checked={isSelected}
+              onChange={() => {
+                posthog?.capture("landing:hero_demo_vote_change", { vote });
+                setValue(vote);
+              }}
+              aria-label={voteLabels[vote]}
+              className="sr-only"
+            />
+            <VoteIcon
+              vote={vote}
+              className={cn(
+                !isSelected &&
+                  "text-gray-400 opacity-50 transition-opacity group-hover:opacity-100",
+              )}
+            />
+          </label>
+        );
+      })}
+    </div>
+  );
+};


### PR DESCRIPTION
## Description

Fixes the React hydration error on the landing page homepage ("Hydration failed because the server rendered HTML didn't match the client"), introduced with the hero demo in #2934.

### Root cause

Not what it looked like. The dates were **not** diverging between server and client — the visible HTML and the embedded RSC payload contained identical date strings, and a structural walk of the served HTML against the hydrated DOM showed no difference.

The actual problem: `getDemoDays(new Date())` ran inside a `"use cache"` scope. The pages that render the demo are `"use cache"` with `cacheLife("days")`, and `cacheComponents` is enabled. That had two consequences:

- The dates were **baked into the prerendered HTML and RSC payload at build time** (confirmed in `.next/server/app/en.html` and `en.rsc`, both frozen to the build date).
- Those are separate cache entries that revalidate independently. The demo's date set flips at **UTC Friday 00:00**. When one entry was regenerated across that boundary and the other was not, the served HTML and the hydration payload disagreed.

That's why the failure was intermittent and self-healing, and why a post-hoc DOM diff couldn't see it — React had already patched the DOM by the time it was inspectable.

This is the `new Date()`-during-cached-server-render rule in CLAUDE.md, but the failure mode is a step removed from "server and client compute different dates".

### The fix

Derive an anchor — the first Thursday at least a week out — as a plain `YYYY-MM-DD` string, and key the cached demo on it:

- `getDemoAnchor(now)` is the only thing that reads the clock. `getDemoDays(anchor)` is now a pure function of that string.
- `CachedDemo` is cached on the anchor, so the HTML and the RSC payload are produced from the same key and cannot straddle the rollover.
- `cacheLife("hours")` keeps the rendered dates from trailing the rollover for long.

Also converts `MobileDemo` from one large `"use client"` component (243 lines) into a server component (~85 lines), with the interactive parts extracted into small islands — `VoteSelector` (per-option tri-state) and `VoteButton` (submit + confirmation modal). The demo stays server rendered and cacheable while keeping the voting interaction.

### Verification

Built a reliable repro (break the generated Prisma client → load → restore → reload), which produced the hydration error consistently on the committed code and produces none after the fix.

- `next build` passes
- `tsc --noEmit` clean
- `biome check` clean
- Cold dev server, fresh tabs: `/`, `/when2meet-alternative`, `/best-doodle-alternative`, `/de` all load with zero console errors
- Interaction verified: vote selector toggles (`No` / `Yes` / `If need be`), Vote opens the confirmation with CTA, Close dismisses it
- Dates render correctly per locale (`Thu, Aug 27, 2026` in en; `Do., 27. Aug. 2026` in de)

### Note for reviewers

I hit a **separate** hydration error on `/de` once, in a session where I'd loaded `/en` pages first. It did not reproduce on a cold server on either the pristine code or this branch. It looks like the pre-existing `apps/landing/src/i18n/` singleton issue already documented in CLAUDE.md (`getTranslation` calls `changeLanguage()` on a process-wide instance). It's independent of the hero demo and is **not** addressed here — happy to chase it separately if you want.

## Checklist

Please check off all the following items with an "x" in the boxes before requesting a review.

- [x] I have performed a self-review of my code
- [x] My code follows the code style of this project
- [x] I have commented my code, particularly in hard-to-understand areas

🤖 Generated with [Claude Code](https://claude.com/claude-code)
