### PR TITLE
🐛 Fix step animation timing for horizontally scrolled cards

### DIFF
--- a/apps/landing/src/components/home/how-it-works/step-stage.tsx
+++ b/apps/landing/src/components/home/how-it-works/step-stage.tsx
@@ -23,11 +23,9 @@ export type StepKey = keyof typeof DEMOS;
 // so the next one starts as the previous settles.
 const STEP_STAGGER = 900;
 
-// The cue comes from the first step rather than each step watching itself:
-// below lg the later cards sit outside the viewport in a horizontal scroller,
-// so self-observation would start their sequences whenever they were scrolled
-// to, breaking the order.
-const StepCueContext = React.createContext(false);
+// When the section came into view, so a step can tell how much of its slot in
+// the walkthrough is left. Null until it does.
+const StepCueContext = React.createContext<number | null>(null);
 
 export const StepCue = ({
   children,
@@ -42,10 +40,17 @@ export const StepCue = ({
   // strip can be taller than the viewport, where a fraction like 0.4 would
   // never be reached and the section would never play.
   const started = useInView(ref, { once: true, margin: "0px 0px -15% 0px" });
+  const [startedAt, setStartedAt] = React.useState<number | null>(null);
+
+  React.useEffect(() => {
+    if (started) {
+      setStartedAt(performance.now());
+    }
+  }, [started]);
 
   return (
     <div ref={ref} className={className}>
-      <StepCueContext.Provider value={started}>
+      <StepCueContext.Provider value={startedAt}>
         {children}
       </StepCueContext.Provider>
     </div>
@@ -61,7 +66,13 @@ export const StepStage = ({
   index: number;
   className?: string;
 }) => {
-  const started = React.useContext(StepCueContext);
+  const startedAt = React.useContext(StepCueContext);
+  const ref = React.useRef<HTMLDivElement>(null);
+  // Below lg the cards sit in a horizontal scroller, so a step can be off to
+  // the side long after the section itself is on screen. Waiting for the stage
+  // itself means a demo never plays out of sight; half of it keeps the card
+  // peeking in past the gutter from counting as arrived.
+  const arrived = useInView(ref, { once: true, amount: 0.5 });
   const [play, setPlay] = React.useState(false);
   const reduceMotion = useReducedMotion();
   const Demo = DEMOS[step];
@@ -70,17 +81,24 @@ export const StepStage = ({
   const playback: Playback = reduceMotion ? "done" : play ? "play" : "idle";
 
   React.useEffect(() => {
-    if (!started) {
+    if (startedAt === null || !arrived) {
       return;
     }
+    // The stagger orders steps that arrive together: what is left of this
+    // step's slot, and nothing at all for a step scrolled to later, which is
+    // its own cue and should play as it lands.
+    const delay = Math.max(
+      0,
+      index * STEP_STAGGER - (performance.now() - startedAt),
+    );
     // Plays once and holds: the finished state says more than the empty one,
     // so there is nothing to gain from resetting it.
-    const timer = setTimeout(() => setPlay(true), index * STEP_STAGGER);
+    const timer = setTimeout(() => setPlay(true), delay);
     return () => clearTimeout(timer);
-  }, [started, index]);
+  }, [startedAt, arrived, index]);
 
   return (
-    <div aria-hidden="true" className={className}>
+    <div ref={ref} aria-hidden="true" className={className}>
       <div className="w-full max-w-64">
         <Demo playback={playback} />
       </div>


### PR DESCRIPTION
## Description

This change fixes the animation timing for the "how it works" step cards on the landing page, particularly when they're displayed in a horizontal scroller on smaller screens.

**Problem:** The previous implementation used a boolean context value to signal when the section came into view. This caused steps to play their animations whenever they were scrolled into the viewport, breaking the intended staggered animation order. On smaller screens where cards sit in a horizontal scroller, later cards would trigger their animations out of sequence.

**Solution:** 
- Changed `StepCueContext` from a boolean to track the timestamp (`number | null`) when the section came into view
- Added individual `useInView` observation to each `StepStage` component to detect when that specific card arrives in the viewport
- Updated the animation delay calculation to account for elapsed time since the section started, ensuring steps that arrive late play immediately rather than waiting for their original stagger delay
- Added comments explaining the rationale for observing individual steps rather than relying on section-level observation

The fix ensures animations play in the correct order regardless of scroll position, and steps that are scrolled to after the section loads play immediately upon arrival rather than being delayed.

## Checklist

- [x] I have performed a self-review of my code
- [x] My code follows the code style of this project
- [x] I have commented my code, particularly in hard-to-understand areas

https://claude.ai/code/session_01B5pcjGQoGdvnhS8oan9cym

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved “How It Works” stage animations by coordinating playback from the section start time.
  * Ensured each stage begins animating when at least half of its card is visible.
  * Improved consistency of staggered animation timing as users scroll through the section.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->