### PR TITLE
💬 Differentiate final CTA copy from the hero subheading

### DIFF
--- a/apps/landing/public/locales/en/home.json
+++ b/apps/landing/public/locales/en/home.json
@@ -8,7 +8,7 @@
   "doodleAlternativeMetaTitle": "Best Free Doodle Alternative | Rallly",
   "ericJobTitle": "Executive Assistant at MIT",
   "ericQuote": "“If your scheduling workflow lives in emails, I strongly encourage you to try and let Rallly simplify your scheduling tasks for a more organized and less stressful workday.”",
-  "finalCtaDescription": "Create a poll, share the link, and let everyone vote on times that work.",
+  "finalCtaDescription": "Set up your poll in under a minute. No account, no downloads, no chasing people for replies.",
   "finalCtaTitle": "Ready to find the best time to meet?",
   "fiveStars": "5 stars",
   "freeSchedulingPollDescription": "Rallly lets you create beautiful and easy to use scheduling polls so you can find the best time for your next event.",

--- a/apps/landing/src/components/home/cta.tsx
+++ b/apps/landing/src/components/home/cta.tsx
@@ -38,7 +38,7 @@ export async function Cta({
                 t={t}
                 ns="home"
                 i18nKey="finalCtaDescription"
-                defaults="Create a poll, share the link, and let everyone vote on times that work."
+                defaults="Set up your poll in under a minute. No account, no downloads, no chasing people for replies."
               />
             )}
           </p>


### PR DESCRIPTION
## What

Rewrites the landing page's final CTA description.

| | Copy |
| --- | --- |
| Before | Create a poll, share the link, and let everyone vote on times that work. |
| After | Set up your poll in under a minute. No account, no downloads, no chasing people for replies. |

## Why

The hero subheading and the final CTA both used the same three-verb formula ("Create a poll, share the link, and let everyone vote..."), so the page said essentially the same sentence twice.

They also do different jobs. The hero is first contact and needs to explain the mechanism. By the time a reader reaches the final CTA they have already passed the stats, the testimonial and four press quotes, so restating the mechanism wastes the slot — hence the reframe around effort and friction.

The hero subheading is deliberately **unchanged**: it stays the place that explains how the product works.

## Reviewer notes

- **"under a minute" is a new claim.** The previous copy asserted no time. It is consistent with the PCMag quote already on the page ("Set up a scheduling poll in as little time as possible"), but it is a concrete number we had not committed to before. Happy to drop it if you would rather not assert one.
- **"No chasing people for replies"** echoes the footer's existing "without the back and forth" — same idea, different words, far enough apart on the page that it reads as reinforcement rather than repetition.
- **Source string change clears existing translations.** The other 15 locales keep the old sentence until Crowdin syncs, and this being a source-string change will clear their translations on merge — the usual pre-fill-right-after-merge case.
- `pnpm i18n:scan` reports no changes; only the `en` value was updated, no other locale files touched.

## Verification

Verified against the landing dev server: the final CTA renders the new copy while the hero renders the original sentence, no console errors, and the paragraph wraps to two balanced lines on desktop and two on mobile with no horizontal overflow. `biome check` clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Content Updates**
  * Updated the homepage final call-to-action messaging to highlight fast setup, no account required, no downloads, and no follow-up needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->