### PR TITLE
💄 Remove stray paragraph margin in branding page alerts

### DIFF
--- a/apps/web/src/app/[locale]/control-panel/branding/components/branding-settings.tsx
+++ b/apps/web/src/app/[locale]/control-panel/branding/components/branding-settings.tsx
@@ -1,4 +1,4 @@
-import { Alert, AlertDescription } from "@rallly/ui/alert";
+import { Alert, AlertAction, AlertDescription } from "@rallly/ui/alert";
 import {
   Field,
   FieldContent,
@@ -47,33 +47,31 @@ async function StorageNotConfiguredAlert() {
   return (
     <Alert>
       <HardDriveIcon />
-      <AlertDescription className="flex gap-2">
-        <p className="flex-1">
+      <AlertDescription>
+        <Trans
+          t={t}
+          i18n={i18n}
+          ns="app"
+          i18nKey="brandingStorageNotConfigured"
+          defaults="Logo uploads require object storage, which has not been configured on this instance."
+        />
+      </AlertDescription>
+      <AlertAction>
+        <a
+          href="https://support.rallly.co/self-hosting/configuration#external-object-storage"
+          target="_blank"
+          className="underline"
+          rel="noreferrer"
+        >
           <Trans
             t={t}
             i18n={i18n}
             ns="app"
-            i18nKey="brandingStorageNotConfigured"
-            defaults="Logo uploads require object storage, which has not been configured on this instance."
+            i18nKey="learnMore"
+            defaults="Learn more"
           />
-        </p>
-        <p>
-          <a
-            href="https://support.rallly.co/self-hosting/configuration#external-object-storage"
-            target="_blank"
-            className="underline"
-            rel="noreferrer"
-          >
-            <Trans
-              t={t}
-              i18n={i18n}
-              ns="app"
-              i18nKey="learnMore"
-              defaults="Learn more"
-            />
-          </a>
-        </p>
-      </AlertDescription>
+        </a>
+      </AlertAction>
     </Alert>
   );
 }
@@ -121,33 +119,31 @@ export async function BrandingSettings() {
       {!hasWhiteLabelAddon ? (
         <Alert variant="primary">
           <GemIcon />
-          <AlertDescription className="flex gap-2">
-            <p className="flex-1">
+          <AlertDescription>
+            <Trans
+              t={t}
+              i18n={i18n}
+              ns="app"
+              i18nKey="customBrandingAlertDescription"
+              defaults="Custom branding is available to Enterprise license holders as a paid add-on."
+            />
+          </AlertDescription>
+          <AlertAction>
+            <a
+              href="https://support.rallly.co/self-hosting/white-labeling"
+              target="_blank"
+              className="underline"
+              rel="noreferrer"
+            >
               <Trans
                 t={t}
                 i18n={i18n}
                 ns="app"
-                i18nKey="customBrandingAlertDescription"
-                defaults="Custom branding is available to Enterprise license holders as a paid add-on."
+                i18nKey="learnMore"
+                defaults="Learn more"
               />
-            </p>
-            <p>
-              <a
-                href="https://support.rallly.co/self-hosting/white-labeling"
-                target="_blank"
-                className="underline"
-                rel="noreferrer"
-              >
-                <Trans
-                  t={t}
-                  i18n={i18n}
-                  ns="app"
-                  i18nKey="learnMore"
-                  defaults="Learn more"
-                />
-              </a>
-            </p>
-          </AlertDescription>
+            </a>
+          </AlertAction>
         </Alert>
       ) : null}
       <PageSectionGroup>


### PR DESCRIPTION
## Problem

The Enterprise add-on alert (and the storage-not-configured alert) on the control panel branding page showed extra space below the description. Both alerts wrapped their text and trailing link in `<p>` tags inside a flex `AlertDescription`, so the first paragraph matched the prose rule `[&_p:not(:last-child)]:mb-4` and stretched the alert.

## Fix

Use the `AlertAction` slot the alert component already provides for trailing links, removing the `<p>` wrappers and the hand-rolled flex layout.

## Verification

Rendered the branding page against a dev server: the alert is now 38px tall with symmetric 9px spacing above and below the description, no paragraph margins. Biome and type-check pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved branding alerts by separating explanatory text from external “Learn more” links.
  * Updated alert link presentation for a clearer, more consistent interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->