### PR TITLE
💄 Make landing stats digits roll straight vertically

### DIFF
--- a/apps/landing/src/components/home/animated-number.tsx
+++ b/apps/landing/src/components/home/animated-number.tsx
@@ -91,6 +91,9 @@ function AnimatedNumber({
           value={shown}
           locales={locale}
           animated={animated}
+          // Layout snaps instantly so digits spin straight vertically in
+          // place instead of sliding sideways while the width grows.
+          transformTiming={{ duration: 0 }}
           spinTiming={{
             duration: DURATION_MS,
             easing: "cubic-bezier(0.16, 1, 0.3, 1)",


### PR DESCRIPTION
## Description

Sets `transformTiming={{ duration: 0 }}` on the `NumberFlow` in the landing stats counter so the numbers roll straight vertically instead of drifting diagonally.

The stat rolls up from 0, so the digit count changes mid-animation. NumberFlow animates two things independently: the vertical digit spin (our `spinTiming`, 1200ms) and the layout — every digit and separator gets a `translateX` as the number widens, driven by `transformTiming`, which defaults to a 900ms spring. The vertical roll riding on that horizontal slide made the animation read as diagonal.

With `transformTiming` zeroed, the layout snaps to full width at animation start and every digit spins vertically in its final position. The snap isn't visible: the component already snaps to 0 unanimated two frames earlier, so the collapse and re-expand cancel within ~30ms and the surrounding sentence never moves. Entering digits keep their 450ms opacity fade-in.

**Verification:** instrumented `Element.prototype.animate` on the dev server and captured every WAAPI call across both stats. Before: 7 `transform` + 2 width/dx animations at 900ms running under the 5 digit spins at 1200ms. After: the same 9 layout animations at duration 0; only the 5 vertical spins (1200ms) and 3 opacity fades (450ms) animate over time. Verified behaviorally, not visually (the embedded browser pane suppresses NumberFlow animation on hidden documents), so worth one glance in a real browser.

## Checklist

- [x] I have performed a self-review of my code
- [x] My code follows the code style of this project
- [x] I have commented my code, particularly in hard-to-understand areas

🤖 Generated with [Claude Code](https://claude.com/claude-code)