### PR TITLE
🐛 Fix stale, deleted and cancelled events on the public calendar routes (RAL-1561)

### DIFF
--- a/apps/web/biome.json
+++ b/apps/web/biome.json
@@ -181,7 +181,6 @@
     },
     {
       "includes": [
-        "src/app/api/event/**",
         "src/app/api/legacy/**",
         "src/app/api/status/**",
         "src/app/api/updates/**",

--- a/apps/web/src/app/api/event/[...route]/route.ts
+++ b/apps/web/src/app/api/event/[...route]/route.ts
@@ -1,4 +1,3 @@
-import { prisma } from "@rallly/database";
 import type { CalendarEvent } from "calendar-link";
 import { google, office365, outlook, yahoo } from "calendar-link";
 import { Hono } from "hono";
@@ -8,36 +7,21 @@ import { parseConferencing } from "@/features/conferencing/data";
 import { getConferencingUri } from "@/features/conferencing/utils";
 import { parseLocation } from "@/features/location/data";
 import { formatLocationText } from "@/features/location/utils";
+import { getScheduledEventCalendarData } from "@/features/scheduled-event/data";
+import { createRatelimit } from "@/lib/rate-limit";
 import { createIcsEvent } from "@/lib/utils/ics";
 
 const app = new Hono().basePath("/api/event");
 
-async function getScheduledEvent(eventId: string) {
-  return prisma.scheduledEvent.findUnique({
-    where: { id: eventId },
-    select: {
-      id: true,
-      uid: true,
-      title: true,
-      description: true,
-      location: true,
-      conferencing: true,
-      start: true,
-      end: true,
-      allDay: true,
-      timeZone: true,
-      user: {
-        select: {
-          name: true,
-          email: true,
-        },
-      },
-    },
-  });
-}
+// These routes are unauthenticated by design: an event's calendar links are
+// handed to invitees who have no account, exactly like the public /e/[id]
+// page. The event id is the only credential and the ICS carries the host's
+// address, so the budget bounds what a leaked or guessed id is worth in bulk.
+// A real attendee adds an event to their calendar once.
+const ratelimit = createRatelimit(60, "1 h");
 
 type ScheduledEventRow = NonNullable<
-  Awaited<ReturnType<typeof getScheduledEvent>>
+  Awaited<ReturnType<typeof getScheduledEventCalendarData>>
 >;
 
 // Flattens structured location/conferencing into the single-string fields the
@@ -85,8 +69,19 @@ function toCalendarEvent(event: ScheduledEventRow): CalendarEvent {
   };
 }
 
+app.use("/:eventId/*", async (c, next) => {
+  if (ratelimit) {
+    const ip = c.req.header("x-forwarded-for")?.split(",")[0]?.trim();
+    const { success } = await ratelimit.limit(`api:event:${ip || "unknown"}`);
+    if (!success) {
+      return c.json({ error: "Too many requests" }, 429);
+    }
+  }
+  return next();
+});
+
 app.get("/:eventId/google-calendar", async (c) => {
-  const event = await getScheduledEvent(c.req.param("eventId"));
+  const event = await getScheduledEventCalendarData(c.req.param("eventId"));
   if (!event) {
     return c.json({ error: "Event not found" }, 404);
   }
@@ -94,7 +89,7 @@ app.get("/:eventId/google-calendar", async (c) => {
 });
 
 app.get("/:eventId/outlook", async (c) => {
-  const event = await getScheduledEvent(c.req.param("eventId"));
+  const event = await getScheduledEventCalendarData(c.req.param("eventId"));
   if (!event) {
     return c.json({ error: "Event not found" }, 404);
   }
@@ -102,7 +97,7 @@ app.get("/:eventId/outlook", async (c) => {
 });
 
 app.get("/:eventId/office365", async (c) => {
-  const event = await getScheduledEvent(c.req.param("eventId"));
+  const event = await getScheduledEventCalendarData(c.req.param("eventId"));
   if (!event) {
     return c.json({ error: "Event not found" }, 404);
   }
@@ -110,7 +105,7 @@ app.get("/:eventId/office365", async (c) => {
 });
 
 app.get("/:eventId/yahoo", async (c) => {
-  const event = await getScheduledEvent(c.req.param("eventId"));
+  const event = await getScheduledEventCalendarData(c.req.param("eventId"));
   if (!event) {
     return c.json({ error: "Event not found" }, 404);
   }
@@ -118,7 +113,7 @@ app.get("/:eventId/yahoo", async (c) => {
 });
 
 app.get("/:eventId/ics", async (c) => {
-  const event = await getScheduledEvent(c.req.param("eventId"));
+  const event = await getScheduledEventCalendarData(c.req.param("eventId"));
   if (!event) {
     return c.json({ error: "Event not found" }, 404);
   }
@@ -127,6 +122,9 @@ app.get("/:eventId/ics", async (c) => {
 
   const { error, value } = createIcsEvent({
     uid: event.uid,
+    // Carries the event's revision so a re-download supersedes the copy
+    // already in the client's calendar instead of being dropped as not-newer.
+    sequence: event.sequence,
     title: event.title,
     description,
     location,
@@ -136,6 +134,7 @@ app.get("/:eventId/ics", async (c) => {
     timeZone: event.timeZone ?? undefined,
     organizer: { name: event.user.name, email: event.user.email },
     method: "publish",
+    status: event.status === "canceled" ? "CANCELLED" : "CONFIRMED",
   });
 
   if (error || !value) {

--- a/apps/web/src/features/scheduled-event/data.ts
+++ b/apps/web/src/features/scheduled-event/data.ts
@@ -32,6 +32,38 @@ export function getPublicScheduledEvent(id: string) {
   });
 }
 
+// Backs the unauthenticated /api/event/:id calendar routes. The host is
+// selected as the ICS organizer, matching the copy attached to the RSVP
+// confirmation email: same UID, same ORGANIZER, so the downloaded and emailed
+// events reconcile in the attendee's calendar instead of conflicting.
+// Soft-deleted events are excluded here rather than at the call site so the
+// route cannot forget the filter.
+export function getScheduledEventCalendarData(id: string) {
+  return prisma.scheduledEvent.findFirst({
+    where: { id, deletedAt: null },
+    select: {
+      id: true,
+      uid: true,
+      sequence: true,
+      title: true,
+      description: true,
+      location: true,
+      conferencing: true,
+      start: true,
+      end: true,
+      allDay: true,
+      timeZone: true,
+      status: true,
+      user: {
+        select: {
+          name: true,
+          email: true,
+        },
+      },
+    },
+  });
+}
+
 // Everything the RSVP confirmation email needs: ICS identity (uid/sequence),
 // event details, the host as organizer, and the space's branding fields.
 export function getScheduledEventRsvpEmailData(eventId: string) {


### PR DESCRIPTION
## Description

Closes RAL-1561.

RAL-1556 surfaced the `/api/event/:id` ICS and calendar links from inside the authenticated dashboard, which made them read as private when they are not. The issue asked for an explicit decision on the exposure model rather than inheriting it by default.

### Decision: the exposure model is correct and is unchanged

These routes stay unauthenticated, and `ORGANIZER` keeps carrying the host's real name and email. Recorded here so it is a decision rather than an assumption:

- **Event IDs are not enumerable.** `@default(cuid())` on Prisma 7.8 is cuid v1, generated in Prisma's Rust query engine using a ChaCha12 CSPRNG (`rand::rng()` → `ThreadRng`, which is `CryptoRng`) — not the `Math.random()` of the original JS implementation. Two base36 blocks give ~41 bits. At an aggressive 10k guesses/sec that is thousands of years for a single hit, and it is now rate limited. So there is no instance-wide harvesting path. Worth noting separately that a cuid v1 does leak its own creation timestamp and a host fingerprint, so these ids should not be treated as capability tokens in future work — nothing here depends on that.
- **Public-by-design calendar links are the norm.** Luma serves an unauthenticated ICS; Cal.com builds theirs client-side with no server route at all.
- **The recipient already has the address.** The ICS attached to the RSVP confirmation email (`features/scheduled-event/actions.ts`) already carries the host's real email as `ORGANIZER`, on the same `UID`.

That last point is also why substituting a no-reply address here would be actively harmful, not merely cautious: `ORGANIZER` asserts who owns the event, so the emailed and downloaded copies of one event would disagree on organizer identity for the same UID — the mismatch that makes calendar clients ignore updates or duplicate events. It would also break reply-to-organiser, and on self-hosted instances would route attendee replies to the operator's own address. If suppressing the host address is ever wanted for healthcare or public-sector instances, the right shape is an explicit per-space or per-instance setting, not a silent global substitution.

### What this PR actually fixes

Three defects found on the same routes while investigating, none of which touch the exposure model:

- **`sequence` was hardcoded to `0`** while the column *is* incremented on every edit (`trpc/routers/events.ts`), and the RSVP email path already passes it through. Because the UID is stable, an edited event that was re-downloaded got dropped by calendar clients as not-newer. It now carries the event's real revision.
- **Soft-deleted events served full details**, including the organiser's address. They now 404 like every other consumer. The filter lives in the query rather than the route, so the call site cannot forget it.
- **Cancelled events were served as `STATUS:CONFIRMED`**, so cancelling an event never propagated to anyone who used these links.

Plus **per-IP rate limiting** at 60/hour, reusing the existing `createRatelimit` precedent from `/api/updates`. The routes previously bypassed rate limiting entirely; this bounds what a leaked or guessed event id is worth in bulk.

The query also moves into `features/scheduled-event/data.ts`, which lets `src/app/api/event/**` come off the biome migration allowlist.

### Verification

Checked against a dev server with seeded data, before and after:

| Case | Before | After |
| --- | --- | --- |
| Event with `sequence = 4` | `SEQUENCE:0` | `SEQUENCE:4` |
| Cancelled event | `STATUS:CONFIRMED` | `STATUS:CANCELLED` |
| Soft-deleted event | `200` + full details | `404` |
| 63 requests from one IP | all `200` | `60 × 200`, then `429` |
| Different IP after limit | — | `200` (per-IP keying confirmed) |
| `ORGANIZER` | host's real address | unchanged — byte-identical to `main` |

`pnpm type-check` clean, `pnpm check` clean, 404 unit tests pass.

## Checklist

- [x] I have performed a self-review of my code
- [x] My code follows the code style of this project
- [x] I have commented my code, particularly in hard-to-understand areas

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Calendar event links and ICS downloads now use improved event data and include updated event status details.
  - Canceled events are correctly marked as canceled in ICS files.
- **Bug Fixes**
  - Added rate limiting to unauthenticated calendar and ICS requests.
  - Improved calendar event loading while preserving existing not-found and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->