### PR TITLE
💄 Expand mobile nav into a full screen menu

### DIFF
--- a/apps/landing/public/locales/en/common.json
+++ b/apps/landing/public/locales/en/common.json
@@ -1,5 +1,6 @@
 {
   "blog": "Blog",
+  "close": "Close",
   "compare": "Compare",
   "cookiePolicy": "Cookie policy",
   "discussions": "Discussions",

--- a/apps/landing/src/app/[locale]/(main)/layout.tsx
+++ b/apps/landing/src/app/[locale]/(main)/layout.tsx
@@ -1,15 +1,4 @@
 import languages from "@rallly/languages";
-import { buttonVariants } from "@rallly/ui";
-import { Button } from "@rallly/ui/button";
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuLabel,
-  DropdownMenuSeparator,
-  DropdownMenuTrigger,
-} from "@rallly/ui/dropdown-menu";
-import { MenuIcon } from "lucide-react";
 import type { Viewport } from "next";
 import { cacheLife } from "next/cache";
 import Image from "next/image";
@@ -20,8 +9,8 @@ import { CtaButton } from "@/components/home/cta-button";
 import { LoginButton } from "@/components/login-button";
 import { LinkBase } from "@/i18n/client/link";
 import { getTranslation } from "@/i18n/server";
-import { linkToApp } from "@/lib/linkToApp";
 import { Footer } from "./footer";
