### PR TITLE
🔒 Guard the orphaned-guest purge against new User cascade relations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,9 @@ jobs:
       - name: Check locale files for unbalanced braces
         run: pnpm check:locales
 
+      - name: Check User cascade relations are covered by the guest purge
+        run: pnpm check:cascades
+
   unit-tests:
     name: Unit tests
     runs-on: ubuntu-latest

--- a/apps/web/src/features/user/mutations.ts
+++ b/apps/web/src/features/user/mutations.ts
@@ -164,6 +164,20 @@ const DELETE_ORPHANED_ANONYMOUS_USERS_BATCH_SIZE = 100;
  *
  * `scheduledEventInvites` is the invitee link (invitee_id, SetNull); a guest
  * on that relation is a live participant elsewhere and must be retained.
+ *
+ * The filter below is the canonical list of guarded relations, and it must
+ * stay exhaustive: every `onDelete: Cascade` relation on `User` is inside
+ * this delete's blast radius. `scripts/check-user-cascade-relations.mjs`
+ * fails CI when the schema grows one that is neither guarded here nor
+ * recorded as deliberately ignored (auth plumbing — sessions, accounts,
+ * notification preferences — which every guest has and which hold no data
+ * worth keeping).
+ *
+ * Most of these can't be reached by an anonymous guest today: the
+ * user-create hook in `lib/auth.ts` returns early for anonymous users, so no
+ * space is provisioned and the space-scoped relations stay empty. That is an
+ * application-code invariant, not a database constraint, so the filter does
+ * not rely on it holding.
  */
 export async function deleteOrphanedAnonymousUsers() {
   const cutoff = new Date(Date.now() - SESSION_TTL_SECONDS * 1000);
@@ -176,6 +190,16 @@ export async function deleteOrphanedAnonymousUsers() {
     comments: { none: {} },
     participants: { none: {} },
     scheduledEventInvites: { none: {} },
+    scheduledEvents: { none: {} },
+    hostedEventTypes: { none: {} },
+    hostedSheets: { none: {} },
+    spaces: { none: {} },
+    memberOf: { none: {} },
+    spaceMemberInvites: { none: {} },
+    subscriptions: { none: {} },
+    paymentMethods: { none: {} },
+    calendarConnections: { none: {} },
+    credentials: { none: {} },
   } satisfies Prisma.UserWhereInput;
 
   let deleted = 0;

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "check:fix": "biome check . --write",
     "check:locales": "node scripts/check-locale-braces.mjs",
     "check:structure": "node scripts/check-feature-structure.mjs && node scripts/check-feature-cycles.mjs",
+    "check:cascades": "node scripts/check-user-cascade-relations.mjs",
     "i18n:scan": "turbo i18n:scan",
     "type-check": "turbo type-check",
     "release": "./scripts/create-release.sh",

--- a/scripts/check-user-cascade-relations.mjs
+++ b/scripts/check-user-cascade-relations.mjs
@@ -1,0 +1,284 @@
+#!/usr/bin/env node
+/**
+ * Fails when a `onDelete: Cascade` relation on `User` is not accounted for by
+ * the orphaned-anonymous-guest purge.
+ *
+ * `deleteOrphanedAnonymousUsers` deletes guest accounts outright, so every
+ * cascading relation on `User` is inside its blast radius. Whether that is
+ * safe is a per-relation judgement, and the purge only encodes half of it:
+ * the relations it filters on. Nothing recorded the relations it deliberately
+ * ignores, so a newly added cascade was indistinguishable from an overlooked
+ * one — and the recurring cron runs unattended.
+ *
+ * Every cascading relation must therefore land in exactly one bucket:
+ *
+ *  - guarded — named in the purge filter, so a guest owning one is retained.
+ *  - ignored — provably not user data worth keeping, with the reason stated
+ *    below. These MUST NOT be added to the purge filter: an anonymous guest
+ *    always has a session and account row, so filtering on those would make
+ *    the purge match nothing at all.
+ *
+ * A relation in neither bucket fails this check. Classify it: if deleting it
+ * along with the guest would destroy something, add it to the purge filter;
+ * if not, add it to IGNORED_RELATIONS with the reason why.
+ */
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+
+const MODELS_DIR = path.join(ROOT, "packages/database/prisma/models");
+const PURGE_FILE = path.join(ROOT, "apps/web/src/features/user/mutations.ts");
+const PURGE_FUNCTION = "deleteOrphanedAnonymousUsers";
+
+// Cascading relations that are intentionally NOT guarded by the purge filter,
+// each with the reason it carries no data worth retaining. Keyed by the field
+// name on the `User` model.
+const IGNORED_RELATIONS = new Map([
+  [
+    "sessions",
+    "Auth plumbing. Every anonymous guest has one by definition — filtering on it would make the purge match nothing. The lastSeenAt cutoff is the liveness guard instead.",
+  ],
+  [
+    "accounts",
+    "Auth plumbing, created alongside the guest account. Carries no user-authored data.",
+  ],
+  [
+    "notificationPreferences",
+    "Per-user settings, meaningless once the account is gone.",
+  ],
+]);
+
+/**
+ * The `User` back-relation field for each cascading relation, resolved from
+ * the `User` model's own field list. Prisma names the two sides
+ * independently, and the purge filter uses the `User` side.
+ */
+function parseUserModelFields(userModelBody) {
+  const fields = new Map();
+  for (const line of userModelBody.split("\n")) {
+    const match = line
+      .trim()
+      .match(/^(\w+)\s+(\w+)(\[\])?\??(\s+@relation\("([^"]+)"[^)]*\))?/);
+    if (!match) {
+      continue;
+    }
+    const [, fieldName, fieldType, , , relationName] = match;
+    fields.set(fieldName, { fieldType, relationName });
+  }
+  return fields;
+}
+
+function readModelBodies(source) {
+  const models = new Map();
+  const pattern = /^model\s+(\w+)\s*\{([\s\S]*?)^\}/gm;
+  for (const match of source.matchAll(pattern)) {
+    models.set(match[1], match[2]);
+  }
+  return models;
+}
+
+const allModels = new Map();
+
+for (const entry of fs.readdirSync(MODELS_DIR)) {
+  if (!entry.endsWith(".prisma")) {
+    continue;
+  }
+  const source = fs.readFileSync(path.join(MODELS_DIR, entry), "utf8");
+  for (const [modelName, body] of readModelBodies(source)) {
+    allModels.set(modelName, { body, file: entry });
+  }
+}
+
+const userModel = allModels.get("User");
+
+if (!userModel) {
+  console.error("Could not find the `User` model in the Prisma schema.");
+  process.exit(1);
+}
+
+const userFields = parseUserModelFields(userModel.body);
+
+// Collect every relation that cascades from `User`, then map each back to the
+// field on `User` that the purge filter would have to name.
+const cascadingRelations = [];
+
+for (const [modelName, { body, file }] of allModels) {
+  for (const line of body.split("\n")) {
+    const relationMatch = line.match(
+      /^\s*(\w+)\s+User(\[\])?\??\s+@relation\(([^)]*)\)/,
+    );
+    if (!relationMatch) {
+      continue;
+    }
+    const args = relationMatch[3];
+    if (!args.includes("onDelete: Cascade")) {
+      continue;
+    }
+
+    const relationNameMatch = args.match(/^\s*"([^"]+)"/);
+    const relationName = relationNameMatch ? relationNameMatch[1] : null;
+
+    // Find the field on `User` that points back at this model. Named
+    // relations disambiguate when a model relates to `User` more than once.
+    let userField = null;
+    for (const [fieldName, field] of userFields) {
+      if (field.fieldType !== modelName) {
+        continue;
+      }
+      if (relationName && field.relationName !== relationName) {
+        continue;
+      }
+      if (!relationName && field.relationName) {
+        continue;
+      }
+      userField = fieldName;
+      break;
+    }
+
+    cascadingRelations.push({
+      model: modelName,
+      file,
+      field: relationMatch[1],
+      userField,
+      relationName,
+    });
+  }
+}
+
+if (cascadingRelations.length === 0) {
+  console.error(
+    "Found no cascading `User` relations — the schema parser is probably broken.",
+  );
+  process.exit(1);
+}
+
+// Extract the purge function body and read the relations it filters on. Only
+// `<relation>: { none: {} }` counts: that is the shape that retains a guest
+// who owns one.
+const purgeSource = fs.readFileSync(PURGE_FILE, "utf8");
+const purgeStart = purgeSource.indexOf(
+  `export async function ${PURGE_FUNCTION}`,
+);
+
+if (purgeStart === -1) {
+  console.error(
+    `Could not find \`${PURGE_FUNCTION}\` in ${path.relative(ROOT, PURGE_FILE)}.`,
+  );
+  console.error(
+    "If it was renamed or moved, update PURGE_FILE/PURGE_FUNCTION in this script.",
+  );
+  process.exit(1);
+}
+
+// Bound the slice to this function so a `none: {}` in a later one can't be
+// mistaken for a guard.
+const nextExportOffset = purgeSource.slice(purgeStart + 1).indexOf("\nexport ");
+const purgeBody = purgeSource.slice(
+  purgeStart,
+  nextExportOffset === -1 ? undefined : purgeStart + 1 + nextExportOffset,
+);
+
+const guardedRelations = new Set(
+  [...purgeBody.matchAll(/(\w+)\s*:\s*\{\s*none\s*:\s*\{\s*\}\s*\}/g)].map(
+    (match) => match[1],
+  ),
+);
+
+if (guardedRelations.size === 0) {
+  console.error(
+    `Found no \`<relation>: { none: {} }\` guards in \`${PURGE_FUNCTION}\`.`,
+  );
+  console.error(
+    "Either the filter lost its guards or this script can no longer parse it.",
+  );
+  process.exit(1);
+}
+
+const unclassified = [];
+const unresolved = [];
+
+for (const relation of cascadingRelations) {
+  if (!relation.userField) {
+    unresolved.push(relation);
+    continue;
+  }
+  if (guardedRelations.has(relation.userField)) {
+    continue;
+  }
+  if (IGNORED_RELATIONS.has(relation.userField)) {
+    continue;
+  }
+  unclassified.push(relation);
+}
+
+// A guarded relation that no longer cascades is stale — either the schema
+// changed or the filter names something that isn't a cascade.
+const cascadingUserFields = new Set(
+  cascadingRelations.map((relation) => relation.userField).filter(Boolean),
+);
+
+const staleIgnores = [...IGNORED_RELATIONS.keys()].filter(
+  (field) => !cascadingUserFields.has(field),
+);
+
+let failed = false;
+
+if (unresolved.length > 0) {
+  failed = true;
+  console.error(
+    "Could not resolve the `User` field for these cascading relations:\n",
+  );
+  for (const relation of unresolved) {
+    console.error(`  ${relation.model}.${relation.field} (${relation.file})`);
+  }
+  console.error(
+    "\nThis is a parser limitation — check the relation is declared on the `User` model.",
+  );
+}
+
+if (unclassified.length > 0) {
+  failed = true;
+  console.error(
+    "These `onDelete: Cascade` relations on `User` are not accounted for by the",
+  );
+  console.error(`orphaned-guest purge (\`${PURGE_FUNCTION}\`):\n`);
+  for (const relation of unclassified) {
+    console.error(
+      `  User.${relation.userField} → ${relation.model}.${relation.field} (${relation.file})`,
+    );
+  }
+  console.error(
+    "\nThe purge deletes anonymous guests outright, so each of these cascades with them.",
+  );
+  console.error("Decide which it is, then record the decision:\n");
+  console.error("  - Deleting it with the guest would destroy data → add");
+  console.error(
+    `    \`${unclassified[0].userField}: { none: {} }\` to the purge filter in`,
+  );
+  console.error(`    ${path.relative(ROOT, PURGE_FILE)}.`);
+  console.error(
+    "  - It holds nothing worth keeping → add it to IGNORED_RELATIONS in this",
+  );
+  console.error("    script, with the reason.");
+}
+
+if (staleIgnores.length > 0) {
+  failed = true;
+  console.error(
+    "\nThese entries in IGNORED_RELATIONS no longer match a cascading `User` relation:\n",
+  );
+  for (const field of staleIgnores) {
+    console.error(`  ${field}`);
+  }
+  console.error("\nRemove them — the relation was renamed or dropped.");
+}
+
+if (failed) {
+  process.exit(1);
+}
+
+console.log(
+  `All ${cascadingRelations.length} cascading \`User\` relations are accounted for by ${PURGE_FUNCTION} (${guardedRelations.size} guarded, ${IGNORED_RELATIONS.size} ignored)`,
+);


