### PR TITLE
Refactor winner row styling with gradient edge and layered background

### DIFF
--- a/apps/landing/src/components/home/how-it-works/accent.ts
+++ b/apps/landing/src/components/home/how-it-works/accent.ts
@@ -2,3 +2,8 @@
 // reuse it so the walkthrough reads as the same product surface as the hero,
 // rather than a flat indigo that appears nowhere else.
 export const ACCENT = "bg-linear-to-r from-indigo-500 to-violet-500";
+
+// The same gradient at the weight a hairline carries, for edges that used to
+// be a flat indigo-200. Gradients cannot live in border-color, so this is
+// applied as a padded backdrop behind the surface rather than as a border.
+export const ACCENT_EDGE = "bg-linear-to-r from-indigo-500/30 to-violet-500/30";

--- a/apps/landing/src/components/home/how-it-works/decide-step-demo.tsx
+++ b/apps/landing/src/components/home/how-it-works/decide-step-demo.tsx
@@ -4,7 +4,7 @@ import { cn } from "@rallly/ui";
 import { VoteIcon } from "@rallly/ui/vote-icon";
 import * as m from "motion/react-m";
 import { DemoScreen } from "../hero-demo/demo-frame";
-import { ACCENT } from "./accent";
+import { ACCENT, ACCENT_EDGE } from "./accent";
 import type { Playback } from "./motion";
 import { EASE_OUT, EXIT } from "./motion";
 