+import { MobileMenu } from "./mobile-menu";
 import { NavLink } from "./nav-link";
 
 export async function generateStaticParams() {
@@ -86,48 +75,20 @@ export default async function Root(props: {
               </CtaButton>
             </div>
             <div className="flex items-center justify-center lg:hidden">
-              <DropdownMenu>
-                <DropdownMenuTrigger
-                  render={
-                    <Button
-                      size="sm"
-                      variant="ghost"
-                      aria-label={t("menu", { defaultValue: "Menu" })}
-                    />
-                  }
-                >
-                  <MenuIcon className="size-4 text-muted-foreground" />
-                </DropdownMenuTrigger>
-                <DropdownMenuContent
-                  className="w-48"
-                  align="end"
-                  sideOffset={16}
-                >
-                  <DropdownMenuItem render={<LinkBase href="/pricing" />}>
-                    <Trans t={t} i18nKey="pricing" defaults="Pricing" />
-                  </DropdownMenuItem>
-                  <DropdownMenuItem render={<LinkBase href="/blog" />}>
-                    <Trans t={t} i18nKey="blog" />
-                  </DropdownMenuItem>
-                  <DropdownMenuItem
-                    render={<LinkBase href="https://support.rallly.co" />}
-                  >
-                    <Trans t={t} i18nKey="support" />
-                  </DropdownMenuItem>
-                  <DropdownMenuSeparator />
-                  <DropdownMenuLabel className="space-y-2">
-                    <LinkBase
-                      href={linkToApp("/login")}
-                      className={buttonVariants({
-                        variant: "default",
-                        className: "w-full",
-                      })}
-                    >
-                      <Trans t={t} i18nKey="login" defaults="Login" />
-                    </LinkBase>
-                  </DropdownMenuLabel>
-                </DropdownMenuContent>
-              </DropdownMenu>
+              <MobileMenu
+                links={[
+                  { href: "/pricing", label: t("pricing") },
+                  { href: "/blog", label: t("blog") },
+                  { href: "https://support.rallly.co", label: t("support") },
+                ]}
+                menuLabel={t("menu", { defaultValue: "Menu" })}
+                closeLabel={t("close", { defaultValue: "Close" })}
+                loginLabel={t("login", { defaultValue: "Login" })}
+                ctaLabel={t("createAPoll", {
+                  ns: "home",
+                  defaultValue: "Create a poll",
+                })}
+              />
             </div>
           </div>
         </div>

--- a/apps/landing/src/app/[locale]/(main)/mobile-menu.tsx
+++ b/apps/landing/src/app/[locale]/(main)/mobile-menu.tsx
@@ -10,6 +10,8 @@ import { LinkBase } from "@/i18n/client/link";
 import { linkToApp } from "@/lib/linkToApp";
 
 const PANEL_ID = "mobile-menu-panel";
+// Matches the `lg:hidden` on the panel below. Tailwind's default `lg`.
+const DESKTOP_MEDIA_QUERY = "(min-width: 1024px)";
 
 export const MobileMenu = ({
   links,
@@ -34,6 +36,16 @@ export const MobileMenu = ({
 
   React.useEffect(() => {
     if (!open) return;
+    const mediaQuery = window.matchMedia(DESKTOP_MEDIA_QUERY);
+    if (mediaQuery.matches) {
+      setOpen(false);
+      return;
+    }
+    const onDesktop = (event: MediaQueryListEvent) => {
+      if (event.matches) setOpen(false);
+    };
+    mediaQuery.addEventListener("change", onDesktop);
+
     const { body } = document;
     const previous = body.style.overflow;
     body.style.overflow = "hidden";
@@ -46,6 +58,7 @@ export const MobileMenu = ({
     return () => {
       body.style.overflow = previous;
       document.removeEventListener("keydown", onKeyDown);
+      mediaQuery.removeEventListener("change", onDesktop);
     };
   }, [open]);
 

--- a/apps/landing/src/app/[locale]/(main)/mobile-menu.tsx
+++ b/apps/landing/src/app/[locale]/(main)/mobile-menu.tsx
@@ -1,0 +1,123 @@
+"use client";
+
+import { buttonVariants, cn } from "@rallly/ui";
+import { Button } from "@rallly/ui/button";
+import { MenuIcon, XIcon } from "lucide-react";
+import { usePathname } from "next/navigation";
+import React from "react";
+import { CtaButton } from "@/components/home/cta-button";
+import { LinkBase } from "@/i18n/client/link";
+import { linkToApp } from "@/lib/linkToApp";
+
+const PANEL_ID = "mobile-menu-panel";
+
+export const MobileMenu = ({
+  links,
+  menuLabel,
+  closeLabel,
+  loginLabel,
+  ctaLabel,
+}: {
+  links: { href: string; label: string }[];
+  menuLabel: string;
+  closeLabel: string;
+  loginLabel: string;
+  ctaLabel: string;
+}) => {
+  const pathname = usePathname();
+  const [open, setOpen] = React.useState(false);
+
+  // biome-ignore lint/correctness/useExhaustiveDependencies: dismiss the menu whenever navigation happens
+  React.useEffect(() => {
+    setOpen(false);
+  }, [pathname]);
+
+  React.useEffect(() => {
+    if (!open) return;
+    const { body } = document;
+    const previous = body.style.overflow;
+    body.style.overflow = "hidden";
+
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") setOpen(false);
+    };
+    document.addEventListener("keydown", onKeyDown);
+
+    return () => {
+      body.style.overflow = previous;
+      document.removeEventListener("keydown", onKeyDown);
+    };
+  }, [open]);
+
+  return (
+    <>
+      <Button
+        size="icon"
+        variant="ghost"
+        aria-label={open ? closeLabel : menuLabel}
+        aria-expanded={open}
+        aria-controls={PANEL_ID}
+        onClick={() => setOpen((value) => !value)}
+      >
+        <span className="relative block size-4">
+          <span
+            className={cn(
+              "absolute inset-0 flex items-center justify-center transition-all duration-200 ease-out",
+              open
+                ? "rotate-90 scale-50 opacity-0"
+                : "rotate-0 scale-100 opacity-100",
+            )}
+          >
+            <MenuIcon className="size-4 text-muted-foreground" />
+          </span>
+          <span
+            className={cn(
+              "absolute inset-0 flex items-center justify-center transition-all duration-200 ease-out",
+              open
+                ? "rotate-0 scale-100 opacity-100"
+                : "-rotate-90 scale-50 opacity-0",
+            )}
+          >
+            <XIcon className="size-4 text-muted-foreground" />
+          </span>
+        </span>
+      </Button>
+      <div
+        id={PANEL_ID}
+        hidden={!open}
+        className="absolute inset-x-0 top-full z-10 flex h-[calc(100dvh-100%)] flex-col bg-gray-100 lg:hidden"
+      >
+        <nav className="flex grow flex-col gap-1 overflow-y-auto px-4 py-8 sm:px-6">
+          {links.map((link) => (
+            <LinkBase
+              key={link.href}
+              href={link.href}
+              className="-mx-2 block rounded-lg px-2 py-3 font-normal text-3xl text-foreground tracking-tight hover:bg-gray-200 hover:no-underline"
+            >
+              {link.label}
+            </LinkBase>
+          ))}
+        </nav>
+        <div className="flex flex-col gap-3 border-t px-4 py-6 sm:px-6">
+          <LinkBase
+            href={linkToApp("/login")}
+            className={buttonVariants({
+              variant: "default",
+              size: "lg",
+              className: "w-full",
+            })}
+          >
+            {loginLabel}
+          </LinkBase>
+          <CtaButton
+            size="lg"
+            className="w-full"
+            captureEvent="landing:mobile_menu_cta_click"
+          >
+            {ctaLabel}
+          </CtaButton>
+        </div>
+      </div>
+    </>
+  );
+};


### PR DESCRIPTION
## Description

Replaces the landing header's dropdown menu on mobile with a panel that expands to fill the screen below the existing header bar.

The burger button toggles in place and morphs into a close icon. It's an `icon`-size button (`size-9`), matching the height of the adjacent "Create a poll" CTA. Nav items are full width with `font-normal`, and Login / Create a poll sit in a bordered footer pinned to the bottom.

### Notes for reviewers

Three implementation details that aren't obvious from the diff:

- **The icon animation is on wrapper spans, not the SVGs.** `buttonVariants` applies `[&_svg]:opacity-90`; that descendant selector's specificity beats a plain `opacity-0` class, so animating the SVGs directly leaves both glyphs visible mid-morph.
- **The panel is positioned inside the sticky header**, `absolute top-full` with `h-[calc(100dvh-100%)]`. The `100%` resolves against the header's own box, so it fills the viewport below the header without a hardcoded offset — the header height differs between `py-4` and `sm:py-6`.
- **Labels are passed as props rather than rendered with the client `Trans`.** `createAPoll` lives in the `home` namespace, but the client i18n provider is only seeded with `common`.

Adds one new i18n key (`close`) to `en/common.json`, generated via `pnpm i18n:scan`.

### Verification

Checked on the dev server at 375px and 1280px:

- open/close toggle, with `aria-expanded` and `aria-label` flipping between Menu/Close
- icon opacity and rotate settling correctly in both states
- link navigation closes the panel and restores `body` overflow
- Escape closes it
- at `lg`, trigger and panel are hidden and the desktop nav is visible
- burger measures 36×36 against the CTA's 36px height; nav links span the full 359px

`biome check` and `tsc --noEmit` both pass.

## Checklist

- [x] I have performed a self-review of my code
- [x] My code follows the code style of this project
- [x] I have commented my code, particularly in hard-to-understand areas

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a responsive mobile navigation menu with animated open and close controls.
  * Added localized labels for menu actions, navigation links, login, and calls to action.
  * Improved mobile menu accessibility with keyboard support and scroll handling.
* **Bug Fixes**
  * The mobile menu now closes automatically when navigating to a different page or switching to desktop view.
  * Prevented the menu from opening when viewed on desktop screens.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->