### PR TITLE
💄 Stop animating in the final CTA

### DIFF
--- a/apps/landing/src/components/home/capture-on-view.tsx
+++ b/apps/landing/src/components/home/capture-on-view.tsx
@@ -1,21 +1,24 @@
 "use client";
 
 import { posthog } from "@rallly/posthog/client";
+import type { ReactNode } from "react";
 import * as React from "react";
 
 /**
  * Fires a PostHog event the first time its contents scroll into view.
  *
- * Uses a partial threshold rather than requiring the whole block to be visible:
- * a full-visibility threshold silently never fires when the block is taller
- * than the viewport, which would drop the event on small screens.
+ * Deliberately not a ratio threshold: a block taller than twice the viewport
+ * can never reach a 0.5 ratio, and one taller than the viewport can never
+ * reach 1, so either would silently stop reporting on small screens. Insetting
+ * the root bottom edge instead means "scrolled meaningfully into view" holds
+ * at any element height.
  */
 export function CaptureOnView({
   event,
   children,
 }: {
   event: string;
-  children: React.ReactNode;
+  children: ReactNode;
 }) {
   const ref = React.useRef<HTMLDivElement>(null);
 
@@ -32,7 +35,7 @@ export function CaptureOnView({
         observer.disconnect();
         posthog.capture(event);
       },
-      { threshold: 0.5 },
+      { rootMargin: "0px 0px -150px 0px" },
     );
     observer.observe(el);
     return () => observer.disconnect();

--- a/apps/landing/src/components/home/capture-on-view.tsx
+++ b/apps/landing/src/components/home/capture-on-view.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+import { posthog } from "@rallly/posthog/client";
+import * as React from "react";
+
+/**
+ * Fires a PostHog event the first time its contents scroll into view.
+ *
+ * Uses a partial threshold rather than requiring the whole block to be visible:
+ * a full-visibility threshold silently never fires when the block is taller
+ * than the viewport, which would drop the event on small screens.
+ */
+export function CaptureOnView({
+  event,
+  children,
+}: {
+  event: string;
+  children: React.ReactNode;
+}) {
+  const ref = React.useRef<HTMLDivElement>(null);
+
+  React.useEffect(() => {
+    const el = ref.current;
+    if (!el) {
+      return;
+    }
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (!entry.isIntersecting) {
+          return;
+        }
+        observer.disconnect();
+        posthog.capture(event);
+      },
+      { threshold: 0.5 },
+    );
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, [event]);
+
+  return <div ref={ref}>{children}</div>;
+}

--- a/apps/landing/src/components/home/cta.tsx
+++ b/apps/landing/src/components/home/cta.tsx
@@ -1,7 +1,7 @@
 import { cn } from "@rallly/ui";
 import type * as React from "react";
+import { CaptureOnView } from "@/components/home/capture-on-view";
 import { CtaButton } from "@/components/home/cta-button";
-import { FadeIn } from "@/components/home/fade-in";
 import { handwritten } from "@/fonts/handwritten";
 
 export function Cta({
@@ -16,7 +16,7 @@ export function Cta({
   hint: React.ReactNode;
 }) {
   return (
-    <FadeIn amount="all" captureOnEnter="landing:final_cta_view">
+    <CaptureOnView event="landing:final_cta_view">
       <div className="grid gap-4 text-center sm:grid-cols-2 sm:gap-6 sm:text-left">
         <h2 className="text-balance font-medium text-2xl text-gray-800 leading-tight tracking-tight sm:text-4xl">
           {title}
@@ -39,6 +39,6 @@ export function Cta({
           {hint}
         </p>
       </div>
-    </FadeIn>
+    </CaptureOnView>
   );
 }


### PR DESCRIPTION
The final CTA faded and slid into view on scroll. This removes that animation so it renders in place.

## Why this isn't a one-line deletion

`FadeIn` was doing double duty: the fade/slide animation **and** firing the `landing:final_cta_view` PostHog event via Motion's `onViewportEnter`. Deleting the wrapper outright would have silently dropped that event.

So the two concerns are split. A new `CaptureOnView` component fires the event with a plain `IntersectionObserver` and no animation. `FadeIn` is untouched and still used by `mentions.tsx` and `testimonial.tsx`.

## One deliberate behaviour change

The old wrapper used `amount="all"`, firing only once the block was **fully** visible. When the CTA is taller than the viewport that condition can never be met, so the event never fires. `CaptureOnView` uses `threshold: 0.5` instead, so it still fires on small screens.

**This means `landing:final_cta_view` counts may tick up slightly** — flagging it since it's an analytics metric, not just cosmetics.

## Verification

The browser preview pane reported `window.innerHeight: 0`, so nothing can intersect its viewport and it can't validate observer behaviour. Verified with Playwright in a real browser instead, at 1280x800 and 375x600:

- Below the fold: `opacity: 1`, `transform: none`, no inline style. Motion previously set `opacity: 0; translateY(20px)` here.
- `landing:final_cta_view` absent at page top, fires once scrolled into view — at both viewports, including the narrow case the old code was at risk of dropping.

Biome and `tsc --noEmit` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added one-time analytics tracking when the landing page’s final call-to-action enters the viewport.
  * Detection now works reliably for call-to-action sections of varying heights after meaningful visibility.

* **Bug Fixes**
  * Simplified the final call-to-action’s visibility handling by removing unnecessary animation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->