### PR TITLE
💄 Sync support docs colors with the ui package palette

### DIFF
--- a/apps/docs/docs.json
+++ b/apps/docs/docs.json
@@ -4,7 +4,7 @@
   "name": "Rallly",
   "colors": {
     "primary": "#4f39f6",
-    "light": "#F8FAFC",
+    "light": "#615fff",
     "dark": "#4f39f6"
   },
   "favicon": "/favicon.png",

--- a/apps/docs/style.css
+++ b/apps/docs/style.css
@@ -1,0 +1,40 @@
+/*
+  Keep the docs theme in sync with the product design tokens defined in
+  packages/tailwind-config/shared-styles.css.
+
+  Mintlify generates a gray scale tinted from the primary color; the product
+  remaps gray-* to Tailwind's zinc scale, so the same values go here (as the
+  RGB triplets Mintlify's variables expect).
+*/
+:root {
+  --gray-50: 250 250 250;
+  --gray-100: 244 244 245;
+  --gray-200: 228 228 231;
+  --gray-300: 212 212 216;
+  --gray-400: 161 161 170;
+  --gray-500: 113 113 122;
+  --gray-600: 82 82 91;
+  --gray-700: 63 63 70;
+  --gray-800: 39 39 42;
+  --gray-900: 24 24 27;
+  --gray-950: 9 9 11;
+}
+
+/* --foreground: zinc-800 in light mode, white in dark mode. Body text gets
+   its color by inheritance from the app shell, so re-anchor it on the
+   documented #content-area selector. */
+#content-area {
+  color: rgb(39 39 42);
+}
+
+.dark #content-area {
+  color: rgb(255 255 255);
+}
+
+/* Headings carry their own text-gray-* utilities that beat inheritance */
+.dark #content-area h1,
+.dark #content-area h2,
+.dark #content-area h3,
+.dark #content-area h4 {
+  color: rgb(255 255 255);
+}


### PR DESCRIPTION
## Description

Dark-mode text on support.rallly.co rendered in Mintlify's default tinted grays (paragraphs `#A0A0A6`, headings `#E0E0E6`) instead of white, and the theme's gray scale and dark accent were off the product palette. This syncs the docs theme with the tokens in `packages/tailwind-config/shared-styles.css`.

**What changed:**

- **apps/docs/docs.json** — `colors.light` was `#F8FAFC` (slate-50, off-palette). It is Mintlify's dark-mode accent, so active sidebar items and links rendered near-white in dark mode. Now `#615fff` (indigo-500), matching the ui package's dark-mode `--primary`. Primary (`#4f39f6` = indigo-600) and backgrounds (white / `#18181B` = zinc-900) were already in sync.
- **apps/docs/style.css** (new) — Mintlify auto-applies any CSS file in the docs directory:
  - Overrides Mintlify's generated `--gray-*` scale (tinted from the primary color, hence the purple-ish grays) with the zinc scale — the same gray→zinc remap the ui package does. Syncs all text, border, and surface grays site-wide.
  - Sets the dark-mode foreground to white via `.dark #content-area`, with explicit heading overrides since headings carry their own `dark:text-gray-*` utilities that beat inheritance.

**Verified:** ran `mint dev` locally and checked computed values in both modes: dark paragraphs/h1/h2 are `rgb(255,255,255)`, active sidebar link indigo-500, background zinc-900; light body zinc-700, headings zinc-900, accent indigo-600.

**Reviewer note:** `#content-area` is Mintlify's documented customization hook, but the `--gray-*` variable names are theme internals — a Mintlify theme update could change them, so re-check `style.css` after major mint upgrades.

## Checklist

- [x] I have performed a self-review of my code
- [x] My code follows the code style of this project
- [x] I have commented my code, particularly in hard-to-understand areas

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the documentation theme with the product’s primary color.
  * Improved light and dark mode text colors for better visual consistency and readability.
  * Added clearer dark-mode heading colors and aligned the documentation palette with the zinc color scheme.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->