### PR TITLE
💄 Make the stats badges tick and roll up more naturally

### DIFF
--- a/apps/landing/src/components/home/animated-number.tsx
+++ b/apps/landing/src/components/home/animated-number.tsx
@@ -5,6 +5,16 @@ import { BarChart2Icon, UsersIcon } from "lucide-react";
 import * as React from "react";
 
 const DURATION_MS = 1200;
+// Logarithmic spin: log10(1 + 9t) sampled into a CSS linear() easing.
+//
+// The obvious "decelerating" curves (expo-out and friends) put ~97% of the
+// count in the first half of the duration, so the digits snap to nearly the
+// final value and then sit still through a long dead tail. A log curve keeps
+// them visibly climbing for the whole spin — quick off the mark, easing down,
+// but still moving at t=0.9 — which is what reads as counting up rather than
+// landing. Falls back to constant-rate easing below Safari 17.2.
+const LOG_EASING =
+  "linear(0, 0.1383, 0.243, 0.3274, 0.3979, 0.4586, 0.5119, 0.5593, 0.6021, 0.641, 0.6767, 0.7097, 0.7404, 0.769, 0.7959, 0.8212, 0.8451, 0.8678, 0.8893, 0.9098, 0.9294, 0.9482, 0.9661, 0.9834, 1)";
 
 // Locates the first localized integer (any Unicode numbering system, with
 // locale grouping separators) so the surrounding translation stays untouched.
@@ -40,8 +50,29 @@ function parseLocalizedInteger(text: string, locale: string) {
 }
 
 const THIRTY_DAYS_MS = 30 * 24 * 60 * 60 * 1000;
