### PR TITLE
💄 Increase premium poll coming soon container radius

### DIFF
--- a/apps/web/src/features/billing/components/pay-wall-dialog.tsx
+++ b/apps/web/src/features/billing/components/pay-wall-dialog.tsx
@@ -327,7 +327,7 @@ export function PayWallDialog({
               )}
               {selectedPlan === "premium-poll" &&
                 (isComingSoonVisible ? (
-                  <div className="space-y-3 rounded-xl bg-gray-50 p-4 ring ring-button-outline ring-inset dark:bg-gray-700/50">
+                  <div className="space-y-3 rounded-2xl bg-gray-50 p-4 ring ring-button-outline ring-inset dark:bg-gray-700/50">
                     <div className="font-medium text-sm">
                       <Trans
                         i18nKey="premiumPollComingSoonTitle"


### PR DESCRIPTION
Follow-up to #3009. Bumps the "Premium polls are coming soon" container in the paywall dialog from `rounded-xl` (12px) to `rounded-2xl` (16px).

Reviewed live in the dev server before merging #3009, but the radius change didn't make it into that PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)