### PR TITLE
⚡️ Cache landing stats for hours instead of days

### DIFF
--- a/apps/landing/src/lib/data.ts
+++ b/apps/landing/src/lib/data.ts
@@ -7,7 +7,7 @@ const THIRTY_DAYS_MS = 30 * 24 * 60 * 60 * 1000;
 
 export const getMonthlyPollCount = async () => {
   "use cache";
-  cacheLife("days");
+  cacheLife("hours");
   return prisma.poll.count({
     where: {
       deleted: false,
@@ -23,7 +23,7 @@ export const getMonthlyPollCount = async () => {
 
 export const getMonthlyVoterCount = async () => {
   "use cache";
-  cacheLife("days");
+  cacheLife("hours");
   return prisma.participant.count({
     where: {
       createdAt: { gte: new Date(Date.now() - THIRTY_DAYS_MS) },


### PR DESCRIPTION
## Description

The monthly poll and voter counts shown as social proof on the landing pages were cached with `cacheLife("days")`, so the numbers could lag a full day behind reality. This shortens both `getMonthlyPollCount` and `getMonthlyVoterCount` in `apps/landing/src/lib/data.ts` to `cacheLife("hours")`.

**Note for reviewers:** this change alone won't make the numbers visibly refresh hourly. The pages that render these stats set their own `cacheLife("days")` at the page level — `(main)/page.tsx`, the four `(seo)` pages, and `pricing/page.tsx` — and that page-level cache entry governs what actually gets served. Shortening the data functions lowers the revalidation floor but the rendered HTML on those routes still turns over daily. If hourly-fresh numbers are the goal, those page-level calls need the same treatment; I left them alone since it changes the cache behaviour of the whole page, not just the stats.

## Checklist

Please check off all the following items with an "x" in the boxes before requesting a review.

- [x] I have performed a self-review of my code
- [x] My code follows the code style of this project
- [x] I have commented my code, particularly in hard-to-understand areas

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the freshness of monthly poll and voter statistics by updating cached data more frequently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->