### PR TITLE
💄 Animate the how it works steps

### DIFF
--- a/apps/landing/src/components/home/how-it-works/accent.ts
+++ b/apps/landing/src/components/home/how-it-works/accent.ts
@@ -1,0 +1,4 @@
+// The accent gradient from the hero event card. The demos' primary actions
+// reuse it so the walkthrough reads as the same product surface as the hero,
+// rather than a flat indigo that appears nowhere else.
+export const ACCENT = "bg-linear-to-r from-indigo-500 to-violet-500";

--- a/apps/landing/src/components/home/how-it-works/create-step-demo.tsx
+++ b/apps/landing/src/components/home/how-it-works/create-step-demo.tsx
@@ -12,12 +12,17 @@ import { PressButton } from "./press-button";
 // it doesn't compete with the section text. Sized to fit the 4:3 artboard on
 // the how it works section.
 //
-// On play the selected column fills in one date per week, top to bottom, then
-// the submit button presses.
+// On play the picked dates land one at a time in the order listed, then the
+// submit button presses.
 const WEEKS = 4;
 const START_OFFSET = 2;
-const SELECTED_COLUMN = 3;
-const SUBMIT_DELAY = WEEKS * STAGGER + 0.12;
+
+// Scattered rather than a single column: a weekly cadence reads as a
+// recurring event, where the point here is someone picking whichever days
+// happen to suit. Indices are cells in the WEEKS x 7 grid, listed in the
+// order they get picked, which is deliberately not left to right.
+const SELECTED = [10, 4, 17, 23, 12, 27];
+const SUBMIT_DELAY = SELECTED.length * STAGGER + 0.12;
 
 export const CreateStepDemo = ({ play }: { play: boolean }) => (
   <DemoScreen className="space-y-2 p-4">
@@ -51,7 +56,8 @@ export const CreateStepDemo = ({ play }: { play: boolean }) => (
               />
             );
           }
-          if (index % 7 !== SELECTED_COLUMN) {
+          const pickedAt = SELECTED.indexOf(index);
+          if (pickedAt === -1) {
             return (
               <div
                 // biome-ignore lint/suspicious/noArrayIndexKey: calendar cells are positional
@@ -77,13 +83,13 @@ export const CreateStepDemo = ({ play }: { play: boolean }) => (
                       backgroundColor: {
                         duration: 0.22,
                         ease: EASE_OUT,
-                        delay: Math.floor(index / 7) * STAGGER,
+                        delay: pickedAt * STAGGER,
                       },
                       scale: {
                         type: "spring",
                         duration: 0.44,
                         bounce: 0.42,
-                        delay: Math.floor(index / 7) * STAGGER,
+                        delay: pickedAt * STAGGER,
                       },
                     }
                   : EXIT

--- a/apps/landing/src/components/home/how-it-works/create-step-demo.tsx
+++ b/apps/landing/src/components/home/how-it-works/create-step-demo.tsx
@@ -4,6 +4,7 @@ import { cn } from "@rallly/ui";
 import * as m from "motion/react-m";
 import { DemoScreen } from "../hero-demo/demo-frame";
 import { ACCENT } from "./accent";
+import type { Playback } from "./motion";
 import { EASE_OUT, EXIT, STAGGER } from "./motion";
 import { PressButton } from "./press-button";
 
@@ -24,87 +25,96 @@ const START_OFFSET = 2;
 const SELECTED = [10, 4, 17, 23, 12, 27];
 const SUBMIT_DELAY = SELECTED.length * STAGGER + 0.12;
 
-export const CreateStepDemo = ({ play }: { play: boolean }) => (
-  <DemoScreen className="space-y-2 p-4">
-    <div className="space-y-1.5">
-      <div className="h-1.5 w-8 rounded-full bg-gray-300" />
-      <div className="flex h-6 items-center rounded-md border border-gray-200 px-2">
-        <div className="h-1.5 w-24 rounded-full bg-gray-300" />
+export const CreateStepDemo = ({ playback }: { playback: Playback }) => {
+  const on = playback !== "idle";
+  const instant = playback === "done";
+  return (
+    <DemoScreen className="space-y-2 p-4">
+      <div className="space-y-1.5">
+        <div className="h-1.5 w-8 rounded-full bg-gray-300" />
+        <div className="flex h-6 items-center rounded-md border border-gray-200 px-2">
+          <div className="h-1.5 w-24 rounded-full bg-gray-300" />
+        </div>
       </div>
-    </div>
-    <div className="space-y-1.5">
-      <div className="flex items-center justify-between">
-        <div className="h-1.5 w-14 rounded-full bg-gray-300" />
-        <div className="h-1.5 w-10 rounded-full bg-gray-200" />
-      </div>
-      <div className="grid grid-cols-7 gap-1">
-        {Array.from({ length: 7 }, (_, index) => (
-          <div
-            // biome-ignore lint/suspicious/noArrayIndexKey: weekday header cells are positional
-            key={index}
-            className="flex justify-center py-0.5"
-          >
-            <div className="h-1 w-2 rounded-full bg-gray-200" />
-          </div>
-        ))}
-        {Array.from({ length: WEEKS * 7 }, (_, index) => {
-          if (index < START_OFFSET) {
+      <div className="space-y-1.5">
+        <div className="flex items-center justify-between">
+          <div className="h-1.5 w-14 rounded-full bg-gray-300" />
+          <div className="h-1.5 w-10 rounded-full bg-gray-200" />
+        </div>
+        <div className="grid grid-cols-7 gap-1">
+          {Array.from({ length: 7 }, (_, index) => (
+            <div
+              // biome-ignore lint/suspicious/noArrayIndexKey: weekday header cells are positional
+              key={index}
+              className="flex justify-center py-0.5"
+            >
+              <div className="h-1 w-2 rounded-full bg-gray-200" />
+            </div>
+          ))}
+          {Array.from({ length: WEEKS * 7 }, (_, index) => {
+            if (index < START_OFFSET) {
+              return (
+                <div
+                  // biome-ignore lint/suspicious/noArrayIndexKey: calendar cells are positional
+                  key={index}
+                />
+              );
+            }
+            const pickedAt = SELECTED.indexOf(index);
+            if (pickedAt === -1) {
+              return (
+                <div
+                  // biome-ignore lint/suspicious/noArrayIndexKey: calendar cells are positional
+                  key={index}
+                  className="h-3.5 rounded bg-gray-100"
+                />
+              );
+            }
             return (
-              <div
-                // biome-ignore lint/suspicious/noArrayIndexKey: calendar cells are positional
-                key={index}
-              />
-            );
-          }
-          const pickedAt = SELECTED.indexOf(index);
-          if (pickedAt === -1) {
-            return (
-              <div
+              <m.div
                 // biome-ignore lint/suspicious/noArrayIndexKey: calendar cells are positional
                 key={index}
                 className="h-3.5 rounded bg-gray-100"
+                initial={false}
+                animate={
+                  on
+                    ? {
+                        backgroundColor: "#d1d5db",
+                        scale: instant ? 1 : [0.88, 1],
+                      }
+                    : { backgroundColor: "#f3f4f6", scale: 1 }
+                }
+                transition={
+                  instant
+                    ? { duration: 0 }
+                    : on
+                      ? {
+                          backgroundColor: {
+                            duration: 0.22,
+                            ease: EASE_OUT,
+                            delay: pickedAt * STAGGER,
+                          },
+                          scale: {
+                            type: "spring",
+                            duration: 0.44,
+                            bounce: 0.42,
+                            delay: pickedAt * STAGGER,
+                          },
+                        }
+                      : EXIT
+                }
               />
             );
-          }
-          return (
-            <m.div
-              // biome-ignore lint/suspicious/noArrayIndexKey: calendar cells are positional
-              key={index}
-              className="h-3.5 rounded bg-gray-100"
-              initial={false}
-              animate={
-                play
-                  ? { backgroundColor: "#d1d5db", scale: [0.88, 1] }
-                  : { backgroundColor: "#f3f4f6", scale: 1 }
-              }
-              transition={
-                play
-                  ? {
-                      backgroundColor: {
-                        duration: 0.22,
-                        ease: EASE_OUT,
-                        delay: pickedAt * STAGGER,
-                      },
-                      scale: {
-                        type: "spring",
-                        duration: 0.44,
-                        bounce: 0.42,
-                        delay: pickedAt * STAGGER,
-                      },
-                    }
-                  : EXIT
-              }
-            />
-          );
-        })}
+          })}
+        </div>
       </div>
-    </div>
-    <div className="flex justify-end border-gray-200/60 border-t pt-2">
-      <PressButton
-        play={play}
-        delay={SUBMIT_DELAY}
-        className={cn("h-7 w-14 rounded-md", ACCENT)}
-      />
-    </div>
-  </DemoScreen>
-);
+      <div className="flex justify-end border-gray-200/60 border-t pt-2">
+        <PressButton
+          playback={playback}
+          delay={SUBMIT_DELAY}
+          className={cn("h-7 w-14 rounded-md", ACCENT)}
+        />
+      </div>
+    </DemoScreen>
+  );
+};

--- a/apps/landing/src/components/home/how-it-works/create-step-demo.tsx
+++ b/apps/landing/src/components/home/how-it-works/create-step-demo.tsx
@@ -1,7 +1,9 @@
 "use client";
 
+import { cn } from "@rallly/ui";
 import * as m from "motion/react-m";
 import { DemoScreen } from "../hero-demo/demo-frame";
+import { ACCENT } from "./accent";
 import { EASE_OUT, EXIT, STAGGER } from "./motion";
 import { PressButton } from "./press-button";
 
@@ -95,7 +97,7 @@ export const CreateStepDemo = ({ play }: { play: boolean }) => (
       <PressButton
         play={play}
         delay={SUBMIT_DELAY}
-        className="h-7 w-14 rounded-md bg-indigo-600/90"
+        className={cn("h-7 w-14 rounded-md", ACCENT)}
       />
     </div>
   </DemoScreen>

--- a/apps/landing/src/components/home/how-it-works/create-step-demo.tsx
+++ b/apps/landing/src/components/home/how-it-works/create-step-demo.tsx
@@ -1,15 +1,22 @@
-import { cn } from "@rallly/ui";
+"use client";
+
+import * as m from "motion/react-m";
 import { DemoScreen } from "../hero-demo/demo-frame";
 
 // A textless mock of the poll creation form: title field and a month
 // calendar with a weekly cadence of selected days. Bars stand in for copy so
 // it doesn't compete with the section text. Sized to fit the 4:3 artboard on
 // the how it works section.
+//
+// On play the selected column fills in one date per week, top to bottom, then
+// the submit button presses.
 const WEEKS = 4;
 const START_OFFSET = 2;
 const SELECTED_COLUMN = 3;
+const DATE_STAGGER = 0.11;
+const SUBMIT_DELAY = WEEKS * DATE_STAGGER + 0.15;
 
-export const CreateStepDemo = () => (
+export const CreateStepDemo = ({ play }: { play: boolean }) => (
   <DemoScreen className="space-y-2 p-4">
     <div className="space-y-1.5">
       <div className="h-1.5 w-8 rounded-full bg-gray-300" />
@@ -41,21 +48,42 @@ export const CreateStepDemo = () => (
               />
             );
           }
+          if (index % 7 !== SELECTED_COLUMN) {
+            return (
+              <div
+                // biome-ignore lint/suspicious/noArrayIndexKey: calendar cells are positional
+                key={index}
+                className="h-3.5 rounded bg-gray-100"
+              />
+            );
+          }
           return (
-            <div
+            <m.div
               // biome-ignore lint/suspicious/noArrayIndexKey: calendar cells are positional
               key={index}
-              className={cn(
-                "h-3.5 rounded",
-                index % 7 === SELECTED_COLUMN ? "bg-gray-300" : "bg-gray-100",
-              )}
+              className="h-3.5 rounded bg-gray-100"
+              initial={false}
+              animate={
+                play
+                  ? { backgroundColor: "#d1d5db", scale: [1, 1.15, 1] }
+                  : { backgroundColor: "#f3f4f6", scale: 1 }
+              }
+              transition={{
+                duration: 0.3,
+                delay: play ? Math.floor(index / 7) * DATE_STAGGER : 0,
+              }}
             />
           );
         })}
       </div>
     </div>
     <div className="flex justify-end border-gray-200/60 border-t pt-2">
-      <div className="h-7 w-14 rounded-md bg-indigo-600/90" />
+      <m.div
+        className="h-7 w-14 rounded-md bg-indigo-600/90"
+        initial={false}
+        animate={play ? { scale: [1, 0.92, 1] } : { scale: 1 }}
+        transition={{ duration: 0.35, delay: play ? SUBMIT_DELAY : 0 }}
+      />
     </div>
   </DemoScreen>
 );

--- a/apps/landing/src/components/home/how-it-works/create-step-demo.tsx
+++ b/apps/landing/src/components/home/how-it-works/create-step-demo.tsx
@@ -2,6 +2,8 @@
 
 import * as m from "motion/react-m";
 import { DemoScreen } from "../hero-demo/demo-frame";
+import { EASE_OUT, EXIT, STAGGER } from "./motion";
+import { PressButton } from "./press-button";
 
 // A textless mock of the poll creation form: title field and a month
 // calendar with a weekly cadence of selected days. Bars stand in for copy so
@@ -13,8 +15,7 @@ import { DemoScreen } from "../hero-demo/demo-frame";
 const WEEKS = 4;
 const START_OFFSET = 2;
 const SELECTED_COLUMN = 3;
-const DATE_STAGGER = 0.11;
-const SUBMIT_DELAY = WEEKS * DATE_STAGGER + 0.15;
+const SUBMIT_DELAY = WEEKS * STAGGER + 0.12;
 
 export const CreateStepDemo = ({ play }: { play: boolean }) => (
   <DemoScreen className="space-y-2 p-4">
@@ -65,24 +66,36 @@ export const CreateStepDemo = ({ play }: { play: boolean }) => (
               initial={false}
               animate={
                 play
-                  ? { backgroundColor: "#d1d5db", scale: [1, 1.15, 1] }
+                  ? { backgroundColor: "#d1d5db", scale: [0.88, 1] }
                   : { backgroundColor: "#f3f4f6", scale: 1 }
               }
-              transition={{
-                duration: 0.3,
-                delay: play ? Math.floor(index / 7) * DATE_STAGGER : 0,
-              }}
+              transition={
+                play
+                  ? {
+                      backgroundColor: {
+                        duration: 0.22,
+                        ease: EASE_OUT,
+                        delay: Math.floor(index / 7) * STAGGER,
+                      },
+                      scale: {
+                        type: "spring",
+                        duration: 0.44,
+                        bounce: 0.42,
+                        delay: Math.floor(index / 7) * STAGGER,
+                      },
+                    }
+                  : EXIT
+              }
             />
           );
         })}
       </div>
     </div>
     <div className="flex justify-end border-gray-200/60 border-t pt-2">
