### PR TITLE
💄 Disable text selection inside the hero demo

### DIFF
--- a/apps/landing/src/components/home/hero-demo/hero-demo.tsx
+++ b/apps/landing/src/components/home/hero-demo/hero-demo.tsx
@@ -33,7 +33,7 @@ const CachedDemo = async ({
   const scores = getScores(days);
 
   return (
-    <div className="relative z-10 md:mx-auto md:max-w-full lg:mb-12">
+    <div className="relative z-10 select-none md:mx-auto md:max-w-full lg:mb-12">
       <div className="mr-[calc(50%-50vw)] overflow-hidden [mask-image:linear-gradient(to_left,transparent,black_6rem)] md:mr-0 md:overflow-visible md:[mask-image:none]">
         <div
           aria-hidden="true"


### PR DESCRIPTION
## Description

Adds `select-none` to the hero demo root on the landing page.

The vote toggles in the phone demo are label-wrapped hidden radios, so they don't get the browser's default non-selectable treatment that buttons do. Double-clicking a toggle (which the demo invites) selected the adjacent time text and painted selection highlights across the mockup, breaking the app illusion. The demo is sample content, so nothing copyable is lost; page copy outside the demo stays selectable.

No accessibility impact: `user-select` only affects pointer selection, not the accessibility tree, screen reader output, or keyboard operability — verified that the vote radios still toggle and the desktop replica was already `aria-hidden`.

## Checklist

- [x] I have performed a self-review of my code
- [x] My code follows the code style of this project
- [x] I have commented my code, particularly in hard-to-understand areas

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Prevented accidental text and element selection within the hero demo.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->