### PR TITLE
🔥 Remove "Help translate" links

### DIFF
--- a/apps/landing/public/locales/en/common.json
+++ b/apps/landing/public/locales/en/common.json
@@ -34,6 +34,5 @@
   "status": "Status",
   "support": "Support",
   "termsOfUse": "Terms of use",
-  "volunteerTranslator": "Help translate this site",
   "when2MeetAlternative": "When2Meet alternative"
 }

--- a/apps/landing/src/app/[locale]/(main)/footer.tsx
+++ b/apps/landing/src/app/[locale]/(main)/footer.tsx
@@ -8,7 +8,6 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@rallly/ui/select";
-import { LanguagesIcon } from "lucide-react";
 import Image from "next/image";
 import Link from "next/link";
 import { usePathname, useRouter } from "next/navigation";
@@ -271,13 +270,6 @@ export const Footer: React.FunctionComponent = () => {
           <div className="w-48">
             <LanguageSelect />
           </div>
-          <a
-            href="https://support.rallly.co/contribute/translations"
-            className="inline-flex h-9 shrink-0 items-center rounded-md border px-3 text-gray-600 text-xs hover:border-primary hover:text-primary"
-          >
-            <LanguagesIcon className="mr-2 size-4" />
-            <Trans ns="common" i18nKey="volunteerTranslator" /> &rarr;
-          </a>
         </div>
       </div>
     </div>

--- a/apps/web/public/locales/en/app.json
+++ b/apps/web/public/locales/en/app.json
@@ -88,7 +88,6 @@
   "banUserTitle": "Ban user",
   "basicPolls": "Basic polls",
   "basicPollsDescription": "Create simple scheduling polls",
-  "becomeATranslator": "Help translate",
   "billing": "Billing",
   "billingDescription": "Manage your billing information and subscription.",
   "billingPlanTitle": "Plan",

--- a/apps/web/src/app/[locale]/(space)/settings/preferences/components/localization-preferences.tsx
+++ b/apps/web/src/app/[locale]/(space)/settings/preferences/components/localization-preferences.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { buttonVariants } from "@rallly/ui";
 import {
   Field,
   FieldContent,
@@ -17,13 +16,11 @@ import {
 } from "@rallly/ui/select";
 import { toast } from "@rallly/ui/sonner";
 import {
-  ArrowUpRight,
   CalendarIcon,
   ClockIcon,
   GlobeIcon,
   LanguagesIcon,
 } from "lucide-react";
-import Link from "next/link";
 import React from "react";
 import { LanguageSelect } from "@/components/language-selector";
 import { SettingIcon } from "@/components/setting-icon";
@@ -255,16 +252,6 @@ export const LocalizationPreferences = ({
           </Select>
         </Field>
       </FieldGroup>
-      <div className="mt-4 border-t pt-4">
-        <Link
-          target="_blank"
-          href="https://support.rallly.co/contribute/translations"
-          className={buttonVariants({ variant: "ghost" })}
-        >
-          <Trans i18nKey="becomeATranslator" defaults="Help translate" />
-          <ArrowUpRight className="size-4" />
-        </Link>
-      </div>
     </div>
   );
 };


### PR DESCRIPTION
## Description

Removes the "Help translate this site" link from two places:

- **Landing page footer** (`apps/landing/src/app/[locale]/(main)/footer.tsx`) — the bordered link next to the language selector.
- **Localization preferences** (`apps/web/.../preferences/components/localization-preferences.tsx`) — the "Help translate" button in the section below the settings fields, along with its `border-t` wrapper.

Imports that became unused as a result were dropped: `LanguagesIcon` in the footer, and `buttonVariants` / `ArrowUpRight` / `Link` in the preferences component.

The `volunteerTranslator` and `becomeATranslator` keys are now dead, so the second commit removes them from the English source files via `pnpm i18n:scan` (the scanner runs with `removeUnusedKeys: true` and `locales: ["en"]`, so it only touches the source locale). Non-English locale files are untouched — Crowdin drops those on its next sync now that the source key is gone.

### Notes for reviewers

- Nothing else in either file changed; the language selector itself stays.
- `pnpm check` / `type-check` were not run locally: `pnpm check` fails on a pre-existing Biome config error (`tailwindDirectives` is not a known key under `css.parser`), unrelated to this change. The pre-commit hook's `biome check --write` did run over both staged files and passed.

## Checklist

- [x] I have performed a self-review of my code
- [x] My code follows the code style of this project
- [x] I have commented my code, particularly in hard-to-understand areas

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Updates**
  * Removed the “Volunteer translator” link from the landing page footer.
  * Removed the translation-support link from localization preferences.
  * Language selection controls remain available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->