### PR TITLE
💄 Let the hero demo poll description fill the card

### DIFF
--- a/apps/landing/src/components/home/hero-demo/desktop-demo.tsx
+++ b/apps/landing/src/components/home/hero-demo/desktop-demo.tsx
@@ -54,7 +54,7 @@ export const DesktopDemo = ({
                     defaultValue: "Q3 Board Meeting",
                   })}
                 </h3>
-                <p className="mt-1 max-w-[70ch] text-gray-600 text-sm">
+                <p className="mt-1 text-gray-600 text-sm">
                   {t("heroDemoDescription", {
                     ns: "home",
                     defaultValue:


### PR DESCRIPTION
Removes the `max-w-[70ch]` cap from the poll description in the landing page's desktop hero demo.

The card's width is set by the participants grid below it (`grid-cols-[172px_repeat(8,84px)]`, ~844px). The description was capped well short of that, leaving a ragged gap on the right that didn't match the other content in the card.

### Note on line length

The description now stretches to the full card width, so the demo copy renders as a single long line rather than wrapping. That's the intended effect here — it's fixed sample copy in a mockup, not user content — but it does mean the paragraph's line length is no longer bounded by anything. If a longer string (e.g. a translation that runs long) lands in `heroDemoDescription`, it will run the full width before wrapping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the hero demo description layout by removing its maximum width constraint, allowing the text to use more available space.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->