### PR TITLE
💄 Rework the pricing billing interval control

### DIFF
--- a/apps/landing/src/app/[locale]/(main)/pricing/billing-interval.tsx
+++ b/apps/landing/src/app/[locale]/(main)/pricing/billing-interval.tsx
@@ -77,14 +77,17 @@ export function BillingIntervalSwitch({
         </div>
       ) : null}
       <div className="flex items-center gap-x-3">
-        <span
+        <button
+          type="button"
+          aria-pressed={!isYearly}
+          onClick={() => setInterval("monthly")}
           className={cn(
-            "font-medium text-sm",
+            "cursor-pointer rounded-sm font-medium text-sm transition-colors focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2",
             isYearly ? "text-gray-500" : "text-gray-800",
           )}
         >
           {monthlyLabel}
-        </span>
+        </button>
         <Switch
           aria-label={switchLabel}
           checked={isYearly}
@@ -92,14 +95,17 @@ export function BillingIntervalSwitch({
             setInterval(checked ? "yearly" : "monthly")
           }
         />
-        <span
+        <button
+          type="button"
+          aria-pressed={isYearly}
+          onClick={() => setInterval("yearly")}
           className={cn(
-            "font-medium text-sm",
+            "cursor-pointer rounded-sm font-medium text-sm transition-colors focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2",
             isYearly ? "text-gray-800" : "text-gray-500",
           )}
         >
           {yearlyLabel}
-        </span>
+        </button>
       </div>
     </div>
   );