-// Below this the ticker would fire faster than it reads as a discrete event.
-const MIN_TICK_MS = 2000;
+// Keeps a burst from firing faster than a digit roll can settle.
+const MIN_GAP_MS = 700;
+// Stops a long random gap from reading as "the ticker died". Relative to the
+// mean so a slow badge keeps its shape instead of being squashed against a
+// fixed ceiling, with an absolute backstop for very slow ones.
+const MAX_GAP_FACTOR = 2.5;
+const MAX_GAP_MS = 25000;
+
+/**
+ * Random gap around a mean, drawn from an exponential distribution.
+ *
+ * Votes arrive independently of each other, which makes arrivals a Poisson
+ * process and the gaps between them exponential — so sampling this way makes
+ * the badge cluster and pause the way real traffic does, instead of ticking
+ * like a metronome. The clamps trade a little of that shape for the two
+ * things a uniform timer got for free: no burst too fast to read, no gap long
+ * enough to look broken.
+ */
+function nextGapMs(meanMs: number) {
+  const gap = -Math.log(1 - Math.random()) * meanMs;
+  const ceiling = Math.min(meanMs * MAX_GAP_FACTOR, MAX_GAP_MS);
+  return Math.min(Math.max(gap, MIN_GAP_MS), Math.max(ceiling, MIN_GAP_MS));
+}
 
 /**
  * Ticks the badge up at the average rate the 30-day count was accumulated,
@@ -69,15 +100,40 @@ function useLiveCount({
     if (!enabled || tickMs <= 0) {
       return;
     }
-    const interval = Math.max(tickMs, MIN_TICK_MS);
     const startedAt = Date.now();
-    // Derived from the wall clock rather than incremented, so a throttled or
-    // suspended timer catches up in one step instead of drifting behind.
-    const id = window.setInterval(() => {
+    let timeout: number;
+    // The displayed count is always derived from elapsed wall-clock time, so
+    // the jitter only decides *when* to look — it never feeds back into the
+    // arithmetic. That keeps the average exactly the measured rate however
+    // the gaps fall, and lets a throttled or suspended timer catch up in one
+    // step instead of drifting behind.
+    const sample = () => {
       const elapsed = Math.max(0, Date.now() - startedAt);
-      setValue(baseValue + Math.floor(elapsed / interval));
-    }, interval);
-    return () => window.clearInterval(id);
+      setValue(baseValue + Math.floor(elapsed / tickMs));
+    };
+    const schedule = () => {
+      timeout = window.setTimeout(() => {
+        sample();
+        schedule();
+      }, nextGapMs(tickMs));
+    };
+    schedule();
+
+    const onVisibility = () => {
+      if (document.visibilityState !== "visible") {
+        return;
+      }
+      // Resync on return so a backgrounded tab shows the right number
+      // immediately rather than waiting out a stale timer.
+      window.clearTimeout(timeout);
+      sample();
+      schedule();
+    };
+    document.addEventListener("visibilitychange", onVisibility);
+    return () => {
+      window.clearTimeout(timeout);
+      document.removeEventListener("visibilitychange", onVisibility);
+    };
   }, [baseValue, tickMs, enabled]);
 
   return value;
@@ -185,7 +241,7 @@ function AnimatedNumber({
           transformTiming={{ duration: 0 }}
           spinTiming={{
             duration: DURATION_MS,
-            easing: "cubic-bezier(0.16, 1, 0.3, 1)",
+            easing: LOG_EASING,
           }}
         />
       </span>


### PR DESCRIPTION
Follow-up to #3038. Two feel changes, no change to what the numbers claim.

## Jittered ticking

The ticker fired on a fixed interval — at current volume (296,372 voters) that's a flat 8.7s wait, which is easy to miss entirely if you glance at the line and look away.

Gaps are now drawn from an **exponential distribution** around the true interval. Votes arrive independently of one another, so that's the distribution real arrival gaps actually follow: the badge clusters and pauses like traffic instead of ticking like a metronome.

| | fixed | jittered |
|---|---|---|
| median gap | 8.7s | 6.1s |
| tick within 3s | 0% | 29% |
| tick within 5s | 0% | 44% |

**The average rate is unchanged and still exactly the measured one.** The displayed value stays derived from elapsed wall-clock time (`base + floor(elapsed / trueInterval)`), so jitter only decides *when to sample* — it never feeds back into the arithmetic. Simulating a 30-minute session, the displayed count lands within 1 of truth for both badges.

Clamps: a 700ms floor so a burst can't outrun a digit roll settling, and a ceiling at 2.5x the mean (absolute backstop 25s) so a long random gap doesn't read as "the ticker died".

## Logarithmic roll-up

The scroll-in spin used `cubic-bezier(0.16, 1, 0.3, 1)` — an expo-out curve that reaches ~97% of the count by the halfway point. The digits snapped to nearly the final value and then sat still through a long dead tail.

A log curve (`log10(1 + 9t)`, sampled into CSS `linear()`) keeps them climbing for the whole 1.2s:

| elapsed | old (expo-out) | new (log) |
|---|---|---|
| 120ms | 146,407 | 82,023 |
| 600ms | 288,073 | 219,433 |
| 840ms | 295,186 | 255,846 |
| 1080ms | 296,372 | 284,202 |

Still to climb in the final third: **1,186 before, 40,526 now.**

Slightly counterintuitive but worth noting: logarithmic is *gentler* early than what it replaces. The win isn't a faster start, it's that the animation stops finishing early and going quiet.

`linear()` needs Chrome 113+ / Firefox 112+ / Safari 17.2+; older browsers fall back to constant-rate easing, which is a fine degradation.

## Verification

Easing verified in-browser against the real page: the browser accepts the string, and sampling the running animation gives 0.277 / 0.568 / 0.740 / 0.863 / 0.959 at t = 0.1–0.9, matching the logarithmic target to three decimals. Jitter distribution and drift verified by simulation. `tsc` and Biome clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Improved animated number transitions with smoother roll-up easing.
  * Live count updates now appear more naturally paced.
  * Counts resynchronize when returning to the page after it was hidden.
  * Improved timer handling for more reliable animation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->