### PR TITLE
💄 Center the final CTA content on mobile

### DIFF
--- a/apps/landing/src/components/home/cta.tsx
+++ b/apps/landing/src/components/home/cta.tsx
@@ -17,15 +17,15 @@ export function Cta({
 }) {
   return (
     <FadeIn amount="all" captureOnEnter="landing:final_cta_view">
-      <div className="grid gap-4 sm:grid-cols-2 sm:gap-6">
+      <div className="grid gap-4 text-center sm:grid-cols-2 sm:gap-6 sm:text-left">
         <h2 className="text-balance font-medium text-2xl text-gray-800 leading-tight tracking-tight sm:text-4xl">
           {title}
         </h2>
-        <p className="max-w-prose text-pretty text-base/6 text-gray-500 sm:text-balance sm:text-lg">
+        <p className="mx-auto max-w-prose text-pretty text-base/6 text-gray-500 sm:mx-0 sm:text-balance sm:text-lg">
           {description}
         </p>
       </div>
-      <div className="mt-6 flex flex-col items-start gap-4">
+      <div className="mt-6 flex flex-col items-center gap-4 sm:items-start">
         <CtaButton size="lg" captureEvent="landing:final_cta_click">
           {buttonLabel}
         </CtaButton>


### PR DESCRIPTION
## Description

The final CTA's heading, description, button and hint were left aligned on mobile, where the section stacks into a single column. They are now centered below `sm`, and the two-column left-aligned layout is unchanged from `sm` up.

- Grid wrapper: `text-center sm:text-left` centers the heading and description copy on mobile.
- Description: `mx-auto sm:mx-0` centers the `max-w-prose` block itself, so the centered text sits in the middle of the column rather than in a left-hugging box.
- Button column: `items-center sm:items-start` centers the CTA button and the handwritten hint under it.

This component is shared by the home page, the three SEO landing pages, and the pricing page, so the change applies to the final CTA on all of them.

## Checklist

Please check off all the following items with an "x" in the boxes before requesting a review.

- [x] I have performed a self-review of my code
- [x] My code follows the code style of this project
- [x] I have commented my code, particularly in hard-to-understand areas

---
_Generated by [Claude Code](https://claude.ai/code/session_01HZPohUJ6XjamtH39imZa4U)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved responsive alignment of the call-to-action section.
  * Adjusted text spacing and action placement for clearer presentation across screen sizes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->