### PR TITLE
♻️ Make Stats presentational and move count fetching into pages

### DIFF
--- a/apps/landing/src/app/[locale]/(main)/(seo)/best-doodle-alternative/page.tsx
+++ b/apps/landing/src/app/[locale]/(main)/(seo)/best-doodle-alternative/page.tsx
@@ -5,6 +5,7 @@ import { cacheLife } from "next/cache";
 import Image from "next/image";
 import Link from "next/link";
 import { Trans } from "react-i18next/TransWithoutContext";
+import { AnimatedStat } from "@/components/home/animated-number";
 import { Cta } from "@/components/home/cta";
 import { Faq, FaqItem } from "@/components/home/faq";
 import { Hero, HeroAnnouncement } from "@/components/home/hero";
@@ -20,6 +21,7 @@ import {
   SectionTitle,
 } from "@/components/section";
 import { getTranslation } from "@/i18n/server";
+import { getMonthlyPollCount, getMonthlyVoterCount } from "@/lib/data";
 
 export default async function Page(props: {
   params: Promise<{ locale: string }>;
@@ -27,6 +29,10 @@ export default async function Page(props: {
   cacheLife("days");
   const { locale } = await props.params;
   const { t } = await getTranslation(locale, ["home"]);
+  const [pollCount, voterCount] = await Promise.all([
+    getMonthlyPollCount(),
+    getMonthlyVoterCount(),
+  ]);
   return (
     <div className="divide-y">
       <Section>
@@ -60,7 +66,18 @@ export default async function Page(props: {
         >
           <HeroDemo locale={locale} />
         </Hero>
-        <Stats locale={locale} className="mt-4 sm:mt-16" />
+        <Stats className="mt-4 sm:mt-16">
+          <Trans
+            t={t}
+            ns="home"
+            i18nKey="statsLast30Days"
+            defaults="<b>{voterCount, plural, one {# person} other {# people}}</b> voted on <b>{pollCount, plural, one {# poll} other {# polls}}</b> in the last 30 days"
+            values={{ voterCount, pollCount }}
+            components={{
+              b: <AnimatedStat locale={locale} />,
+            }}
+          />
+        </Stats>
       </Section>
       <Section>
         <Testimonial

--- a/apps/landing/src/app/[locale]/(main)/(seo)/best-doodle-alternative/page.tsx
+++ b/apps/landing/src/app/[locale]/(main)/(seo)/best-doodle-alternative/page.tsx
@@ -66,7 +66,7 @@ export default async function Page(props: {
         >
           <HeroDemo locale={locale} />
         </Hero>
-        <Stats className="mt-4 sm:mt-16">
+        <Stats className="mt-8 sm:mt-24">
           <Trans
             t={t}
             ns="home"

--- a/apps/landing/src/app/[locale]/(main)/(seo)/free-scheduling-poll/page.tsx
+++ b/apps/landing/src/app/[locale]/(main)/(seo)/free-scheduling-poll/page.tsx
@@ -5,6 +5,7 @@ import { cacheLife } from "next/cache";
 import Image from "next/image";
 import Link from "next/link";
 import { Trans } from "react-i18next/TransWithoutContext";
+import { AnimatedStat } from "@/components/home/animated-number";
 import { Cta } from "@/components/home/cta";
 import { Faq, FaqItem } from "@/components/home/faq";
 import { Hero, HeroAnnouncement } from "@/components/home/hero";
@@ -20,6 +21,7 @@ import {
   SectionTitle,
 } from "@/components/section";
 import { getTranslation } from "@/i18n/server";
+import { getMonthlyPollCount, getMonthlyVoterCount } from "@/lib/data";
 
 export default async function Page(props: {
   params: Promise<{ locale: string }>;
@@ -27,6 +29,10 @@ export default async function Page(props: {
   cacheLife("days");
   const { locale } = await props.params;
   const { t } = await getTranslation(locale, ["home"]);
+  const [pollCount, voterCount] = await Promise.all([
+    getMonthlyPollCount(),
+    getMonthlyVoterCount(),
+  ]);
   return (
     <div className="divide-y">
       <Section>
@@ -60,7 +66,18 @@ export default async function Page(props: {
         >
           <HeroDemo locale={locale} />
         </Hero>
-        <Stats locale={locale} className="mt-4 sm:mt-16" />
+        <Stats className="mt-4 sm:mt-16">
+          <Trans
+            t={t}
+            ns="home"
+            i18nKey="statsLast30Days"
+            defaults="<b>{voterCount, plural, one {# person} other {# people}}</b> voted on <b>{pollCount, plural, one {# poll} other {# polls}}</b> in the last 30 days"
+            values={{ voterCount, pollCount }}
+            components={{
+              b: <AnimatedStat locale={locale} />,
+            }}
+          />
+        </Stats>
       </Section>
       <Section>
         <Testimonial

--- a/apps/landing/src/app/[locale]/(main)/(seo)/free-scheduling-poll/page.tsx
+++ b/apps/landing/src/app/[locale]/(main)/(seo)/free-scheduling-poll/page.tsx
@@ -66,7 +66,7 @@ export default async function Page(props: {
         >
           <HeroDemo locale={locale} />
         </Hero>
-        <Stats className="mt-4 sm:mt-16">
+        <Stats className="mt-8 sm:mt-24">
           <Trans
             t={t}
             ns="home"

--- a/apps/landing/src/app/[locale]/(main)/(seo)/when2meet-alternative/page.tsx
+++ b/apps/landing/src/app/[locale]/(main)/(seo)/when2meet-alternative/page.tsx
@@ -5,6 +5,7 @@ import { cacheLife } from "next/cache";
 import Image from "next/image";
 import Link from "next/link";
 import { Trans } from "react-i18next/TransWithoutContext";
+import { AnimatedStat } from "@/components/home/animated-number";
 import { Cta } from "@/components/home/cta";
 import { Faq, FaqItem } from "@/components/home/faq";
 import { Hero, HeroAnnouncement } from "@/components/home/hero";
@@ -20,6 +21,7 @@ import {
   SectionTitle,
 } from "@/components/section";
 import { getTranslation } from "@/i18n/server";
+import { getMonthlyPollCount, getMonthlyVoterCount } from "@/lib/data";
 
 export default async function Page(props: {
   params: Promise<{ locale: string }>;
@@ -27,6 +29,10 @@ export default async function Page(props: {
   cacheLife("days");
   const { locale } = await props.params;
   const { t } = await getTranslation(locale, ["home"]);
+  const [pollCount, voterCount] = await Promise.all([
+    getMonthlyPollCount(),
+    getMonthlyVoterCount(),
+  ]);
   return (
     <div className="divide-y">
       <Section>
@@ -60,7 +66,18 @@ export default async function Page(props: {
         >
           <HeroDemo locale={locale} />
         </Hero>
-        <Stats locale={locale} className="mt-4 sm:mt-16" />
+        <Stats className="mt-4 sm:mt-16">
+          <Trans
+            t={t}
+            ns="home"
+            i18nKey="statsLast30Days"
+            defaults="<b>{voterCount, plural, one {# person} other {# people}}</b> voted on <b>{pollCount, plural, one {# poll} other {# polls}}</b> in the last 30 days"
+            values={{ voterCount, pollCount }}
+            components={{
+              b: <AnimatedStat locale={locale} />,
+            }}
+          />
+        </Stats>
       </Section>
       <Section>
         <Testimonial

--- a/apps/landing/src/app/[locale]/(main)/(seo)/when2meet-alternative/page.tsx
+++ b/apps/landing/src/app/[locale]/(main)/(seo)/when2meet-alternative/page.tsx
@@ -66,7 +66,7 @@ export default async function Page(props: {
         >
           <HeroDemo locale={locale} />
         </Hero>
-        <Stats className="mt-4 sm:mt-16">
+        <Stats className="mt-8 sm:mt-24">
           <Trans
             t={t}
             ns="home"

--- a/apps/landing/src/app/[locale]/(main)/page.tsx
+++ b/apps/landing/src/app/[locale]/(main)/page.tsx
@@ -69,7 +69,7 @@ export default async function Page(props: {
         >
           <HeroDemo locale={locale} />
         </Hero>
-        <Stats className="mt-4 sm:mt-16">
+        <Stats className="mt-8 sm:mt-24">
           <Trans
             t={t}
             ns="home"

--- a/apps/landing/src/app/[locale]/(main)/page.tsx
+++ b/apps/landing/src/app/[locale]/(main)/page.tsx
@@ -5,6 +5,7 @@ import { cacheLife } from "next/cache";
 import Image from "next/image";
 import Link from "next/link";
 import { Trans } from "react-i18next/TransWithoutContext";
+import { AnimatedStat } from "@/components/home/animated-number";
 import { Cta } from "@/components/home/cta";
 import { Faq, FaqItem } from "@/components/home/faq";
 import { Hero, HeroAnnouncement } from "@/components/home/hero";
@@ -20,6 +21,7 @@ import {
   SectionTitle,
 } from "@/components/section";
 import { getTranslation } from "@/i18n/server";
+import { getMonthlyPollCount, getMonthlyVoterCount } from "@/lib/data";
 
 export default async function Page(props: {
   params: Promise<{ locale: string }>;
@@ -27,6 +29,10 @@ export default async function Page(props: {
   cacheLife("days");
   const { locale } = await props.params;
   const { t } = await getTranslation(locale, ["home", "common"]);
+  const [pollCount, voterCount] = await Promise.all([
+    getMonthlyPollCount(),
+    getMonthlyVoterCount(),
+  ]);
   return (
     <div className="divide-y">
       <Section>
@@ -63,7 +69,18 @@ export default async function Page(props: {
         >
           <HeroDemo locale={locale} />
         </Hero>
-        <Stats locale={locale} className="mt-4 sm:mt-16" />
+        <Stats className="mt-4 sm:mt-16">
+          <Trans
+            t={t}
+            ns="home"
+            i18nKey="statsLast30Days"
+            defaults="<b>{voterCount, plural, one {# person} other {# people}}</b> voted on <b>{pollCount, plural, one {# poll} other {# polls}}</b> in the last 30 days"
+            values={{ voterCount, pollCount }}
+            components={{
+              b: <AnimatedStat locale={locale} />,
+            }}
+          />
+        </Stats>
       </Section>
       <Section>
         <Testimonial

--- a/apps/landing/src/components/home/stats.tsx
+++ b/apps/landing/src/components/home/stats.tsx
@@ -1,22 +1,13 @@
 import { cn } from "@rallly/ui";
-import { Trans } from "react-i18next/TransWithoutContext";
-import { AnimatedStat } from "@/components/home/animated-number";
-import { getTranslation } from "@/i18n/server";
-import { getMonthlyPollCount, getMonthlyVoterCount } from "@/lib/data";
+import type * as React from "react";
 
-export async function Stats({
-  locale,
+export function Stats({
   className,
+  children,
 }: {
-  locale: string;
   className?: string;
+  children: React.ReactNode;
 }) {
-  const [pollCount, voterCount] = await Promise.all([
-    getMonthlyPollCount(),
-    getMonthlyVoterCount(),
-  ]);
-  const { t } = await getTranslation(locale, ["home"]);
-
   return (
     <p
       className={cn(
@@ -24,16 +15,7 @@ export async function Stats({
         className,
       )}
     >
-      <Trans
-        t={t}
-        ns="home"
-        i18nKey="statsLast30Days"
-        defaults="<b>{voterCount, plural, one {# person} other {# people}}</b> voted on <b>{pollCount, plural, one {# poll} other {# polls}}</b> in the last 30 days"
-        values={{ voterCount, pollCount }}
-        components={{
-          b: <AnimatedStat locale={locale} />,
-        }}
-      />
+      {children}
     </p>
   );
 }


### PR DESCRIPTION
## Description

Follow-up to #2990, which merged before this commit landed. Finishes the presentational refactor by removing the last `locale`-drilling component: `Stats` is now a styled paragraph shell, and the four landing pages fetch the poll and voter counts themselves and render the stat line `Trans` inline, consistent with how they own all other content. `AnimatedStat` keeps its `locale` prop since it needs it for Intl number parsing; pages pass it directly.

Verified in the browser: the stat line renders with working animated numbers on the home page, and all four pages type-check and lint clean.

Note: the merge of #2990 deleted `luke/faq-section` and a follow-up push recreated it as an orphan branch. It can be deleted; this PR replaces it.

## Checklist

- [x] I have performed a self-review of my code
- [x] My code follows the code style of this project
- [x] I have commented my code, particularly in hard-to-understand areas

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Landing pages now display live poll and voter activity from the last 30 days.
  * Statistics include localized, pluralized messaging with animated counts.
* **Improvements**
  * Updated statistics presentation for a more engaging and responsive experience across supported locales.
  * Improved spacing around the statistics section for better visual balance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->