### PR TITLE
💄 Make how it works steps horizontally scrollable below lg

### DIFF
--- a/apps/landing/src/components/home/how-it-works/how-it-works.tsx
+++ b/apps/landing/src/components/home/how-it-works/how-it-works.tsx
@@ -115,7 +115,7 @@ export const HowItWorks = async ({ locale }: { locale: string }) => {
       <SectionContent>
         {/* Below lg the three steps stay side by side and scroll horizontally,
             bleeding past the page gutters so the next card peeks in. */}
-        <dl className="-mx-4 grid snap-x snap-mandatory grid-cols-[repeat(3,min(75vw,20rem))] grid-rows-[auto_auto] gap-x-4 gap-y-1 overflow-x-auto scroll-px-4 px-4 sm:-mx-6 sm:scroll-px-6 sm:px-6 lg:mx-0 lg:grid-cols-3 lg:overflow-x-visible lg:px-0">
+        <dl className="-mx-4 grid snap-x snap-mandatory scroll-px-4 grid-cols-[repeat(3,min(75vw,20rem))] grid-rows-[auto_auto] gap-x-4 gap-y-1 overflow-x-auto px-4 sm:-mx-6 sm:scroll-px-6 sm:px-6 lg:mx-0 lg:grid-cols-3 lg:overflow-x-visible lg:px-0">
           {steps.map((step, index) => (
             <div
               key={step.key}

--- a/apps/landing/src/components/home/how-it-works/how-it-works.tsx
+++ b/apps/landing/src/components/home/how-it-works/how-it-works.tsx
@@ -113,11 +113,13 @@ export const HowItWorks = async ({ locale }: { locale: string }) => {
         </a>
       </SectionHeading>
       <SectionContent>
-        <dl className="grid gap-x-4 gap-y-4 lg:grid-cols-3 lg:grid-rows-[auto_auto] lg:gap-y-1">
+        {/* Below lg the three steps stay side by side and scroll horizontally,
+            bleeding past the page gutters so the next card peeks in. */}
+        <dl className="-mx-4 grid snap-x snap-mandatory grid-cols-[repeat(3,min(75vw,20rem))] grid-rows-[auto_auto] gap-x-4 gap-y-1 overflow-x-auto scroll-px-4 px-4 sm:-mx-6 sm:scroll-px-6 sm:px-6 lg:mx-0 lg:grid-cols-3 lg:overflow-x-visible lg:px-0">
           {steps.map((step, index) => (
             <div
               key={step.key}
-              className="flex flex-col gap-1 rounded-2xl border bg-white p-1 lg:row-span-2 lg:grid lg:grid-rows-subgrid"
+              className="row-span-2 grid snap-start grid-rows-subgrid rounded-2xl border bg-white p-1"
             >
               <div className="space-y-4 rounded-xl border bg-gray-100 p-4">
                 <div className="font-mono text-gray-400 text-xs uppercase tracking-wide">


### PR DESCRIPTION
## Description

Below `lg` the three "How it works" steps stacked into a single column, pushing the later steps far down the page. They now stay side by side at every width and the row scrolls horizontally instead.

- The `dl` keeps three columns at all widths. Below `lg` the tracks are fixed at `min(75vw, 20rem)` and the row is `overflow-x-auto`, so the next card peeks in as a scroll affordance; at `lg` it reverts to `grid-cols-3` with `overflow-x-visible`.
- Negative gutters (`-mx-4 px-4`, `sm:-mx-6 sm:px-6`) let cards scroll to the screen edge while the first one still lines up with the page content. `snap-x snap-mandatory` + `snap-start` + `scroll-px-*` snap each card to that same edge.
- Cards use `row-span-2 grid grid-rows-subgrid` at all widths (previously `lg:` only), so titles and descriptions stay aligned across the three cards while scrolling. The card's own `gap-1` is dropped — the parent's `gap-y-1` drives the subgrid rows.

Verified in Chromium against a CSS replica of the resolved classes: at 390px the track scrolls (942px of content in a 390px viewport, cards 292px wide) with no horizontal scroll on the page itself, and the three titles share a top edge; at 1280px it renders as three equal columns with no overflow.

## Checklist

Please check off all the following items with an "x" in the boxes before requesting a review.

- [x] I have performed a self-review of my code
- [x] My code follows the code style of this project
- [x] I have commented my code, particularly in hard-to-understand areas

---
_Generated by [Claude Code](https://claude.ai/code/session_01HZPohUJ6XjamtH39imZa4U)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated the “How it works” section for improved mobile browsing.
  * Steps now appear in a horizontally scrollable, snap-scrolling layout with a preview of the next card.
  * Preserved the three-column layout on larger screens.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->