### PR TITLE
💄 Render error page logo in the shared logo viewbox

### DIFF
--- a/apps/web/src/app/[locale]/error.tsx
+++ b/apps/web/src/app/[locale]/error.tsx
@@ -8,6 +8,7 @@ import Link from "next/link";
 import { useRouter } from "next/navigation";
 import React from "react";
 import { ErrorPage, ErrorPageLinkItem } from "@/components/error-page";
+import { DefaultLogo } from "@/features/branding/components/default-logo";
 import { Trans } from "@/i18n/client";
 import { signOut } from "@/lib/auth-client";
 import { INVALID_SESSION } from "@/lib/errors/invalid-session-error";
@@ -34,6 +35,7 @@ export default function LocaleErrorBoundary({
     // infinite loop with the login page.
     return (
       <ErrorPage
+        logo={<DefaultLogo />}
         label={<Trans i18nKey="invalidSessionLabel" defaults="Session" />}
         title={
           <Trans
@@ -69,6 +71,7 @@ export default function LocaleErrorBoundary({
 
   return (
     <ErrorPage
+      logo={<DefaultLogo />}
       label={<Trans i18nKey="errorLabel" defaults="Error" />}
       title={<Trans i18nKey="errorTitle" defaults="Something went wrong" />}
       description={

--- a/apps/web/src/app/[locale]/maintenance/page.tsx
+++ b/apps/web/src/app/[locale]/maintenance/page.tsx
@@ -2,6 +2,7 @@ import { buttonVariants } from "@rallly/ui";
 import Link from "next/link";
 
 import { ErrorPage } from "@/components/error-page";
+import { DefaultLogo } from "@/features/branding/components/default-logo";
 import { getTranslation } from "@/i18n/server";
 
 export default async function MaintenancePage({
@@ -14,6 +15,7 @@ export default async function MaintenancePage({
 
   return (
     <ErrorPage
+      logo={<DefaultLogo />}
       label={t("maintenanceLabel", { defaultValue: "Maintenance" })}
       title={t("maintenanceTitle", { defaultValue: "Be right back" })}
       description={t("maintenanceDescription", {

--- a/apps/web/src/app/[locale]/not-found.tsx
+++ b/apps/web/src/app/[locale]/not-found.tsx
@@ -3,6 +3,7 @@ import { GithubIcon, HomeIcon, LifeBuoyIcon, PlusIcon } from "lucide-react";
 import Link from "next/link";
 
 import { ErrorPage, ErrorPageLinkItem } from "@/components/error-page";
+import { DefaultLogo } from "@/features/branding/components/default-logo";
 import { getTranslation } from "@/i18n/server";
 
 export default async function NotFoundPage() {
@@ -12,6 +13,7 @@ export default async function NotFoundPage() {
 
   return (
     <ErrorPage
+      logo={<DefaultLogo />}
       label={t("notFoundLabel", { defaultValue: "404" })}
       title={t("notFoundTitle", { defaultValue: "Page not found" })}
       description={t("notFoundDescription", {

--- a/apps/web/src/components/error-page.tsx
+++ b/apps/web/src/components/error-page.tsx
@@ -1,16 +1,17 @@
 "use client";
 
 import { ChevronRightIcon } from "lucide-react";
-import Image from "next/image";
 import Link from "next/link";
 
 export function ErrorPage({
+  logo,
   label,
   title,
   description,
   children,
   actions,
 }: {
+  logo: React.ReactNode;
   label: React.ReactNode;
   title: React.ReactNode;
   description: React.ReactNode;
@@ -24,20 +25,7 @@ export function ErrorPage({
         tabIndex={-1}
         className="mx-auto w-full max-w-7xl px-6 pt-10 pb-16 sm:pb-24 lg:px-8"
       >
-        <Image
-          src="/static/logo.svg"
-          alt="Rallly"
-          width={130}
-          height={30}
-          className="mx-auto dark:hidden"
-        />
-        <Image
-          src="/static/logo-dark.svg"
-          alt="Rallly"
-          width={130}
-          height={30}
-          className="mx-auto hidden dark:block"
-        />
+        <header className="flex justify-center">{logo}</header>
         <div className="mx-auto mt-16 max-w-2xl text-center">
           <p className="font-semibold text-base/8 text-primary">{label}</p>
           <h1 className="mt-4 text-balance font-semibold text-3xl text-foreground tracking-tight sm:text-5xl">

--- a/apps/web/src/features/branding/components/default-logo.tsx
+++ b/apps/web/src/features/branding/components/default-logo.tsx
@@ -1,0 +1,29 @@
+import { cn } from "@rallly/ui";
+import { DEFAULT_APP_NAME, LOGO_VIEWBOX } from "@/features/branding/constants";
+
+/**
+ * Renders the default logo in the same viewbox as `Logo` with `size="fit"`.
+ * Static assets only, so it stays safe to render from client error boundaries
+ * where instance branding config is unavailable.
+ */
+export function DefaultLogo({ className }: { className?: string }) {
+  return (
+    <div
+      className={cn("flex items-center justify-center", className)}
+      style={{ width: LOGO_VIEWBOX.width, height: LOGO_VIEWBOX.height }}
+    >
+      {/* biome-ignore lint/performance/noImgElement: we don't need Image component here */}
+      <img
+        src="/static/logo.svg"
+        alt={DEFAULT_APP_NAME}
+        className="block max-h-full max-w-full object-contain dark:hidden"
+      />
+      {/* biome-ignore lint/performance/noImgElement: we don't need Image component here */}
+      <img
+        src="/static/logo-dark.svg"
+        alt={DEFAULT_APP_NAME}
+        className="hidden max-h-full max-w-full object-contain dark:block"
+      />
+    </div>
+  );
+}


### PR DESCRIPTION
## Description

Error pages hardcoded a 130x30 `next/image` logo pair while the auth layout renders the logo inside the shared 192x128 `LOGO_VIEWBOX` slot. This aligns them so custom and default logos occupy the same slot everywhere.

- Added `DefaultLogo` in `features/branding/components/` — reproduces the `size="fit"` branch of `Logo` (fixed `LOGO_VIEWBOX` container, light/dark static images with `object-contain`), using static assets only so it is safe to render from client error boundaries where instance branding config is unreachable.
- `ErrorPage` now takes a `logo` slot rendered in a centered header; `error.tsx` (both branches), `not-found.tsx` and `maintenance/page.tsx` pass `logo={<DefaultLogo />}`. Composition happens at the page level because `components/` is lint-banned from importing `@/features/**`.

Notes for review: the logo renders larger on error pages now (192px wide vs 130px) — that is the point of sharing the viewbox. Verified in the browser: the slot measures exactly 192x128 and the logo scales with `object-contain`, matching `<Logo size="fit" />` on /login. Biome and tsc pass.

## Checklist

- [x] I have performed a self-review of my code
- [x] My code follows the code style of this project
- [x] I have commented my code, particularly in hard-to-understand areas

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added consistent default branding to error, maintenance, and not-found pages.
  * Added light- and dark-mode logo support across these pages.
* **Bug Fixes**
  * Improved branding consistency across fallback and error states.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->