-      <m.div
+      <PressButton
+        play={play}
+        delay={SUBMIT_DELAY}
         className="h-7 w-14 rounded-md bg-indigo-600/90"
-        initial={false}
-        animate={play ? { scale: [1, 0.92, 1] } : { scale: 1 }}
-        transition={{ duration: 0.35, delay: play ? SUBMIT_DELAY : 0 }}
       />
     </div>
   </DemoScreen>

--- a/apps/landing/src/components/home/how-it-works/decide-step-demo.tsx
+++ b/apps/landing/src/components/home/how-it-works/decide-step-demo.tsx
@@ -5,6 +5,7 @@ import { VoteIcon } from "@rallly/ui/vote-icon";
 import * as m from "motion/react-m";
 import { DemoScreen } from "../hero-demo/demo-frame";
 import { ACCENT } from "./accent";
+import type { Playback } from "./motion";
 import { EASE_OUT, EXIT } from "./motion";
 
 // A textless mock of the results: one row per option with real vote icons,
@@ -28,81 +29,94 @@ const VOTER_STAGGER = 0.09;
 const ROW_STAGGER = 0.02;
 const WINNER_DELAY = ROWS[0].votes.length * VOTER_STAGGER + 0.12;
 
-export const DecideStepDemo = ({ play }: { play: boolean }) => (
-  <DemoScreen className="space-y-1.5 p-4">
-    {ROWS.map((row, rowIndex) => (
-      <m.div
-        // biome-ignore lint/suspicious/noArrayIndexKey: static wireframe rows
-        key={rowIndex}
-        className={cn(
-          "flex items-center justify-between gap-3 rounded-md border px-2.5 py-2",
-          row.winner ? "border-indigo-200" : "border-gray-200",
-        )}
-        initial={false}
-        animate={{
-          backgroundColor:
-            play && row.winner ? "rgb(238 242 255)" : "rgba(255,255,255,0)",
-        }}
-        transition={
-          play ? { duration: 0.34, ease: EASE_OUT, delay: WINNER_DELAY } : EXIT
-        }
-      >
-        <div className="min-w-0 space-y-1.5">
-          <div
-            className={cn(
-              "h-1.5 w-16 rounded-full",
-              row.winner ? "bg-indigo-400" : "bg-gray-300",
-            )}
-          />
-          <div className="flex items-center gap-2">
-            <div className="h-1.5 w-10 rounded-full bg-gray-200" />
-            {row.winner ? (
-              <m.div
-                className={cn("h-1.5 w-12 rounded-full", ACCENT)}
-                initial={false}
-                animate={{ opacity: play ? 1 : 0, scaleX: play ? 1 : 0.4 }}
-                style={{ originX: 0 }}
-                transition={
-                  play
-                    ? {
-                        type: "spring",
-                        duration: 0.5,
-                        bounce: 0.24,
-                        delay: WINNER_DELAY + 0.08,
-                      }
-                    : EXIT
-                }
-              />
-            ) : null}
+export const DecideStepDemo = ({ playback }: { playback: Playback }) => {
+  const on = playback !== "idle";
+  const instant = playback === "done";
+  return (
+    <DemoScreen className="space-y-1.5 p-4">
+      {ROWS.map((row, rowIndex) => (
+        <m.div
+          // biome-ignore lint/suspicious/noArrayIndexKey: static wireframe rows
+          key={rowIndex}
+          className={cn(
+            "flex items-center justify-between gap-3 rounded-md border px-2.5 py-2",
+            row.winner ? "border-indigo-200" : "border-gray-200",
+          )}
+          initial={false}
+          animate={{
+            backgroundColor:
+              on && row.winner ? "rgb(238 242 255)" : "rgba(255,255,255,0)",
+          }}
+          transition={
+            instant
+              ? { duration: 0 }
+              : on
+                ? { duration: 0.34, ease: EASE_OUT, delay: WINNER_DELAY }
+                : EXIT
+          }
+        >
+          <div className="min-w-0 space-y-1.5">
+            <div
+              className={cn(
+                "h-1.5 w-16 rounded-full",
+                row.winner ? "bg-indigo-400" : "bg-gray-300",
+              )}
+            />
+            <div className="flex items-center gap-2">
+              <div className="h-1.5 w-10 rounded-full bg-gray-200" />
+              {row.winner ? (
+                <m.div
+                  className={cn("h-1.5 w-12 rounded-full", ACCENT)}
+                  initial={false}
+                  animate={{ opacity: on ? 1 : 0, scaleX: on ? 1 : 0.4 }}
+                  style={{ originX: 0 }}
+                  transition={
+                    instant
+                      ? { duration: 0 }
+                      : on
+                        ? {
+                            type: "spring",
+                            duration: 0.5,
+                            bounce: 0.24,
+                            delay: WINNER_DELAY + 0.08,
+                          }
+                        : EXIT
+                  }
+                />
+              ) : null}
+            </div>
           </div>
-        </div>
-        <div className="flex shrink-0 items-center gap-1">
-          {row.votes.map((vote, voteIndex) => (
-            <m.div
-              // biome-ignore lint/suspicious/noArrayIndexKey: static wireframe votes
-              key={voteIndex}
-              initial={false}
-              animate={
-                play
-                  ? { opacity: 1, scale: 1, y: 0 }
-                  : { opacity: 0, scale: 0.82, y: -3 }
-              }
-              transition={
-                play
-                  ? {
-                      type: "spring",
-                      duration: 0.46,
-                      bounce: 0.38,
-                      delay: voteIndex * VOTER_STAGGER + rowIndex * ROW_STAGGER,
-                    }
-                  : EXIT
-              }
-            >
-              <VoteIcon type={vote} className="size-3.5" />
-            </m.div>
-          ))}
-        </div>
-      </m.div>
-    ))}
-  </DemoScreen>
-);
+          <div className="flex shrink-0 items-center gap-1">
+            {row.votes.map((vote, voteIndex) => (
+              <m.div
+                // biome-ignore lint/suspicious/noArrayIndexKey: static wireframe votes
+                key={voteIndex}
+                initial={false}
+                animate={
+                  on
+                    ? { opacity: 1, scale: 1, y: 0 }
+                    : { opacity: 0, scale: 0.82, y: -3 }
+                }
+                transition={
+                  instant
+                    ? { duration: 0 }
+                    : on
+                      ? {
+                          type: "spring",
+                          duration: 0.46,
+                          bounce: 0.38,
+                          delay:
+                            voteIndex * VOTER_STAGGER + rowIndex * ROW_STAGGER,
+                        }
+                      : EXIT
+                }
+              >
+                <VoteIcon type={vote} className="size-3.5" />
+              </m.div>
+            ))}
+          </div>
+        </m.div>
+      ))}
+    </DemoScreen>
+  );
+};

