### PR TITLE
🔍️ Add SEO landing pages to the sitemap

### DIFF
--- a/apps/landing/src/app/sitemap.ts
+++ b/apps/landing/src/app/sitemap.ts
@@ -6,6 +6,12 @@ import { getAllPosts } from "@/lib/api";
 
 const alternateLanguages = supportedLngs.filter((lng) => lng !== "en");
 
+const seoPages = [
+  "/best-doodle-alternative",
+  "/free-scheduling-poll",
+  "/when2meet-alternative",
+];
+
 const getAlternateLanguages = (path: string) => {
   return alternateLanguages.reduce<Record<string, string>>((acc, locale) => {
     acc[locale] = absoluteUrl(`/${locale}${path}`);
@@ -35,6 +41,15 @@ export default async function Sitemap(): Promise<MetadataRoute.Sitemap> {
         languages: getAlternateLanguages("/pricing"),
       },
     },
+    ...seoPages.map((path) => ({
+      url: absoluteUrl(path),
+      lastModified: new Date(),
+      changeFrequency: "weekly" as const,
+      priority: 0.8,
+      alternates: {
+        languages: getAlternateLanguages(path),
+      },
+    })),
     {
       url: absoluteUrl("/blog"),
       lastModified: new Date(),


### PR DESCRIPTION
## Problem

The three pages under `app/[locale]/(main)/(seo)/` were absent from the sitemap:

- `/best-doodle-alternative`
- `/free-scheduling-poll`
- `/when2meet-alternative`

Only `/`, `/pricing`, `/blog` and blog posts were listed, so the localized variants of these pages were never declared to search engines via hreflang.

## Change

Adds all three with the same shape as the existing entries (weekly, priority 0.8, full hreflang alternates). Used an array + map rather than three near-identical literal blocks, so adding a fourth SEO page is a one-line change.

## Verification

- `tsc --noEmit` on `apps/landing` — clean
- `biome check` — clean
- Fetched the rendered `/sitemap.xml` from a dev server: 22 URL entries, all three pages present with 16 language alternates each
- Sampled URLs return 200, including `/de/best-doodle-alternative` and `/fr/when2meet-alternative`

## Expected impact

Modest. All three pages are **already indexed and ranking** — Google discovers them via the footer "Compare" links. Verified in live SERPs: `/best-doodle-alternative` ranks #2 for `doodle poll alternatives` and #3 for `alternative zu doodle` (DE), `/free-scheduling-poll` ranks #1 for `free scheduling poll`, `/when2meet-alternative` ranks #4 for `when2meet alternative`.

So this is not unblocking discovery. The benefit is explicitly declaring the hreflang relationships, which mainly helps localized variants get served to the right locale. Worth fixing because it's wrong, not because it's a traffic lever.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added three SEO landing pages to the sitemap.
  * Included localized alternate links, weekly update frequency, and improved sitemap prioritization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->