### PR TITLE
📈 Include locale in PostHog person properties

### DIFF
--- a/apps/web/src/features/user/client.tsx
+++ b/apps/web/src/features/user/client.tsx
@@ -6,6 +6,7 @@ import type { UserAbility } from "@/features/user/ability";
 import { defineAbilityFor } from "@/features/user/ability";
 import type { UserDTO } from "@/features/user/schema";
 import { authClient } from "@/lib/auth-client";
+import { useLocale } from "@/lib/locale/client";
 import { isOwner } from "@/lib/utils/permissions";
 
 const UserContext = React.createContext<UserDTO | null | undefined>(undefined);
@@ -19,12 +20,16 @@ export function UserProvider({
 }) {
   const userId = user?.id;
   const isGuest = user?.isGuest;
+  const { locale } = useLocale();
 
+  // Changing the language refreshes the router with a new [locale] param, so
+  // this re-runs; posthog-js turns a repeat identify into a $set and drops it
+  // when the properties are unchanged.
   React.useEffect(() => {
     if (userId && !isGuest) {
-      posthog.identify(userId);
+      posthog.identify(userId, { locale });
     }
-  }, [userId, isGuest]);
+  }, [userId, isGuest, locale]);
 
   return <UserContext.Provider value={user}>{children}</UserContext.Provider>;
 }


### PR DESCRIPTION
## What
Pass the active locale as a person property when identifying users in PostHog, and keep it in sync when the user changes their language.

## How
`UserProvider`'s identify effect now reads the `[locale]` route param via `useLocale()` and passes it to `posthog.identify(userId, { locale })`. Changing the language in preferences refreshes the router with a new locale param, so the effect re-runs; posthog-js turns a repeat identify with an unchanged distinct id into a `$set` capture and drops it entirely when the properties haven't changed (verified in posthog-js 1.407.2 source), so there is no duplicate-event noise on ordinary re-renders.

## Verification
Ran the app locally with a throwaway PostHog key and confirmed via posthog-js persistence and the capture requests:
- On login, identify fires with `{ locale: "en" }`
- Switching the language to Suomi in settings (soft refresh, no reload) updates the stored person properties to `{ locale: "fi" }` and sends a `$set`
- Switching back to English flips it back to `{ locale: "en" }`

## Why
Enables language-based survey targeting and cohorting (immediate use case: asking Finnish users which vowel harmony "Rallly" should inflect with — the fi locale files currently mix `Ralllya`/`Ralllyä`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * User analytics identification now reflects the current locale.
  * Locale changes trigger refreshed user context while avoiding duplicate analytics events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->