### PR TITLE
💄 Make mentions a horizontally scrollable row on small screens

### DIFF
--- a/apps/landing/public/locales/en/home.json
+++ b/apps/landing/public/locales/en/home.json
@@ -91,6 +91,7 @@
   "howItWorksStepLabel": "Step {number}",
   "howItWorksTitle": "How it works",
   "hubspotQuote": "“The simplest choice for availability polling for large groups.”",
+  "mentionsLabel": "Press mentions",
   "metaDescription": "Rallly is the fastest and easiest scheduling and collaboration tool. Create a meeting poll in seconds, no login required.",
   "metaTitle": "Rallly: Free Group Meeting Scheduling Tool",
   "mobileVotingBlog": "A clearer way to vote on your phone",

--- a/apps/landing/src/app/[locale]/(main)/(seo)/best-doodle-alternative/page.tsx
+++ b/apps/landing/src/app/[locale]/(main)/(seo)/best-doodle-alternative/page.tsx
@@ -100,7 +100,7 @@ export default async function Page(props: {
         </Testimonial>
       </Section>
       <Section>
-        <Mentions>
+        <Mentions locale={locale}>
           <Mention
             delay={0.25}
             logo={

--- a/apps/landing/src/app/[locale]/(main)/(seo)/free-scheduling-poll/page.tsx
+++ b/apps/landing/src/app/[locale]/(main)/(seo)/free-scheduling-poll/page.tsx
@@ -100,7 +100,7 @@ export default async function Page(props: {
         </Testimonial>
       </Section>
       <Section>
-        <Mentions>
+        <Mentions locale={locale}>
           <Mention
             delay={0.25}
             logo={

--- a/apps/landing/src/app/[locale]/(main)/(seo)/scheduling-for/executive-assistants/page.tsx
+++ b/apps/landing/src/app/[locale]/(main)/(seo)/scheduling-for/executive-assistants/page.tsx
@@ -103,7 +103,7 @@ export default async function Page(props: {
         </Testimonial>
       </Section>
       <Section>
-        <Mentions>
+        <Mentions locale={locale}>
           <Mention
             delay={0.25}
             logo={

--- a/apps/landing/src/app/[locale]/(main)/(seo)/when2meet-alternative/page.tsx
+++ b/apps/landing/src/app/[locale]/(main)/(seo)/when2meet-alternative/page.tsx
@@ -100,7 +100,7 @@ export default async function Page(props: {
         </Testimonial>
       </Section>
       <Section>
-        <Mentions>
+        <Mentions locale={locale}>
           <Mention
             delay={0.25}
             logo={

--- a/apps/landing/src/app/[locale]/(main)/page.tsx
+++ b/apps/landing/src/app/[locale]/(main)/page.tsx
@@ -123,7 +123,7 @@ export default async function Page(props: {
         </Testimonial>
       </Section>
       <Section>
-        <Mentions>
+        <Mentions locale={locale}>
           <Mention
             delay={0.25}
             logo={

--- a/apps/landing/src/components/home/mentions.tsx
+++ b/apps/landing/src/components/home/mentions.tsx
@@ -10,7 +10,10 @@ export function Mention({
   delay?: number;
 }>) {
   return (
-    <FadeIn delay={delay} className="flex flex-col space-y-4 rounded-md">
+    <FadeIn
+      delay={delay}
+      className="flex snap-start flex-col space-y-4 rounded-md"
+    >
       <div className="flex items-start justify-between">{logo}</div>
       <p className="grow text-base">{children}</p>
     </FadeIn>
@@ -18,5 +21,16 @@ export function Mention({
 }
 
 export function Mentions({ children }: { children: React.ReactNode }) {
-  return <div className="grid gap-8 md:grid-cols-4">{children}</div>;
+  return (
+    // Below xl the four mentions stay side by side and scroll horizontally,
+    // bleeding past the page gutters so the next one peeks in. The column width
+    // is pinned to what a mention gets in the xl grid — the page container maxes
+    // out at 72rem with 1.5rem gutters, so (69rem - 3 * 2rem) / 4 = 15.75rem —
+    // which keeps every quote breaking across the same lines at every width.
+    // The pb/-mb pair gives the mentions' fade-in-up room to land inside the
+    // scroll port, which would otherwise show a vertical scrollbar for it.
+    <div className="-mx-4 -mb-5 grid snap-x snap-mandatory scroll-px-4 grid-cols-[repeat(4,15.75rem)] gap-4 overflow-x-auto overflow-y-hidden px-4 pb-5 sm:-mx-6 sm:scroll-px-6 sm:px-6 md:gap-8 xl:mx-0 xl:mb-0 xl:grid-cols-4 xl:overflow-visible xl:px-0 xl:pb-0">
+      {children}
+    </div>
+  );
 }

--- a/apps/landing/src/components/home/mentions.tsx
+++ b/apps/landing/src/components/home/mentions.tsx
@@ -1,5 +1,6 @@
 import type * as React from "react";
 import { FadeIn } from "@/components/home/fade-in";
+import { getTranslation } from "@/i18n/server";
 
 export function Mention({
   logo,
@@ -20,7 +21,14 @@ export function Mention({
   );
 }
 
-export function Mentions({ children }: { children: React.ReactNode }) {
+export async function Mentions({
+  locale,
+  children,
+}: {
+  locale: string;
+  children: React.ReactNode;
+}) {
+  const { t } = await getTranslation<"home">(locale, "home");
   return (
     // Below xl the four mentions stay side by side and scroll horizontally,
     // bleeding past the page gutters so the next one peeks in. The column width
@@ -29,8 +37,20 @@ export function Mentions({ children }: { children: React.ReactNode }) {
     // which keeps every quote breaking across the same lines at every width.
     // The pb/-mb pair gives the mentions' fade-in-up room to land inside the
     // scroll port, which would otherwise show a vertical scrollbar for it.
-    <div className="-mx-4 -mb-5 grid snap-x snap-mandatory scroll-px-4 grid-cols-[repeat(4,15.75rem)] gap-4 overflow-x-auto overflow-y-hidden px-4 pb-5 sm:-mx-6 sm:scroll-px-6 sm:px-6 md:gap-8 xl:mx-0 xl:mb-0 xl:grid-cols-4 xl:overflow-visible xl:px-0 xl:pb-0">
+    // A named, focusable section so the mentions that start off screen can be
+    // scrolled to by keyboard: none of them contain a focusable element, so
+    // without this the strip is unreachable outside of Chromium's own
+    // keyboard-focusable scrollers.
+    <section
+      aria-label={t("mentionsLabel", {
+        ns: "home",
+        defaultValue: "Press mentions",
+      })}
+      // biome-ignore lint/a11y/noNoninteractiveTabindex: a scroll port needs to be focusable to be scrollable by keyboard
+      tabIndex={0}
+      className="-mx-4 -mb-5 grid snap-x snap-mandatory scroll-px-4 grid-cols-[repeat(4,15.75rem)] gap-4 overflow-x-auto overflow-y-hidden px-4 pb-5 sm:-mx-6 sm:scroll-px-6 sm:px-6 md:gap-8 xl:mx-0 xl:mb-0 xl:grid-cols-4 xl:overflow-visible xl:px-0 xl:pb-0"
+    >
       {children}
-    </div>
+    </section>
   );
 }


### PR DESCRIPTION
Match the how it works section: below xl the four press mentions stay
side by side and scroll horizontally, bleeding past the page gutters so
the next one peeks in.

Each mention keeps the width it has in the large-screen grid (15.75rem —
the page container's 69rem of content minus three 2rem gaps, over four
columns), so every quote breaks across the same lines at every viewport
width instead of reflowing as the grid squeezes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved the mentions section layout across screen sizes.
  * Added horizontal scrolling and snap behavior on smaller screens.
  * Preserved the four-column grid layout on larger screens.
  * Enhanced mention animation timing for smoother presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->