@@ -35,87 +35,99 @@ export const DecideStepDemo = ({ playback }: { playback: Playback }) => {
   return (
     <DemoScreen className="space-y-1.5 p-4">
       {ROWS.map((row, rowIndex) => (
-        <m.div
+        <div
           // biome-ignore lint/suspicious/noArrayIndexKey: static wireframe rows
           key={rowIndex}
+          // The winner's edge is the accent gradient, so it has to be a padded
+          // backdrop behind the surface rather than a border. Every row uses
+          // the same shape so the metrics stay identical.
           className={cn(
-            "flex items-center justify-between gap-3 rounded-md border px-2.5 py-2",
-            row.winner ? "border-indigo-200" : "border-gray-200",
+            "rounded-md p-px",
+            row.winner ? ACCENT_EDGE : "bg-gray-200",
           )}
-          initial={false}
-          animate={{
-            backgroundColor:
-              on && row.winner ? "rgb(238 242 255)" : "rgba(255,255,255,0)",
-          }}
-          transition={
-            instant
-              ? { duration: 0 }
-              : on
-                ? { duration: 0.34, ease: EASE_OUT, delay: WINNER_DELAY }
-                : EXIT
-          }
         >
-          <div className="min-w-0 space-y-1.5">
-            <div
-              className={cn(
-                "h-1.5 w-16 rounded-full",
-                row.winner ? "bg-indigo-400" : "bg-gray-300",
-              )}
-            />
-            <div className="flex items-center gap-2">
-              <div className="h-1.5 w-10 rounded-full bg-gray-200" />
-              {row.winner ? (
-                <m.div
-                  className={cn("h-1.5 w-12 rounded-full", ACCENT)}
-                  initial={false}
-                  animate={{ opacity: on ? 1 : 0, scaleX: on ? 1 : 0.4 }}
-                  style={{ originX: 0 }}
-                  transition={
-                    instant
-                      ? { duration: 0 }
-                      : on
-                        ? {
-                            type: "spring",
-                            duration: 0.5,
-                            bounce: 0.24,
-                            delay: WINNER_DELAY + 0.08,
-                          }
-                        : EXIT
-                  }
-                />
-              ) : null}
-            </div>
-          </div>
-          <div className="flex shrink-0 items-center gap-1">
-            {row.votes.map((vote, voteIndex) => (
+          <div className="relative overflow-hidden rounded-[5px] bg-white">
+            {/* The winning row's wash lives in its own layer and fades in,
+                because a gradient cannot be animated the way a colour can. */}
+            {row.winner ? (
               <m.div
-                // biome-ignore lint/suspicious/noArrayIndexKey: static wireframe votes
-                key={voteIndex}
+                className={cn("pointer-events-none absolute inset-0", ACCENT)}
                 initial={false}
-                animate={
-                  on
-                    ? { opacity: 1, scale: 1, y: 0 }
-                    : { opacity: 0, scale: 0.82, y: -3 }
-                }
+                animate={{ opacity: on ? 0.08 : 0 }}
                 transition={
                   instant
                     ? { duration: 0 }
                     : on
-                      ? {
-                          type: "spring",
-                          duration: 0.46,
-                          bounce: 0.38,
-                          delay:
-                            voteIndex * VOTER_STAGGER + rowIndex * ROW_STAGGER,
-                        }
+                      ? { duration: 0.34, ease: EASE_OUT, delay: WINNER_DELAY }
                       : EXIT
                 }
-              >
-                <VoteIcon type={vote} className="size-3.5" />
-              </m.div>
-            ))}
+              />
+            ) : null}
+            <div className="relative flex items-center justify-between gap-3 px-2.5 py-2">
+              <div className="min-w-0 space-y-1.5">
+                <div
+                  className={cn(
+                    "h-1.5 w-16 rounded-full",
+                    row.winner ? ACCENT : "bg-gray-300",
+                  )}
+                />
+                <div className="flex items-center gap-2">
+                  <div className="h-1.5 w-10 rounded-full bg-gray-200" />
+                  {row.winner ? (
+                    <m.div
+                      className={cn("h-1.5 w-12 rounded-full", ACCENT)}
+                      initial={false}
+                      animate={{ opacity: on ? 1 : 0, scaleX: on ? 1 : 0.4 }}
+                      style={{ originX: 0 }}
+                      transition={
+                        instant
+                          ? { duration: 0 }
+                          : on
+                            ? {
+                                type: "spring",
+                                duration: 0.5,
+                                bounce: 0.24,
+                                delay: WINNER_DELAY + 0.08,
+                              }
+                            : EXIT
+                      }
+                    />
+                  ) : null}
+                </div>
+              </div>
+              <div className="flex shrink-0 items-center gap-1">
+                {row.votes.map((vote, voteIndex) => (
+                  <m.div
+                    // biome-ignore lint/suspicious/noArrayIndexKey: static wireframe votes
+                    key={voteIndex}
+                    initial={false}
+                    animate={
+                      on
+                        ? { opacity: 1, scale: 1, y: 0 }
+                        : { opacity: 0, scale: 0.82, y: -3 }
+                    }
+                    transition={
+                      instant
+                        ? { duration: 0 }
+                        : on
+                          ? {
+                              type: "spring",
+                              duration: 0.46,
+                              bounce: 0.38,
+                              delay:
+                                voteIndex * VOTER_STAGGER +
+                                rowIndex * ROW_STAGGER,
+                            }
+                          : EXIT
+                    }
+                  >
+                    <VoteIcon type={vote} className="size-3.5" />
+                  </m.div>
+                ))}
+              </div>
+            </div>
           </div>
-        </m.div>
+        </div>
       ))}
     </DemoScreen>
   );

--- a/apps/landing/src/components/home/how-it-works/decide-step-demo.tsx
+++ b/apps/landing/src/components/home/how-it-works/decide-step-demo.tsx
@@ -14,7 +14,10 @@ import { EASE_OUT, EXIT } from "./motion";
 // section.
 //
 // On play the votes arrive a participant at a time, so each column drops in as
-// one response, and the winning row lights up once they're all in.
+// one response. Until they are all in every option looks the same: the winning
+// row starts as grey as the rest and only takes on the accent once the last
+// vote lands, so the demo shows the decision being made rather than announcing
+// it up front.
 const ROWS: { votes: ("yes" | "ifNeedBe" | "no")[]; winner: boolean }[] = [
   { votes: ["yes", "yes", "yes", "yes"], winner: true },
   { votes: ["yes", "no", "yes", "no"], winner: false },
@@ -32,45 +35,56 @@ const WINNER_DELAY = ROWS[0].votes.length * VOTER_STAGGER + 0.12;
 export const DecideStepDemo = ({ playback }: { playback: Playback }) => {
   const on = playback !== "idle";
   const instant = playback === "done";
+  // Every part of the winner's accent — edge, wash, label — arrives on the
+  // same beat, so the row reads as one thing lighting up.
+  const accentIn = instant
+    ? { duration: 0 }
+    : on
+      ? { duration: 0.34, ease: EASE_OUT, delay: WINNER_DELAY }
+      : EXIT;
   return (
     <DemoScreen className="space-y-1.5 p-4">
       {ROWS.map((row, rowIndex) => (
         <div
           // biome-ignore lint/suspicious/noArrayIndexKey: static wireframe rows
           key={rowIndex}
-          // The winner's edge is the accent gradient, so it has to be a padded
-          // backdrop behind the surface rather than a border. Every row uses
-          // the same shape so the metrics stay identical.
-          className={cn(
-            "rounded-md p-px",
-            row.winner ? ACCENT_EDGE : "bg-gray-200",
-          )}
+          // A gradient cannot live in border-color, so the edge is a padded
+          // backdrop behind the surface. Every row keeps the same shape, and
+          // the winner's gradient edge cross-fades over the grey one.
+          className="relative rounded-md bg-gray-200 p-px"
         >
+          {row.winner ? (
+            <m.div
+              className={cn(
+                "pointer-events-none absolute inset-0 rounded-md",
+                ACCENT_EDGE,
+              )}
+              initial={false}
+              animate={{ opacity: on ? 1 : 0 }}
+              transition={accentIn}
+            />
+          ) : null}
           <div className="relative overflow-hidden rounded-[5px] bg-white">
-            {/* The winning row's wash lives in its own layer and fades in,
-                because a gradient cannot be animated the way a colour can. */}
             {row.winner ? (
               <m.div
                 className={cn("pointer-events-none absolute inset-0", ACCENT)}
                 initial={false}
                 animate={{ opacity: on ? 0.08 : 0 }}
-                transition={
-                  instant
-                    ? { duration: 0 }
-                    : on
-                      ? { duration: 0.34, ease: EASE_OUT, delay: WINNER_DELAY }
-                      : EXIT
-                }
+                transition={accentIn}
               />
             ) : null}
             <div className="relative flex items-center justify-between gap-3 px-2.5 py-2">
               <div className="min-w-0 space-y-1.5">
-                <div
-                  className={cn(
-                    "h-1.5 w-16 rounded-full",
-                    row.winner ? ACCENT : "bg-gray-300",
-                  )}
-                />
+                <div className="relative h-1.5 w-16 overflow-hidden rounded-full bg-gray-300">
+                  {row.winner ? (
+                    <m.div
+                      className={cn("absolute inset-0", ACCENT)}
+                      initial={false}
+                      animate={{ opacity: on ? 1 : 0 }}
+                      transition={accentIn}
+                    />
+                  ) : null}
+                </div>
                 <div className="flex items-center gap-2">
                   <div className="h-1.5 w-10 rounded-full bg-gray-200" />
                   {row.winner ? (


### PR DESCRIPTION
## Description

Refactored the "decide step" demo component to improve the visual treatment of winning rows by:

1. **Introduced `ACCENT_EDGE` constant** - A semi-transparent gradient variant of the accent color (indigo-500/30 to violet-500/30) for use as a padded backdrop edge instead of a flat border
2. **Restructured row layout** - Changed from a motion-animated outer div with border to a static outer div with gradient edge padding, containing an inner white surface with a layered gradient wash
3. **Separated gradient animation** - The winning row's gradient background now lives in its own animated layer that fades in/out, since gradients cannot be animated the way solid colors can
4. **Improved visual consistency** - The gradient treatment now matches the accent used elsewhere in the product (hero section), creating a more cohesive design language

The refactoring maintains all existing animations for vote icons and accent elements while improving the structural approach to styling the winner's edge and background wash.

## Checklist

- [x] I have performed a self-review of my code
- [x] My code follows the code style of this project
- [x] I have commented my code, particularly in hard-to-understand areas

https://claude.ai/code/session_01KzpdGTfwoeALGRzrpGzRzu

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Refined the winner-row presentation in the “How it works” demo with a subtle gradient edge and animated accent effect.
  - Improved clipping and spacing to keep highlighted rows visually consistent.
  - Preserved the existing winner bars and staggered vote-icon animations while enhancing the overall visual polish.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->