--- a/apps/landing/src/app/[locale]/(main)/pricing/billing-interval.tsx
+++ b/apps/landing/src/app/[locale]/(main)/pricing/billing-interval.tsx
@@ -50,26 +50,26 @@ export function BillingIntervalSwitch({
   const { interval, setInterval } = useBillingInterval();
   const isYearly = interval === "yearly";
   return (
-    <div className="flex flex-col items-center gap-y-2">
+    <div className="flex flex-col items-center gap-y-4">
       {badge ? (
         <div className="relative">
           {badge}
           <svg
             aria-hidden="true"
-            viewBox="0 0 48 40"
-            className="pointer-events-none absolute top-0 -right-16 hidden h-12 w-16 text-green-500 sm:block"
+            viewBox="0 0 48 32"
+            className="pointer-events-none absolute top-0 -right-16 hidden h-9 w-16 text-gray-400 sm:block"
             fill="none"
           >
             <path
-              d="M2 8c18-7 33 2 32 20"
+              d="M2 7c17-6 31 1 30 15"
               stroke="currentColor"
-              strokeWidth="2.5"
+              strokeWidth="1.5"
               strokeLinecap="round"
             />
             <path
-              d="M27 22l7 7 5-6"
+              d="M26 18l6 5 4-5"
               stroke="currentColor"
-              strokeWidth="2.5"
+              strokeWidth="1.5"
               strokeLinecap="round"
               strokeLinejoin="round"
             />

--- a/apps/landing/src/app/[locale]/(main)/pricing/billing-interval.tsx
+++ b/apps/landing/src/app/[locale]/(main)/pricing/billing-interval.tsx
@@ -50,31 +50,57 @@ export function BillingIntervalSwitch({
   const { interval, setInterval } = useBillingInterval();
   const isYearly = interval === "yearly";
   return (
-    <div className="flex items-center gap-x-3">
-      <span
-        className={cn(
-          "font-medium text-sm",
-          isYearly ? "text-gray-500" : "text-gray-800",
-        )}
-      >
-        {monthlyLabel}
-      </span>
-      <Switch
-        aria-label={switchLabel}
-        checked={isYearly}
-        onCheckedChange={(checked) =>
-          setInterval(checked ? "yearly" : "monthly")
-        }
-      />
-      <span
-        className={cn(
-          "font-medium text-sm",
-          isYearly ? "text-gray-800" : "text-gray-500",
-        )}
-      >
-        {yearlyLabel}
-      </span>
-      {badge}
+    <div className="flex flex-col items-center gap-y-2">
+      {badge ? (
+        <div className="relative">
+          {badge}
+          <svg
+            aria-hidden="true"
+            viewBox="0 0 48 40"
+            className="pointer-events-none absolute top-0 -right-16 hidden h-12 w-16 text-green-500 sm:block"
+            fill="none"
+          >
+            <path
+              d="M2 8c18-7 33 2 32 20"
+              stroke="currentColor"
+              strokeWidth="2.5"
+              strokeLinecap="round"
+            />
+            <path
+              d="M27 22l7 7 5-6"
+              stroke="currentColor"
+              strokeWidth="2.5"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            />
+          </svg>
+        </div>
+      ) : null}
+      <div className="flex items-center gap-x-3">
+        <span
+          className={cn(
+            "font-medium text-sm",
+            isYearly ? "text-gray-500" : "text-gray-800",
+          )}
+        >
+          {monthlyLabel}
+        </span>
+        <Switch
+          aria-label={switchLabel}
+          checked={isYearly}
+          onCheckedChange={(checked) =>
+            setInterval(checked ? "yearly" : "monthly")
+          }
+        />
+        <span
+          className={cn(
+            "font-medium text-sm",
+            isYearly ? "text-gray-800" : "text-gray-500",
+          )}
+        >
+          {yearlyLabel}
+        </span>
+      </div>
     </div>
   );
 }

--- a/apps/landing/src/app/[locale]/(main)/pricing/page.tsx
+++ b/apps/landing/src/app/[locale]/(main)/pricing/page.tsx
@@ -140,7 +140,7 @@ export default async function Page(props: {
               }
             />
           </div>
-          <PlanCards className="mx-auto mt-4 w-full max-w-3xl sm:mt-6">
+          <PlanCards className="mx-auto mt-4 w-full max-w-6xl sm:mt-6">
             <PlanCard className="md:col-span-2">
               <PlanCardHeader>
                 <PlanCardName>{PLAN_NAMES.HOBBY}</PlanCardName>

--- a/apps/landing/src/app/[locale]/(main)/pricing/page.tsx
+++ b/apps/landing/src/app/[locale]/(main)/pricing/page.tsx
@@ -140,8 +140,8 @@ export default async function Page(props: {
               }
             />
           </div>
-          <PlanCards className="mx-auto mt-4 w-full max-w-6xl sm:mt-6">
-            <PlanCard className="md:col-span-2">
+          <PlanCards className="mx-auto mt-4 max-w-6xl sm:mt-6">
+            <PlanCard>
               <PlanCardHeader>
                 <PlanCardName>{PLAN_NAMES.HOBBY}</PlanCardName>
                 <PlanCardDescription>
@@ -219,7 +219,7 @@ export default async function Page(props: {
                 </PlanBenefit>
               </PlanBenefits>
             </PlanCard>
-            <PlanCard className="md:col-span-3">
+            <PlanCard>
               <PlanCardHeader>
                 <div className="flex items-center justify-between gap-x-4">
                   <PlanCardName>{PLAN_NAMES.PRO}</PlanCardName>

--- a/apps/landing/src/app/[locale]/(main)/pricing/plan-card.tsx
+++ b/apps/landing/src/app/[locale]/(main)/pricing/plan-card.tsx
@@ -9,7 +9,7 @@ export function PlanCards({
   return (
     <div
       className={cn(
-        "grid divide-y divide-gray-950/5 overflow-hidden rounded-2xl border bg-white md:grid-cols-5 md:divide-x md:divide-y-0",
+        "grid w-fit max-w-full divide-y divide-gray-950/5 overflow-hidden rounded-2xl border bg-white md:grid-cols-[minmax(16rem,2fr)_minmax(24rem,3fr)] md:divide-x md:divide-y-0",
         className,
       )}
       {...props}


### PR DESCRIPTION
## Summary

Reworks the billing interval control on the pricing page and lets the plan card size itself to its content.

- **Badge centered above the switch** with a curved arrow pointing at the yearly option, replacing the badge that trailed the yearly label.
- **Arrow is a thin gray hairline** (stroke 1.5, `text-gray-400`) so it reads as a quiet pointer rather than a second accent next to the green badge. Hidden below `sm` where the row has no room for it, and decorative (`aria-hidden`) since it carries no information the labels don't.
- **The interval labels are now clickable.** "Pay monthly" and "Pay yearly" select that interval directly.
- **The plan card sizes to its content** instead of always filling the page container.

## Notes

The obvious way to make the labels clickable is `<Label htmlFor>` pointing at the switch — `packages/ui/src/switch.tsx` is deliberately built as a native `<button>` to support exactly that. It isn't right here: `htmlFor` *toggles*, so clicking "Pay monthly" while already on monthly would flip you to yearly. The labels are buttons that set an explicit value, making a click on the already-active label a no-op. `aria-pressed` exposes the selection so the active state isn't carried by text color alone.

For the card width, `w-fit` alone won't hold the 2:3 Hobby/Pro proportion — `fr` units resolve against the container, so shrink-to-fit collapses the ratio. Explicit `minmax()` tracks keep the proportion, and `max-w-full` clamps to the page container.

## Verification

Measured on a local dev server via `getBoundingClientRect`, not eyeballed:

| Locale | Before | After | Wrapped labels |
| --- | --- | --- | --- |
| English | 768px (forced) | 725px | 0 of 10 |
| Spanish | 768px | 1071px | 3 → 0 |

- 2:3 column ratio holds exactly (1.50) at every width.
- Interval clicks verified for all four cases: monthly→monthly, monthly→yearly, yearly→yearly, yearly→monthly. Price follows (`$7.00 /seat/mo` vs `$4.67 /seat/mo, billed yearly`).
- German checked as the longest string set — no wrapping, including `"Powered by Rallly"-Hinweis entfernen`.
- No horizontal overflow at 375, 768, 900, 1280 or 1440px. Mobile layout unchanged (grid collapses to one column below `md`, so the `minmax` floors never apply).
- `tsc --noEmit` and Biome pass.

Below roughly 1100px some long translations still wrap — at that width there genuinely isn't room. If that needs solving, the lever is Pro's two-column benefit grid dropping to one column below `lg`, not more width.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved the pricing billing interval switch with clearer monthly and yearly controls, accessibility states, and a promotional badge with a responsive visual indicator.
  * Updated pricing plan cards with a wider, more flexible layout for improved presentation across screen sizes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->