### PR TITLE
💄 Match landing description text size to how it works steps on small screens

### DIFF
--- a/apps/landing/src/components/home/cta.tsx
+++ b/apps/landing/src/components/home/cta.tsx
@@ -21,7 +21,7 @@ export function Cta({
         <h2 className="text-balance font-medium text-2xl text-gray-800 leading-tight tracking-tight sm:text-4xl">
           {title}
         </h2>
-        <p className="max-w-prose text-pretty text-gray-500 text-sm sm:text-balance sm:text-lg">
+        <p className="max-w-prose text-pretty text-base/6 text-gray-500 sm:text-balance sm:text-lg">
           {description}
         </p>
       </div>

--- a/apps/landing/src/components/home/hero.tsx
+++ b/apps/landing/src/components/home/hero.tsx
@@ -48,7 +48,7 @@ export function Hero({
       <h1 className="text-balance font-medium text-3xl text-gray-800 tracking-tight sm:text-5xl">
         {title}
       </h1>
-      <p className="mt-4 text-balance font-normal text-gray-500 text-sm leading-relaxed sm:text-lg">
+      <p className="mt-4 text-balance font-normal text-base/6 text-gray-500 sm:text-lg sm:leading-relaxed">
         {description}
       </p>
       {announcement ? <div className="mt-8">{announcement}</div> : null}

--- a/apps/landing/src/components/section.tsx
+++ b/apps/landing/src/components/section.tsx
@@ -37,7 +37,7 @@ export function SectionDescription({
   return (
     <p
       className={cn(
-        "max-w-prose text-pretty text-gray-500 text-sm sm:text-lg",
+        "max-w-prose text-pretty text-base/6 text-gray-500 sm:text-lg",
         className,
       )}
       {...props}


### PR DESCRIPTION
Section, hero and CTA descriptions rendered at text-sm on small screens
while the how it works step descriptions rendered at text-base/6. Bump
them all to text-base/6 so mobile body copy is consistent, keeping the
existing sm: and up sizes.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01HZPohUJ6XjamtH39imZa4U

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved readability across landing page descriptions by increasing the default text size and line spacing.
  * Updated hero, call-to-action, and section description text while preserving responsive styling on larger screens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->