### PR TITLE
✨ Make the update check channel-aware and add the new-major notice

### DIFF
--- a/apps/web/public/locales/en/app.json
+++ b/apps/web/public/locales/en/app.json
@@ -813,6 +813,7 @@
   "verifyEmail": "Verify your email",
   "verifyEmailDescription": "Enter the 6-digit code we sent to <b>{email}</b>",
   "verifyEmailTitle": "Verify your email",
+  "versionTileNewMajorNotice": "v{major} is available. Read the migration guide.",
   "viewClosedPolls": "View closed polls",
   "viewInvites": "View invites",
   "viewPoll": "View poll",

--- a/apps/web/src/app/[locale]/control-panel/version-tile.tsx
+++ b/apps/web/src/app/[locale]/control-panel/version-tile.tsx
@@ -9,48 +9,92 @@ import { appVersion } from "@/lib/constants";
 
 const RELEASES_URL = "https://github.com/lukevella/rallly/releases";
 
-async function UpdateStatus() {
+const versionLabel = appVersion
+  ? `v${appVersion.replace(/^v/, "")}`
+  : "unknown";
+
+// The title link is stretched over the whole tile; the new-major notice sits
+// above it (position: relative) so both stay real, non-nested anchors.
+function VersionTileFrame({
+  href,
+  children,
+}: {
+  href: string;
+  children?: React.ReactNode;
+}) {
+  return (
+    <Tile>
+      <PageIcon>
+        <DownloadIcon />
+      </PageIcon>
+      <TileTitle>
+        <a
+          href={href}
+          target="_blank"
+          rel="noreferrer noopener"
+          className="after:absolute after:inset-0"
+        >
+          {versionLabel}
+        </a>
+      </TileTitle>
+      {children}
+    </Tile>
+  );
+}
+
+async function UpdateStatusTile() {
   const update = await loadUpdateStatus();
 
   if (!update) {
-    return null;
+    return <VersionTileFrame href={RELEASES_URL} />;
   }
 
   const { t } = await getTranslation();
 
-  if (update.status === "up-to-date") {
-    return (
-      <span className="text-green-600 text-sm">
-        {t("upToDate", { defaultValue: "Up to date" })}
-      </span>
-    );
-  }
-
   return (
-    <span className="text-primary text-sm">
-      {t("updateAvailable", { defaultValue: "Update available" })}
-    </span>
+    <VersionTileFrame
+      href={update.status === "update-available" ? update.url : RELEASES_URL}
+    >
+      {update.newMajor ? (
+        <a
+          href={update.newMajor.migrationGuideUrl}
+          target="_blank"
+          rel="noreferrer noopener"
+          className="relative mt-1 text-amber-600 text-sm hover:underline"
+        >
+          {t("versionTileNewMajorNotice", {
+            defaultValue: "v{major} is available. Read the migration guide.",
+            major: update.newMajor.major,
+          })}
+        </a>
+      ) : null}
+      <TileDescription>
+        {update.status === "up-to-date" ? (
+          <span className="text-green-600">
+            {t("upToDate", { defaultValue: "Up to date" })}
+          </span>
+        ) : (
+          <span className="text-primary">
+            {t("updateAvailable", { defaultValue: "Update available" })}
+          </span>
+        )}
+      </TileDescription>
+    </VersionTileFrame>
   );
 }
 
 export function VersionTile() {
   return (
-    <Tile
-      render={
-        <a href={RELEASES_URL} target="_blank" rel="noreferrer noopener" />
+    <Suspense
+      fallback={
+        <VersionTileFrame href={RELEASES_URL}>
+          <TileDescription>
+            <Skeleton className="h-4 w-24" />
+          </TileDescription>
+        </VersionTileFrame>
       }
     >
-      <PageIcon>
-        <DownloadIcon />
-      </PageIcon>
-      <TileTitle>
-        {appVersion ? `v${appVersion.replace(/^v/, "")}` : "unknown"}
-      </TileTitle>
-      <TileDescription>
-        <Suspense fallback={<Skeleton className="h-4 w-24" />}>
-          <UpdateStatus />
-        </Suspense>
-      </TileDescription>
-    </Tile>
+      <UpdateStatusTile />
+    </Suspense>
   );
 }

--- a/apps/web/src/app/api/updates/release-channels.test.ts
+++ b/apps/web/src/app/api/updates/release-channels.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest";
+import { buildReleaseChannels } from "./release-channels";
+
+function release(tag: string, overrides: Record<string, unknown> = {}) {
+  return {
+    tag_name: tag,
+    html_url: `https://github.com/lukevella/rallly/releases/tag/${tag}`,
+    published_at: "2026-01-01T00:00:00Z",
+    draft: false,
+    prerelease: false,
+    ...overrides,
+  };
+}
+
+describe("buildReleaseChannels", () => {
+  it("keeps the newest release per major regardless of list order", () => {
+    const channels = buildReleaseChannels([
+      release("v4.2.0"),
+      release("v5.0.0"),
+      release("v4.10.0"),
+      release("v4.1.0"),
+      release("v5.1.0"),
+    ]);
+
+    expect(channels).not.toBeNull();
+    expect(channels?.latestByMajor[4]?.version).toBe("v4.10.0");
+    expect(channels?.latestByMajor[5]?.version).toBe("v5.1.0");
+    expect(channels?.latestMajor).toBe(5);
+  });
+
+  it("excludes drafts, prereleases, and non-stable tags", () => {
+    const channels = buildReleaseChannels([
+      release("v4.1.0"),
+      release("v6.0.0", { draft: true }),
+      release("v5.0.0", { prerelease: true }),
+      release("v5.0.0-beta.1"),
+      release("4-beta"),
+    ]);
+
+    expect(channels?.latestMajor).toBe(4);
+    expect(channels?.latestByMajor[5]).toBeUndefined();
+    expect(channels?.latestByMajor[6]).toBeUndefined();
+  });
+
+  it("skips releases without a published date", () => {
+    const channels = buildReleaseChannels([
+      release("v4.1.0"),
+      release("v5.0.0", { published_at: null }),
+    ]);
+
+    expect(channels?.latestMajor).toBe(4);
+  });
+
+  it("skips malformed entries instead of failing the list", () => {
+    const channels = buildReleaseChannels([
+      null,
+      {},
+      { tag_name: "v9.0.0" },
+      release("v4.1.0"),
+    ]);
+
+    expect(channels?.latestMajor).toBe(4);
+    expect(channels?.latestByMajor[4]?.version).toBe("v4.1.0");
+  });
+
+  it("returns null when nothing usable remains", () => {
+    expect(buildReleaseChannels([])).toBeNull();
+    expect(buildReleaseChannels([release("nightly")])).toBeNull();
+    expect(buildReleaseChannels({ not: "an array" })).toBeNull();
+  });
+});

--- a/apps/web/src/app/api/updates/release-channels.ts
+++ b/apps/web/src/app/api/updates/release-channels.ts
@@ -1,0 +1,58 @@
+import * as z from "zod";
+import {
+  getMajorVersion,
+  isOutdated,
+} from "@/features/instance-settings/utils";
+
+const releaseSchema = z.object({
+  tag_name: z.string().min(1),
+  html_url: z.string().min(1),
+  published_at: z.string().nullish(),
+  draft: z.boolean().optional(),
+  prerelease: z.boolean().optional(),
+});
+
+const STABLE_TAG_REGEX = /^v?\d+\.\d+\.\d+$/;
+
+export type ReleaseInfo = {
+  version: string;
+  url: string;
+  publishedAt: string;
+};
+
+export type ReleaseChannels = {
+  latestByMajor: Record<number, ReleaseInfo>;
+  latestMajor: number;
+};
+
+export function buildReleaseChannels(input: unknown): ReleaseChannels | null {
+  if (!Array.isArray(input)) return null;
+
+  const latestByMajor: Record<number, ReleaseInfo> = {};
+
+  for (const item of input) {
+    const parsed = releaseSchema.safeParse(item);
+    if (!parsed.success) continue;
+
+    const { tag_name, html_url, published_at, draft, prerelease } = parsed.data;
+    if (draft || prerelease || !published_at) continue;
+    if (!STABLE_TAG_REGEX.test(tag_name)) continue;
+
+    const major = getMajorVersion(tag_name);
+    if (major === null) continue;
+
+    const current = latestByMajor[major];
+    if (!current || isOutdated(current.version, tag_name)) {
+      latestByMajor[major] = {
+        version: tag_name,
+        url: html_url,
+        publishedAt: published_at,
+      };
+    }
+  }
+
+  const majors = Object.keys(latestByMajor).map(Number);
+  if (majors.length === 0) return null;
+
+  return { latestByMajor, latestMajor: Math.max(...majors) };
+}

--- a/apps/web/src/app/api/updates/route.ts
+++ b/apps/web/src/app/api/updates/route.ts
@@ -44,15 +44,23 @@ const seenInstanceCache = createCache<string>({
 const ratelimit = createRatelimit(60, "1 h");
 
 async function fetchReleaseChannels(): Promise<ReleaseChannels | null> {
-  const res = await fetch(GITHUB_RELEASES_URL, {
-    headers: {
-      Accept: "application/vnd.github+json",
-      "User-Agent": "Rallly",
-    },
-  });
-  if (!res.ok) return null;
+  try {
+    const res = await fetch(GITHUB_RELEASES_URL, {
+      headers: {
+        Accept: "application/vnd.github+json",
+        "User-Agent": "Rallly",
+      },
+      // Just under the self-hosted client's 3s budget so a slow GitHub
+      // response still yields our controlled 502 instead of a hung slot
+      signal: AbortSignal.timeout(2500),
+    });
+    if (!res.ok) return null;
 
-  return buildReleaseChannels(await res.json());
+    return buildReleaseChannels(await res.json());
+  } catch (error) {
+    logger.warn({ error }, "Failed to fetch releases from GitHub");
+    return null;
+  }
 }
 
 async function getReleaseChannels(): Promise<ReleaseChannels | null> {

--- a/apps/web/src/app/api/updates/route.ts
+++ b/apps/web/src/app/api/updates/route.ts
@@ -13,7 +13,11 @@ import { buildReleaseChannels } from "./release-channels";
 const logger = createLogger("api/updates");
 
 const GITHUB_RELEASES_URL =
-  "https://api.github.com/repos/lukevella/rallly/releases?per_page=100";
+  "https://api.github.com/repos/lukevella/rallly/releases";
+const RELEASES_PER_PAGE = 100;
+// Sequential unauthenticated requests count against a 60/hour IP budget, so
+// pagination is bounded; older majors beyond this window report no update.
+const MAX_RELEASE_PAGES = 3;
 
 // The fleet starts linking here the moment a new major's first release is
 // tagged — the guide must be published at this path before tagging.
@@ -45,18 +49,39 @@ const ratelimit = createRatelimit(60, "1 h");
 
 async function fetchReleaseChannels(): Promise<ReleaseChannels | null> {
   try {
-    const res = await fetch(GITHUB_RELEASES_URL, {
-      headers: {
-        Accept: "application/vnd.github+json",
-        "User-Agent": "Rallly",
-      },
-      // Just under the self-hosted client's 3s budget so a slow GitHub
-      // response still yields our controlled 502 instead of a hung slot
-      signal: AbortSignal.timeout(2500),
-    });
-    if (!res.ok) return null;
+    // One deadline for the whole pagination, just under the self-hosted
+    // client's 3s budget so a slow GitHub response still yields our
+    // controlled 502 instead of a hung slot
+    const signal = AbortSignal.timeout(2500);
+    const releases: unknown[] = [];
 
-    return buildReleaseChannels(await res.json());
+    for (let page = 1; page <= MAX_RELEASE_PAGES; page++) {
+      const res = await fetch(
+        `${GITHUB_RELEASES_URL}?per_page=${RELEASES_PER_PAGE}&page=${page}`,
+        {
+          headers: {
+            Accept: "application/vnd.github+json",
+            "User-Agent": "Rallly",
+          },
+          signal,
+        },
+      );
+      if (!res.ok) return null;
+
+      const batch = await res.json();
+      if (!Array.isArray(batch)) return null;
+
+      releases.push(...batch);
+      if (batch.length < RELEASES_PER_PAGE) break;
+      if (page === MAX_RELEASE_PAGES) {
+        logger.warn(
+          { pages: MAX_RELEASE_PAGES },
+          "Release list truncated at the pagination bound",
+        );
+      }
+    }
+
+    return buildReleaseChannels(releases);
   } catch (error) {
     logger.warn({ error }, "Failed to fetch releases from GitHub");
     return null;

--- a/apps/web/src/app/api/updates/route.ts
+++ b/apps/web/src/app/api/updates/route.ts
@@ -3,29 +3,36 @@ import { createLogger } from "@rallly/logger";
 import type { NextRequest } from "next/server";
 import { after, NextResponse } from "next/server";
 import * as z from "zod";
+import { getMajorVersion } from "@/features/instance-settings/utils";
 import { createCache } from "@/lib/cache";
 import { isSelfHosted } from "@/lib/constants";
 import { createRatelimit } from "@/lib/rate-limit";
+import type { ReleaseChannels } from "./release-channels";
+import { buildReleaseChannels } from "./release-channels";
 
 const logger = createLogger("api/updates");
 
 const GITHUB_RELEASES_URL =
-  "https://api.github.com/repos/lukevella/rallly/releases/latest";
+  "https://api.github.com/repos/lukevella/rallly/releases?per_page=100";
 
-const upstreamSchema = z.object({
-  tag_name: z.string().min(1),
-  html_url: z.string().min(1),
-  published_at: z.string().min(1),
-});
+// The fleet starts linking here the moment a new major's first release is
+// tagged — the guide must be published at this path before tagging.
+function getMigrationGuideUrl(major: number) {
+  return `https://support.rallly.co/self-hosting/migrate-to-v${major}`;
+}
 
 type UpdatesPayload = {
-  latest: string;
-  url: string;
-  publishedAt: string;
+  latest: string | null;
+  url: string | null;
+  publishedAt: string | null;
+  newMajor?: {
+    version: string;
+    migrationGuideUrl: string;
+  };
 };
 
-const latestReleaseCache = createCache<UpdatesPayload>({
-  namespace: "updates:latest-release",
+const releaseChannelsCache = createCache<ReleaseChannels>({
+  namespace: "updates:release-channels",
   ttl: "1 h",
 });
 
@@ -36,7 +43,7 @@ const seenInstanceCache = createCache<string>({
 
 const ratelimit = createRatelimit(60, "1 h");
 
-async function fetchLatestRelease(): Promise<UpdatesPayload | null> {
+async function fetchReleaseChannels(): Promise<ReleaseChannels | null> {
   const res = await fetch(GITHUB_RELEASES_URL, {
     headers: {
       Accept: "application/vnd.github+json",
@@ -45,23 +52,47 @@ async function fetchLatestRelease(): Promise<UpdatesPayload | null> {
   });
   if (!res.ok) return null;
 
-  const parsed = upstreamSchema.safeParse(await res.json());
-  if (!parsed.success) return null;
-
-  return {
-    latest: parsed.data.tag_name,
-    url: parsed.data.html_url,
-    publishedAt: parsed.data.published_at,
-  };
+  return buildReleaseChannels(await res.json());
 }
 
-async function getLatestRelease(): Promise<UpdatesPayload | null> {
-  const cached = await latestReleaseCache.get("latest");
+async function getReleaseChannels(): Promise<ReleaseChannels | null> {
+  const cached = await releaseChannelsCache.get("channels");
   if (cached) return cached;
 
-  const fresh = await fetchLatestRelease();
-  if (fresh) await latestReleaseCache.set("latest", fresh);
+  const fresh = await fetchReleaseChannels();
+  if (fresh) await releaseChannelsCache.set("channels", fresh);
   return fresh;
+}
+
+function buildPayload(
+  channels: ReleaseChannels,
+  requestedMajor: number | null,
+): UpdatesPayload {
+  const latestRelease = channels.latestByMajor[channels.latestMajor];
+
+  if (requestedMajor === null) {
+    return {
+      latest: latestRelease.version,
+      url: latestRelease.url,
+      publishedAt: latestRelease.publishedAt,
+    };
+  }
+
+  const ownChannel = channels.latestByMajor[requestedMajor];
+
+  return {
+    latest: ownChannel?.version ?? null,
+    url: ownChannel?.url ?? null,
+    publishedAt: ownChannel?.publishedAt ?? null,
+    ...(channels.latestMajor > requestedMajor
+      ? {
+          newMajor: {
+            version: latestRelease.version,
+            migrationGuideUrl: getMigrationGuideUrl(channels.latestMajor),
+          },
+        }
+      : {}),
+  };
 }
 
 export async function GET(request: NextRequest) {
@@ -78,9 +109,9 @@ export async function GET(request: NextRequest) {
     }
   }
 
-  const payload = await getLatestRelease();
+  const channels = await getReleaseChannels();
 
-  if (!payload) {
+  if (!channels) {
     return NextResponse.json(
       { error: "upstream_unavailable" },
       { status: 502 },
@@ -119,5 +150,9 @@ export async function GET(request: NextRequest) {
     });
   }
 
-  return NextResponse.json(payload);
+  const requestedMajor = parsedVersion.success
+    ? getMajorVersion(parsedVersion.data)
+    : null;
+
+  return NextResponse.json(buildPayload(channels, requestedMajor));
 }

--- a/apps/web/src/features/instance-settings/service.ts
+++ b/apps/web/src/features/instance-settings/service.ts
@@ -4,34 +4,21 @@ import { createLogger } from "@rallly/logger";
 import * as z from "zod";
 import { env } from "@/env";
 import { appVersion } from "@/lib/constants";
+import { getMajorVersion, isOutdated } from "./utils";
 
 const logger = createLogger("update-check");
 
 const updateStatusSchema = z.object({
-  latest: z.string(),
-  url: z.string(),
-  publishedAt: z.string(),
+  latest: z.string().nullish(),
+  url: z.string().nullish(),
+  publishedAt: z.string().nullish(),
+  newMajor: z
+    .object({
+      version: z.string(),
+      migrationGuideUrl: z.string(),
+    })
+    .nullish(),
 });
-
-function normalizeVersion(version: string) {
-  return version.replace(/^v/, "").split(/[-+]/)[0];
-}
-
-function isOutdated(current: string, latest: string) {
-  const a = normalizeVersion(current)
-    .split(".")
-    .map((n) => Number(n) || 0);
-  const b = normalizeVersion(latest)
-    .split(".")
-    .map((n) => Number(n) || 0);
-  const len = Math.max(a.length, b.length);
-  for (let i = 0; i < len; i++) {
-    const ai = a[i] ?? 0;
-    const bi = b[i] ?? 0;
-    if (ai !== bi) return ai < bi;
-  }
-  return false;
-}
 
 export async function getUpdateStatus({ instanceId }: { instanceId: string }) {
   if (!appVersion || !env.API_BASE_URL) return null;
@@ -62,10 +49,43 @@ export async function getUpdateStatus({ instanceId }: { instanceId: string }) {
       );
       return null;
     }
-    if (!isOutdated(appVersion, parsed.data.latest)) {
-      return { status: "up-to-date" as const };
-    }
-    return { status: "update-available" as const, ...parsed.data };
+
+    const currentMajor = getMajorVersion(appVersion);
+    const { latest, url: releaseUrl, publishedAt, newMajor } = parsed.data;
+
+    // The endpoint scopes `latest` to our own major. Guard anyway: a release
+    // from another major must never surface as a pullable update, and this
+    // code is frozen in fleet binaries.
+    const withinMajor =
+      latest &&
+      releaseUrl &&
+      publishedAt &&
+      currentMajor !== null &&
+      getMajorVersion(latest) === currentMajor &&
+      isOutdated(appVersion, latest)
+        ? {
+            status: "update-available" as const,
+            latest,
+            url: releaseUrl,
+            publishedAt,
+          }
+        : { status: "up-to-date" as const };
+
+    const newMajorVersion = newMajor ? getMajorVersion(newMajor.version) : null;
+
+    return {
+      ...withinMajor,
+      newMajor:
+        newMajor &&
+        currentMajor !== null &&
+        newMajorVersion !== null &&
+        newMajorVersion > currentMajor
+          ? {
+              major: newMajorVersion,
+              migrationGuideUrl: newMajor.migrationGuideUrl,
+            }
+          : null,
+    };
   } catch (error) {
     logger.warn(
       { error, instanceId, version: appVersion },

--- a/apps/web/src/features/instance-settings/utils.test.ts
+++ b/apps/web/src/features/instance-settings/utils.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+import { getMajorVersion, isOutdated } from "./utils";
+
+describe("getMajorVersion", () => {
+  it("extracts the major from a tagged version", () => {
+    expect(getMajorVersion("v4.5.1")).toBe(4);
+  });
+
+  it("extracts the major from an untagged version", () => {
+    expect(getMajorVersion("4.5.1")).toBe(4);
+  });
+
+  it("ignores prerelease suffixes", () => {
+    expect(getMajorVersion("5.0.0-beta.1")).toBe(5);
+  });
+
+  it("returns null for non-version strings", () => {
+    expect(getMajorVersion("unknown")).toBeNull();
+    expect(getMajorVersion("")).toBeNull();
+  });
+});
+
+describe("isOutdated", () => {
+  it("detects an older patch version", () => {
+    expect(isOutdated("4.1.0", "4.1.1")).toBe(true);
+  });
+
+  it("detects an older minor version numerically", () => {
+    expect(isOutdated("4.9.0", "4.10.0")).toBe(true);
+  });
+
+  it("treats equal versions as current", () => {
+    expect(isOutdated("v4.2.0", "v4.2.0")).toBe(false);
+  });
+
+  it("treats newer versions as current", () => {
+    expect(isOutdated("4.10.0", "4.9.0")).toBe(false);
+  });
+
+  it("compares across majors without guarding", () => {
+    expect(isOutdated("4.2.0", "5.0.0")).toBe(true);
+  });
+
+  it("ignores prerelease suffixes", () => {
+    expect(isOutdated("4.2.0-beta.1", "4.2.0")).toBe(false);
+  });
+});

--- a/apps/web/src/features/instance-settings/utils.test.ts
+++ b/apps/web/src/features/instance-settings/utils.test.ts
@@ -18,6 +18,11 @@ describe("getMajorVersion", () => {
     expect(getMajorVersion("unknown")).toBeNull();
     expect(getMajorVersion("")).toBeNull();
   });
+
+  it("rejects malformed versions with numeric prefixes", () => {
+    expect(getMajorVersion("4foo")).toBeNull();
+    expect(getMajorVersion("4.5x")).toBeNull();
+  });
 });
 
 describe("isOutdated", () => {

--- a/apps/web/src/features/instance-settings/utils.ts
+++ b/apps/web/src/features/instance-settings/utils.ts
@@ -12,8 +12,9 @@ function normalizeVersion(version: string) {
 }
 
 export function getMajorVersion(version: string) {
-  const major = Number.parseInt(normalizeVersion(version).split(".")[0], 10);
-  return Number.isNaN(major) ? null : major;
+  const normalized = normalizeVersion(version);
+  if (!/^\d+(\.\d+){0,2}$/.test(normalized)) return null;
+  return Number(normalized.split(".")[0]);
 }
 
 // Compares release numbers only — prerelease/build suffixes are ignored, so

--- a/apps/web/src/features/instance-settings/utils.ts
+++ b/apps/web/src/features/instance-settings/utils.ts
@@ -6,3 +6,31 @@ export function isInitialAdmin(email: string) {
     email.toLowerCase() === process.env.INITIAL_ADMIN_EMAIL.toLowerCase()
   );
 }
+
+function normalizeVersion(version: string) {
+  return version.replace(/^v/, "").split(/[-+]/)[0];
+}
+
+export function getMajorVersion(version: string) {
+  const major = Number.parseInt(normalizeVersion(version).split(".")[0], 10);
+  return Number.isNaN(major) ? null : major;
+}
+
+// Compares release numbers only — prerelease/build suffixes are ignored, so
+// "4.2.0-beta.1" is not outdated relative to "4.2.0". Callers that must not
+// cross majors need to guard with getMajorVersion themselves.
+export function isOutdated(current: string, latest: string) {
+  const a = normalizeVersion(current)
+    .split(".")
+    .map((n) => Number(n) || 0);
+  const b = normalizeVersion(latest)
+    .split(".")
+    .map((n) => Number(n) || 0);
+  const len = Math.max(a.length, b.length);
+  for (let i = 0; i < len; i++) {
+    const ai = a[i] ?? 0;
+    const bi = b[i] ?? 0;
+    if (ai !== bi) return ai < bi;
+  }
+  return false;
+}


### PR DESCRIPTION
Closes RAL-1528.

## What changed

**Cloud endpoint (`/api/updates`)** now fetches the releases list (`?per_page=100`, currently spans v4.12.3 back to v2.0.0 in one page) instead of `releases/latest`:

- `latest`/`url`/`publishedAt` are scoped to the newest stable release **within the requesting instance's own major** — the actionable upgrade.
- A `newMajor` block is added when a newer major exists, carrying the newest version in that major and a **server-controlled migration guide URL** (`https://support.rallly.co/self-hosting/migrate-to-v{major}`). Keeping the URL server-side means it stays correctable after fleet binaries freeze.
- Drafts, prereleases, and non-stable tags (e.g. the planned `4-beta` channel) are excluded.
- Callers without a valid `version` param get the old shape (newest overall, no `newMajor`) — backward compatible with instances running the current client.

**Self-hosted client (`instance-settings/service.ts`)**:

- Parses the new shape; `newMajor` is surfaced separately from the within-major status.
- Defense in depth: a release from another major is never treated as a pullable update, and a `newMajor` block is only honored if its major is actually greater than ours — this code freezes in fleet binaries, so it doesn't trust the endpoint to stay well-behaved.

**Control panel version tile**:

- Within-major status unchanged: "Up to date" / "Update available" top right; the tile now links to the specific own-major release when an update exists (previously the generic releases page, which would be headed by v5.0.0 after the tag).
- New-major case renders as a distinct amber notice ("v5 is available. Read the migration guide.") linking to the migration guide — never a version to pull. Both links coexist without nested anchors via a stretched title link with the notice layered above it.

## Verified

- 15 new unit tests (channel building, version helpers), full unit suite green, type check and lint clean.
- Ran the endpoint locally against the live GitHub payload: `?version=v3.0.0` → `latest: v3.11.2` + `newMajor: v4.12.3` with guide URL; `?version=v4.0.0` → `latest: v4.12.3`, no `newMajor`; no params → old shape.
- Rendered the tile in self-hosted mode (faked v3.0.0 instance against a stubbed endpoint): both the "Update available" status and the amber migration notice render, and each link resolves independently (title → v3.11.2 release, notice → migration guide). Also verified the plain up-to-date state and light/dark themes.

## Before tagging v5.0.0

Two operational notes (also why this must ship in a v4 point release first, per RAL-1528):

1. This release must be **in the fleet before the first v5 tag exists** — the tag is what triggers the notice fleet-wide.
2. The migration guide must be published at `support.rallly.co/self-hosting/migrate-to-v5` before tagging — the fleet starts linking there the moment the tag is created.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Update notifications distinguish newer releases in the current major version from available major upgrades.
  - Major upgrades include a direct migration-guide link.
  - Available updates link directly to release details.
  - Release information reflects the latest stable version for each major release channel.

- **Bug Fixes**
  - Improved handling of incomplete, invalid, prerelease, and unavailable release data.
  - The version tile remains visible while update information loads.
  - Update checks handle network and service errors more gracefully.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->