### PR TITLE
💄 Give every demo preset a single winning column

### DIFF
--- a/apps/landing/src/components/home/hero-demo/demo-presets.ts
+++ b/apps/landing/src/components/home/hero-demo/demo-presets.ts
@@ -23,8 +23,13 @@ export type DemoPresetName =
 
 // Votes are indexed against the flattened option list — four Thursdays, two
 // slots each — so every participant needs exactly eight, or the scores and the
-// winning-column highlight fall out of alignment. The last column is a "yes"
-// from everyone in every preset, so the demo always resolves to a clear winner.
+// winning-column highlight fall out of alignment.
+//
+// Every preset holds to the same invariant: the last column is a "yes" from
+// everyone, and no other column ties it. The highlight lights up every column
+// matching the top score, so a tie would highlight several at once and lose the
+// "here is your answer" read. Note the score counts "ifNeedBe" as available, so
+// breaking a tie needs a hard "no", not an "ifNeedBe".
 //
 // Presets are built with literal t() calls rather than looked up by key: the
 // extractor works by static analysis and removeUnusedKeys is on, so a dynamic
@@ -184,7 +189,7 @@ const defaultParticipants: DemoPreset["participants"] = [
   },
   {
     name: "Priya Patel",
-    votes: ["yes", "yes", "yes", "no", "yes", "yes", "no", "yes"],
+    votes: ["yes", "yes", "yes", "no", "no", "yes", "no", "yes"],
   },
   {
     name: "Tom Becker",
@@ -192,18 +197,18 @@ const defaultParticipants: DemoPreset["participants"] = [
   },
   {
     name: "Grace Okafor",
-    votes: ["no", "yes", "no", "yes", "yes", "no", "no", "yes"],
+    votes: ["no", "no", "no", "yes", "yes", "no", "no", "yes"],
   },
 ];
 
 // An interview panel: four colleagues plus the candidate, who is the one
-// external in the room and the reason the poll gets shared as a link. Their
-// availability is the tightest, which is what makes the last slot the only one
-// that works for everyone.
+// external in the room and the reason the poll gets shared as a link. The
+// candidate's availability is the tightest, which is what leaves the last slot
+// as the only one that works for everyone.
 const executiveAssistantParticipants: DemoPreset["participants"] = [
   {
     name: "Daniel Whitfield",
-    votes: ["no", "ifNeedBe", "no", "yes", "no", "yes", "ifNeedBe", "no"],
+    votes: ["no", "ifNeedBe", "no", "no", "no", "yes", "ifNeedBe", "yes"],
   },
   {
     name: "Amara Osei",
@@ -211,11 +216,11 @@ const executiveAssistantParticipants: DemoPreset["participants"] = [
   },
   {
     name: "Henrik Lindqvist",
-    votes: ["no", "yes", "ifNeedBe", "yes", "yes", "yes", "no", "no"],
+    votes: ["no", "yes", "ifNeedBe", "no", "yes", "yes", "no", "yes"],
   },
   {
     name: "Claire Fontaine",
-    votes: ["yes", "no", "no", "yes", "ifNeedBe", "no", "yes", "ifNeedBe"],
+    votes: ["yes", "no", "no", "ifNeedBe", "ifNeedBe", "no", "yes", "yes"],
   },
   {
     name: "Jordan Reyes",


### PR DESCRIPTION
Follow-up to #3049.

Every hero demo preset already had a slot that worked for everyone, but two broke the stricter rule the winning-column highlight depends on: exactly one winner, in the last column.

## The two problems

**The default preset had three tied winners.** Columns 2, 5 and 8 all scored 4/4. The highlight added in #3048 uses `score === topScore`, so it lights up *every* column matching the top score — meaning the homepage and footer demo highlighted three columns at once, which undercuts the "here is your answer" read the highlight exists to deliver.

**The executive assistants preset resolved in column 4.** Its highlight sat mid-table, and a reader scanning left to right saw the demo end on a losing 3/5. Swapped columns 4 and 8. The preset's own comment already claimed the last slot was the winner, so the data now matches its documentation.

## Before / after

| Preset | Before | After |
| --- | --- | --- |
| default | `3,4,2,3,4,2,1,4` — winners at 2, 5, 8 | `3,3,2,3,3,2,1,4` — winner at 8 |
| executiveAssistant | `2,2,2,5,2,3,3,3` — winner at 4 | `2,2,2,3,2,3,3,5` — winner at 8 |
| committee | `3,2,2,3,3,2,2,5` | unchanged |
| sportsClub | `3,3,4,3,3,4,3,6` | unchanged |
| thesisDefense | `2,2,2,2,2,1,2,4` | unchanged |
| legal | `2,3,3,3,2,2,3,5` | unchanged |

## Note for whoever edits these next

The score counts `ifNeedBe` as available, so breaking a tie needs a hard `no` — an `ifNeedBe` looks like it should lower the score and doesn't. I hit this while fixing the default preset and have documented it on the invariant comment.

## Verification

Checked the rendered pages, not just the arrays: all six demos show exactly one highlighted vote count, in the last column, equal to the participant count. Confirmed the highlight styling (`font-medium`) applies to exactly one badge per demo. Type-check and lint pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated preset guidance to clarify eight-vote alignment requirements.
  * Documented that the final column must have a unique winning option, including tie-breaking considerations.
* **Bug Fixes**
  * Adjusted sample voting data to consistently produce a single winning option in the final column.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->