### PR TITLE
💄 Use "Create poll" for the submit button on the new poll page

### DIFF
--- a/apps/web/src/features/poll/components/create-poll.tsx
+++ b/apps/web/src/features/poll/components/create-poll.tsx
@@ -116,7 +116,7 @@ const CreatePollActions = ({
       {form.formState.isSubmitting ? (
         <Trans i18nKey="createPollFooterCreating" defaults="Creating…" />
       ) : (
-        <Trans i18nKey="create" defaults="Create" />
+        <Trans i18nKey="createPoll" defaults="Create poll" />
       )}
     </Button>
   );

--- a/apps/web/tests/new-poll-page.ts
+++ b/apps/web/tests/new-poll-page.ts
@@ -64,7 +64,7 @@ export class NewPollPage {
       await page.getByRole("switch", { name: /comments/i }).click();
     }
 
-    await page.getByRole("button", { name: /^create$/i }).click();
+    await page.getByRole("button", { name: /^create poll$/i }).click();
 
     const successDialog = new CreatePollSuccessDialog(page);
     await successDialog.dialog.waitFor({ state: "visible" });


### PR DESCRIPTION
## Description

The primary submit button on /new said "Create" via the shared `create` i18n key. This points it at the existing `createPoll` key ("Create poll") instead, so the label is specific to the action without renaming the other surfaces that share `create` (API key dialog, dashboard, event type creation).

Because `createPoll` already exists with this exact English value (it's used on the polls page), existing Crowdin translations apply immediately and no `i18n:scan`/`i18n:sync` run is needed.

Verified in the browser: the /new page renders "Create poll" on the primary button.

## Checklist

- [x] I have performed a self-review of my code
- [x] My code follows the code style of this project
- [x] I have commented my code, particularly in hard-to-understand areas

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated the poll creation submit button label from “Create” to “Create poll” for clearer context.
  * Updated the related poll creation flow to recognize the revised button label.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->