### PR TITLE
🐛 Sync the branding page preview with the actual logo viewbox

### DIFF
--- a/apps/web/src/app/[locale]/control-panel/branding/components/logo-upload-field.tsx
+++ b/apps/web/src/app/[locale]/control-panel/branding/components/logo-upload-field.tsx
@@ -2,6 +2,7 @@
 
 import { cn } from "@rallly/ui";
 import { ImageUploadControl } from "@/components/image-upload";
+import { LOGO_VIEWBOX } from "@/features/branding/constants";
 import { brandingLogoProfiles } from "@/features/instance-settings/constants";
 import type { BrandingLogoType } from "@/features/instance-settings/schema";
 import { useSafeAction } from "@/lib/safe-action/client";
@@ -51,16 +52,19 @@ export function LogoUploadField({
 
   return (
     <div className="w-full space-y-3">
-      {/* Full-width preview of the 200x160 slot the logo renders in. The
-          cell's guide lines are oversized and clipped by the strip, so they
-          run edge to edge. */}
+      {/* Full-width preview of the slot the logo renders in. The cell's guide
+          lines are oversized and clipped by the strip, so they run edge to
+          edge. */}
       <div
         className={cn(
           "flex w-full items-center justify-center overflow-hidden rounded-lg border py-10",
           previewVariants[logoType].container,
         )}
       >
-        <div className="relative flex h-40 w-50 items-center justify-center">
+        <div
+          className="relative flex items-center justify-center"
+          style={{ width: LOGO_VIEWBOX.width, height: LOGO_VIEWBOX.height }}
+        >
           {logoType !== "logoIcon" ? (
             <>
               <div
@@ -98,7 +102,7 @@ export function LogoUploadField({
                   previewVariants[logoType].label,
                 )}
               >
-                200px
+                {LOGO_VIEWBOX.width}px
               </span>
               <span
                 aria-hidden="true"
@@ -107,7 +111,7 @@ export function LogoUploadField({
                   previewVariants[logoType].label,
                 )}
               >
-                160px
+                {LOGO_VIEWBOX.height}px
               </span>
             </>
           ) : null}

--- a/apps/web/src/features/branding/components/logo.tsx
+++ b/apps/web/src/features/branding/components/logo.tsx
@@ -1,5 +1,6 @@
 import { cn } from "@rallly/ui";
 import { env } from "@/env";
+import { LOGO_VIEWBOX } from "@/features/branding/constants";
 import { getInstanceBrandingConfig } from "@/features/branding/data";
 
 const sizes = {
@@ -23,7 +24,8 @@ export const Logo = async ({
   if (size === "fit") {
     return (
       <div
-        className={cn("flex h-32 w-48 items-center justify-center", className)}
+        className={cn("flex items-center justify-center", className)}
+        style={{ width: LOGO_VIEWBOX.width, height: LOGO_VIEWBOX.height }}
       >
         {/* biome-ignore lint/performance/noImgElement: we don't need Image component here */}
         <img

--- a/apps/web/src/features/branding/constants.ts
+++ b/apps/web/src/features/branding/constants.ts
@@ -7,5 +7,6 @@ export const DEFAULT_LOGO_ICON_URL = absoluteUrl(
   "/images/rallly-logo-mark.png",
 );
 export const DEFAULT_APP_NAME = "Rallly";
+export const LOGO_VIEWBOX = { width: 192, height: 128 };
 export const LIGHT_MODE_BACKGROUND = "#ffffff";
 export const DARK_MODE_BACKGROUND = "#171717";


### PR DESCRIPTION
The control panel branding preview misrepresented how uploaded logos actually render.

Commit 5952a4277 shrank the `fit` logo slot from 200×160 to 192×128 (`h-32 w-48`), but the preview box in `logo-upload-field.tsx` kept drawing at `h-40 w-50` (200×160) with hardcoded "200px" / "160px" dimension labels. Anyone sizing an upload against those guides was working to the wrong numbers.

Both surfaces now read a single `LOGO_VIEWBOX` constant from `features/branding/constants.ts` and apply it via inline style, so the two cannot drift apart again. The dimension labels render from the same constant.

No behavior, spacing or copy changes beyond the corrected dimensions. Dimension guides were deliberately not added to the icon slot to keep this focused.

Fixes RAL-1552

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved logo previews and displayed logos by using consistent 192×128 dimensions.
  * Updated sizing guides to accurately match the logo display area.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->