### PR TITLE
💄 Cap poll description width at a readable line length

### DIFF
--- a/apps/landing/src/components/home/hero-demo/desktop-demo.tsx
+++ b/apps/landing/src/components/home/hero-demo/desktop-demo.tsx
@@ -54,7 +54,7 @@ export const DesktopDemo = ({
                     defaultValue: "Q3 Board Meeting",
                   })}
                 </h3>
-                <p className="mt-1 text-gray-600 text-sm">
+                <p className="mt-1 max-w-prose text-gray-600 text-sm">
                   {t("heroDemoDescription", {
                     ns: "home",
                     defaultValue:

--- a/apps/web/src/features/poll/components/event-meta.tsx
+++ b/apps/web/src/features/poll/components/event-meta.tsx
@@ -29,7 +29,7 @@ export function EventMetaDescription({
   return (
     <MarkdownDescription
       content={content}
-      className={cn(className, "min-w-0 opacity-90")}
+      className={cn(className, "min-w-0 max-w-prose opacity-90")}
     />
   );
 }


### PR DESCRIPTION
## What changed

Added `max-w-prose` to the poll description on the two surfaces that render it:

- **Event card** (`EventMetaDescription` in `apps/web`) — covers the invite and admin pages
- **Landing hero demo** (`desktop-demo.tsx`)

## Why

Long descriptions spanned the full card width (~896px on the invite page), well past comfortable reading line length. `max-w-prose` caps lines at 65ch — the middle of the 45–75 characters-per-line readability range — and scales with the element's font size, so at `text-sm` it computes to ~574px.

## Notes for review

- `MarkdownDescription` in `packages/ui` is intentionally untouched: other call sites (dialogs) manage their own width.
- Verified in the browser on both surfaces: the invite card description now wraps at 574px inside the 896px card; the hero demo paragraph carries the same cap (only bites when the date grid makes the card wide).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved readability of descriptive text in the hero demo and event details by limiting line length.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->