### PR TITLE
📝 Update white-labeling docs for the branding UI

### DIFF
--- a/apps/docs/self-hosting/configuration.mdx
+++ b/apps/docs/self-hosting/configuration.mdx
@@ -106,7 +106,7 @@ See the [Single Sign-On guide](/self-hosting/single-sign-on) for setup instructi
 
 ## Branding
 
-Customise the look of your instance. See [White Labeling](/self-hosting/white-labeling) for details.
+Customise the look of your instance. These settings can also be changed from the Control Panel, where a saved value takes precedence over the environment variable. See [White Labeling](/self-hosting/white-labeling) for details.
 
 <Note>
   Available from v4.6.0 and later. Requires an Enterprise license with the white-label add-on.
@@ -124,16 +124,16 @@ Customise the look of your instance. See [White Labeling](/self-hosting/white-la
   Primary brand color for dark mode. Auto-calculated from `PRIMARY_COLOR` if not set.
 </ParamField>
 
-<ParamField path="LOGO_URL" default="/static/logo.svg">
-  URL to your logo for light mode. SVG recommended.
+<ParamField path="LOGO_URL">
+  Absolute URL to your logo for light mode. SVG recommended. Defaults to the Rallly logo.
 </ParamField>
 
 <ParamField path="LOGO_URL_DARK">
-  URL to your logo for dark mode. Falls back to `LOGO_URL` if not set.
+  Absolute URL to your logo for dark mode. Falls back to `LOGO_URL` if not set.
 </ParamField>
 
-<ParamField path="LOGO_ICON_URL" default="/images/rallly-logo-mark.png">
-  URL to your logo icon, used in emails and as a favicon.
+<ParamField path="LOGO_ICON_URL">
+  Absolute URL to your logo icon, shown at the top of emails. Defaults to the Rallly logo mark. Use a raster format, as SVG rendering is unreliable across mail clients.
 </ParamField>
 
 <ParamField path="HIDE_ATTRIBUTION" default="false">

--- a/apps/docs/self-hosting/white-labeling.mdx
+++ b/apps/docs/self-hosting/white-labeling.mdx
@@ -14,20 +14,63 @@ These options are available from v4.6.0 and later and require an Enterprise lice
 
 White labeling allows you to customize the appearance of your Rallly instance to match your organization's branding. You can change the application name, primary colors, logos, and hide attribution text.
 
-## What You Can Customize
+## What you can customize
 
-- **Application Name** - Change the name displayed in page titles, navigation, and emails
-- **Primary Colors** - Set custom brand colors for both light and dark modes
-- **Logos** - Use your own logos for the application and emails
+- **App name** - The name displayed in page titles, navigation, and emails
+- **Primary colors** - Brand colors for both light and dark modes
+- **Logos** - Your own logo for light mode, dark mode, and the icon used in emails
 - **Attribution** - Hide the "Powered by Rallly" text in polls and emails
 
-## Configuration
+## Configuring branding
 
-All white labeling options are configured via environment variables. See the [Configuration Options](/self-hosting/configuration#branding) page for the full list of available settings.
+Branding is configured from the [Control Panel](/self-hosting/control-panel) under **Branding**. Changes take effect immediately, with no restart required.
 
-## Example
+1. Sign in as an administrator and go to `/control-panel/branding`.
+2. Set the app name, primary colors, logos, and attribution settings.
+3. Each field saves on its own, so you can change one setting at a time.
 
-Add your white labeling values to the `.env` file at the root of your self-hosted stack, then apply them with `./rallly.sh restart`:
+The same settings can also be supplied as environment variables. A value saved in the Control Panel takes precedence over the matching environment variable, and clearing it falls back to the environment variable, then to the Rallly default. Precedence is applied per field, so you can set some values in `.env` and others in the UI.
+
+When a field is backed by an environment variable and has no saved value yet, the Branding page shows a note saying so. Saving a value in the UI overrides it.
+
+## Logos
+
+The three logo slots serve different purposes:
+
+- **Logo** - The wordmark shown on light backgrounds
+- **Logo (dark mode)** - The wordmark shown on dark backgrounds. Falls back to the light logo if not set
+- **Logo icon** - A square icon shown at the top of emails
+
+### Uploading a logo
+
+Logo uploads require object storage to be configured. The stack installed by the [Rallly CLI](/self-hosting/installation/docker) includes storage by default, so this works out of the box. If your instance has no storage configured, the Branding page says so and you can point at externally hosted images with `LOGO_URL`, `LOGO_URL_DARK` and `LOGO_ICON_URL` instead. See [External object storage](/self-hosting/configuration#external-object-storage) for the storage variables.
+
+| Slot | Accepted formats | Maximum size |
+| --- | --- | --- |
+| Logo | SVG, PNG, JPEG | 2 MB |
+| Logo (dark mode) | SVG, PNG, JPEG | 2 MB |
+| Logo icon | PNG, JPEG | 2 MB |
+
+The logo icon is raster only because it is embedded in emails, where SVG rendering is unreliable across mail clients.
+
+Removing an uploaded logo clears the saved value, so the instance falls back to the environment variable if one is set, and to the Rallly logo otherwise.
+
+### Preparing your logo
+
+There is no logo size setting. On the sign-in and registration pages your wordmark is drawn inside a fixed slot of 192 by 128 pixels, scaled down to fit inside it while keeping its aspect ratio, so it is never cropped or stretched. Elsewhere in the app it is scaled to a fixed height.
+
+Because the slot is fixed, the shape of your asset determines how large it renders:
+
+- Crop the asset tightly to the artwork. Whitespace baked into the file is scaled along with the logo, so a padded asset renders visually smaller than a tight one.
+- Prefer SVG for the wordmark logos so they stay sharp at any size. If you upload a raster wordmark, supply it at roughly twice the slot size so it holds up on high density displays.
+- Wide, horizontal wordmarks fill the slot better than tall or square ones.
+- For the dark mode logo, supply a variant that reads well on a dark background rather than reusing the light one.
+
+The Branding page previews each logo inside the slot it renders in, on the background it will appear against, so you can check the result before rolling it out.
+
+## Environment variables
+
+Use these when you prefer to configure branding from `.env`, or when your instance has no object storage for uploads. Add the values to the `.env` file at the root of your self-hosted stack, then apply them with `./rallly.sh restart`.
 
 ```sh
 # White labeling
@@ -40,13 +83,11 @@ LOGO_ICON_URL="https://example.com/icon.png"
 HIDE_ATTRIBUTION="true"
 ```
 
-## Viewing Current Settings
-
-You can view the current branding configuration in the [Control Panel](/self-hosting/control-panel) under the **Branding** section. These settings are read-only in the UI and must be changed via environment variables.
+The three logo variables must be absolute URLs to images your instance can reach. See the [Configuration Options](/self-hosting/configuration#branding) page for the full list of available settings.
 
 ## Requirements
 
 - **Enterprise License with White Label Add-on**: White labeling features are only available with an active Enterprise license that includes the white label add-on.
-- Without the add-on, your instance will use the default Rallly branding regardless of environment variable settings.
+- Without the add-on, the Branding page is read-only and your instance uses the default Rallly branding regardless of any saved or environment variable settings.
 
 To inquire about Enterprise licensing, please fill out our [Enterprise Requirements Survey](https://app.formbricks.com/s/cmebvnf2ohvjkt901eefxsonr).


### PR DESCRIPTION
Self-hosted white-label branding is now configured through the control panel branding page, not environment variables alone. The docs still described the control panel as read-only and env vars as the only way to change anything.

## Changes

`apps/docs/self-hosting/white-labeling.mdx`
- Control panel is now the primary configuration path; env vars documented as per-field fallbacks. A saved value wins over the env var, clearing it falls back to the env var, then the default.
- New **Logos** section: what each of the three slots is for, accepted formats per slot (wordmarks take SVG/PNG/JPEG, the icon PNG/JPEG only), the 2 MB cap, and the object storage requirement with the URL-based escape hatch for instances without storage.
- New **Preparing your logo** section: there is no logo size setting, so document the fixed 192x128 contain-fit slot plus asset guidance (crop tight, no baked-in padding, prefer SVG, wide wordmarks fill better). Mentions that the branding page previews each upload in the slot.
- Sentence case headings.

`apps/docs/self-hosting/configuration.mdx`
- Note that the branding variables can also be set from the control panel, which takes precedence.
- Corrected `LOGO_ICON_URL`: it feeds emails only, it is not used as a favicon. Added the raster-only recommendation.
- All three logo variables are `z.url()` in `env.ts`, so they must be absolute URLs. The old `LOGO_URL` / `LOGO_ICON_URL` defaults were shown as relative paths, which are not valid values to set.

## Discrepancy found while verifying

The control panel's logo preview draws a 200x160 guide box labelled "200px" / "160px", but the actual slot in `features/branding/components/logo.tsx` is `h-32 w-48` (192x128). The slot was shrunk in 5952a4277 and the preview was not updated. The docs state 192x128, matching the rendering code. The preview needs a separate fix.

Fixes RAL-1512

🤖 Generated with [Claude Code](https://claude.com/claude-code)