### PR TITLE
💄 Rename CTA experiment variant to create-free-poll

### DIFF
--- a/apps/landing/public/locales/en/home.json
+++ b/apps/landing/public/locales/en/home.json
@@ -1,4 +1,5 @@
 {
+  "createAFreePoll": "Create a free poll",
   "createAPoll": "Create a poll",
   "doodleAlternative": "The best free Doodle alternative",
   "doodleAlternativeDescription": "Rallly is the Doodle alternative that everyone is looking for. Thousands of users have already made the switch and are now enjoying professional ad-free meeting polls in an intuitive and easy-to-use interface.        ",
@@ -17,7 +18,6 @@
   "freeSchedulingPollMetaDescription": "Create a free scheduling poll in seconds. Ideal for organizing meetings, events, conferences, sports teams and more.",
   "freeSchedulingPollMetaTitle": "Create a Free Scheduling Poll Instantly | No Account Required",
   "freeSchedulingPollTitle": "Find a date for your next event",
-  "getStartedForFree": "Get started for free",
   "goodfirmsQuote": "“Unique in its simplicity and requires minimum interaction time.”",
   "headline": "Find the best time to meet",
   "heroDemoClose": "Close",

--- a/apps/landing/src/app/[locale]/(main)/home-page.tsx
+++ b/apps/landing/src/app/[locale]/(main)/home-page.tsx
@@ -11,7 +11,7 @@ export async function HomePage({
   ctaVariant,
 }: {
   locale: string;
-  ctaVariant?: "control" | "get-started";
+  ctaVariant?: "control" | "create-free-poll";
 }) {
   const { t } = await getTranslation(locale, ["home", "common"]);
   return (

--- a/apps/landing/src/app/[locale]/(main)/landing-shell.tsx
+++ b/apps/landing/src/app/[locale]/(main)/landing-shell.tsx
@@ -29,7 +29,7 @@ export async function LandingShell({
   children,
 }: {
   locale: string;
-  ctaVariant?: "control" | "get-started";
+  ctaVariant?: "control" | "create-free-poll";
   children: React.ReactNode;
 }) {
   const { t } = await getTranslation(locale, ["common", "home"]);

--- a/apps/landing/src/app/[locale]/exp/landing-cta-create-free-poll/layout.tsx
+++ b/apps/landing/src/app/[locale]/exp/landing-cta-create-free-poll/layout.tsx
@@ -23,7 +23,7 @@ export default async function Root(props: {
   const { locale } = await params;
 
   return (
-    <LandingShell locale={locale} ctaVariant="get-started">
+    <LandingShell locale={locale} ctaVariant="create-free-poll">
       {children}
     </LandingShell>
   );

--- a/apps/landing/src/app/[locale]/exp/landing-cta-create-free-poll/page.tsx
+++ b/apps/landing/src/app/[locale]/exp/landing-cta-create-free-poll/page.tsx
@@ -13,7 +13,7 @@ export default async function Page(props: {
 }) {
   cacheLife("days");
   const { locale } = await props.params;
-  return <HomePage locale={locale} ctaVariant="get-started" />;
+  return <HomePage locale={locale} ctaVariant="create-free-poll" />;
 }
 
 export async function generateMetadata(props: {

--- a/apps/landing/src/components/home/cta-label.tsx
+++ b/apps/landing/src/components/home/cta-label.tsx
@@ -3,7 +3,11 @@ import { useFeatureFlagVariantKey } from "@rallly/posthog/client";
 import React from "react";
 import { Trans } from "@/i18n/client/trans";
 
-export function CtaLabel({ variant }: { variant?: "control" | "get-started" }) {
+export function CtaLabel({
+  variant,
+}: {
+  variant?: "control" | "create-free-poll";
+}) {
   const flagVariant = useFeatureFlagVariantKey("landing-cta-copy");
   // Without a server-assigned variant the static HTML says control, so the
   // flag value (which may be bootstrapped from a cookie and available on the
@@ -11,12 +15,12 @@ export function CtaLabel({ variant }: { variant?: "control" | "get-started" }) {
   const [mounted, setMounted] = React.useState(false);
   React.useEffect(() => setMounted(true), []);
   const resolved = variant ?? (mounted ? flagVariant : undefined);
-  if (resolved === "get-started") {
+  if (resolved === "create-free-poll") {
     return (
       <Trans
         ns="home"
-        i18nKey="getStartedForFree"
-        defaults="Get started for free"
+        i18nKey="createAFreePoll"
+        defaults="Create a free poll"
       />
     );
   }

--- a/apps/landing/src/lib/cta-experiment.ts
+++ b/apps/landing/src/lib/cta-experiment.ts
@@ -15,7 +15,7 @@ import { fallbackLng, languages } from "@/i18n/settings";
 // events report the variant the visitor actually saw.
 
 const EXPERIMENT_FLAG = "landing-cta-copy";
-const REWRITE_VARIANT = "get-started";
+const REWRITE_VARIANT = "create-free-poll";
 const FLAG_COOKIE = `ph_ff_${EXPERIMENT_FLAG}`;
 const DISTINCT_ID_COOKIE = "ph_did";
 const FLAG_COOKIE_MAX_AGE = 60 * 60;


### PR DESCRIPTION
Follow-up to #2963. Luke flagged that "Get started for free" → poll creation wizard is a label to destination mismatch: it promises onboarding, then asks the visitor to configure a poll. The variant also changed two things at once (action specificity + the free claim), so a result would have been unattributable.

New challenger: **"Create a free poll"** — same verb, same object, same destination match as control; the only delta is surfacing *free* at the point of action.

- Variant key `get-started` → `create-free-poll` everywhere (CtaLabel, shell/page prop types, middleware rewrite constant, variant route directory)
- i18n: `getStartedForFree` removed, `createAFreePoll` added (via `pnpm i18n:scan`)
- Stale `get-started` cookies (≤1h TTL) degrade to control

PostHog side already done: [experiment 90945](https://eu.posthog.com/project/1971/experiments/90945) analysis reset to draft (the few hours of exposures are discarded from analysis), flag disabled, variant renamed to `create-free-poll`, metrics preserved, hypothesis updated. Nobody is currently exposed to any variant.

**Launch sequence: merge → wait for the landing deploy → press Launch on the experiment.** Launching before the deploy would serve `create-free-poll` to code that doesn't recognize it (visitors would see control while exposures record the variant).

Verified locally: `create-free-poll` cookie → variant HTML server-rendered at `/` (both CTAs); stale `get-started` cookie → control; no cookie with flag disabled → control cached.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Updated the landing page call-to-action wording to “Create a free poll.”
  * Updated the CTA experiment variant to consistently use the new wording across landing page layouts and pages.
  * Replaced the previous “Get started for free” localization with the clearer “Create a free poll” label.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->