### PR TITLE
✨ Add an animated poll demo to the landing footer

### DIFF
--- a/apps/landing/src/app/[locale]/(main)/footer.tsx
+++ b/apps/landing/src/app/[locale]/(main)/footer.tsx
@@ -5,6 +5,7 @@ import DiscordIcon from "@/assets/discord.svg";
 import GithubIcon from "@/assets/github.svg";
 import LinkedinIcon from "@/assets/linkedin.svg";
 import XIcon from "@/assets/x.svg";
+import { FooterDemo } from "@/components/home/footer-demo";
 import { LinkBase } from "@/i18n/client/link";
 import { getTranslation } from "@/i18n/server";
 import { LanguageSelect } from "./language-select";
@@ -13,67 +14,70 @@ export const Footer = async ({ locale }: { locale: string }) => {
   const { t } = await getTranslation(locale, "common");
   return (
     <div className="mx-auto space-y-12">
-      <div className="space-y-6">
-        <div className="relative size-8">
-          <Image
-            src="/logo-footer.svg"
-            fill
-            alt="Rallly"
-            className="object-contain"
-          />
+      <div className="flex flex-col gap-8 lg:flex-row lg:items-center">
+        <div className="space-y-6">
+          <div className="relative size-8">
+            <Image
+              src="/logo-footer.svg"
+              fill
+              alt="Rallly"
+              className="object-contain"
+            />
+          </div>
+          <p className="max-w-sm text-pretty text-gray-600 text-sm leading-relaxed">
+            <Trans
+              t={t}
+              ns="common"
+              i18nKey="footerTagline"
+              defaults="Rallly is an open-source meeting scheduling tool that helps you find the best time to meet, without the back and forth."
+            />
+          </p>
+          <div className="flex items-center space-x-4">
+            <a
+              target="_blank"
+              href="https://x.com/ralllyco"
+              className="text-gray-600 text-sm hover:text-primary hover:no-underline"
+              rel="noreferrer noopener"
+              aria-label={t("footerXLabel", { defaultValue: "Follow us on X" })}
+            >
+              <XIcon className="size-4" />
+            </a>
+            <a
+              target="_blank"
+              href="https://discord.gg/uzg4ZcHbuM"
+              className="text-gray-600 text-sm hover:text-primary hover:no-underline"
+              rel="noreferrer noopener"
+              aria-label={t("footerDiscordLabel", {
+                defaultValue: "Join us on Discord",
+              })}
+            >
+              <DiscordIcon className="size-4" />
+            </a>
+            <a
+              target="_blank"
+              href="https://www.linkedin.com/company/rallly"
+              className="text-gray-600 text-sm hover:text-primary hover:no-underline"
+              rel="noreferrer noopener"
+              aria-label={t("footerLinkedinLabel", {
+                defaultValue: "Follow us on LinkedIn",
+              })}
+            >
+              <LinkedinIcon className="size-4" />
+            </a>
+            <a
+              target="_blank"
+              href="https://github.com/lukevella/rallly"
+              className="text-gray-600 text-sm hover:text-primary hover:no-underline"
+              rel="noreferrer noopener"
+              aria-label={t("footerGithubLabel", {
+                defaultValue: "View our GitHub repository",
+              })}
+            >
+              <GithubIcon className="size-4" />
+            </a>
+          </div>
         </div>
-        <p className="max-w-sm text-pretty text-gray-600 text-sm leading-relaxed">
-          <Trans
-            t={t}
-            ns="common"
-            i18nKey="footerTagline"
-            defaults="Rallly is an open-source meeting scheduling tool that helps you find the best time to meet, without the back and forth."
-          />
-        </p>
-        <div className="flex items-center space-x-4">
-          <a
-            target="_blank"
-            href="https://x.com/ralllyco"
-            className="text-gray-600 text-sm hover:text-primary hover:no-underline"
-            rel="noreferrer noopener"
-            aria-label={t("footerXLabel", { defaultValue: "Follow us on X" })}
-          >
-            <XIcon className="size-4" />
-          </a>
-          <a
-            target="_blank"
-            href="https://discord.gg/uzg4ZcHbuM"
-            className="text-gray-600 text-sm hover:text-primary hover:no-underline"
-            rel="noreferrer noopener"
-            aria-label={t("footerDiscordLabel", {
-              defaultValue: "Join us on Discord",
-            })}
-          >
-            <DiscordIcon className="size-4" />
-          </a>
-          <a
-            target="_blank"
-            href="https://www.linkedin.com/company/rallly"
-            className="text-gray-600 text-sm hover:text-primary hover:no-underline"
-            rel="noreferrer noopener"
-            aria-label={t("footerLinkedinLabel", {
-              defaultValue: "Follow us on LinkedIn",
-            })}
-          >
-            <LinkedinIcon className="size-4" />
-          </a>
-          <a
-            target="_blank"
-            href="https://github.com/lukevella/rallly"
-            className="text-gray-600 text-sm hover:text-primary hover:no-underline"
-            rel="noreferrer noopener"
-            aria-label={t("footerGithubLabel", {
-              defaultValue: "View our GitHub repository",
-            })}
-          >
-            <GithubIcon className="size-4" />
-          </a>
-        </div>
+        <FooterDemo className="w-full lg:min-w-0 lg:flex-1" />
       </div>
       <div className="grid grid-cols-1 gap-x-8 gap-y-12 sm:grid-cols-3">
         <div>

--- a/apps/landing/src/components/home/footer-demo.tsx
+++ b/apps/landing/src/components/home/footer-demo.tsx
@@ -22,11 +22,12 @@ const VOTES: ("yes" | "ifNeedBe" | "no")[][] = [
   ["ifNeedBe", "no", "yes", "yes", "no"],
 ];
 
-type Stage = "times" | "voting" | "decided";
-
 const STEP_MS = 900;
 const DECIDE_MS = 1600;
 const HOLD_MS = 2600;
+// Long enough for the card to finish clearing before the next pass builds it
+// back up, so the loop never shows an exit and an entrance at once.
+const EXIT_MS = 700;
 
 /**
  * True once the bottom of the page has been reached, and false again when it
@@ -72,12 +73,13 @@ function useScrolledToBottom(
 }
 
 // step 0: empty card. step 1: the proposed times appear. steps 2..n+1: one
-// voter row each. step n+2: decided, held. Then back to 0 for the next pass.
+// voter row each. step n+2: decided, held. step n+3: everything clears
+// together. Then back to 0 for the next pass.
 const STEP_EMPTY = 0;
 const STEP_TIMES = 1;
-const STEP_FIRST_VOTE = 2;
 const STEP_DECIDED = VOTES.length + 2;
-const TOTAL_STEPS = VOTES.length + 3;
+const STEP_EXIT = VOTES.length + 3;
+const TOTAL_STEPS = VOTES.length + 4;
 
 /**
  * Walks the cycle above, resetting to the empty card whenever it is disabled
@@ -95,11 +97,13 @@ function useCycle(enabled: boolean) {
     }
 
     const delay =
-      step === STEP_DECIDED
-        ? HOLD_MS
-        : step === STEP_DECIDED - 1
-          ? DECIDE_MS
-          : STEP_MS;
+      step === STEP_EXIT
+        ? EXIT_MS
+        : step === STEP_DECIDED
+          ? HOLD_MS
+          : step === STEP_DECIDED - 1
+            ? DECIDE_MS
+            : STEP_MS;
 
     const timeout = setTimeout(() => {
       setStep((current) => (current + 1) % TOTAL_STEPS);
@@ -108,17 +112,16 @@ function useCycle(enabled: boolean) {
     return () => clearTimeout(timeout);
   }, [step, enabled]);
 
-  const stage: Stage =
-    step === STEP_DECIDED
-      ? "decided"
-      : step >= STEP_FIRST_VOTE
-        ? "voting"
-        : "times";
+  // On the exit step everything hides at once, still wearing its decided
+  // colours. Nothing un-solves on screen: the solved card simply clears.
+  const exiting = step === STEP_EXIT;
 
   return {
-    visibleRows: Math.max(0, Math.min(step - 1, VOTES.length)),
-    showTimes: step >= STEP_TIMES,
-    stage,
+    visibleRows: exiting ? 0 : Math.max(0, Math.min(step - 1, VOTES.length)),
+    showTimes: !exiting && step >= STEP_TIMES,
+    // Hold the decided styling through the exit so the winner fades out as
+    // part of the card rather than reverting to grey first.
+    decided: step === STEP_DECIDED || exiting,
   };
 }
 
@@ -138,7 +141,7 @@ export function FooterDemo({ className }: { className?: string }) {
   // The cycle runs only while the page is at the bottom, so arriving there
   // always starts from the top of the story rather than mid vote.
   const animated = inView === true && !shouldReduceMotion;
-  const { visibleRows, showTimes, stage } = useCycle(animated);
+  const { visibleRows, showTimes, decided: cycleDecided } = useCycle(animated);
 
   // Show the solved poll only when no animation will play: reduced motion, or
   // no IntersectionObserver at all. Otherwise the cycle owns the card from the
@@ -148,7 +151,7 @@ export function FooterDemo({ className }: { className?: string }) {
 
   const rows = solved ? VOTES.length : visibleRows;
   const times = solved ? true : showTimes;
-  const decided = solved ? true : stage === "decided";
+  const decided = solved ? true : cycleDecided;
 
   return (
     <div

--- a/apps/landing/src/components/home/footer-demo.tsx
+++ b/apps/landing/src/components/home/footer-demo.tsx
@@ -1,0 +1,272 @@
+"use client";
+
+import { cn } from "@rallly/ui";
+import { VoteIcon } from "@rallly/ui/vote-icon";
+import { useReducedMotion } from "motion/react";
+import React from "react";
+
+// A textless loop of the core Rallly cycle: a host proposes times (a row of
+// blocks), invitees vote one by one, and the one column everyone said yes to
+// wins. Decorative only, so the whole thing is aria-hidden and the copy
+// alongside it carries the meaning.
+
+const COLUMN_COUNT = 5;
+const WINNING_COLUMN = 3;
+const columns = Array.from({ length: COLUMN_COUNT }, (_, index) => index);
+
+// Each row is one voter. Column 3 is "yes" for everyone, so it is the only
+// one that can win.
+const VOTES: ("yes" | "ifNeedBe" | "no")[][] = [
+  ["yes", "no", "ifNeedBe", "yes", "no"],
+  ["no", "yes", "no", "yes", "ifNeedBe"],
+  ["ifNeedBe", "no", "yes", "yes", "no"],
+];
+
+type Stage = "times" | "voting" | "decided";
+
+const STEP_MS = 900;
+const DECIDE_MS = 1600;
+const HOLD_MS = 2600;
+
+/**
+ * True once the bottom of the page has been reached, and false again when it
+ * is left. Watches the end of the enclosing footer rather than the card
+ * itself: the card clears the viewport a few hundred pixels before the page
+ * does, so keying off the card would finish the reveal mid scroll.
+ *
+ * Plain IntersectionObserver rather than Motion's `useInView` so the reveal
+ * does not depend on an animation frame being scheduled.
+ */
+function useScrolledToBottom(
+  ref: React.RefObject<Element | null>,
+  enabled: boolean,
+) {
+  // Starts null — "not yet known" — so the card can stay visible until an
+  // observer actually reports otherwise. Only ever hides on a real `false`.
+  const [atBottom, setAtBottom] = React.useState<boolean | null>(null);
+
+  React.useEffect(() => {
+    const element = ref.current;
+    if (!enabled || !element) return;
+
+    const footer = element.closest("footer") ?? element;
+    // A probe at the very end of the footer, entering the viewport only once
+    // the page is scrolled to the bottom.
+    const sentinel = document.createElement("div");
+    sentinel.setAttribute("aria-hidden", "true");
+    sentinel.style.cssText = "height:1px;width:100%;pointer-events:none";
+    footer.append(sentinel);
+
+    const observer = new IntersectionObserver(([entry]) =>
+      setAtBottom(entry.isIntersecting),
+    );
+    observer.observe(sentinel);
+
+    return () => {
+      observer.disconnect();
+      sentinel.remove();
+    };
+  }, [ref, enabled]);
+
+  return atBottom;
+}
+
+// step 0: empty card. step 1: the proposed times appear. steps 2..n+1: one
+// voter row each. step n+2: decided, held. Then back to 0 for the next pass.
+const STEP_EMPTY = 0;
+const STEP_TIMES = 1;
+const STEP_FIRST_VOTE = 2;
+const STEP_DECIDED = VOTES.length + 2;
+const TOTAL_STEPS = VOTES.length + 3;
+
+/**
+ * Walks the cycle above, resetting to the empty card whenever it is disabled
+ * so every visit replays the story from the beginning.
+ */
+function useCycle(enabled: boolean) {
+  const [step, setStep] = React.useState(STEP_EMPTY);
+
+  React.useEffect(() => {
+    // Reset so leaving and returning always replays from the empty card
+    // rather than resuming wherever the last pass stopped.
+    if (!enabled) {
+      setStep(STEP_EMPTY);
+      return;
+    }
+
+    const delay =
+      step === STEP_DECIDED
+        ? HOLD_MS
+        : step === STEP_DECIDED - 1
+          ? DECIDE_MS
+          : STEP_MS;
+
+    const timeout = setTimeout(() => {
+      setStep((current) => (current + 1) % TOTAL_STEPS);
+    }, delay);
+
+    return () => clearTimeout(timeout);
+  }, [step, enabled]);
+
+  const stage: Stage =
+    step === STEP_DECIDED
+      ? "decided"
+      : step >= STEP_FIRST_VOTE
+        ? "voting"
+        : "times";
+
+  return {
+    visibleRows: Math.max(0, Math.min(step - 1, VOTES.length)),
+    showTimes: step >= STEP_TIMES,
+    stage,
+  };
+}
+
+export function FooterDemo({ className }: { className?: string }) {
+  const shouldReduceMotion = useReducedMotion();
+  const ref = React.useRef<HTMLDivElement>(null);
+  // False on the server and in browsers without IntersectionObserver, where
+  // the cycle can never run and the card must show its finished state.
+  const [hasObserver, setHasObserver] = React.useState(false);
+  React.useEffect(() => {
+    setHasObserver(typeof IntersectionObserver !== "undefined");
+  }, []);
+  // With reduced motion the observer never runs: nothing reveals, nothing
+  // loops, the solved poll is simply there.
+  const inView = useScrolledToBottom(ref, !shouldReduceMotion);
+
+  // The cycle runs only while the page is at the bottom, so arriving there
+  // always starts from the top of the story rather than mid vote.
+  const animated = inView === true && !shouldReduceMotion;
+  const { visibleRows, showTimes, stage } = useCycle(animated);
+
+  // Show the solved poll only when no animation will play: reduced motion, or
+  // no IntersectionObserver at all. Otherwise the cycle owns the card from the
+  // first render, so it always begins on an empty card rather than snapping
+  // back from a populated one when the observer reports.
+  const solved = shouldReduceMotion || !hasObserver;
+
+  const rows = solved ? VOTES.length : visibleRows;
+  const times = solved ? true : showTimes;
+  const decided = solved ? true : stage === "decided";
+
+  return (
+    <div
+      ref={ref}
+      aria-hidden
+      className={cn(
+        "relative isolate flex items-center justify-center py-10",
+        // The card rises into place once the page bottom is reached.
+        // `inView === false` is the only state that hides it, so a missing
+        // observer or reduced motion leaves it plainly visible.
+        "transition-all duration-700 ease-out",
+        inView === false
+          ? "translate-y-4 opacity-0"
+          : "translate-y-0 opacity-100",
+        className,
+      )}
+    >
+      {/* Graph paper filling the whole slot, dissolving well before the edges
+          so the pattern has no hard border and reads as texture behind the
+          panel rather than a box around it. */}
+      <div
+        className={cn(
+          // Fills the slot's full width and bleeds up into the footer's top
+          // padding, where the mask fades it out just shy of the border. No
+          // sideways bleed: that would widen the page.
+          "absolute -top-14 right-0 -bottom-10 left-0 -z-10",
+          "bg-[linear-gradient(to_right,--theme(--color-black/2.5%)_1px,transparent_1px),linear-gradient(to_bottom,--theme(--color-black/2.5%)_1px,transparent_1px)]",
+          "bg-[size:32px_32px]",
+          // Fades out on every edge, so the pattern approaches the footer's
+          // top border without ever meeting it.
+          "[mask-image:linear-gradient(to_right,transparent,black_15%,black_85%,transparent),linear-gradient(to_bottom,transparent,black_18%,black_75%,transparent)]",
+          "[mask-composite:intersect]",
+        )}
+      />
+      {/* A soft neutral cast under the panel, sitting between it and the grid
+          so the pattern darkens slightly towards the middle. */}
+      <div
+        className={cn(
+          "absolute inset-0 -z-10",
+          "[background:radial-gradient(ellipse_at_center,--theme(--color-black/4%),transparent_70%)]",
+        )}
+      />
+      <div className="w-full max-w-sm space-y-1.5 rounded-xl border bg-white/80 p-3 shadow-[0_1px_2px_--theme(--color-black/5%),0_8px_24px_-4px_--theme(--color-black/8%)] backdrop-blur-sm">
+        {/* The proposed times */}
+        <div className="flex items-center gap-1.5">
+          <div
+            className={cn(
+              "h-2 w-8 shrink-0 rounded-full bg-gray-200 transition-opacity duration-500",
+              times ? "opacity-100" : "opacity-0",
+            )}
+          />
+          {columns.map((column) => (
+            <div
+              key={column}
+              className={cn(
+                "relative h-5 flex-1 overflow-hidden rounded-md bg-gray-100",
+                // The proposed times drop in first, one shortly after another.
+                "transition-all duration-500",
+                times
+                  ? "translate-y-0 opacity-100"
+                  : "-translate-y-1 opacity-0",
+              )}
+              style={{ transitionDelay: times ? `${column * 60}ms` : "0ms" }}
+            >
+              {/* The winner's accent is the same gradient as the event card in
+                  the hero. It lives in its own layer and cross-fades, because
+                  background-image cannot be transitioned the way a colour can. */}
+              <div
+                className={cn(
+                  "absolute inset-0 bg-linear-to-r from-indigo-500 to-violet-500",
+                  "transition-opacity duration-500",
+                  decided && column === WINNING_COLUMN
+                    ? "opacity-100"
+                    : "opacity-0",
+                )}
+              />
+            </div>
+          ))}
+        </div>
+
+        {/* One row per voter, arriving in turn. The height is reserved for the
+            full set so the footer does not reflow as rows come and go. */}
+        <div className="h-[72px] space-y-1.5">
+          {VOTES.map((votes, rowIndex) => (
+            <div
+              // biome-ignore lint/suspicious/noArrayIndexKey: fixed-length wireframe rows
+              key={rowIndex}
+              className={cn(
+                "flex items-center gap-1.5 transition-all duration-500",
+                // Rows slide in as their vote lands. Kept mounted and merely
+                // transparent so nothing depends on an animation frame firing.
+                rowIndex < rows
+                  ? "translate-x-0 opacity-100"
+                  : "-translate-x-2 opacity-0",
+              )}
+            >
+              <div className="h-2 w-8 shrink-0 rounded-full bg-gray-200" />
+              {votes.map((vote, column) => (
+                <div
+                  // biome-ignore lint/suspicious/noArrayIndexKey: fixed-length wireframe votes
+                  key={column}
+                  className={cn(
+                    "flex h-5 flex-1 items-center justify-center rounded-md transition-all duration-500",
+                    decided && column === WINNING_COLUMN
+                      ? "bg-gray-100"
+                      : "bg-gray-50",
+                    // Everything but the winning column recedes once decided,
+                    // so the eye lands on the agreed time.
+                    decided && column !== WINNING_COLUMN && "opacity-40",
+                  )}
+                >
+                  <VoteIcon type={vote} className="size-3.5" />
+                </div>
+              ))}
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
Fills the empty space beside the footer tagline with a textless loop of the core Rallly cycle: times are proposed, invitees vote one row at a time, and the column everyone said yes to wins.

The card sits on faint graph paper that fades out on every edge, and reveals itself once the page is scrolled to the bottom.

## The loop

`empty card → times appear → three voter rows arrive → winner revealed and held → repeat`

The winning column uses the same indigo→violet gradient as the event card in the hero. Everything else is neutral, so that accent is the only colour in the composition.

## Notes for review

- **CSS transitions, not Motion.** The reveal animates from a hidden state, so anything depending on an animation frame being scheduled (backgrounded tab, throttled rAF) would leave the grid permanently invisible. An earlier Motion-based version did exactly that.
- **The reveal watches a sentinel at the end of the footer, not the card.** The card clears the viewport a few hundred pixels before the page bottom does, so keying off the card finished the fade mid-scroll — it was over before you arrived.
- **Degrades to the solved poll.** With `prefers-reduced-motion`, or no `IntersectionObserver`, the card renders the finished poll with no timers running. It is never blank.
- **The vote rows reserve their full height** (`h-[72px]`), so the footer does not reflow as rows come and go.
- Decorative only: the whole card is `aria-hidden`, and the adjacent tagline carries the meaning. No new i18n keys.

## Core Web Vitals

- **CLS** — the reserved row height prevents reflow; the reveal only animates `opacity` and `transform`, which are compositor-only.
- **LCP** — unaffected, the footer is below the fold.
- **INP** — one `setTimeout` per ~900ms, and only while the page is at the bottom. The cycle stops when the sentinel leaves the viewport.
- No new dependencies. `backdrop-blur-sm` on the panel is the one thing worth watching on low-end mobile; it is the first thing I would drop if field data moves.

## Verification

Type-check and Biome pass. Layout, sizing and the state machine were verified in the browser at 1280px and 390px, with no horizontal overflow at either.

One caveat: `IntersectionObserver` and rAF do not fire in the automated browser pane I had available (`visibilityState` is permanently `hidden`), so **the scroll-triggered reveal itself is not verified end to end** — I validated the step-to-state machine by extracting and running it standalone instead. Worth one manual scroll to the footer to confirm the first pass starts on an empty card.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an animated poll demonstration to the landing page footer.
  * The demo reveals as visitors scroll into view and cycles through proposed times, votes, and the winning option.
  * Added responsive footer layout that adapts between side-by-side and stacked arrangements.
  * Supports reduced-motion preferences and provides an accessible completed-state experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->