### PR TITLE
🐛 Center the hero demo success dialog over the phone screen

### DIFF
--- a/apps/landing/src/components/home/hero-demo/mobile-demo.tsx
+++ b/apps/landing/src/components/home/hero-demo/mobile-demo.tsx
@@ -3,7 +3,7 @@ import { UserIcon } from "lucide-react";
 import type { DemoDay, DemoVote } from "./demo-data";
 import { formatDemoParts } from "./demo-data";
 import { DemoFrame, DemoScreen } from "./demo-frame";
-import { VoteButton } from "./vote-button";
+import { VoteActions } from "./vote-actions";
 import { VoteCount } from "./vote-count";
 import { VoteSelector } from "./vote-selector";
 
@@ -76,15 +76,7 @@ export const MobileDemo = ({
             );
           })}
         </div>
-        <div className="absolute inset-x-0 bottom-0 flex items-center gap-2 bg-gradient-to-t from-55% from-white via-85% via-white/70 to-transparent p-3 pt-10">
-          <span
-            aria-hidden="true"
-            className="flex-1 rounded-xl border border-white/60 bg-white/70 py-2.5 text-center font-medium text-gray-800 text-sm shadow-sm backdrop-blur-md"
-          >
-            {t("heroDemoDecline", { ns: "home", defaultValue: "Decline" })}
-          </span>
-          <VoteButton />
-        </div>
+        <VoteActions />
       </DemoScreen>
     </DemoFrame>
   );

--- a/apps/landing/src/components/home/hero-demo/vote-actions.tsx
+++ b/apps/landing/src/components/home/hero-demo/vote-actions.tsx
@@ -8,24 +8,33 @@ import { Trans } from "@/i18n/client/trans";
 import { useTranslation } from "@/i18n/client/use-translation";
 import { linkToApp } from "@/lib/linkToApp";
 
-// The submit action of the phone demo, plus the confirmation it opens. The
-// surrounding poll layout stays on the server.
-export const VoteButton = () => {
+// The action bar of the phone demo, plus the confirmation it opens. The
+// surrounding poll layout stays on the server. Must be a direct child of the
+// relative DemoScreen so the confirmation overlay covers the whole screen.
+export const VoteActions = () => {
   const { t } = useTranslation("home");
   const [submitted, setSubmitted] = React.useState(false);
 
   return (
     <>
-      <button
-        type="button"
-        onClick={() => {
-          posthog?.capture("landing:hero_demo_continue_click");
-          setSubmitted(true);
-        }}
-        className="flex-[2] cursor-pointer rounded-xl bg-indigo-500/90 py-2.5 text-center font-medium text-sm text-white shadow-sm backdrop-blur-md hover:bg-indigo-500"
-      >
-        <Trans ns="home" i18nKey="heroDemoVote" defaults="Vote" />
-      </button>
+      <div className="absolute inset-x-0 bottom-0 flex items-center gap-2 bg-gradient-to-t from-55% from-white via-85% via-white/70 to-transparent p-3 pt-10">
+        <span
+          aria-hidden="true"
+          className="flex-1 rounded-xl border border-white/60 bg-white/70 py-2.5 text-center font-medium text-gray-800 text-sm shadow-sm backdrop-blur-md"
+        >
+          <Trans ns="home" i18nKey="heroDemoDecline" defaults="Decline" />
+        </span>
+        <button
+          type="button"
+          onClick={() => {
+            posthog?.capture("landing:hero_demo_continue_click");
+            setSubmitted(true);
+          }}
+          className="flex-[2] cursor-pointer rounded-xl bg-indigo-500/90 py-2.5 text-center font-medium text-sm text-white shadow-sm backdrop-blur-md hover:bg-indigo-500"
+        >
+          <Trans ns="home" i18nKey="heroDemoVote" defaults="Vote" />
+        </button>
+      </div>
       {submitted && (
         <div className="absolute inset-0 z-10 flex items-center justify-center bg-gray-900/20 p-4">
           <m.div


### PR DESCRIPTION
## What changed

The landing hero's phone demo showed its "That was easy!" confirmation squashed into the bottom action bar instead of centered over the screen.

The hydration-mismatch refactor (#2948) moved the overlay into `VoteButton`, which renders inside the bottom action bar. The bar is `absolute inset-x-0 bottom-0`, so it became the overlay's containing block and `inset-0` anchored the dialog to the ~70px bar rather than the phone screen.

The client component now owns the whole action bar (Decline + Vote) plus the overlay, rendered as siblings directly under the `relative` `DemoScreen` — restoring the pre-refactor geometry while keeping the rest of the poll layout on the server. Renamed `vote-button.tsx` → `vote-actions.tsx` (`VoteActions`) since it is no longer just the button.

## Notes for review

- The "Decline" label moved from server-side `t()` to the client `Trans` with the same key (`heroDemoDecline`), so no locale changes.
- Verified in the dev server: overlay spans the full 620px screen, card centers on it, close button dismisses, type-check and biome pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated the voting action area to display both “Decline” and “Vote” options.
  * Added a consistent action bar for voting interactions in the mobile demo.

* **Bug Fixes**
  * Preserved existing vote submission, confirmation, analytics, and loading behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->