### PR DESCRIPTION
Closes [RAL-1564](https://linear.app/rallly/issue/RAL-1564/guard-the-orphaned-guest-purge-against-new-user-cascade-relations)

## Problem

`deleteOrphanedAnonymousUsers` deletes anonymous guests outright, so every `onDelete: Cascade` relation on `User` is inside its blast radius. The filter guarded four of them, and nothing detected when the schema grew more.

With the recurring cron about to be registered (RAL-1475), that widening blast radius would run daily and unattended. The failure mode is a background job quietly cascading away real data, discovered long after the fact.

## Approach

Added `scripts/check-user-cascade-relations.mjs`, wired into the CI linting job. It parses the Prisma schema for relations that cascade from `User` and requires each to land in exactly one bucket:

- **guarded** — named in the purge filter, so a guest owning one is retained
- **ignored** — recorded in the script with the reason it holds nothing worth keeping

A relation in neither fails the build with an actionable message naming the relation and both options.

### Why not a plain "must appear in the filter" assertion

The issue proposed asserting every cascade appears in the purge filter. That would have been wrong. Three cascades — `sessions`, `accounts`, `notificationPreferences` — are auth plumbing that every anonymous guest has *by definition*. Guarding on those would make the purge match nothing at all, silently turning it into a no-op. The two-bucket split is what makes the check correct.

### Why a script rather than a vitest test

The project has a documented preference against filesystem-convention tests. That rule targets tests asserting things a linter could express, or that encode taste rather than behaviour. This is a different category: a safety invariant *between two artifacts* (the Prisma schema and a destructive delete filter) that no linter can express, where the failure mode is silent data loss.

It's a standalone script rather than a test because it reads `.prisma` files from another package — repo-shape work, matching the existing `check:structure` and `check:locales` precedent. It gets its own `check:cascades` script since it guards data safety rather than folder shape.

## Also in this PR

Guarded the ten relations the check surfaced: `scheduledEvents`, `hostedEventTypes`, `hostedSheets`, `spaces`, `memberOf`, `spaceMemberInvites`, `subscriptions`, `paymentMethods`, `calendarConnections`, `credentials`.

All ten were verified **0** against prod on 2026-08-20, so no data was at risk. Guests can't reach them today because the user-create hook in `lib/auth.ts` returns early for anonymous users, so no space is provisioned. But that invariant lives in application code, not a database constraint, so the filter no longer depends on it holding.

## Verification

- Adding a new `onDelete: Cascade` relation to `User` fails the check with exit code 1 (**verified** by temporarily adding one to the schema)
- Guarding that relation resolves the failure (**verified**)
- A stale `IGNORED_RELATIONS` entry that no longer matches a cascade fails (**verified**)
- The script exits non-zero if it finds zero cascades or zero guards, so a parser break can't silently pass
- `type-check` passes — the `satisfies Prisma.UserWhereInput` clause validates all ten added relation names are real fields
- `test:unit` passes (404 tests)

Two pre-existing failures on `main` are unrelated and untouched: a Biome config error (`tailwindDirectives` unknown key) and 5 Crowdin brace artifacts in locale files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cleanup of orphaned anonymous accounts by preserving users linked to scheduled events, hosted resources, spaces, memberships, subscriptions, payment methods, calendar connections, or credentials.

* **Chores**
  * Added automated validation to help ensure account cleanup rules remain aligned with data relationships.
  * Expanded safeguards and documentation around anonymous-account deletion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->