--- a/apps/landing/src/components/home/how-it-works/decide-step-demo.tsx
+++ b/apps/landing/src/components/home/how-it-works/decide-step-demo.tsx
@@ -4,6 +4,7 @@ import { cn } from "@rallly/ui";
 import { VoteIcon } from "@rallly/ui/vote-icon";
 import * as m from "motion/react-m";
 import { DemoScreen } from "../hero-demo/demo-frame";
+import { EASE_OUT, EXIT } from "./motion";
 
 // A textless mock of the results: one row per option with real vote icons,
 // the winner highlighted. Bars stand in for copy so it doesn't compete with
@@ -19,8 +20,12 @@ const ROWS: { votes: ("yes" | "ifNeedBe" | "no")[]; winner: boolean }[] = [
   { votes: ["no", "yes", "ifNeedBe", "no"], winner: false },
 ];
 
-const VOTER_STAGGER = 0.22;
-const WINNER_DELAY = ROWS[0].votes.length * VOTER_STAGGER + 0.1;
+// Votes land per participant, so the column is the beat. Rows within a column
+// are nudged apart a little so a response reads as arriving rather than
+// stamping four cells at once.
+const VOTER_STAGGER = 0.09;
+const ROW_STAGGER = 0.02;
+const WINNER_DELAY = ROWS[0].votes.length * VOTER_STAGGER + 0.12;
 
 export const DecideStepDemo = ({ play }: { play: boolean }) => (
   <DemoScreen className="space-y-1.5 p-4">
@@ -37,7 +42,9 @@ export const DecideStepDemo = ({ play }: { play: boolean }) => (
           backgroundColor:
             play && row.winner ? "rgb(238 242 255)" : "rgba(255,255,255,0)",
         }}
-        transition={{ duration: 0.3, delay: play ? WINNER_DELAY : 0 }}
+        transition={
+          play ? { duration: 0.34, ease: EASE_OUT, delay: WINNER_DELAY } : EXIT
+        }
       >
         <div className="min-w-0 space-y-1.5">
           <div
@@ -52,8 +59,18 @@ export const DecideStepDemo = ({ play }: { play: boolean }) => (
               <m.div
                 className="h-1.5 w-12 rounded-full bg-indigo-600"
                 initial={false}
-                animate={{ opacity: play ? 1 : 0 }}
-                transition={{ duration: 0.3, delay: play ? WINNER_DELAY : 0 }}
+                animate={{ opacity: play ? 1 : 0, scaleX: play ? 1 : 0.4 }}
+                style={{ originX: 0 }}
+                transition={
+                  play
+                    ? {
+                        type: "spring",
+                        duration: 0.5,
+                        bounce: 0.24,
+                        delay: WINNER_DELAY + 0.08,
+                      }
+                    : EXIT
+                }
               />
             ) : null}
           </div>
