### PR TITLE
💄 Add duplicate polls and advanced poll settings to pricing page

### DIFF
--- a/apps/landing/public/locales/en/pricing.json
+++ b/apps/landing/public/locales/en/pricing.json
@@ -1,4 +1,6 @@
 {
+  "advancedPollSettings": "Advanced poll settings",
+  "advancedPollSettingsDescription": "Require participant emails, hide participant names, and hide votes",
   "basicPolls": "Basic polls",
   "basicPollsDescription": "Create simple scheduling polls",
   "cancelSubscription": "How do I cancel my subscription?",
@@ -16,6 +18,8 @@
   "compareUnlimited": "Unlimited",
   "customBranding": "Custom branding",
   "customBrandingDescription": "Show your logo and brand colors to your participants",
+  "duplicatePolls": "Duplicate polls",
+  "duplicatePollsDescription": "Create a new poll based on an existing one",
   "extendedPollLifetimeDescription": "Keep polls indefinitely",
   "faq": "Frequently asked questions",
   "featureNameExtendedPollLifetime": "Extended poll lifetime",

--- a/apps/landing/src/app/[locale]/(main)/pricing/compare-table.tsx
+++ b/apps/landing/src/app/[locale]/(main)/pricing/compare-table.tsx
@@ -1,4 +1,5 @@
 import { cn } from "@rallly/ui";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@rallly/ui/tooltip";
 import { CircleCheckIcon, XIcon } from "lucide-react";
 import type * as React from "react";
 
@@ -53,6 +54,23 @@ export function CompareTableCell({
       className={cn("whitespace-nowrap px-4 py-4 text-gray-800", className)}
       {...props}
     />
+  );
+}
+
+export function CompareTableTooltip({
+  content,
+  children,
+}: {
+  content: React.ReactNode;
+  children: React.ReactNode;
+}) {
+  return (
+    <Tooltip>
+      <TooltipTrigger className="cursor-help text-left underline decoration-gray-400 decoration-dotted underline-offset-4">
+        {children}
+      </TooltipTrigger>
+      <TooltipContent className="max-w-64">{content}</TooltipContent>
+    </Tooltip>
   );
 }
 

--- a/apps/landing/src/app/[locale]/(main)/pricing/page.tsx
+++ b/apps/landing/src/app/[locale]/(main)/pricing/page.tsx
@@ -7,9 +7,11 @@ import {
   CalendarCheckIcon,
   CalendarSearchIcon,
   ClockIcon,
+  CopyIcon,
   EyeOffIcon,
   LifeBuoyIcon,
   PaletteIcon,
+  Settings2Icon,
   TimerResetIcon,
   UserPlusIcon,
 } from "lucide-react";
@@ -46,6 +48,7 @@ import {
   CompareTableDash,
   CompareTableFeature,
   CompareTableHead,
+  CompareTableTooltip,
 } from "./compare-table";
 import {
   PlanBenefit,
@@ -359,6 +362,44 @@ export default async function Page(props: {
                     />
                   </PlanBenefitTooltip>
                 </PlanBenefit>
+                <PlanBenefit icon={<CopyIcon />}>
+                  <PlanBenefitTooltip
+                    content={
+                      <Trans
+                        t={t}
+                        ns="pricing"
+                        i18nKey="duplicatePollsDescription"
+                        defaults="Create a new poll based on an existing one"
+                      />
+                    }
+                  >
+                    <Trans
+                      t={t}
+                      ns="pricing"
+                      i18nKey="duplicatePolls"
+                      defaults="Duplicate polls"
+                    />
+                  </PlanBenefitTooltip>
+                </PlanBenefit>
+                <PlanBenefit icon={<Settings2Icon />}>
+                  <PlanBenefitTooltip
+                    content={
+                      <Trans
+                        t={t}
+                        ns="pricing"
+                        i18nKey="advancedPollSettingsDescription"
+                        defaults="Require participant emails, hide participant names, and hide votes"
+                      />
+                    }
+                  >
+                    <Trans
+                      t={t}
+                      ns="pricing"
+                      i18nKey="advancedPollSettings"
+                      defaults="Advanced poll settings"
+                    />
+                  </PlanBenefitTooltip>
+                </PlanBenefit>
                 <PlanBenefit icon={<UserPlusIcon />}>
                   <PlanBenefitName>
                     <Trans
@@ -496,12 +537,23 @@ export default async function Page(props: {
                   />
                 </CompareTableFeature>
                 <CompareTableCell>
-                  <Trans
-                    t={t}
-                    ns="pricing"
-                    i18nKey="comparePollRetention30Days"
-                    defaults="30 days"
-                  />
+                  <CompareTableTooltip
+                    content={
+                      <Trans
+                        t={t}
+                        ns="pricing"
+                        i18nKey="thirtyDayPollRetentionDescription"
+                        defaults="Polls are kept for 30 days after their final date"
+                      />
+                    }
+                  >
+                    <Trans
+                      t={t}
+                      ns="pricing"
+                      i18nKey="comparePollRetention30Days"
+                      defaults="30 days"
+                    />
+                  </CompareTableTooltip>
                 </CompareTableCell>
                 <CompareTableCell>
                   <Trans
@@ -520,6 +572,49 @@ export default async function Page(props: {
                     i18nKey="finalizeDate"
                     defaults="Finalize date"
                   />
+                </CompareTableFeature>
+                <CompareTableCell>
+                  <CompareTableDash label={notIncluded} />
+                </CompareTableCell>
+                <CompareTableCell>
+                  <CompareTableCheck label={included} />
+                </CompareTableCell>
+              </tr>
+              <tr>
+                <CompareTableFeature>
+                  <Trans
+                    t={t}
+                    ns="pricing"
+                    i18nKey="duplicatePolls"
+                    defaults="Duplicate polls"
+                  />
+                </CompareTableFeature>
+                <CompareTableCell>
+                  <CompareTableDash label={notIncluded} />
+                </CompareTableCell>
+                <CompareTableCell>
+                  <CompareTableCheck label={included} />
+                </CompareTableCell>
+              </tr>
+              <tr>
+                <CompareTableFeature>
+                  <CompareTableTooltip
+                    content={
+                      <Trans
+                        t={t}
+                        ns="pricing"
+                        i18nKey="advancedPollSettingsDescription"
+                        defaults="Require participant emails, hide participant names, and hide votes"
+                      />
+                    }
+                  >
+                    <Trans
+                      t={t}
+                      ns="pricing"
+                      i18nKey="advancedPollSettings"
+                      defaults="Advanced poll settings"
+                    />
+                  </CompareTableTooltip>
                 </CompareTableFeature>
                 <CompareTableCell>
                   <CompareTableDash label={notIncluded} />


### PR DESCRIPTION
## Description

Duplicate polls and the advanced poll settings (require email, hide participant names, hide votes) are Pro-gated in the app but were not mentioned anywhere on the pricing page. This surfaces them so the page reflects what Pro actually includes, and so users who hit the in-app paywall find the feature listed when they check pricing.

- Pro plan card: added "Duplicate polls" and "Advanced poll settings" benefits with tooltips (the latter enumerates the three gated toggles)
- Compare plans table: added rows for both features after "Finalize date"
- Compare plans table: the "30 days" retention cell now has a tooltip ("Polls are kept for 30 days after their final date"), reusing the same key as the Hobby plan card so the copy stays in sync
- New `CompareTableTooltip` component mirrors the plan card tooltip pattern but inherits the table's text styling
- Four new i18n keys extracted via the landing scanner (`en/pricing.json` only)

Verified locally: type-check and Biome pass, tooltips confirmed rendering in the browser.

## Checklist

- [x] I have performed a self-review of my code
- [x] My code follows the code style of this project
- [x] I have commented my code, particularly in hard-to-understand areas

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Duplicate Polls and Advanced Poll Settings to the Pro plan.
  * Expanded the pricing comparison table with new Pro-only features.
  * Added helpful tooltips explaining poll retention details and feature availability.
  * Updated English pricing page text for the new features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->