### PR TITLE
🔧 Register the orphaned-guest cleanup cron

### DIFF
--- a/apps/web/src/features/user/mutations.ts
+++ b/apps/web/src/features/user/mutations.ts
@@ -155,9 +155,14 @@ const DELETE_ORPHANED_ANONYMOUS_USERS_BATCH_SIZE = 100;
  *
  * Two guards, both required:
  *  - The `lastSeenAt` window IS the liveness check. Prod sessions live in
- *    Redis, so we can't probe them at delete time; but session TTL equals
- *    this window and every session refresh bumps `lastSeenAt`, so a guest
- *    below the cutoff provably has no live session left to orphan.
+ *    Redis, so we can't probe them at delete time. What rules out a live
+ *    session is the session TTL: it equals this window, so any session
+ *    belonging to a guest below the cutoff has already expired. `lastSeenAt`
+ *    is a lower bound on that expiry, not a record of it — a returning guest
+ *    gets a fresh session, and `session.create` writes `lastSeenAt`, lifting
+ *    them back above the cutoff. Note the value can also predate any session
+ *    at all: rows carrying the column's backfill default were never observed,
+ *    so read a stale `lastSeenAt` as "no session since", not "last active at".
  *  - The resource filter guards the cascade. A guest's polls/comments are
  *    onDelete: Cascade, so deleting one who still owns a live poll would
  *    destroy everyone's votes/comments.

--- a/apps/web/src/features/user/mutations.ts
+++ b/apps/web/src/features/user/mutations.ts
@@ -147,7 +147,12 @@ export async function hardDeleteUser({ userId }: { userId: string }) {
   await prisma.user.delete({ where: { id: userId } });
 }
 
-const DELETE_ORPHANED_ANONYMOUS_USERS_BATCH_SIZE = 100;
+// Each batch is one round trip, and the handler's budget is maxDuration (300s),
+// so this sets how much backlog a single run can clear. 100 left the job unable
+// to drain even a modest arrivals backlog inside the budget; 1000 keeps the
+// per-batch transaction small while giving a run an order of magnitude more
+// headroom. Raising it further trades that headroom against lock and WAL size.
+const DELETE_ORPHANED_ANONYMOUS_USERS_BATCH_SIZE = 1000;
 
 /**
  * Delete orphaned anonymous guest users: guests that own no resources and

--- a/apps/web/vercel.json
+++ b/apps/web/vercel.json
@@ -22,6 +22,10 @@
     {
       "path": "/api/house-keeping/remove-deleted-users",
       "schedule": "0 7 * * *"
+    },
+    {
+      "path": "/api/house-keeping/delete-orphaned-anonymous-users",
+      "schedule": "30 7 * * *"
     }
   ]
 }


### PR DESCRIPTION
Enables the `delete-orphaned-anonymous-users` house-keeping job, which has shipped dormant since #2764.

Closes RAL-1475.

## Why now

The endpoint was deliberately left out of `vercel.json` because the accumulated backlog of anonymous guests meant its first run would have tried to delete too large a batch in one pass. That backlog has now been drained as a supervised one-off — **608,780 users** — so the daily job only ever sees a trickle from here.

The drain also verified the purge's guards against production: all fourteen cascading `User` relations matched zero anonymous users, confirming the invariant that guests own no resources. The CI guard added in #3023 keeps that list from drifting.

## Changes

**Register the cron** at 07:30 UTC, after `remove-deleted-users`, continuing the half-hour spacing of the existing house-keeping crons and staying inside the same quiet window.

**Raise the batch size 100 → 1000.** Each batch is a round trip and the handler is capped at `maxDuration = 300`, so the batch size decides how much backlog one run can clear. At 100 a run tops out around a few thousand rows — below the ~10k arrivals backlog the job faces on its first scheduled execution. 1000 keeps each transaction small while giving a run an order of magnitude more headroom. No test depends on the constant.

**Correct the liveness argument** in the mutation's docblock. It read as though a stale `lastSeenAt` were itself proof of no live session, which is circular — the column is written by the session hooks it claims to vouch for. What actually rules out a live session is the session TTL equalling the window. The distinction matters for rows carrying the column's backfill default: those were never observed at all, and made up 587,787 of the 608,780 rows drained.

## Verification

- `pnpm check` — clean (one pre-existing unrelated warning)
- `pnpm type-check` — clean
- `pnpm check:cascades` — all 15 relations accounted for
- `vercel.json` parses, five crons in the expected order

Behavior of the endpoint itself is unchanged apart from batch size; the existing coverage in `apps/web/tests/house-keeping.spec.ts` still applies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an automated daily cleanup of orphaned anonymous accounts at 07:30 UTC.

* **Performance**
  * Increased the cleanup batch size to process more orphaned accounts per run.

* **Documentation**
  * Clarified cleanup behavior, including session expiration, session refreshes, and stale activity timestamps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->