### PR TITLE
💄 Make mentions scroll horizontally below md

### DIFF
--- a/apps/landing/src/components/home/mentions.tsx
+++ b/apps/landing/src/components/home/mentions.tsx
@@ -26,7 +26,7 @@ export function Mentions({ children }: { children: React.ReactNode }) {
   // padding leaves room for the mentions' fade-in offset, which would
   // otherwise make the scroller overflow vertically as it animates.
   return (
-    <div className="-mx-4 grid snap-x snap-mandatory grid-cols-[repeat(4,min(75vw,20rem))] gap-8 overflow-x-auto scroll-px-4 px-4 pb-5 sm:-mx-6 sm:scroll-px-6 sm:px-6 md:mx-0 md:grid-cols-4 md:overflow-x-visible md:px-0 md:pb-0">
+    <div className="-mx-4 grid snap-x snap-mandatory scroll-px-4 grid-cols-[repeat(4,min(75vw,20rem))] gap-8 overflow-x-auto px-4 pb-5 sm:-mx-6 sm:scroll-px-6 sm:px-6 md:mx-0 md:grid-cols-4 md:overflow-x-visible md:px-0 md:pb-0">
       {children}
     </div>
   );

--- a/apps/landing/src/components/home/mentions.tsx
+++ b/apps/landing/src/components/home/mentions.tsx
@@ -10,7 +10,10 @@ export function Mention({
   delay?: number;
 }>) {
   return (
-    <FadeIn delay={delay} className="flex flex-col space-y-4 rounded-md">
+    <FadeIn
+      delay={delay}
+      className="flex snap-start flex-col space-y-4 rounded-md"
+    >
       <div className="flex items-start justify-between">{logo}</div>
       <p className="grow text-base">{children}</p>
     </FadeIn>
@@ -18,5 +21,13 @@ export function Mention({
 }
 
 export function Mentions({ children }: { children: React.ReactNode }) {
-  return <div className="grid gap-8 md:grid-cols-4">{children}</div>;
+  // Below md the four mentions stay side by side and scroll horizontally,
+  // bleeding past the page gutters so the next one peeks in. The bottom
+  // padding leaves room for the mentions' fade-in offset, which would
+  // otherwise make the scroller overflow vertically as it animates.
+  return (
+    <div className="-mx-4 grid snap-x snap-mandatory grid-cols-[repeat(4,min(75vw,20rem))] gap-8 overflow-x-auto scroll-px-4 px-4 pb-5 sm:-mx-6 sm:scroll-px-6 sm:px-6 md:mx-0 md:grid-cols-4 md:overflow-x-visible md:px-0 md:pb-0">
+      {children}
+    </div>
+  );
 }

--- a/apps/landing/src/components/home/mentions.tsx
+++ b/apps/landing/src/components/home/mentions.tsx
@@ -12,10 +12,12 @@ export function Mention({
   return (
     <FadeIn
       delay={delay}
-      className="flex snap-start flex-col space-y-4 rounded-md"
+      className="flex snap-start flex-col space-y-4 rounded-2xl border bg-white p-4"
     >
       <div className="flex items-start justify-between">{logo}</div>
-      <p className="grow text-base">{children}</p>
+      <p className="grow text-pretty text-base/6 text-gray-500 sm:text-lg">
+        {children}
+      </p>
     </FadeIn>
   );
 }
@@ -26,7 +28,7 @@ export function Mentions({ children }: { children: React.ReactNode }) {
   // padding leaves room for the mentions' fade-in offset, which would
   // otherwise make the scroller overflow vertically as it animates.
   return (
-    <div className="-mx-4 grid snap-x snap-mandatory scroll-px-4 grid-cols-[repeat(4,min(75vw,20rem))] gap-8 overflow-x-auto px-4 pb-5 sm:-mx-6 sm:scroll-px-6 sm:px-6 md:mx-0 md:grid-cols-4 md:overflow-x-visible md:px-0 md:pb-0">
+    <div className="-mx-4 grid snap-x snap-mandatory scroll-px-4 grid-cols-[repeat(4,min(75vw,20rem))] gap-4 overflow-x-auto px-4 pb-5 sm:-mx-6 sm:scroll-px-6 sm:px-6 md:mx-0 md:grid-cols-4 md:overflow-x-visible md:px-0 md:pb-0">
       {children}
     </div>
   );


### PR DESCRIPTION
## Description

Below `md` the four press mentions stacked into a single column, adding a long run of sparse rows to the page. They now stay side by side and the row scrolls horizontally, matching the treatment applied to the "How it works" steps in #3018.

- The `Mentions` grid keeps four columns at all widths. Below `md` the tracks are fixed at `min(75vw, 20rem)` and the row is `overflow-x-auto`, so the next mention peeks in as a scroll affordance; at `md` it reverts to `grid-cols-4` with `overflow-x-visible`.
- Negative gutters (`-mx-4 px-4`, `sm:-mx-6 sm:px-6`) let mentions scroll to the screen edge while the first one stays aligned with the page content. `snap-x snap-mandatory` + `snap-start` + `scroll-px-*` snap each mention to that edge.
- `pb-5` below `md` leaves room for each mention's fade-in offset (it animates in from 20px below), which would otherwise make the scroller overflow vertically mid-animation.

Verified in Chromium against a CSS replica of the resolved classes: at 390px the track scrolls (1298px of content in a 390px viewport, items 293px wide) with no vertical overflow inside the scroller and no horizontal scroll on the page itself; at 768px and 1280px it renders as four equal columns with no overflow, unchanged from today.

## Checklist

Please check off all the following items with an "x" in the boxes before requesting a review.

- [x] I have performed a self-review of my code
- [x] My code follows the code style of this project
- [x] I have commented my code, particularly in hard-to-understand areas

---
_Generated by [Claude Code](https://claude.ai/code/session_01HZPohUJ6XjamtH39imZa4U)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Refined mention cards with rounded borders, white backgrounds, and improved padding.
  * Improved text readability with enhanced wrapping, line height, gray coloring, and larger text on small screens.
  * Reduced spacing between cards for a more compact browsing experience.
  * Preserved responsive horizontal scrolling, snap-to-card behavior, and the four-column layout on medium and larger screens.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->