### PR TITLE
Fix plan card layout on mobile devices

### DIFF
--- a/apps/landing/src/app/[locale]/(main)/pricing/plan-card.tsx
+++ b/apps/landing/src/app/[locale]/(main)/pricing/plan-card.tsx
@@ -9,7 +9,7 @@ export function PlanCards({
   return (
     <div
       className={cn(
-        "grid w-fit max-w-full divide-y divide-gray-950/5 overflow-hidden rounded-2xl border bg-white md:grid-cols-[minmax(16rem,2fr)_minmax(24rem,3fr)] md:divide-x md:divide-y-0",
+        "grid w-full max-w-full divide-y divide-gray-950/5 overflow-hidden rounded-2xl border bg-white md:w-fit md:grid-cols-[minmax(16rem,2fr)_minmax(24rem,3fr)] md:divide-x md:divide-y-0",
         className,
       )}
       {...props}


### PR DESCRIPTION
## Description

Fixed the plan card component to display at full width on mobile devices while maintaining the optimized two-column layout on desktop screens.

**Changes:**
- Modified the `PlanCards` component's className to use `w-full` on mobile and `md:w-fit` on desktop
- This ensures the pricing cards are responsive and fill the available width on smaller screens
- Desktop behavior remains unchanged with the two-column grid layout

## Checklist

- [x] I have performed a self-review of my code
- [x] My code follows the code style of this project
- [x] I have commented my code, particularly in hard-to-understand areas

https://claude.ai/code/session_01DamCDYHz6PMFZSxicbyoXe

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Pricing plan cards now use the full available width on smaller screens while retaining a compact layout on medium and larger screens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->