### PR TITLE
🐛 Cap the orphaned-guest cleanup and run it hourly

### DIFF
--- a/apps/web/src/app/api/house-keeping/[...method]/route.ts
+++ b/apps/web/src/app/api/house-keeping/[...method]/route.ts
@@ -185,10 +185,14 @@ app.get("/remove-deleted-users", async (c) => {
 app.get("/delete-orphaned-anonymous-users", async (c) => {
   const deleted = await deleteOrphanedAnonymousUsers();
 
-  logger.info(
-    { task: "delete-orphaned-anonymous-users", deleted },
-    "Deleted orphaned anonymous guest users idle longer than the session length",
-  );
+  // Runs hourly and most runs find nothing, so stay quiet unless there was
+  // work — otherwise the signal is buried in 24 no-op lines a day.
+  if (deleted > 0) {
+    logger.info(
+      { task: "delete-orphaned-anonymous-users", deleted },
+      "Deleted orphaned anonymous guest users idle longer than the session length",
+    );
+  }
 
   return c.json({
     success: true,

--- a/apps/web/src/features/user/mutations.ts
+++ b/apps/web/src/features/user/mutations.ts
@@ -147,12 +147,21 @@ export async function hardDeleteUser({ userId }: { userId: string }) {
   await prisma.user.delete({ where: { id: userId } });
 }
 
-// Each batch is one round trip, and the handler's budget is maxDuration (300s),
-// so this sets how much backlog a single run can clear. 100 left the job unable
-// to drain even a modest arrivals backlog inside the budget; 1000 keeps the
-// per-batch transaction small while giving a run an order of magnitude more
-// headroom. Raising it further trades that headroom against lock and WAL size.
-const DELETE_ORPHANED_ANONYMOUS_USERS_BATCH_SIZE = 1000;
+const DELETE_ORPHANED_ANONYMOUS_USERS_BATCH_SIZE = 500;
+
+// Hard ceiling on one invocation. The job runs hourly, so capacity is
+// 500/hour against an arrival rate well under that — the cap exists so a
+// run's cost stays flat regardless of how much backlog is waiting, rather
+// than to keep pace on its own. An unbounded loop is what timed out when
+// the cron was first enabled: the eligibility predicate spans fifteen
+// relations, so re-deriving it per batch is the dominant cost, and a large
+// backlog made the number of derivations unbounded too.
+//
+// A backlog therefore drains over hours rather than in one run, which is
+// the intended behaviour: this job maintains a steady state. A one-time
+// accumulation (a migration backfill, a long outage) wants a supervised
+// drain, not a bigger ceiling here.
+const DELETE_ORPHANED_ANONYMOUS_USERS_MAX_PER_RUN = 500;
 
 /**
  * Delete orphaned anonymous guest users: guests that own no resources and
@@ -213,17 +222,18 @@ export async function deleteOrphanedAnonymousUsers() {
   } satisfies Prisma.UserWhereInput;
 
   let deleted = 0;
-  let hasMore = true;
 
-  while (hasMore) {
+  while (deleted < DELETE_ORPHANED_ANONYMOUS_USERS_MAX_PER_RUN) {
     const batch = await prisma.user.findMany({
       where: orphanedAnonymousFilter,
       select: { id: true },
-      take: DELETE_ORPHANED_ANONYMOUS_USERS_BATCH_SIZE,
+      take: Math.min(
+        DELETE_ORPHANED_ANONYMOUS_USERS_BATCH_SIZE,
+        DELETE_ORPHANED_ANONYMOUS_USERS_MAX_PER_RUN - deleted,
+      ),
     });
 
     if (batch.length === 0) {
-      hasMore = false;
       break;
     }
 
@@ -238,6 +248,15 @@ export async function deleteOrphanedAnonymousUsers() {
     });
 
     deleted += count;
+
+    // A batch can select rows that the re-check then rejects, and a fully
+    // rejected batch leaves `deleted` unmoved. Those rows no longer match the
+    // filter, so the next pass excludes them — but only once the write that
+    // disqualified them is visible here, so stop rather than risk re-selecting
+    // the same batch indefinitely. The next scheduled run picks up the rest.
+    if (count < batch.length) {
+      break;
+    }
   }
 
   return deleted;

--- a/apps/web/vercel.json
+++ b/apps/web/vercel.json
@@ -25,7 +25,7 @@
     },
     {
       "path": "/api/house-keeping/delete-orphaned-anonymous-users",
-      "schedule": "30 7 * * *"
+      "schedule": "45 * * * *"
     }
   ]
 }


### PR DESCRIPTION
Follow-up to #3055. The `delete-orphaned-anonymous-users` cron timed out on its first scheduled run.

## Cause

Not the batch size. The eligibility predicate spans fifteen relations, so re-deriving it is the dominant cost of each batch — the `EXPLAIN` from the manual backfill showed the driving index scan feeding a chain of anti-joins, with `participants` (304k rows) and `spaces` (92k) seq-scanned as hash anti-joins. The loop ran that predicate twice per batch and had no bound on iterations, so with ~10k rows waiting the number of derivations was unbounded too.

Raising the batch size 100 → 1000 in #3055 didn't help, because per-batch cost scales with the predicate rather than the row count. That was my misdiagnosis.

## Fix

Bound the work per invocation. A run deletes at most 500 rows; the cron moves from daily to hourly, giving 500/hour capacity against an arrival rate well under that. Cost per run is now flat regardless of backlog — the property the job was missing.

This follows the conventional shape for cleanup jobs (small batches, frequent runs, no attempt to finish in one pass): failures are cheap, runtime is predictable, and the job is sized for steady state rather than for a backlog it sees once.

A backlog now drains over hours instead of in one run. That's intended — a one-time accumulation wants a supervised drain, which is how the original 608,780-row backlog was handled.

## Also in here

**Terminate on partial rejection.** A batch can select rows the delete-time re-check then rejects. Those rows no longer match the filter, but only once the disqualifying write is visible, so continuing risked re-selecting the same batch. Nothing bounded that before; a fully-rejected batch would have spun indefinitely.

**Quiet no-op runs.** Hourly means 24 invocations a day, most finding nothing. The handler now logs only when it deleted something.

**Schedule at :45** to stay clear of the other house-keeping crons, which run on the hour and half-hour.

## Notes

`BATCH_SIZE` and `MAX_PER_RUN` are both 500, so the loop currently runs a single iteration. They're kept separate because the cap is the knob worth tuning, and decoupling it now avoids a refactor if it's raised later.

## Verification

- `pnpm check` — clean (one pre-existing unrelated warning)
- `pnpm type-check` — clean
- `pnpm check:cascades` — all 15 relations accounted for
- `vercel.json` parses, five crons in the expected order

Existing coverage in `apps/web/tests/house-keeping.spec.ts` uses single-digit fixtures, so it exercises correctness but not the cap. It still passes; nothing there depends on either constant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cleanup of inactive anonymous accounts to prevent repeated processing and enforce safe deletion limits.
  * Reduced unnecessary housekeeping logs when no accounts are removed.

* **Maintenance**
  * Anonymous-account cleanup now runs hourly, improving the timeliness of account removal.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->