### PR TITLE
🐛 Fix double scrollbar on the invite page

### DIFF
--- a/apps/web/src/features/poll/components/voting-footer.tsx
+++ b/apps/web/src/features/poll/components/voting-footer.tsx
@@ -45,9 +45,14 @@ export const VotingFooter = ({ className }: { className?: string }) => {
 
   return (
     <div
-      className={cn("flex items-center gap-x-2.5 md:justify-end", className)}
+      className={cn(
+        "relative flex items-center gap-x-2.5 md:justify-end",
+        className,
+      )}
     >
-      {/* Invisible, but keeps vote taps audible for screen readers. */}
+      {/* Invisible, but keeps vote taps audible for screen readers. The
+          wrapper is positioned so this absolutely positioned node resolves
+          against it instead of the body, which would extend the document. */}
       <p aria-live="polite" className="sr-only">
         <Trans
           i18nKey="optionsSelected"


### PR DESCRIPTION
Reported on `/invite/...`: the page renders two vertical scrollbars.

## Cause

The voting footer's screen reader announcer uses Tailwind's `sr-only`, which sets `position: absolute` but leaves `top`/`left` as `auto`. An absolutely positioned element with `auto` offsets resolves to its **static position** — where it would have sat in normal flow.

That position is resolved against its containing block, and this `<p>` had **no positioned ancestor** between it and `<body>` (verified in prod: `offsetParent` was `BODY`, and walking the ancestor chain for `position`/`transform`/`contain` returned an empty list). So its static offset — roughly 1428px down, deep inside the tall `h-dvh overflow-auto` scroll container — was measured from the initial containing block instead.

The 1px node landed 1428px down the *document*, pushing `documentElement.scrollHeight` to 1429 against a 720px viewport. That produced a document scrollbar on top of the scroll container's own intended one.

Because the element is 1px and `clip: inset(50%)`, the symptom is a phantom scrollbar with nothing visible to scroll to.

## Fix

Add `relative` to the footer wrapper so the announcer resolves against it rather than the body. The announcer stays visually hidden and its `aria-live` behaviour is unchanged.

## Verification

Measured on the live page, applying the change to the DOM and re-measuring (read-only; no interaction with the poll):

| | before | after |
|---|---|---|
| `documentElement.scrollHeight` | 1429 | **720** (= viewport) |
| inner scroll container | scrolls (1578 > 720) | still scrolls, unchanged |

Isolating the element confirmed it was solely responsible: hiding that single node dropped `documentElement.scrollHeight` from 1429 to 720.

## Scope

Every other `sr-only` in the codebase is a `<span>` inside a button, dialog, sheet, or pagination control — all have positioned or short ancestors, so none reproduce this. The closest analogue, `packages/ui/src/max-char-length.tsx`, sits in an `inline-flex` beside visible content and can't land deep in a tall scroll container; left as is.

`VotingFooter` renders on both the desktop and mobile voting forms, so this covers the poll page as well as `/invite`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility**
  * Improved screen-reader announcement handling in the voting footer.
* **Style**
  * Updated the voting footer layout and positioning for more consistent display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->