### PR TITLE
💄 Align alert icon with the first line of text

### DIFF
--- a/packages/ui/src/alert.tsx
+++ b/packages/ui/src/alert.tsx
@@ -5,7 +5,7 @@ import type * as React from "react";
 import { cn } from "./lib/utils";
 
 const alertVariants = cva(
-  "group/alert relative grid w-full items-start gap-0.5 rounded-xl border p-2 text-left text-sm has-[>svg]:has-data-[slot=alert-action]:grid-cols-[auto_1fr_auto] has-[>svg]:grid-cols-[auto_1fr] has-data-[slot=alert-action]:grid-cols-[1fr_auto] has-[>svg]:gap-x-2 has-data-[slot=alert-action]:gap-x-2 *:[svg:not([class*='size-'])]:size-4 *:[svg]:translate-y-0.5 *:[svg]:text-current has-data-[slot=alert-title]:*:[svg]:row-span-2",
+  "group/alert relative grid w-full not-has-data-[slot=alert-action]:items-start items-center gap-0.5 rounded-xl border p-2 text-left text-sm has-[>svg]:has-data-[slot=alert-action]:grid-cols-[auto_1fr_auto] has-[>svg]:grid-cols-[auto_1fr] has-data-[slot=alert-action]:grid-cols-[1fr_auto] has-data-[slot=alert-title]:items-start has-[>svg]:gap-x-2 has-data-[slot=alert-action]:gap-x-2 *:[svg:not([class*='size-'])]:size-4 not-has-data-[slot=alert-action]:*:[svg]:translate-y-0.5 *:[svg]:text-current has-data-[slot=alert-title]:*:[svg]:row-span-2 has-data-[slot=alert-title]:*:[svg]:translate-y-0.5",
   {
     variants: {
       variant: {

--- a/packages/ui/src/alert.tsx
+++ b/packages/ui/src/alert.tsx
@@ -5,7 +5,7 @@ import type * as React from "react";
 import { cn } from "./lib/utils";
 
 const alertVariants = cva(
-  "group/alert relative grid w-full items-center gap-0.5 rounded-xl border p-2 text-left text-sm has-[>svg]:has-data-[slot=alert-action]:grid-cols-[auto_1fr_auto] has-[>svg]:grid-cols-[auto_1fr] has-data-[slot=alert-action]:grid-cols-[1fr_auto] has-data-[slot=alert-title]:items-start has-[>svg]:gap-x-2 has-data-[slot=alert-action]:gap-x-2 *:[svg:not([class*='size-'])]:size-4 *:[svg]:text-current has-data-[slot=alert-title]:*:[svg]:row-span-2 has-data-[slot=alert-title]:*:[svg]:translate-y-0.5",
+  "group/alert relative grid w-full items-start gap-0.5 rounded-xl border p-2 text-left text-sm has-[>svg]:has-data-[slot=alert-action]:grid-cols-[auto_1fr_auto] has-[>svg]:grid-cols-[auto_1fr] has-data-[slot=alert-action]:grid-cols-[1fr_auto] has-[>svg]:gap-x-2 has-data-[slot=alert-action]:gap-x-2 *:[svg:not([class*='size-'])]:size-4 *:[svg]:translate-y-0.5 *:[svg]:text-current has-data-[slot=alert-title]:*:[svg]:row-span-2",
   {
     variants: {
       variant: {


### PR DESCRIPTION
## Summary
The alert grid start-aligned its content (and gave the icon the first-line offset) only when an `AlertTitle` was present, so a description-only alert with wrapped text got its icon centered against the whole text block.

Alignment now follows the content shape:
- **Title present or no action**: grid start-aligns and the icon gets the `translate-y-0.5` offset that centers it on the first text line — fixes multiline description-only alerts.
- **Action without a title**: grid center-aligns (previous behavior), since the button defines the row height there — icon, text, and button share one axis.

Verified in-browser across five combinations (multiline description only, title + description, single-line description, description + action, title + description + action): icon center matches the first text line center exactly in all of them, and the description + action case also has the button on the same axis.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved alert layout alignment when no action is present.
  * Preserved centered alignment for alerts with actions.
  * Applied consistent icon positioning for alerts with or without titles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->