### PR TITLE
🔊 Log failures in the session.create lastSeenAt write

### DIFF
--- a/apps/web/src/lib/auth.ts
+++ b/apps/web/src/lib/auth.ts
@@ -502,7 +502,13 @@ export const authLib = betterAuth({
                 data: { lastSeenAt: new Date() },
                 select: { isAnonymous: true, lastLoginMethod: true },
               })
-              .catch(() => null);
+              .catch((error) => {
+                logger.error(
+                  { error, userId: session.userId },
+                  "Failed to update lastSeenAt",
+                );
+                return null;
+              });
 
             // Anonymous users shouldn't trigger login events or create person profiles.
             if (user && !user.isAnonymous) {


### PR DESCRIPTION
Closes [RAL-1565](https://linear.app/rallly/issue/RAL-1565/log-failures-in-the-sessioncreate-lastseenat-write)

The two `lastSeenAt` write paths in `apps/web/src/lib/auth.ts` handled failure inconsistently: `session.update.after` logged the error, `session.create.after` swallowed it with `.catch(() => null)`.

`lastSeenAt` is the liveness signal the orphaned-guest purge deletes on (RAL-1237, RAL-1475). This is not a correctness bug in the purge — a single lost bump cannot make a user eligible, since that requires every write across the full 60-day window to fail. But it meant one of the two paths feeding that signal could fail at any rate with no trace, which made verification impossible during the RAL-1237 backfill investigation.

This matches the `session.update.after` handler: log the error with `userId`, return `null`. Both writes stay fire-and-forget — blocking session creation on a telemetry write would be worse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error logging when session activity updates fail, making issues easier to diagnose.
  * Login tracking behavior remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->