@@ -67,12 +84,18 @@ export const DecideStepDemo = ({ play }: { play: boolean }) => (
               animate={
                 play
                   ? { opacity: 1, scale: 1, y: 0 }
-                  : { opacity: 0, scale: 0.6, y: -4 }
+                  : { opacity: 0, scale: 0.82, y: -3 }
               }
-              transition={{
-                duration: 0.3,
-                delay: play ? voteIndex * VOTER_STAGGER : 0,
-              }}
+              transition={
+                play
+                  ? {
+                      type: "spring",
+                      duration: 0.46,
+                      bounce: 0.38,
+                      delay: voteIndex * VOTER_STAGGER + rowIndex * ROW_STAGGER,
+                    }
+                  : EXIT
+              }
             >
               <VoteIcon type={vote} className="size-3.5" />
             </m.div>

--- a/apps/landing/src/components/home/how-it-works/decide-step-demo.tsx
+++ b/apps/landing/src/components/home/how-it-works/decide-step-demo.tsx
@@ -4,6 +4,7 @@ import { cn } from "@rallly/ui";
 import { VoteIcon } from "@rallly/ui/vote-icon";
 import * as m from "motion/react-m";
 import { DemoScreen } from "../hero-demo/demo-frame";
+import { ACCENT } from "./accent";
 import { EASE_OUT, EXIT } from "./motion";
 
 // A textless mock of the results: one row per option with real vote icons,
@@ -57,7 +58,7 @@ export const DecideStepDemo = ({ play }: { play: boolean }) => (
             <div className="h-1.5 w-10 rounded-full bg-gray-200" />
             {row.winner ? (
               <m.div
-                className="h-1.5 w-12 rounded-full bg-indigo-600"
+                className={cn("h-1.5 w-12 rounded-full", ACCENT)}
                 initial={false}
                 animate={{ opacity: play ? 1 : 0, scaleX: play ? 1 : 0.4 }}
                 style={{ originX: 0 }}

--- a/apps/landing/src/components/home/how-it-works/decide-step-demo.tsx
+++ b/apps/landing/src/components/home/how-it-works/decide-step-demo.tsx
@@ -1,11 +1,17 @@
+"use client";
+
 import { cn } from "@rallly/ui";
 import { VoteIcon } from "@rallly/ui/vote-icon";
+import * as m from "motion/react-m";
 import { DemoScreen } from "../hero-demo/demo-frame";
 
 // A textless mock of the results: one row per option with real vote icons,
 // the winner highlighted. Bars stand in for copy so it doesn't compete with
 // the section text. Sized to fit the 4:3 artboard on the how it works
 // section.
+//
+// On play the votes arrive a participant at a time, so each column drops in as
+// one response, and the winning row lights up once they're all in.
 const ROWS: { votes: ("yes" | "ifNeedBe" | "no")[]; winner: boolean }[] = [
   { votes: ["yes", "yes", "yes", "yes"], winner: true },
   { votes: ["yes", "no", "yes", "no"], winner: false },
@@ -13,16 +19,25 @@ const ROWS: { votes: ("yes" | "ifNeedBe" | "no")[]; winner: boolean }[] = [
   { votes: ["no", "yes", "ifNeedBe", "no"], winner: false },
 ];
 
-export const DecideStepDemo = () => (
+const VOTER_STAGGER = 0.22;
+const WINNER_DELAY = ROWS[0].votes.length * VOTER_STAGGER + 0.1;
+
+export const DecideStepDemo = ({ play }: { play: boolean }) => (
   <DemoScreen className="space-y-1.5 p-4">
     {ROWS.map((row, rowIndex) => (
-      <div
+      <m.div
         // biome-ignore lint/suspicious/noArrayIndexKey: static wireframe rows
         key={rowIndex}
         className={cn(
           "flex items-center justify-between gap-3 rounded-md border px-2.5 py-2",
-          row.winner ? "border-indigo-200 bg-indigo-50" : "border-gray-200",
+          row.winner ? "border-indigo-200" : "border-gray-200",
         )}
+        initial={false}
+        animate={{
+          backgroundColor:
+            play && row.winner ? "rgb(238 242 255)" : "rgba(255,255,255,0)",
+        }}
+        transition={{ duration: 0.3, delay: play ? WINNER_DELAY : 0 }}
       >
         <div className="min-w-0 space-y-1.5">
           <div
@@ -34,21 +49,36 @@ export const DecideStepDemo = () => (
           <div className="flex items-center gap-2">
             <div className="h-1.5 w-10 rounded-full bg-gray-200" />
             {row.winner ? (
-              <div className="h-1.5 w-12 rounded-full bg-indigo-600" />
+              <m.div
+                className="h-1.5 w-12 rounded-full bg-indigo-600"
+                initial={false}
+                animate={{ opacity: play ? 1 : 0 }}
+                transition={{ duration: 0.3, delay: play ? WINNER_DELAY : 0 }}
+              />
             ) : null}
           </div>
         </div>
         <div className="flex shrink-0 items-center gap-1">
           {row.votes.map((vote, voteIndex) => (
-            <VoteIcon
+            <m.div
               // biome-ignore lint/suspicious/noArrayIndexKey: static wireframe votes
               key={voteIndex}
-              type={vote}
-              className="size-3.5"
-            />
+              initial={false}
+              animate={
+                play
+                  ? { opacity: 1, scale: 1, y: 0 }
+                  : { opacity: 0, scale: 0.6, y: -4 }
+              }
+              transition={{
+                duration: 0.3,
+                delay: play ? voteIndex * VOTER_STAGGER : 0,
+              }}
+            >
+              <VoteIcon type={vote} className="size-3.5" />
+            </m.div>
           ))}
         </div>
-      </div>
+      </m.div>
     ))}
   </DemoScreen>
 );

--- a/apps/landing/src/components/home/how-it-works/how-it-works.tsx
+++ b/apps/landing/src/components/home/how-it-works/how-it-works.tsx
@@ -9,7 +9,7 @@ import {
 } from "@/components/section";
 import { getTranslation } from "@/i18n/server";
 import type { StepKey } from "./step-stage";
-import { StepStage } from "./step-stage";
+import { StepCue, StepStage } from "./step-stage";
 
 // The meeting poll walkthrough, shared by the home page and the SEO landing
 // pages. Owns its copy, unlike the rest of the landing components, so every
@@ -115,36 +115,39 @@ export const HowItWorks = async ({ locale }: { locale: string }) => {
       <SectionContent>
         {/* Below lg the three steps stay side by side and scroll horizontally,
             bleeding past the page gutters so the next card peeks in. */}
-        <dl className="-mx-4 grid snap-x snap-mandatory scroll-px-4 grid-cols-[repeat(3,min(75vw,20rem))] grid-rows-[auto_auto] gap-x-4 gap-y-1 overflow-x-auto px-4 sm:-mx-6 sm:scroll-px-6 sm:px-6 lg:mx-0 lg:grid-cols-3 lg:overflow-x-visible lg:px-0">
-          {steps.map((step, index) => (
-            <div
-              key={step.key}
-              className="row-span-2 grid snap-start grid-rows-subgrid rounded-2xl border bg-white p-1"
-            >
-              <div className="space-y-4 rounded-xl border bg-gray-100 p-4">
-                <div className="font-mono text-gray-400 text-xs uppercase tracking-wide">
-                  <Trans
-                    t={t}
-                    ns="home"
-                    i18nKey="howItWorksStepLabel"
-                    defaults="Step {number}"
-                    values={{ number: `0${index + 1}` }}
+        <StepCue>
+          <dl className="-mx-4 grid snap-x snap-mandatory scroll-px-4 grid-cols-[repeat(3,min(75vw,20rem))] grid-rows-[auto_auto] gap-x-4 gap-y-1 overflow-x-auto px-4 sm:-mx-6 sm:scroll-px-6 sm:px-6 lg:mx-0 lg:grid-cols-3 lg:overflow-x-visible lg:px-0">
+            {steps.map((step, index) => (
+              <div
+                key={step.key}
+                className="row-span-2 grid snap-start grid-rows-subgrid rounded-2xl border bg-white p-1"
+              >
+                <div className="space-y-4 rounded-xl border bg-gray-100 p-4">
+                  <div className="font-mono text-gray-400 text-xs uppercase tracking-wide">
+                    <Trans
+                      t={t}
+                      ns="home"
+                      i18nKey="howItWorksStepLabel"
+                      defaults="Step {number}"
+                      values={{ number: `0${index + 1}` }}
+                    />
+                  </div>
+                  <StepStage
+                    step={step.key}
+                    index={index}
+                    className="flex h-64 items-center justify-center"
                   />
                 </div>
-                <StepStage
-                  step={step.key}
-                  className="flex h-64 items-center justify-center"
-                />
+                <div className="p-3">
+                  <dt className="font-medium text-gray-900">{step.title}</dt>
+                  <dd className="mt-2 text-pretty text-base/6 text-gray-500 sm:text-sm/5">
+                    {step.description}
+                  </dd>
+                </div>
               </div>
-              <div className="p-3">
-                <dt className="font-medium text-gray-900">{step.title}</dt>
-                <dd className="mt-2 text-pretty text-base/6 text-gray-500 sm:text-sm/5">
-                  {step.description}
-                </dd>
-              </div>
-            </div>
-          ))}
-        </dl>
+            ))}
+          </dl>
+        </StepCue>
       </SectionContent>
     </Section>
   );

--- a/apps/landing/src/components/home/how-it-works/how-it-works.tsx
+++ b/apps/landing/src/components/home/how-it-works/how-it-works.tsx
@@ -8,16 +8,19 @@ import {
   SectionTitle,
 } from "@/components/section";
 import { getTranslation } from "@/i18n/server";
-import { CreateStepDemo } from "./create-step-demo";
-import { DecideStepDemo } from "./decide-step-demo";
-import { ShareStepDemo } from "./share-step-demo";
+import type { StepKey } from "./step-stage";
+import { StepStage } from "./step-stage";
 
 // The meeting poll walkthrough, shared by the home page and the SEO landing
 // pages. Owns its copy, unlike the rest of the landing components, so every
 // page renders the same three steps.
 export const HowItWorks = async ({ locale }: { locale: string }) => {
   const { t } = await getTranslation<"home">(locale, "home");
-  const steps = [
+  const steps: {
+    key: StepKey;
+    title: React.ReactNode;
+    description: React.ReactNode;
+  }[] = [
     {
       key: "create",
       title: (
@@ -36,7 +39,6 @@ export const HowItWorks = async ({ locale }: { locale: string }) => {
           defaults="Pick a few times that could work. Add a title and you're done. No account needed."
         />
       ),
-      visual: <CreateStepDemo />,
     },
     {
       key: "share",
@@ -56,7 +58,6 @@ export const HowItWorks = async ({ locale }: { locale: string }) => {
           defaults="Send it over email, Slack, or WhatsApp. Participants don't need to sign up."
         />
       ),
-      visual: <ShareStepDemo />,
     },
     {
       key: "decide",
@@ -76,7 +77,6 @@ export const HowItWorks = async ({ locale }: { locale: string }) => {
           defaults="Everyone marks the times that work for them, and the best option shows at a glance."
         />
       ),
-      visual: <DecideStepDemo />,
     },
   ];
 
@@ -131,12 +131,10 @@ export const HowItWorks = async ({ locale }: { locale: string }) => {
                     values={{ number: `0${index + 1}` }}
                   />
                 </div>
-                <div
-                  aria-hidden="true"
+                <StepStage
+                  step={step.key}
                   className="flex h-64 items-center justify-center"
-                >
-                  <div className="w-full max-w-64">{step.visual}</div>
-                </div>
+                />
               </div>
               <div className="p-3">
                 <dt className="font-medium text-gray-900">{step.title}</dt>

--- a/apps/landing/src/components/home/how-it-works/motion.ts
+++ b/apps/landing/src/components/home/how-it-works/motion.ts
@@ -23,3 +23,9 @@ export const PRESS_UP = {
   duration: 0.44,
   bounce: 0.42,
 } as const;
+
+// How a demo should render. "idle" is the resting state, "play" runs the timed
+// sequence, and "done" jumps straight to the finished values with no delays or
+// movement, which is what reduced motion wants: the information without the
+// journey to it.
+export type Playback = "idle" | "play" | "done";

--- a/apps/landing/src/components/home/how-it-works/motion.ts
+++ b/apps/landing/src/components/home/how-it-works/motion.ts
@@ -1,0 +1,25 @@
+// Shared motion vocabulary for the how it works demos, so the three steps
+// move with one cadence instead of each inventing its own.
+
+// Strong ease-out. The built-in curves are too soft to read as deliberate at
+// these short durations.
+export const EASE_OUT = [0.23, 1, 0.32, 1] as const;
+
+// Stagger between sibling beats: one date, one participant's votes. Kept
+// short so a four beat sequence still resolves in well under a second.
+export const STAGGER = 0.06;
+
+// Leaving is not a performance: everything drops back at once, faster than it
+// arrived, so moving the pointer away feels like an undo rather than a rewind.
+export const EXIT = { duration: 0.18, ease: EASE_OUT } as const;
+
+// A press is two beats, not one curve: the dip is a quick duration ease, the
+// release settles on a spring so the button rebounds instead of interpolating
+// back. Motion only supports two keyframes on a spring, so these are applied
+// as separate transitions rather than one keyframe array.
+export const PRESS_DOWN = { duration: 0.09, ease: EASE_OUT } as const;
+export const PRESS_UP = {
+  type: "spring",
+  duration: 0.44,
+  bounce: 0.42,
+} as const;

--- a/apps/landing/src/components/home/how-it-works/press-button.tsx
+++ b/apps/landing/src/components/home/how-it-works/press-button.tsx
@@ -1,0 +1,45 @@
+"use client";
+
+import * as m from "motion/react-m";
+import * as React from "react";
+import { EXIT, PRESS_DOWN, PRESS_UP } from "./motion";
+
+// The primary button in a demo, pressed on cue. The dip and the release are
+// separate beats so the button rebounds off a spring instead of interpolating
+// symmetrically back, which is what makes a press read as a press.
+export const PressButton = ({
+  play,
+  delay,
+  className,
+}: {
+  play: boolean;
+  delay: number;
+  className?: string;
+}) => {
+  const [down, setDown] = React.useState(false);
+
+  React.useEffect(() => {
+    if (!play) {
+      setDown(false);
+      return;
+    }
+    const press = setTimeout(() => setDown(true), delay * 1000);
+    const release = setTimeout(
+      () => setDown(false),
+      delay * 1000 + PRESS_DOWN.duration * 1000 + 60,
+    );
+    return () => {
+      clearTimeout(press);
+      clearTimeout(release);
+    };
+  }, [play, delay]);
+
+  return (
+    <m.div
+      className={className}
+      initial={false}
+      animate={{ scale: down ? 0.93 : 1 }}
+      transition={play ? (down ? PRESS_DOWN : PRESS_UP) : EXIT}
+    />
+  );
+};

--- a/apps/landing/src/components/home/how-it-works/press-button.tsx
+++ b/apps/landing/src/components/home/how-it-works/press-button.tsx
@@ -40,8 +40,19 @@ export const PressButton = ({
     <m.div
       className={className}
       initial={false}
-      animate={{ scale: down ? 0.93 : 1 }}
-      transition={playback === "play" ? (down ? PRESS_DOWN : PRESS_UP) : EXIT}
+      // Guarded on playback rather than down alone: switching reduced motion on
+      // mid press would otherwise render the dip for a frame before the effect
+      // clears it, which is the movement reduced motion is meant to avoid.
+      animate={{ scale: playback === "play" && down ? 0.93 : 1 }}
+      transition={
+        playback === "done"
+          ? { duration: 0 }
+          : playback === "play"
+            ? down
+              ? PRESS_DOWN
+              : PRESS_UP
+            : EXIT
+      }
     />
   );
 };

--- a/apps/landing/src/components/home/how-it-works/press-button.tsx
+++ b/apps/landing/src/components/home/how-it-works/press-button.tsx
@@ -2,24 +2,26 @@
 
 import * as m from "motion/react-m";
 import * as React from "react";
+import type { Playback } from "./motion";
 import { EXIT, PRESS_DOWN, PRESS_UP } from "./motion";
 
 // The primary button in a demo, pressed on cue. The dip and the release are
 // separate beats so the button rebounds off a spring instead of interpolating
 // symmetrically back, which is what makes a press read as a press.
 export const PressButton = ({
-  play,
+  playback,
   delay,
   className,
 }: {
-  play: boolean;
+  playback: Playback;
   delay: number;
   className?: string;
 }) => {
   const [down, setDown] = React.useState(false);
 
   React.useEffect(() => {
-    if (!play) {
+    // "done" never presses: a press is movement, and it has already happened.
+    if (playback !== "play") {
       setDown(false);
       return;
     }
@@ -32,14 +34,14 @@ export const PressButton = ({
       clearTimeout(press);
       clearTimeout(release);
     };
-  }, [play, delay]);
+  }, [playback, delay]);
 
   return (
     <m.div
       className={className}
       initial={false}
       animate={{ scale: down ? 0.93 : 1 }}
-      transition={play ? (down ? PRESS_DOWN : PRESS_UP) : EXIT}
+      transition={playback === "play" ? (down ? PRESS_DOWN : PRESS_UP) : EXIT}
     />
   );
 };

--- a/apps/landing/src/components/home/how-it-works/share-step-demo.tsx
+++ b/apps/landing/src/components/home/how-it-works/share-step-demo.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { cn } from "@rallly/ui";
-import { CheckIcon, MailIcon, MessageCircleIcon, SendIcon } from "lucide-react";
+import { MailIcon, MessageCircleIcon, SendIcon } from "lucide-react";
 import * as m from "motion/react-m";
 import { DemoScreen } from "../hero-demo/demo-frame";
 import { ACCENT } from "./accent";
@@ -26,8 +26,8 @@ const PRESS_AT = 0.42;
 const COPIED_AT = PRESS_AT + 0.1;
 
 // Copying recolors the url in place rather than swapping it for a shorter
-// confirmation: the bar keeps its width so the field never shows a gap, and
-// the check is the only thing that appears.
+// confirmation, so the field keeps the same block at the same width and the
+// accent is what signals the copy.
 const SWAP = { duration: 0.2, ease: EASE_OUT } as const;
 
 export const ShareStepDemo = ({ play }: { play: boolean }) => (
@@ -35,26 +35,7 @@ export const ShareStepDemo = ({ play }: { play: boolean }) => (
     <div className="space-y-1.5">
       <div className="h-1.5 w-12 rounded-full bg-gray-300" />
       <div className="flex items-center gap-2">
-        <div className="relative flex h-7 min-w-0 flex-1 items-center rounded-md border border-gray-200 bg-gray-50 px-2">
-          {/* The check sits out of flow so the url keeps its exact position
-              and width when the copy lands. */}
-          <m.div
-            className="absolute -right-0.5 text-violet-500"
-            initial={false}
-            animate={{ opacity: play ? 1 : 0, scale: play ? 1 : 0.7 }}
-            transition={
-              play
-                ? {
-                    type: "spring",
-                    duration: 0.4,
-                    bounce: 0.4,
-                    delay: COPIED_AT,
-                  }
-                : EXIT
-            }
-          >
-            <CheckIcon className="size-3" />
-          </m.div>
+        <div className="flex h-7 min-w-0 flex-1 items-center rounded-md border border-gray-200 bg-gray-50 px-2">
           {/* The accent fades over the resting bar rather than replacing its
               class, so the recolor transitions instead of snapping. */}
           <div className="relative h-1.5 w-28 shrink-0 overflow-hidden rounded-full bg-gray-300">

--- a/apps/landing/src/components/home/how-it-works/share-step-demo.tsx
+++ b/apps/landing/src/components/home/how-it-works/share-step-demo.tsx
@@ -4,6 +4,8 @@ import { cn } from "@rallly/ui";
 import { CheckIcon, MailIcon, MessageCircleIcon, SendIcon } from "lucide-react";
 import * as m from "motion/react-m";
 import { DemoScreen } from "../hero-demo/demo-frame";
+import { EASE_OUT, EXIT } from "./motion";
+import { PressButton } from "./press-button";
 
 // A textless mock of the invite step: a link field with a copy button, ways
 // to send it, and the group it goes out to. Bars stand in for copy so it
@@ -19,8 +21,13 @@ const CHANNELS = [
   { key: "direct", icon: SendIcon, width: "w-24" },
 ];
 
-const PRESS_AT = 0.55;
-const COPIED_AT = PRESS_AT + 0.15;
+const PRESS_AT = 0.42;
+const COPIED_AT = PRESS_AT + 0.1;
+
+// The url and the confirmation blur through each other rather than crossfading
+// cleanly: without it you read two overlapping bars swapping, with it one label
+// turning into the other.
+const SWAP = { duration: 0.2, ease: EASE_OUT } as const;
 
 export const ShareStepDemo = ({ play }: { play: boolean }) => (
   <DemoScreen className="space-y-2 p-4">
@@ -31,33 +38,46 @@ export const ShareStepDemo = ({ play }: { play: boolean }) => (
           <m.div
             className="h-1.5 w-28 rounded-full bg-gray-300"
             initial={false}
-            animate={{ opacity: play ? 0 : 1 }}
-            transition={{ duration: 0.15, delay: play ? COPIED_AT : 0.1 }}
+            animate={{
+              opacity: play ? 0 : 1,
+              filter: play ? "blur(2px)" : "blur(0px)",
+            }}
+            transition={{ ...SWAP, delay: play ? COPIED_AT : 0.06 }}
           />
           <m.div
             className="absolute top-1/2 left-2 flex -translate-y-1/2 items-center gap-1 text-indigo-600"
             initial={false}
-            animate={{ opacity: play ? 1 : 0 }}
-            transition={{ duration: 0.15, delay: play ? COPIED_AT : 0 }}
+            animate={{
+              opacity: play ? 1 : 0,
+              filter: play ? "blur(0px)" : "blur(2px)",
+            }}
+            transition={{ ...SWAP, delay: play ? COPIED_AT : 0 }}
           >
             <CheckIcon className="size-3" />
             <div className="h-1.5 w-14 rounded-full bg-indigo-400" />
           </m.div>
         </div>
         <div className="relative shrink-0">
-          <m.div
+          <PressButton
+            play={play}
+            delay={PRESS_AT}
             className="h-7 w-14 rounded-md bg-indigo-600/90"
-            initial={false}
-            animate={play ? { scale: [1, 0.9, 1] } : { scale: 1 }}
-            transition={{ duration: 0.3, delay: play ? PRESS_AT : 0 }}
           />
           <m.div
             className="pointer-events-none absolute top-4 left-6"
             initial={false}
             animate={
-              play ? { opacity: 1, x: 0, y: 0 } : { opacity: 0, x: 26, y: 22 }
+              play ? { opacity: 1, x: 0, y: 0 } : { opacity: 0, x: 28, y: 24 }
             }
-            transition={{ duration: 0.5 }}
+            transition={
+              play
+                ? {
+                    x: { type: "spring", duration: 0.5, bounce: 0.2 },
+                    y: { type: "spring", duration: 0.5, bounce: 0.2 },
+                    opacity: { duration: 0.14, ease: EASE_OUT },
+                  }
+                : { ...EXIT, opacity: { duration: 0.12 } }
+            }
           >
             <CursorIcon />
           </m.div>

--- a/apps/landing/src/components/home/how-it-works/share-step-demo.tsx
+++ b/apps/landing/src/components/home/how-it-works/share-step-demo.tsx
@@ -5,6 +5,7 @@ import { MailIcon, MessageCircleIcon, SendIcon } from "lucide-react";
 import * as m from "motion/react-m";
 import { DemoScreen } from "../hero-demo/demo-frame";
 import { ACCENT } from "./accent";
+import type { Playback } from "./motion";
 import { EASE_OUT, EXIT } from "./motion";
 import { PressButton } from "./press-button";
 
@@ -30,81 +31,91 @@ const COPIED_AT = PRESS_AT + 0.1;
 // accent is what signals the copy.
 const SWAP = { duration: 0.2, ease: EASE_OUT } as const;
 
-export const ShareStepDemo = ({ play }: { play: boolean }) => (
-  <DemoScreen className="space-y-2 p-4">
-    <div className="space-y-1.5">
-      <div className="h-1.5 w-12 rounded-full bg-gray-300" />
-      <div className="flex items-center gap-2">
-        <div className="flex h-7 min-w-0 flex-1 items-center rounded-md border border-gray-200 bg-gray-50 px-2">
-          {/* The accent fades over the resting bar rather than replacing its
+export const ShareStepDemo = ({ playback }: { playback: Playback }) => {
+  const on = playback !== "idle";
+  const instant = playback === "done";
+  return (
+    <DemoScreen className="space-y-2 p-4">
+      <div className="space-y-1.5">
+        <div className="h-1.5 w-12 rounded-full bg-gray-300" />
+        <div className="flex items-center gap-2">
+          <div className="flex h-7 min-w-0 flex-1 items-center rounded-md border border-gray-200 bg-gray-50 px-2">
+            {/* The accent fades over the resting bar rather than replacing its
               class, so the recolor transitions instead of snapping. */}
-          <div className="relative h-1.5 w-28 shrink-0 overflow-hidden rounded-full bg-gray-300">
+            <div className="relative h-1.5 w-28 shrink-0 overflow-hidden rounded-full bg-gray-300">
+              <m.div
+                className={cn("absolute inset-0", ACCENT)}
+                initial={false}
+                animate={{ opacity: on ? 1 : 0 }}
+                transition={
+                  instant
+                    ? { duration: 0 }
+                    : { ...SWAP, delay: on ? COPIED_AT : 0 }
+                }
+              />
+            </div>
+          </div>
+          <div className="relative shrink-0">
+            <PressButton
+              playback={playback}
+              delay={PRESS_AT}
+              className={cn("h-7 w-14 rounded-md", ACCENT)}
+            />
             <m.div
-              className={cn("absolute inset-0", ACCENT)}
+              className="pointer-events-none absolute top-4 left-6"
               initial={false}
-              animate={{ opacity: play ? 1 : 0 }}
-              transition={{ ...SWAP, delay: play ? COPIED_AT : 0 }}
+              animate={
+                on ? { opacity: 1, x: 0, y: 0 } : { opacity: 0, x: 28, y: 24 }
+              }
+              transition={
+                instant
+                  ? { duration: 0 }
+                  : on
+                    ? {
+                        x: { type: "spring", duration: 0.5, bounce: 0.2 },
+                        y: { type: "spring", duration: 0.5, bounce: 0.2 },
+                        opacity: { duration: 0.14, ease: EASE_OUT },
+                      }
+                    : { ...EXIT, opacity: { duration: 0.12 } }
+              }
+            >
+              <CursorIcon />
+            </m.div>
+          </div>
+        </div>
+      </div>
+      <div className="space-y-1.5">
+        {CHANNELS.map((channel) => (
+          <div
+            key={channel.key}
+            className="flex items-center gap-2 rounded-md border border-gray-200 px-2 py-1.5"
+          >
+            <div className="flex size-5 shrink-0 items-center justify-center rounded bg-gray-100">
+              <channel.icon className="size-3 text-gray-400" />
+            </div>
+            <div
+              className={cn("h-1.5 rounded-full bg-gray-300", channel.width)}
             />
           </div>
-        </div>
-        <div className="relative shrink-0">
-          <PressButton
-            play={play}
-            delay={PRESS_AT}
-            className={cn("h-7 w-14 rounded-md", ACCENT)}
-          />
-          <m.div
-            className="pointer-events-none absolute top-4 left-6"
-            initial={false}
-            animate={
-              play ? { opacity: 1, x: 0, y: 0 } : { opacity: 0, x: 28, y: 24 }
-            }
-            transition={
-              play
-                ? {
-                    x: { type: "spring", duration: 0.5, bounce: 0.2 },
-                    y: { type: "spring", duration: 0.5, bounce: 0.2 },
-                    opacity: { duration: 0.14, ease: EASE_OUT },
-                  }
-                : { ...EXIT, opacity: { duration: 0.12 } }
-            }
-          >
-            <CursorIcon />
-          </m.div>
-        </div>
-      </div>
-    </div>
-    <div className="space-y-1.5">
-      {CHANNELS.map((channel) => (
-        <div
-          key={channel.key}
-          className="flex items-center gap-2 rounded-md border border-gray-200 px-2 py-1.5"
-        >
-          <div className="flex size-5 shrink-0 items-center justify-center rounded bg-gray-100">
-            <channel.icon className="size-3 text-gray-400" />
-          </div>
-          <div
-            className={cn("h-1.5 rounded-full bg-gray-300", channel.width)}
-          />
-        </div>
-      ))}
-    </div>
-    <div className="flex items-center gap-3 border-gray-200/60 border-t pt-3">
-      <div className="flex shrink-0 -space-x-1.5">
-        {[0, 1, 2, 3].map((participant) => (
-          <div
-            key={participant}
-            className="size-6 rounded-full bg-gray-300 ring-2 ring-white"
-          />
         ))}
       </div>
-      <div className="min-w-0 flex-1 space-y-1.5">
-        <div className="h-1.5 max-w-32 rounded-full bg-gray-200" />
-        <div className="h-1.5 max-w-20 rounded-full bg-gray-200" />
+      <div className="flex items-center gap-3 border-gray-200/60 border-t pt-3">
+        <div className="flex shrink-0 -space-x-1.5">
+          {[0, 1, 2, 3].map((participant) => (
+            <div
+              key={participant}
+              className="size-6 rounded-full bg-gray-300 ring-2 ring-white"
+            />
+          ))}
+        </div>
+        <div className="min-w-0 flex-1 space-y-1.5">
+          <div className="h-1.5 max-w-32 rounded-full bg-gray-200" />
+          <div className="h-1.5 max-w-20 rounded-full bg-gray-200" />
+        </div>
       </div>
-    </div>
-  </DemoScreen>
-);
+    </DemoScreen>
+  );
+};
 
 const CursorIcon = () => (
   <svg

--- a/apps/landing/src/components/home/how-it-works/share-step-demo.tsx
+++ b/apps/landing/src/components/home/how-it-works/share-step-demo.tsx
@@ -1,26 +1,67 @@
+"use client";
+
 import { cn } from "@rallly/ui";
-import { MailIcon, MessageCircleIcon, SendIcon } from "lucide-react";
+import { CheckIcon, MailIcon, MessageCircleIcon, SendIcon } from "lucide-react";
+import * as m from "motion/react-m";
 import { DemoScreen } from "../hero-demo/demo-frame";
 
 // A textless mock of the invite step: a link field with a copy button, ways
 // to send it, and the group it goes out to. Bars stand in for copy so it
 // doesn't compete with the section text. Fills the 4:3 frame on the how it
 // works section.
+//
+// On play a pointer travels to the copy button, presses it, and the link field
+// flips to a confirmation. The pointer is drawn rather than implied so the
+// button dip reads as a click.
 const CHANNELS = [
   { key: "email", icon: MailIcon, width: "w-20" },
   { key: "chat", icon: MessageCircleIcon, width: "w-14" },
   { key: "direct", icon: SendIcon, width: "w-24" },
 ];
 
-export const ShareStepDemo = () => (
+const PRESS_AT = 0.55;
+const COPIED_AT = PRESS_AT + 0.15;
+
+export const ShareStepDemo = ({ play }: { play: boolean }) => (
   <DemoScreen className="space-y-2 p-4">
     <div className="space-y-1.5">
       <div className="h-1.5 w-12 rounded-full bg-gray-300" />
       <div className="flex items-center gap-2">
-        <div className="flex h-7 min-w-0 flex-1 items-center gap-1.5 rounded-md border border-gray-200 bg-gray-50 px-2">
-          <div className="h-1.5 w-28 rounded-full bg-gray-300" />
+        <div className="relative flex h-7 min-w-0 flex-1 items-center gap-1.5 rounded-md border border-gray-200 bg-gray-50 px-2">
+          <m.div
+            className="h-1.5 w-28 rounded-full bg-gray-300"
+            initial={false}
+            animate={{ opacity: play ? 0 : 1 }}
+            transition={{ duration: 0.15, delay: play ? COPIED_AT : 0.1 }}
+          />
+          <m.div
+            className="absolute top-1/2 left-2 flex -translate-y-1/2 items-center gap-1 text-indigo-600"
+            initial={false}
+            animate={{ opacity: play ? 1 : 0 }}
+            transition={{ duration: 0.15, delay: play ? COPIED_AT : 0 }}
+          >
+            <CheckIcon className="size-3" />
+            <div className="h-1.5 w-14 rounded-full bg-indigo-400" />
+          </m.div>
         </div>
-        <div className="h-7 w-14 shrink-0 rounded-md bg-indigo-600/90" />
+        <div className="relative shrink-0">
+          <m.div
+            className="h-7 w-14 rounded-md bg-indigo-600/90"
+            initial={false}
+            animate={play ? { scale: [1, 0.9, 1] } : { scale: 1 }}
+            transition={{ duration: 0.3, delay: play ? PRESS_AT : 0 }}
+          />
+          <m.div
+            className="pointer-events-none absolute top-4 left-6"
+            initial={false}
+            animate={
+              play ? { opacity: 1, x: 0, y: 0 } : { opacity: 0, x: 26, y: 22 }
+            }
+            transition={{ duration: 0.5 }}
+          >
+            <CursorIcon />
+          </m.div>
+        </div>
       </div>
     </div>
     <div className="space-y-1.5">
@@ -53,4 +94,15 @@ export const ShareStepDemo = () => (
       </div>
     </div>
   </DemoScreen>
+);
+
+const CursorIcon = () => (
+  <svg
+    aria-hidden="true"
+    viewBox="0 0 12 12"
+    className="size-4 fill-gray-900 stroke-white drop-shadow-sm"
+    strokeWidth="1"
+  >
+    <path d="M1 1 L1 10 L3.5 7.6 L5.3 11 L7 10.1 L5.2 6.9 L8.6 6.7 Z" />
+  </svg>
 );

--- a/apps/landing/src/components/home/how-it-works/share-step-demo.tsx
+++ b/apps/landing/src/components/home/how-it-works/share-step-demo.tsx
@@ -4,6 +4,7 @@ import { cn } from "@rallly/ui";
 import { CheckIcon, MailIcon, MessageCircleIcon, SendIcon } from "lucide-react";
 import * as m from "motion/react-m";
 import { DemoScreen } from "../hero-demo/demo-frame";
+import { ACCENT } from "./accent";
 import { EASE_OUT, EXIT } from "./motion";
 import { PressButton } from "./press-button";
 
@@ -24,9 +25,9 @@ const CHANNELS = [
 const PRESS_AT = 0.42;
 const COPIED_AT = PRESS_AT + 0.1;
 
-// The url and the confirmation blur through each other rather than crossfading
-// cleanly: without it you read two overlapping bars swapping, with it one label
-// turning into the other.
+// Copying recolors the url in place rather than swapping it for a shorter
+// confirmation: the bar keeps its width so the field never shows a gap, and
+// the check is the only thing that appears.
 const SWAP = { duration: 0.2, ease: EASE_OUT } as const;
 
 export const ShareStepDemo = ({ play }: { play: boolean }) => (
@@ -34,34 +35,42 @@ export const ShareStepDemo = ({ play }: { play: boolean }) => (
     <div className="space-y-1.5">
       <div className="h-1.5 w-12 rounded-full bg-gray-300" />
       <div className="flex items-center gap-2">
-        <div className="relative flex h-7 min-w-0 flex-1 items-center gap-1.5 rounded-md border border-gray-200 bg-gray-50 px-2">
+        <div className="relative flex h-7 min-w-0 flex-1 items-center rounded-md border border-gray-200 bg-gray-50 px-2">
+          {/* The check sits out of flow so the url keeps its exact position
+              and width when the copy lands. */}
           <m.div
-            className="h-1.5 w-28 rounded-full bg-gray-300"
+            className="absolute -right-0.5 text-violet-500"
             initial={false}
-            animate={{
-              opacity: play ? 0 : 1,
-              filter: play ? "blur(2px)" : "blur(0px)",
-            }}
-            transition={{ ...SWAP, delay: play ? COPIED_AT : 0.06 }}
-          />
-          <m.div
-            className="absolute top-1/2 left-2 flex -translate-y-1/2 items-center gap-1 text-indigo-600"
-            initial={false}
-            animate={{
-              opacity: play ? 1 : 0,
-              filter: play ? "blur(0px)" : "blur(2px)",
-            }}
-            transition={{ ...SWAP, delay: play ? COPIED_AT : 0 }}
+            animate={{ opacity: play ? 1 : 0, scale: play ? 1 : 0.7 }}
+            transition={
+              play
+                ? {
+                    type: "spring",
+                    duration: 0.4,
+                    bounce: 0.4,
+                    delay: COPIED_AT,
+                  }
+                : EXIT
+            }
           >
             <CheckIcon className="size-3" />
-            <div className="h-1.5 w-14 rounded-full bg-indigo-400" />
           </m.div>
+          {/* The accent fades over the resting bar rather than replacing its
+              class, so the recolor transitions instead of snapping. */}
+          <div className="relative h-1.5 w-28 shrink-0 overflow-hidden rounded-full bg-gray-300">
+            <m.div
+              className={cn("absolute inset-0", ACCENT)}
+              initial={false}
+              animate={{ opacity: play ? 1 : 0 }}
+              transition={{ ...SWAP, delay: play ? COPIED_AT : 0 }}
+            />
+          </div>
         </div>
         <div className="relative shrink-0">
           <PressButton
             play={play}
             delay={PRESS_AT}
-            className="h-7 w-14 rounded-md bg-indigo-600/90"
+            className={cn("h-7 w-14 rounded-md", ACCENT)}
           />
           <m.div
             className="pointer-events-none absolute top-4 left-6"

--- a/apps/landing/src/components/home/how-it-works/step-stage.tsx
+++ b/apps/landing/src/components/home/how-it-works/step-stage.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useReducedMotion } from "motion/react";
+import { useInView, useReducedMotion } from "motion/react";
 import * as React from "react";
 import { CreateStepDemo } from "./create-step-demo";
 import { DecideStepDemo } from "./decide-step-demo";
@@ -36,31 +36,12 @@ export const StepCue = ({
   children: React.ReactNode;
   className?: string;
 }) => {
-  const [started, setStarted] = React.useState(false);
   const ref = React.useRef<HTMLDivElement>(null);
-
-  React.useEffect(() => {
-    const el = ref.current;
-    if (!el) {
-      return;
-    }
-    // A bottom margin so the walkthrough starts as the cards come up rather
-    // than the instant the first pixel appears. Deliberately no ratio
-    // threshold: the strip can be taller than the viewport, where a fraction
-    // like 0.4 would never be reached and the section would never play.
-    const observer = new IntersectionObserver(
-      ([entry]) => {
-        if (!entry.isIntersecting) {
-          return;
-        }
-        observer.disconnect();
-        setStarted(true);
-      },
-      { rootMargin: "0px 0px -15% 0px" },
-    );
-    observer.observe(el);
-    return () => observer.disconnect();
-  }, []);
+  // A bottom margin so the walkthrough starts as the cards come up rather than
+  // the instant the first pixel appears. Deliberately no amount threshold: the
+  // strip can be taller than the viewport, where a fraction like 0.4 would
+  // never be reached and the section would never play.
+  const started = useInView(ref, { once: true, margin: "0px 0px -15% 0px" });
 
   return (
     <div ref={ref} className={className}>

--- a/apps/landing/src/components/home/how-it-works/step-stage.tsx
+++ b/apps/landing/src/components/home/how-it-works/step-stage.tsx
@@ -4,6 +4,7 @@ import { useReducedMotion } from "motion/react";
 import * as React from "react";
 import { CreateStepDemo } from "./create-step-demo";
 import { DecideStepDemo } from "./decide-step-demo";
+import type { Playback } from "./motion";
 import { ShareStepDemo } from "./share-step-demo";
 
 // The demo is picked here rather than passed in: a server component can't hand
@@ -83,6 +84,9 @@ export const StepStage = ({
   const [play, setPlay] = React.useState(false);
   const reduceMotion = useReducedMotion();
   const Demo = DEMOS[step];
+  // Reduced motion skips the sequence and shows the outcome, rather than
+  // playing the same timed choreography with the movement left in.
+  const playback: Playback = reduceMotion ? "done" : play ? "play" : "idle";
 
   React.useEffect(() => {
     if (!started) {
@@ -97,7 +101,7 @@ export const StepStage = ({
   return (
     <div aria-hidden="true" className={className}>
       <div className="w-full max-w-64">
-        <Demo play={reduceMotion ? true : play} />
+        <Demo playback={playback} />
       </div>
     </div>
   );

--- a/apps/landing/src/components/home/how-it-works/step-stage.tsx
+++ b/apps/landing/src/components/home/how-it-works/step-stage.tsx
@@ -1,0 +1,81 @@
+"use client";
+
+import { useReducedMotion } from "motion/react";
+import * as React from "react";
+import { CreateStepDemo } from "./create-step-demo";
+import { DecideStepDemo } from "./decide-step-demo";
+import { ShareStepDemo } from "./share-step-demo";
+
+// Owns when a step's demo animates. Hover is the trigger on pointer devices:
+// each replay starts from the top, so the same card can be watched again.
+// Touch devices never fire hover, so entering the viewport plays it once.
+//
+// The demo is picked here rather than passed in: a server component can't hand
+// a client component a render prop, and the wireframes are decorative, so
+// selecting on a key keeps the section a server component.
+const DEMOS = {
+  create: CreateStepDemo,
+  share: ShareStepDemo,
+  decide: DecideStepDemo,
+};
+
+export type StepKey = keyof typeof DEMOS;
+
+export const StepStage = ({
+  step,
+  className,
+}: {
+  step: StepKey;
+  className?: string;
+}) => {
+  const [play, setPlay] = React.useState(false);
+  const reduceMotion = useReducedMotion();
+  const ref = React.useRef<HTMLDivElement>(null);
+  const Demo = DEMOS[step];
+
+  React.useEffect(() => {
+    const el = ref.current;
+    if (!el) {
+      return;
+    }
+    if (window.matchMedia("(hover: hover)").matches) {
+      return;
+    }
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (!entry.isIntersecting) {
+          return;
+        }
+        observer.disconnect();
+        setPlay(true);
+      },
+      { threshold: 0.5 },
+    );
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, []);
+
+  return (
+    <div
+      ref={ref}
+      aria-hidden="true"
+      className={className}
+      onPointerEnter={(event) => {
+        if (event.pointerType === "touch") {
+          return;
+        }
+        setPlay(true);
+      }}
+      onPointerLeave={(event) => {
+        if (event.pointerType === "touch") {
+          return;
+        }
+        setPlay(false);
+      }}
+    >
+      <div className="w-full max-w-64">
+        <Demo play={reduceMotion ? true : play} />
+      </div>
+    </div>
+  );
+};

--- a/apps/landing/src/components/home/how-it-works/step-stage.tsx
+++ b/apps/landing/src/components/home/how-it-works/step-stage.tsx
@@ -6,10 +6,6 @@ import { CreateStepDemo } from "./create-step-demo";
 import { DecideStepDemo } from "./decide-step-demo";
 import { ShareStepDemo } from "./share-step-demo";
 
-// Owns when a step's demo animates. Hover is the trigger on pointer devices:
-// each replay starts from the top, so the same card can be watched again.
-// Touch devices never fire hover, so entering the viewport plays it once.
-//
 // The demo is picked here rather than passed in: a server component can't hand
 // a client component a render prop, and the wireframes are decorative, so
 // selecting on a key keeps the section a server component.
@@ -21,58 +17,85 @@ const DEMOS = {
 
 export type StepKey = keyof typeof DEMOS;
 
-export const StepStage = ({
-  step,
+// Each step waits its turn so the three read as one walkthrough rather than
+// three things happening at once. Roughly the length of a step's own sequence,
+// so the next one starts as the previous settles.
+const STEP_STAGGER = 900;
+
+// The cue comes from the first step rather than each step watching itself:
+// below lg the later cards sit outside the viewport in a horizontal scroller,
+// so self-observation would start their sequences whenever they were scrolled
+// to, breaking the order.
+const StepCueContext = React.createContext(false);
+
+export const StepCue = ({
+  children,
   className,
 }: {
-  step: StepKey;
+  children: React.ReactNode;
   className?: string;
 }) => {
-  const [play, setPlay] = React.useState(false);
-  const reduceMotion = useReducedMotion();
+  const [started, setStarted] = React.useState(false);
   const ref = React.useRef<HTMLDivElement>(null);
-  const Demo = DEMOS[step];
 
   React.useEffect(() => {
     const el = ref.current;
     if (!el) {
       return;
     }
-    if (window.matchMedia("(hover: hover)").matches) {
-      return;
-    }
+    // A bottom margin so the walkthrough starts as the cards come up rather
+    // than the instant the first pixel appears. Deliberately no ratio
+    // threshold: the strip can be taller than the viewport, where a fraction
+    // like 0.4 would never be reached and the section would never play.
     const observer = new IntersectionObserver(
       ([entry]) => {
         if (!entry.isIntersecting) {
           return;
         }
         observer.disconnect();
-        setPlay(true);
+        setStarted(true);
       },
-      { threshold: 0.5 },
+      { rootMargin: "0px 0px -15% 0px" },
     );
     observer.observe(el);
     return () => observer.disconnect();
   }, []);
 
   return (
-    <div
-      ref={ref}
-      aria-hidden="true"
-      className={className}
-      onPointerEnter={(event) => {
-        if (event.pointerType === "touch") {
-          return;
-        }
-        setPlay(true);
-      }}
-      onPointerLeave={(event) => {
-        if (event.pointerType === "touch") {
-          return;
-        }
-        setPlay(false);
-      }}
-    >
+    <div ref={ref} className={className}>
+      <StepCueContext.Provider value={started}>
+        {children}
+      </StepCueContext.Provider>
+    </div>
+  );
+};
+
+export const StepStage = ({
+  step,
+  index,
+  className,
+}: {
+  step: StepKey;
+  index: number;
+  className?: string;
+}) => {
+  const started = React.useContext(StepCueContext);
+  const [play, setPlay] = React.useState(false);
+  const reduceMotion = useReducedMotion();
+  const Demo = DEMOS[step];
+
+  React.useEffect(() => {
+    if (!started) {
+      return;
+    }
+    // Plays once and holds: the finished state says more than the empty one,
+    // so there is nothing to gain from resetting it.
+    const timer = setTimeout(() => setPlay(true), index * STEP_STAGGER);
+    return () => clearTimeout(timer);
+  }, [started, index]);
+
+  return (
+    <div aria-hidden="true" className={className}>
       <div className="w-full max-w-64">
         <Demo play={reduceMotion ? true : play} />
       </div>


### PR DESCRIPTION
The three how it works cards were static wireframes. They now play their step: dates being picked, the invite link being copied, votes arriving and a winner resolving.

## Behaviour

The section plays once when it scrolls into view and holds the finished state. Steps are staggered, so step 1 runs, then 2, then 3, roughly a step's own length apart.

`StepCue` owns the trigger and shares it through context so all three sequence off a single observer. Observing each card separately breaks the order below `lg`, where the later cards sit outside the viewport in a horizontal scroller and would otherwise start whenever they were scrolled to.

Reduced motion pins the demos to their finished state rather than the empty one, since a permanently blank vote grid would be a regression against the previous static design.

## Motion

A shared vocabulary in `motion.ts` keeps the three steps moving as one system: a strong ease-out curve, one stagger value, one exit. Dates, votes and the score bar settle on springs rather than interpolating, stagger sits in the 60-90ms range, and exits are faster than entrances.

Button presses are two beats (`PressButton`): a fast dip on a duration curve, then a spring release. A keyframe array throws `Only two keyframes currently supported with spring` at runtime, which is worth knowing before reaching for one.

The primary actions reuse the indigo to violet gradient from the hero event card, so the walkthrough reads as the same product surface rather than a flat indigo that appears nowhere else.

## Verification

Type-check and lint pass. The animations were verified running in a browser while they were hover triggered.

**The scroll trigger and the step stagger are not verified running.** `IntersectionObserver` never fires in the browser pane I had available, confirmed against a trivial visible element, so I could not watch the sequence play on scroll. The DOM structure and server render are correct and the logic is straightforward, but the timing wants a look in a real browser before merge.

`STEP_STAGGER` in `step-stage.tsx` is the single knob if the pacing feels off.

## Worth a second opinion

Step 2 is the weakest of the three. Copying a link is one click rather than a process, so the animation spends its time moving a cursor to a button to recolour a bar. Steps 1 and 3 explain something the static wireframe could not; step 2 arguably does not, and could be cut back to just the button press.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added animated walkthrough demonstrations to the landing page’s “How it works” section.
  * Demos now play automatically as they enter the viewport, with sequenced interactions across calendar selection, decision-making, and link sharing.
  * Added reduced-motion support and completed states for accessible, interruption-free playback.
  * Improved visual consistency with shared gradients and smoother button, cursor, vote, and selection animations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->