### PR TITLE
💄 Redesign landing footer with stacked brand row and link columns

### DIFF
--- a/apps/landing/src/app/[locale]/(main)/footer.tsx
+++ b/apps/landing/src/app/[locale]/(main)/footer.tsx
@@ -12,77 +12,75 @@ import { LanguageSelect } from "./language-select";
 export const Footer = async ({ locale }: { locale: string }) => {
   const { t } = await getTranslation(locale, "common");
   return (
-    <div className="mx-auto space-y-8">
-      <div className="space-y-16 lg:flex lg:space-x-8 lg:space-y-0">
-        <div className="lg:mr-16 lg:w-1/4">
-          <div className="relative size-8">
-            <Image
-              src="/logo-footer.svg"
-              fill
-              alt="Rallly"
-              className="object-contain"
-            />
-          </div>
-          <div className="my-8 text-gray-600 text-sm">
-            <p className="leading-relaxed">
-              <Trans
-                t={t}
-                ns="common"
-                i18nKey="footerTagline"
-                defaults="Rallly is an open-source meeting scheduling tool that helps you find the best time to meet, without the back and forth."
-              />
-            </p>
-          </div>
-          <div className="flex items-center space-x-4">
-            <a
-              target="_blank"
-              href="https://x.com/ralllyco"
-              className="text-gray-600 text-sm hover:text-primary hover:no-underline"
-              rel="noreferrer noopener"
-              aria-label={t("footerXLabel", { defaultValue: "Follow us on X" })}
-            >
-              <XIcon className="size-4" />
-            </a>
-            <a
-              target="_blank"
-              href="https://discord.gg/uzg4ZcHbuM"
-              className="text-gray-600 text-sm hover:text-primary hover:no-underline"
-              rel="noreferrer noopener"
-              aria-label={t("footerDiscordLabel", {
-                defaultValue: "Join us on Discord",
-              })}
-            >
-              <DiscordIcon className="size-4" />
-            </a>
-            <a
-              target="_blank"
-              href="https://www.linkedin.com/company/rallly"
-              className="text-gray-600 text-sm hover:text-primary hover:no-underline"
-              rel="noreferrer noopener"
-              aria-label={t("footerLinkedinLabel", {
-                defaultValue: "Follow us on LinkedIn",
-              })}
-            >
-              <LinkedinIcon className="size-4" />
-            </a>
-            <a
-              target="_blank"
-              href="https://github.com/lukevella/rallly"
-              className="text-gray-600 text-sm hover:text-primary hover:no-underline"
-              rel="noreferrer noopener"
-              aria-label={t("footerGithubLabel", {
-                defaultValue: "View our GitHub repository",
-              })}
-            >
-              <GithubIcon className="size-4" />
-            </a>
-          </div>
+    <div className="mx-auto space-y-12">
+      <div className="space-y-6">
+        <div className="relative size-8">
+          <Image
+            src="/logo-footer.svg"
+            fill
+            alt="Rallly"
+            className="object-contain"
+          />
         </div>
-        <div className="lg:flex-1">
-          <div className="mb-6 flex h-8 items-center font-medium">
+        <p className="max-w-sm text-pretty text-gray-600 text-sm leading-relaxed">
+          <Trans
+            t={t}
+            ns="common"
+            i18nKey="footerTagline"
+            defaults="Rallly is an open-source meeting scheduling tool that helps you find the best time to meet, without the back and forth."
+          />
+        </p>
+        <div className="flex items-center space-x-4">
+          <a
+            target="_blank"
+            href="https://x.com/ralllyco"
+            className="text-gray-600 text-sm hover:text-primary hover:no-underline"
+            rel="noreferrer noopener"
+            aria-label={t("footerXLabel", { defaultValue: "Follow us on X" })}
+          >
+            <XIcon className="size-4" />
+          </a>
+          <a
+            target="_blank"
+            href="https://discord.gg/uzg4ZcHbuM"
+            className="text-gray-600 text-sm hover:text-primary hover:no-underline"
+            rel="noreferrer noopener"
+            aria-label={t("footerDiscordLabel", {
+              defaultValue: "Join us on Discord",
+            })}
+          >
+            <DiscordIcon className="size-4" />
+          </a>
+          <a
+            target="_blank"
+            href="https://www.linkedin.com/company/rallly"
+            className="text-gray-600 text-sm hover:text-primary hover:no-underline"
+            rel="noreferrer noopener"
+            aria-label={t("footerLinkedinLabel", {
+              defaultValue: "Follow us on LinkedIn",
+            })}
+          >
+            <LinkedinIcon className="size-4" />
+          </a>
+          <a
+            target="_blank"
+            href="https://github.com/lukevella/rallly"
+            className="text-gray-600 text-sm hover:text-primary hover:no-underline"
+            rel="noreferrer noopener"
+            aria-label={t("footerGithubLabel", {
+              defaultValue: "View our GitHub repository",
+            })}
+          >
+            <GithubIcon className="size-4" />
+          </a>
+        </div>
+      </div>
+      <div className="grid grid-cols-1 gap-x-8 gap-y-12 sm:grid-cols-3">
+        <div>
+          <div className="mb-6 font-medium text-gray-800 text-sm uppercase tracking-wide">
             <Trans t={t} ns="common" i18nKey="product" defaults="Product" />
           </div>
-          <ul className="grid gap-2 text-sm">
+          <ul className="grid gap-3 text-sm">
             <li>
               <LinkBase
                 className="inline-block font-normal text-gray-600 hover:text-gray-800 hover:no-underline"
@@ -106,11 +104,11 @@ export const Footer = async ({ locale }: { locale: string }) => {
             </li>
           </ul>
         </div>
-        <div className="lg:flex-1">
-          <div className="mb-6 flex h-8 items-center font-medium">
+        <div>
+          <div className="mb-6 font-medium text-gray-800 text-sm uppercase tracking-wide">
             <Trans t={t} ns="common" i18nKey="resources" defaults="Resources" />
           </div>
-          <ul className="grid gap-2 text-sm">
+          <ul className="grid gap-3 text-sm">
             <li>
               <LinkBase
                 href="/blog"
@@ -152,11 +150,11 @@ export const Footer = async ({ locale }: { locale: string }) => {
             </li>
           </ul>
         </div>
-        <div className="lg:flex-1">
-          <div className="mb-6 flex h-8 items-center font-medium">
+        <div>
+          <div className="mb-6 font-medium text-gray-800 text-sm uppercase tracking-wide">
             <Trans t={t} ns="common" i18nKey="compare" defaults="Compare" />
           </div>
-          <ul className="grid gap-2 text-sm">
+          <ul className="grid gap-3 text-sm">
             <li>
               <LinkBase
                 className="inline-block font-normal text-gray-600 hover:text-gray-800 hover:no-underline"

--- a/apps/landing/src/components/home/testimonial.tsx
+++ b/apps/landing/src/components/home/testimonial.tsx
@@ -11,7 +11,7 @@ export async function Testimonial({ locale }: { locale: string }) {
         amount="all"
         className="flex flex-col gap-8 sm:flex-row sm:items-start sm:justify-between sm:gap-16"
       >
-        <p className="max-w-2xl text-xl leading-normal sm:text-2xl">
+        <p className="max-w-2xl text-lg leading-normal sm:text-2xl">
           <Trans
             t={t}
             ns="home"


### PR DESCRIPTION
## What changed

- Restructured the landing footer to match the new reference layout: the brand block (logo, tagline, social links) is now a full-width row on top instead of a left-hand column
- Product, Resources and Compare links sit below in a dedicated grid: single column on mobile, three columns from `sm` up
- Column headings are now small uppercase tracked labels, and link spacing loosened from `gap-2` to `gap-3`
- Added `text-pretty` to the tagline so it never ends on an orphan
- Reduced the home testimonial quote from `text-xl` to `text-lg` on small screens

## Notes for review

- No i18n changes: all keys and default strings are unchanged, only layout moved
- The bottom bar (copyright, legal links, language select) is untouched
- Verified in the browser at desktop (1280) and mobile (375) widths

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined the footer layout with tighter branding spacing and improved responsive behavior.
  * Updated footer link headings and spacing for clearer navigation.
  * Adjusted the testimonial quote size for improved readability on smaller screens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->