### PR TITLE
💄 Match event card response options to landing page styling

### DIFF
--- a/apps/web/src/features/poll/components/event-card.tsx
+++ b/apps/web/src/features/poll/components/event-card.tsx
@@ -20,7 +20,7 @@ function IconDescriptionList({
 }: React.HTMLAttributes<HTMLDListElement>) {
   return (
     <dl
-      className="flex flex-col gap-x-2 gap-y-1 text-muted-foreground text-xs sm:flex-row"
+      className="flex flex-wrap items-center gap-4 text-muted-foreground text-sm"
       {...props}
     >
       {children}
@@ -36,7 +36,7 @@ function IconDescription({
   label: React.ReactNode;
 }) {
   return (
-    <div className="flex items-center gap-1">
+    <div className="flex items-center gap-1.5">
       <dt>{icon}</dt>
       <dd>{label}</dd>
     </div>
@@ -83,7 +83,7 @@ export function EventCard() {
             </EventMetaItem>
           ) : null}
         </EventMetaList>
-        <h2 className="mt-4 mb-2 font-medium text-sm">
+        <h2 className="mt-4 mb-1.5 font-medium text-sm">
           <Trans i18nKey="responseOptions" defaults="Response options" />
         </h2>
         <IconDescriptionList aria-label="Response options">

--- a/packages/tailwind-config/shared-styles.css
+++ b/packages/tailwind-config/shared-styles.css
@@ -93,7 +93,7 @@
   --accent-foreground: var(--color-gray-100);
 
   --muted: var(--color-gray-800);
-  --muted-foreground: var(--color-gray-400);
+  --muted-foreground: var(--color-gray-300);
   --muted-border: var(--color-gray-700);
 
   --popover: var(--color-gray-800);


### PR DESCRIPTION
## Description

Aligns the response options row in the poll event card with how it appears in the landing page hero demo, and lightens the dark mode `--muted-foreground` token.

- Response options now render as a single horizontal row (`gap-4`, `text-sm`, `gap-1.5` icon-to-label) instead of stacking vertically on mobile at `text-xs`. Labels are short so the row fits at 375px; `flex-wrap` guards extreme widths.
- Heading gap tightened from `mb-2` to `mb-1.5` to match the landing spacing.
- Dark mode `--muted-foreground` bumped from gray-400 to gray-300 for better contrast.

Both apps already share `VoteIcon` from `@rallly/ui/vote-icon`, so the icons were identical — only the list layout differed. The web app keeps semantic tokens (`text-muted-foreground`) rather than the landing's raw gray classes.

Verified in the dev server on the invite page at desktop and mobile widths, dark mode included.

## Checklist

- [x] I have performed a self-review of my code
- [x] My code follows the code style of this project
- [x] I have commented my code, particularly in hard-to-understand areas

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved event card spacing, layout, and text sizing for clearer presentation.
  * Adjusted icon-label spacing and response-options heading spacing.
  * Increased dark-theme muted text contrast for better readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->