### PR TITLE
✨ Add the how it works section to the SEO landing pages

### DIFF
--- a/apps/landing/src/app/[locale]/(main)/(seo)/best-doodle-alternative/page.tsx
+++ b/apps/landing/src/app/[locale]/(main)/(seo)/best-doodle-alternative/page.tsx
@@ -10,6 +10,7 @@ import { Cta } from "@/components/home/cta";
 import { Faq, FaqItem } from "@/components/home/faq";
 import { Hero, HeroAnnouncement } from "@/components/home/hero";
 import { HeroDemo } from "@/components/home/hero-demo/hero-demo";
+import { HowItWorks } from "@/components/home/how-it-works/how-it-works";
 import { Mention, Mentions } from "@/components/home/mentions";
 import { Stats } from "@/components/home/stats";
 import { Testimonial } from "@/components/home/testimonial";
@@ -80,6 +81,7 @@ export default async function Page(props: {
           />
         </Stats>
       </Section>
+      <HowItWorks locale={locale} />
       <Section>
         <Testimonial
           logo={

--- a/apps/landing/src/app/[locale]/(main)/(seo)/free-scheduling-poll/page.tsx
+++ b/apps/landing/src/app/[locale]/(main)/(seo)/free-scheduling-poll/page.tsx
@@ -10,6 +10,7 @@ import { Cta } from "@/components/home/cta";
 import { Faq, FaqItem } from "@/components/home/faq";
 import { Hero, HeroAnnouncement } from "@/components/home/hero";
 import { HeroDemo } from "@/components/home/hero-demo/hero-demo";
+import { HowItWorks } from "@/components/home/how-it-works/how-it-works";
 import { Mention, Mentions } from "@/components/home/mentions";
 import { Stats } from "@/components/home/stats";
 import { Testimonial } from "@/components/home/testimonial";
@@ -80,6 +81,7 @@ export default async function Page(props: {
           />
         </Stats>
       </Section>
+      <HowItWorks locale={locale} />
       <Section>
         <Testimonial
           logo={

--- a/apps/landing/src/app/[locale]/(main)/(seo)/when2meet-alternative/page.tsx
+++ b/apps/landing/src/app/[locale]/(main)/(seo)/when2meet-alternative/page.tsx
@@ -10,6 +10,7 @@ import { Cta } from "@/components/home/cta";
 import { Faq, FaqItem } from "@/components/home/faq";
 import { Hero, HeroAnnouncement } from "@/components/home/hero";
 import { HeroDemo } from "@/components/home/hero-demo/hero-demo";
+import { HowItWorks } from "@/components/home/how-it-works/how-it-works";
 import { Mention, Mentions } from "@/components/home/mentions";
 import { Stats } from "@/components/home/stats";
 import { Testimonial } from "@/components/home/testimonial";
@@ -80,6 +81,7 @@ export default async function Page(props: {
           />
         </Stats>
       </Section>
+      <HowItWorks locale={locale} />
       <Section>
         <Testimonial
           logo={


### PR DESCRIPTION
## Description

Follow-up to #3011: renders the shared `<HowItWorks locale={locale} />` section after the hero on the three SEO landing pages (best-doodle-alternative, when2meet-alternative, free-scheduling-poll), matching its placement on the homepage. Two lines per page — an import and the component — since the section owns its own copy and translations.

Verified all three pages render the section on the dev server; type-check and Biome pass.

## Checklist

- [x] I have performed a self-review of my code
- [x] My code follows the code style of this project
- [x] I have commented my code, particularly in hard-to-understand areas

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added “How It Works” sections to the Best Doodle Alternative, Free Scheduling Poll, and When2meet Alternative landing pages.
  * The new sections are localized to match each page’s language.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->