### PR TITLE
🐛 Restore 6 missing time zones and show modern city names

### DIFF
--- a/apps/web/src/components/time-zone-picker/time-zone-select.test.tsx
+++ b/apps/web/src/components/time-zone-picker/time-zone-select.test.tsx
@@ -3,6 +3,12 @@ import { describe, expect, it } from "vitest";
 import { render, screen, within } from "@/test/test-utils";
 
 import { TimeZoneSelect } from "./time-zone-select";
+import {
+  curatedTimezoneIds,
+  getAllTimezoneIds,
+  getCityFromTimezoneId,
+  getCuratedTimezoneIds,
+} from "./timezone-data";
 
 describe("TimeZoneSelect", () => {
   it("should render the combobox input", () => {
@@ -104,5 +110,44 @@ describe("TimeZoneSelect", () => {
 
     // The combobox should indicate the list is empty via data attribute
     expect(input).toHaveAttribute("data-list-empty", "");
+  });
+});
+
+describe("curated timezone list", () => {
+  const curatedIds = getCuratedTimezoneIds(getAllTimezoneIds());
+
+  it.each(
+    Array.from(curatedTimezoneIds),
+  )("keeps %s in the curated list", (curatedId) => {
+    // A curated ID that matches nothing must fail here rather than vanish
+    // from the default view. CLDR/ICU keeps pre-2008 tzdb IDs canonical, so
+    // the runtime lists `Asia/Calcutta` where we curate `Asia/Kolkata`; the
+    // intersection compares canonical forms so both spellings match.
+    const cities = curatedIds.map(getCityFromTimezoneId);
+    expect(cities).toContain(getCityFromTimezoneId(curatedId));
+  });
+
+  it("shows modern city names for zones the runtime spells with legacy IDs", () => {
+    const cities = curatedIds.map(getCityFromTimezoneId);
+
+    expect(cities).toContain("Kolkata");
+    expect(cities).toContain("Kathmandu");
+    expect(cities).toContain("Yangon");
+    expect(cities).toContain("Ho Chi Minh");
+    expect(cities).toContain("Buenos Aires");
+    expect(cities).toContain("Kyiv");
+
+    expect(cities).not.toContain("Calcutta");
+    expect(cities).not.toContain("Katmandu");
+    expect(cities).not.toContain("Rangoon");
+    expect(cities).not.toContain("Saigon");
+    expect(cities).not.toContain("Kiev");
+  });
+
+  it("does not duplicate a zone the runtime and curated set spell differently", () => {
+    const kolkata = curatedIds.filter(
+      (id) => getCityFromTimezoneId(id) === "Kolkata",
+    );
+    expect(kolkata).toHaveLength(1);
   });
 });

--- a/apps/web/src/components/time-zone-picker/time-zone-select.test.tsx
+++ b/apps/web/src/components/time-zone-picker/time-zone-select.test.tsx
@@ -1,5 +1,6 @@
 import userEvent from "@testing-library/user-event";
 import { describe, expect, it } from "vitest";
+import { toRuntimeCanonicalIanaId } from "@/lib/utils/timezone-schema";
 import { render, screen, within } from "@/test/test-utils";
 
 import { TimeZoneSelect } from "./time-zone-select";
@@ -8,6 +9,7 @@ import {
   getAllTimezoneIds,
   getCityFromTimezoneId,
   getCuratedTimezoneIds,
+  matchesTimezoneQuery,
 } from "./timezone-data";
 
 describe("TimeZoneSelect", () => {
@@ -116,6 +118,8 @@ describe("TimeZoneSelect", () => {
 describe("curated timezone list", () => {
   const curatedIds = getCuratedTimezoneIds(getAllTimezoneIds());
 
+  const curatedCanonicalIds = new Set(curatedIds.map(toRuntimeCanonicalIanaId));
+
   it.each(
     Array.from(curatedTimezoneIds),
   )("keeps %s in the curated list", (curatedId) => {
@@ -123,8 +127,9 @@ describe("curated timezone list", () => {
     // from the default view. CLDR/ICU keeps pre-2008 tzdb IDs canonical, so
     // the runtime lists `Asia/Calcutta` where we curate `Asia/Kolkata`; the
     // intersection compares canonical forms so both spellings match.
-    const cities = curatedIds.map(getCityFromTimezoneId);
-    expect(cities).toContain(getCityFromTimezoneId(curatedId));
+    // Compare canonical IDs, not city labels — a label is not an identity, so
+    // a label assertion would pass if a different zone shared the name.
+    expect(curatedCanonicalIds).toContain(toRuntimeCanonicalIanaId(curatedId));
   });
 
   it("shows modern city names for zones the runtime spells with legacy IDs", () => {
@@ -149,5 +154,78 @@ describe("curated timezone list", () => {
       (id) => getCityFromTimezoneId(id) === "Kolkata",
     );
     expect(kolkata).toHaveLength(1);
+  });
+
+  it("has one curated entry per zone", () => {
+    expect(curatedCanonicalIds.size).toBe(curatedIds.length);
+  });
+});
+
+describe("timezone search", () => {
+  // Both directions: whichever spelling the runtime lists, either query finds
+  // it. This runtime lists the legacy IDs, so the modern-ID cases guard against
+  // engines that do the opposite.
+  it.each([
+    ["Asia/Calcutta", "Asia/Kolkata", "calcutta", "kolkata"],
+    ["Asia/Katmandu", "Asia/Kathmandu", "katmandu", "kathmandu"],
+    ["Asia/Rangoon", "Asia/Yangon", "rangoon", "yangon"],
+    ["Asia/Saigon", "Asia/Ho_Chi_Minh", "saigon", "ho chi minh"],
+    ["Europe/Kiev", "Europe/Kyiv", "kiev", "kyiv"],
+    [
+      "America/Buenos_Aires",
+      "America/Argentina/Buenos_Aires",
+      "buenos aires",
+      "buenos aires",
+    ],
+  ])("matches %s and %s by either alias", (legacyId, modernId, legacyQuery, modernQuery) => {
+    for (const id of [legacyId, modernId]) {
+      expect(matchesTimezoneQuery(id, legacyQuery)).toBe(true);
+      expect(matchesTimezoneQuery(id, modernQuery)).toBe(true);
+    }
+  });
+});
+
+describe("stored value round trip", () => {
+  it.each([
+    "Asia/Kolkata",
+    "Asia/Kathmandu",
+    "Asia/Yangon",
+    "Asia/Ho_Chi_Minh",
+    "Europe/Kyiv",
+    "America/Argentina/Buenos_Aires",
+  ])("marks %s as selected when stored in its modern spelling", async (stored) => {
+    // `timezoneSchema` persists modern IDs while the runtime lists legacy
+    // ones, so a stored value must still resolve to the item the list
+    // renders — otherwise the saved zone reopens with nothing selected.
+    const user = userEvent.setup();
+    render(<TimeZoneSelect value={stored} />);
+
+    await user.click(screen.getByRole("combobox"));
+
+    const listbox = await screen.findByRole("listbox");
+    const selected = within(listbox)
+      .getAllByRole("option")
+      .filter((option) => option.getAttribute("aria-selected") === "true");
+
+    expect(selected).toHaveLength(1);
+    expect(selected[0].textContent).toContain(getCityFromTimezoneId(stored));
+  });
+
+  it("reports the modern spelling when a legacy-listed zone is picked", async () => {
+    const onValueChange = vi.fn();
+    const user = userEvent.setup();
+    render(<TimeZoneSelect onValueChange={onValueChange} />);
+
+    await user.type(screen.getByRole("combobox"), "kolkata");
+
+    const listbox = await screen.findByRole("listbox");
+    const option = within(listbox)
+      .getAllByRole("option")
+      .find((opt) => opt.textContent?.includes("Kolkata"));
+
+    if (!option) throw new Error("Kolkata option not found");
+    await user.click(option);
+
+    expect(onValueChange).toHaveBeenCalledWith("Asia/Kolkata");
   });
 });

--- a/apps/web/src/components/time-zone-picker/time-zone-select.tsx
+++ b/apps/web/src/components/time-zone-picker/time-zone-select.tsx
@@ -42,7 +42,7 @@ const idByCanonicalForm = new Map(
  * straight through leaves the combobox unable to match any item, so the saved
  * zone renders unselected. Selecting by canonical form fixes that.
  */
-function toItemId(value: string): string {
+function toItemId(value: string) {
   return idByCanonicalForm.get(toRuntimeCanonicalIanaId(value)) ?? value;
 }
 

--- a/apps/web/src/components/time-zone-picker/time-zone-select.tsx
+++ b/apps/web/src/components/time-zone-picker/time-zone-select.tsx
@@ -19,12 +19,32 @@ import {
 } from "@/components/time-zone-picker/timezone-data";
 import { useTranslation } from "@/i18n/client";
 import { Time } from "@/lib/datetime/time";
+import {
+  normalizeLegacyIanaId,
+  toRuntimeCanonicalIanaId,
+} from "@/lib/utils/timezone-schema";
 
 const allIds = getAllTimezoneIds().sort((a, b) =>
   getCityFromTimezoneId(a).localeCompare(getCityFromTimezoneId(b)),
 );
 
 const curatedIds = getCuratedTimezoneIds(allIds);
+
+const idByCanonicalForm = new Map(
+  allIds.map((id) => [toRuntimeCanonicalIanaId(id), id]),
+);
+
+/**
+ * Map a stored ID onto the exact item the list renders.
+ *
+ * Values are persisted in the modern spelling (`timezoneSchema` normalizes on
+ * write), while the runtime lists the legacy one. Passing the stored ID
+ * straight through leaves the combobox unable to match any item, so the saved
+ * zone renders unselected. Selecting by canonical form fixes that.
+ */
+function toItemId(value: string): string {
+  return idByCanonicalForm.get(toRuntimeCanonicalIanaId(value)) ?? value;
+}
 
 export function TimeZoneSelect({
   id,
@@ -53,10 +73,12 @@ export function TimeZoneSelect({
   return (
     <Combobox
       items={isSearching ? allIds : curatedIds}
-      value={value ?? null}
+      value={value ? toItemId(value) : null}
       onValueChange={(id) => {
         if (id) {
-          onValueChange?.(id);
+          // Report the modern spelling regardless of how the runtime spells it,
+          // so callers persist a stable, tzdb-canonical ID.
+          onValueChange?.(normalizeLegacyIanaId(id));
         }
       }}
       onInputValueChange={(inputValue, { reason }) => {

--- a/apps/web/src/components/time-zone-picker/time-zone-select.tsx
+++ b/apps/web/src/components/time-zone-picker/time-zone-select.tsx
@@ -12,9 +12,10 @@ import { InputGroupAddon } from "@rallly/ui/input-group";
 import { GlobeIcon } from "lucide-react";
 import React from "react";
 import {
-  curatedTimezoneIds,
   getAllTimezoneIds,
   getCityFromTimezoneId,
+  getCuratedTimezoneIds,
+  matchesTimezoneQuery,
 } from "@/components/time-zone-picker/timezone-data";
 import { useTranslation } from "@/i18n/client";
 import { Time } from "@/lib/datetime/time";
@@ -23,12 +24,7 @@ const allIds = getAllTimezoneIds().sort((a, b) =>
   getCityFromTimezoneId(a).localeCompare(getCityFromTimezoneId(b)),
 );
 
-const curatedIds = allIds.filter((id) => curatedTimezoneIds.has(id));
-
-function filterTimezone(id: string, query: string): boolean {
-  if (!query) return true;
-  return getCityFromTimezoneId(id).toLowerCase().includes(query.toLowerCase());
-}
+const curatedIds = getCuratedTimezoneIds(allIds);
 
 export function TimeZoneSelect({
   id,
@@ -71,7 +67,7 @@ export function TimeZoneSelect({
         }
       }}
       itemToStringLabel={getCityFromTimezoneId}
-      filter={filterTimezone}
+      filter={matchesTimezoneQuery}
       autoHighlight={true}
     >
       <div ref={anchorRef} className={cn("min-w-64", className)}>

--- a/apps/web/src/components/time-zone-picker/timezone-data.ts
+++ b/apps/web/src/components/time-zone-picker/timezone-data.ts
@@ -23,7 +23,7 @@ export function getCityFromTimezoneId(id: string): string {
  * on both sides instead. `time-zone-select.test.tsx` asserts no curated entry
  * goes missing.
  */
-export function getCuratedTimezoneIds(allIds: string[]): string[] {
+export function getCuratedTimezoneIds(allIds: string[]) {
   const curatedCanonical = new Set(
     Array.from(curatedTimezoneIds, toRuntimeCanonicalIanaId),
   );
@@ -37,7 +37,7 @@ export function getCuratedTimezoneIds(allIds: string[]): string[] {
  * "Calcutta" still finds the zone shown as "Kolkata" — and vice versa on an
  * engine that lists the modern ID.
  */
-export function matchesTimezoneQuery(id: string, query: string): boolean {
+export function matchesTimezoneQuery(id: string, query: string) {
   const normalizedQuery = query.trim().toLowerCase();
   if (!normalizedQuery) return true;
 

--- a/apps/web/src/components/time-zone-picker/timezone-data.ts
+++ b/apps/web/src/components/time-zone-picker/timezone-data.ts
@@ -1,4 +1,7 @@
-import { normalizeLegacyIanaId } from "@/lib/utils/timezone-schema";
+import {
+  normalizeLegacyIanaId,
+  toRuntimeCanonicalIanaId,
+} from "@/lib/utils/timezone-schema";
 
 export function getAllTimezoneIds(): string[] {
   return Intl.supportedValuesOf("timeZone");
@@ -8,6 +11,43 @@ export function getCityFromTimezoneId(id: string): string {
   const resolved = normalizeLegacyIanaId(id);
   const lastSlash = resolved.lastIndexOf("/");
   return resolved.substring(lastSlash + 1).replaceAll("_", " ");
+}
+
+/**
+ * The curated IDs as this runtime spells them.
+ *
+ * CLDR/ICU keeps pre-2008 tzdb IDs canonical, so `Intl.supportedValuesOf`
+ * yields `Asia/Calcutta` where the curated set lists `Asia/Kolkata`. A raw
+ * string intersection silently drops those entries, so compare canonical forms
+ * on both sides instead. `time-zone-select.test.tsx` asserts no curated entry
+ * goes missing.
+ */
+export function getCuratedTimezoneIds(allIds: string[]): string[] {
+  const curatedCanonical = new Set(
+    Array.from(curatedTimezoneIds, toRuntimeCanonicalIanaId),
+  );
+  return allIds.filter((id) =>
+    curatedCanonical.has(toRuntimeCanonicalIanaId(id)),
+  );
+}
+
+/**
+ * Match a query against the displayed (modern) city name and the legacy alias,
+ * so someone typing "Calcutta" still finds the zone shown as "Kolkata".
+ */
+export function matchesTimezoneQuery(id: string, query: string): boolean {
+  const normalizedQuery = query.trim().toLowerCase();
+  if (!normalizedQuery) return true;
+
+  const candidates = new Set([id, normalizeLegacyIanaId(id)]);
+  for (const candidate of candidates) {
+    const lastSlash = candidate.lastIndexOf("/");
+    const city = candidate.substring(lastSlash + 1).replaceAll("_", " ");
+    if (city.toLowerCase().includes(normalizedQuery)) {
+      return true;
+    }
+  }
+  return false;
 }
 
 // Curated set of major cities/timezones covering most common UTC offsets.

--- a/apps/web/src/components/time-zone-picker/timezone-data.ts
+++ b/apps/web/src/components/time-zone-picker/timezone-data.ts
@@ -1,4 +1,5 @@
 import {
+  getIanaIdAliases,
   normalizeLegacyIanaId,
   toRuntimeCanonicalIanaId,
 } from "@/lib/utils/timezone-schema";
@@ -32,15 +33,15 @@ export function getCuratedTimezoneIds(allIds: string[]): string[] {
 }
 
 /**
- * Match a query against the displayed (modern) city name and the legacy alias,
- * so someone typing "Calcutta" still finds the zone shown as "Kolkata".
+ * Match a query against every spelling of the zone, so someone typing
+ * "Calcutta" still finds the zone shown as "Kolkata" — and vice versa on an
+ * engine that lists the modern ID.
  */
 export function matchesTimezoneQuery(id: string, query: string): boolean {
   const normalizedQuery = query.trim().toLowerCase();
   if (!normalizedQuery) return true;
 
-  const candidates = new Set([id, normalizeLegacyIanaId(id)]);
-  for (const candidate of candidates) {
+  for (const candidate of getIanaIdAliases(id)) {
     const lastSlash = candidate.lastIndexOf("/");
     const city = candidate.substring(lastSlash + 1).replaceAll("_", " ");
     if (city.toLowerCase().includes(normalizedQuery)) {

--- a/apps/web/src/lib/utils/timezone-schema.ts
+++ b/apps/web/src/lib/utils/timezone-schema.ts
@@ -16,6 +16,25 @@ export function normalizeLegacyIanaId(id: string): string {
   return ianaOverrides[id] ?? id;
 }
 
+const legacyIdsByModernId = Object.entries(ianaOverrides).reduce<
+  Record<string, string[]>
+>((acc, [legacy, modern]) => {
+  acc[modern] = [...(acc[modern] ?? []), legacy];
+  return acc;
+}, {});
+
+/**
+ * Every spelling of a zone we know about — modern and legacy — for the given
+ * ID, whichever spelling it arrives in. Used for search, so a query matches an
+ * alias no matter which form the runtime happens to list.
+ */
+export function getIanaIdAliases(id: string): string[] {
+  const modern = normalizeLegacyIanaId(id);
+  return Array.from(
+    new Set([id, modern, ...(legacyIdsByModernId[modern] ?? [])]),
+  );
+}
+
 /**
  * Fold an IANA ID to whatever spelling this runtime treats as canonical.
  *

--- a/apps/web/src/lib/utils/timezone-schema.ts
+++ b/apps/web/src/lib/utils/timezone-schema.ts
@@ -28,7 +28,7 @@ const legacyIdsByModernId = Object.entries(ianaOverrides).reduce<
  * ID, whichever spelling it arrives in. Used for search, so a query matches an
  * alias no matter which form the runtime happens to list.
  */
-export function getIanaIdAliases(id: string): string[] {
+export function getIanaIdAliases(id: string) {
   const modern = normalizeLegacyIanaId(id);
   return Array.from(
     new Set([id, modern, ...(legacyIdsByModernId[modern] ?? [])]),

--- a/apps/web/src/lib/utils/timezone-schema.ts
+++ b/apps/web/src/lib/utils/timezone-schema.ts
@@ -1,12 +1,37 @@
 import * as z from "zod";
 
-// Override runtime canonicalization when ICU data lags behind IANA updates.
+// CLDR/ICU keeps pre-2008 tzdb IDs canonical for stability, so the runtime
+// reports (and `Intl.supportedValuesOf` lists) the outdated spellings. Map them
+// back to the modern tzdb-canonical names for display.
 const ianaOverrides: Record<string, string> = {
+  "America/Buenos_Aires": "America/Argentina/Buenos_Aires",
+  "Asia/Calcutta": "Asia/Kolkata",
+  "Asia/Katmandu": "Asia/Kathmandu",
+  "Asia/Rangoon": "Asia/Yangon",
+  "Asia/Saigon": "Asia/Ho_Chi_Minh",
   "Europe/Kiev": "Europe/Kyiv",
 };
 
 export function normalizeLegacyIanaId(id: string): string {
   return ianaOverrides[id] ?? id;
+}
+
+/**
+ * Fold an IANA ID to whatever spelling this runtime treats as canonical.
+ *
+ * The inverse of `normalizeLegacyIanaId`: that maps legacy IDs to modern names
+ * for display, this maps either spelling to the runtime's own. Comparing IDs by
+ * this form matches a curated `Asia/Kolkata` against a runtime `Asia/Calcutta`
+ * without depending on the override map covering that pair, so engines whose
+ * affected set differs are handled too. Unknown IDs are returned unchanged.
+ */
+export function toRuntimeCanonicalIanaId(id: string): string {
+  try {
+    return Intl.DateTimeFormat(undefined, { timeZone: id }).resolvedOptions()
+      .timeZone;
+  } catch {
+    return id;
+  }
 }
 
 const fixedOffsetPrefixes = ["etc/", "gmt", "utc"];


### PR DESCRIPTION
## Description

Fixes [RAL-1568](https://linear.app/rallly/issue/RAL-1568/time-zone-picker-drops-6-curated-zones-and-shows-outdated-city-names). Reported by a user who could not find IST for India — the zone genuinely was not in the picker's default list, and the picker labelled India as "Calcutta".

### Cause

`Intl.supportedValuesOf("timeZone")` returns the IDs **CLDR/ICU** considers canonical, which are the pre-2008 tzdb names — `Asia/Calcutta`, not `Asia/Kolkata`. This is deliberate CLDR policy for ID stability, not ICU lagging behind, so it will not resolve itself on a newer engine or ICU version.

The curated set lists modern names, and the default view was computed as a raw-string intersection:

```ts
const curatedIds = allIds.filter((id) => curatedTimezoneIds.has(id));
```

Curated entries whose modern spelling differs from what the runtime returns never matched, so they were silently dropped — no error, just a missing option. Six zones affected:

| Curated (modern) | Runtime returns | Was displayed as |
| -- | -- | -- |
| `Asia/Kolkata` | `Asia/Calcutta` | Calcutta |
| `Asia/Kathmandu` | `Asia/Katmandu` | Katmandu |
| `Asia/Yangon` | `Asia/Rangoon` | Rangoon |
| `Asia/Ho_Chi_Minh` | `Asia/Saigon` | Saigon |
| `America/Argentina/Buenos_Aires` | `America/Buenos_Aires` | Buenos Aires |
| `Europe/Kyiv` | `Europe/Kiev` | Kyiv |

UTC+5:30 had **no entry at all** in the default view.

### What changed

1. **Extended `ianaOverrides`** in `timezone-schema.ts` with the five missing pairs. That map is the existing, intended mechanism for this problem — it had only ever been populated for Kyiv.
2. **Made the intersection normalization-aware.** New `toRuntimeCanonicalIanaId` folds either spelling to the runtime's own, so curated entries match whichever spelling the runtime uses. Done generally rather than off the hardcoded pairs, since the affected set can differ across engines and ICU versions.
3. **Search matches both names** — typing "Calcutta" still finds the zone now shown as "Kolkata".
4. **Added a regression test** asserting every curated ID survives the intersection. A curated ID matching nothing is now a test failure rather than a silent omission. This is the durable part — it would have caught all six at authoring time.

### Notes for the reviewer

**The two normalization functions are inverses, which is easy to misread.** `normalizeLegacyIanaId` maps legacy → modern for *display*; `toRuntimeCanonicalIanaId` maps either spelling → the runtime's own for *comparison*. `Intl.DateTimeFormat` canonicalizes modern → legacy, i.e. the opposite direction from the override map. The doc comments spell this out.

**The canonicalization helper lives in `timezone-schema.ts`, not the picker.** A Biome plugin (`no-raw-datetime-formatting.grit`) bans inline `Intl.DateTimeFormat`. Rather than widening that allowlist, the helper went into `timezone-schema.ts`, which is already exempt *specifically for zone detection*, already makes the identical call in `resolveTimezone`, and owns the override map.

**Purely a labeling change, no correctness risk.** Both spellings resolve to identical UTC offsets. Modern names are right on all three counts: tzdb-canonical per `zone.tab` in tzdata 2026b, the cities' current legal names, and what users actually type.

### Verification

- Confirmed the new test genuinely catches the bug by temporarily reverting the intersection to the old raw-string form: exactly 8 failures on exactly the six affected zones, then restored.
- `pnpm test:unit` — 576 passed. `pnpm type-check` and `pnpm check` clean.
- Runtime: all six zones present with modern labels, curated view 71 → 77 zones, UTC+5:30 restored, and each spelling pair ("Kolkata"/"Calcutta", "Yangon"/"Rangoon", "Ho Chi Minh"/"Saigon", "Kyiv"/"Kiev", "Kathmandu"/"Katmandu") resolves to a single hit.
- Since `timezoneSchema` now persists modern IDs, also verified stored values round-trip to exactly one picker row with unchanged offsets.

### Out of scope

Searching by "India", "IST" or "Bangalore" still finds nothing — the filter only matches the IANA city segment. That is a separate discoverability problem, tracked as a follow-up on the issue.

## Checklist

- [x] I have performed a self-review of my code
- [x] My code follows the code style of this project
- [x] I have commented my code, particularly in hard-to-understand areas

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved time-zone selection across environments using legacy or alternate IANA identifiers.
  * Prevented duplicate city entries, including Kolkata, when equivalent identifiers are available.
  * Updated search to recognize modern and legacy time-zone names.
  * Search now ignores leading/trailing spaces and is case-insensitive.
  * Ensured saved selections remain selected and use modern identifiers.
* **Tests**
  * Added coverage for curated time zones, identifier normalization, search aliases, and duplicate prevention.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->