### PR TITLE
🔍️ Fix hreflang annotations on landing pages

### DIFF
--- a/apps/landing/src/app/[locale]/(main)/(seo)/best-doodle-alternative/page.tsx
+++ b/apps/landing/src/app/[locale]/(main)/(seo)/best-doodle-alternative/page.tsx
@@ -22,6 +22,7 @@ import {
   SectionTitle,
 } from "@/components/section";
 import { getTranslation } from "@/i18n/server";
+import { getAlternates } from "@/lib/alternates";
 import { getMonthlyPollCount, getMonthlyVoterCount } from "@/lib/data";
 
 export default async function Page(props: {
@@ -389,6 +390,7 @@ export async function generateMetadata(props: {
   const { locale } = await props.params;
   const { t } = await getTranslation(locale, "home");
   return {
+    alternates: getAlternates({ locale, path: "/best-doodle-alternative" }),
     title: t("doodleAlternativeMetaTitle", {
       ns: "home",
     }),

--- a/apps/landing/src/app/[locale]/(main)/(seo)/free-scheduling-poll/page.tsx
+++ b/apps/landing/src/app/[locale]/(main)/(seo)/free-scheduling-poll/page.tsx
@@ -22,6 +22,7 @@ import {
   SectionTitle,
 } from "@/components/section";
 import { getTranslation } from "@/i18n/server";
+import { getAlternates } from "@/lib/alternates";
 import { getMonthlyPollCount, getMonthlyVoterCount } from "@/lib/data";
 
 export default async function Page(props: {
@@ -372,6 +373,7 @@ export async function generateMetadata(props: {
   const { locale } = await props.params;
   const { t } = await getTranslation(locale, "home");
   return {
+    alternates: getAlternates({ locale, path: "/free-scheduling-poll" }),
     title: t("freeSchedulingPollMetaTitle", {
       ns: "home",
     }),

--- a/apps/landing/src/app/[locale]/(main)/(seo)/scheduling-for/committees/page.tsx
+++ b/apps/landing/src/app/[locale]/(main)/(seo)/scheduling-for/committees/page.tsx
@@ -22,6 +22,7 @@ import {
   SectionTitle,
 } from "@/components/section";
 import { getTranslation } from "@/i18n/server";
+import { getAlternates } from "@/lib/alternates";
 import { getMonthlyPollCount, getMonthlyVoterCount } from "@/lib/data";
 
 export default async function Page(props: {
@@ -375,6 +376,7 @@ export async function generateMetadata(props: {
   const { locale } = await props.params;
   const { t } = await getTranslation(locale, "home");
   return {
+    alternates: getAlternates({ locale, path: "/scheduling-for/committees" }),
     title: t("committeesMetaTitle", {
       ns: "home",
       defaultValue:

--- a/apps/landing/src/app/[locale]/(main)/(seo)/scheduling-for/executive-assistants/page.tsx
+++ b/apps/landing/src/app/[locale]/(main)/(seo)/scheduling-for/executive-assistants/page.tsx
@@ -22,6 +22,7 @@ import {
   SectionTitle,
 } from "@/components/section";
 import { getTranslation } from "@/i18n/server";
+import { getAlternates } from "@/lib/alternates";
 import { getMonthlyPollCount, getMonthlyVoterCount } from "@/lib/data";
 
 export default async function Page(props: {
@@ -375,6 +376,10 @@ export async function generateMetadata(props: {
   const { locale } = await props.params;
   const { t } = await getTranslation(locale, "home");
   return {
+    alternates: getAlternates({
+      locale,
+      path: "/scheduling-for/executive-assistants",
+    }),
     title: t("eaMetaTitle", {
       ns: "home",
       defaultValue:

--- a/apps/landing/src/app/[locale]/(main)/(seo)/scheduling-for/legal/page.tsx
+++ b/apps/landing/src/app/[locale]/(main)/(seo)/scheduling-for/legal/page.tsx
@@ -22,6 +22,7 @@ import {
   SectionTitle,
 } from "@/components/section";
 import { getTranslation } from "@/i18n/server";
+import { getAlternates } from "@/lib/alternates";
 import { getMonthlyPollCount, getMonthlyVoterCount } from "@/lib/data";
 
 export default async function Page(props: {
@@ -382,6 +383,7 @@ export async function generateMetadata(props: {
   const { locale } = await props.params;
   const { t } = await getTranslation(locale, "home");
   return {
+    alternates: getAlternates({ locale, path: "/scheduling-for/legal" }),
     title: t("legalMetaTitle", {
       ns: "home",
       defaultValue:

--- a/apps/landing/src/app/[locale]/(main)/(seo)/scheduling-for/sports-clubs/page.tsx
+++ b/apps/landing/src/app/[locale]/(main)/(seo)/scheduling-for/sports-clubs/page.tsx
@@ -22,6 +22,7 @@ import {
   SectionTitle,
 } from "@/components/section";
 import { getTranslation } from "@/i18n/server";
+import { getAlternates } from "@/lib/alternates";
 import { getMonthlyPollCount, getMonthlyVoterCount } from "@/lib/data";
 
 export default async function Page(props: {
@@ -375,6 +376,7 @@ export async function generateMetadata(props: {
   const { locale } = await props.params;
   const { t } = await getTranslation(locale, "home");
   return {
+    alternates: getAlternates({ locale, path: "/scheduling-for/sports-clubs" }),
     title: t("sportsClubsMetaTitle", {
       ns: "home",
       defaultValue:

--- a/apps/landing/src/app/[locale]/(main)/(seo)/scheduling-for/thesis-defense/page.tsx
+++ b/apps/landing/src/app/[locale]/(main)/(seo)/scheduling-for/thesis-defense/page.tsx
@@ -22,6 +22,7 @@ import {
   SectionTitle,
 } from "@/components/section";
 import { getTranslation } from "@/i18n/server";
+import { getAlternates } from "@/lib/alternates";
 import { getMonthlyPollCount, getMonthlyVoterCount } from "@/lib/data";
 
 export default async function Page(props: {
@@ -375,6 +376,10 @@ export async function generateMetadata(props: {
   const { locale } = await props.params;
   const { t } = await getTranslation(locale, "home");
   return {
+    alternates: getAlternates({
+      locale,
+      path: "/scheduling-for/thesis-defense",
+    }),
     title: t("thesisDefenseMetaTitle", {
       ns: "home",
       defaultValue:

--- a/apps/landing/src/app/[locale]/(main)/(seo)/when2meet-alternative/page.tsx
+++ b/apps/landing/src/app/[locale]/(main)/(seo)/when2meet-alternative/page.tsx
@@ -22,6 +22,7 @@ import {
   SectionTitle,
 } from "@/components/section";
 import { getTranslation } from "@/i18n/server";
+import { getAlternates } from "@/lib/alternates";
 import { getMonthlyPollCount, getMonthlyVoterCount } from "@/lib/data";
 
 export default async function Page(props: {
@@ -389,6 +390,7 @@ export async function generateMetadata(props: {
   const { locale } = await props.params;
   const { t } = await getTranslation(locale, "home");
   return {
+    alternates: getAlternates({ locale, path: "/when2meet-alternative" }),
     title: t("when2meetAlternativeMetaTitle", {
       ns: "home",
     }),

--- a/apps/landing/src/app/[locale]/(main)/blog/page.tsx
+++ b/apps/landing/src/app/[locale]/(main)/blog/page.tsx
@@ -4,6 +4,7 @@ import type { Metadata } from "next";
 import { cacheLife } from "next/cache";
 import { Trans } from "react-i18next/TransWithoutContext";
 import { getTranslation } from "@/i18n/server";
+import { getAlternates } from "@/lib/alternates";
 import { getAllPosts } from "@/lib/api";
 import { PostPreview } from "./post-preview";
 
@@ -56,6 +57,7 @@ export async function generateMetadata(props: {
   const { locale } = await props.params;
   const { t } = await getTranslation(locale, "blog");
   return {
+    alternates: getAlternates({ locale, path: "/blog" }),
     title: t("blogTitle", {
       ns: "blog",
       defaultValue: "Rallly - Blog",

--- a/apps/landing/src/app/[locale]/(main)/page.tsx
+++ b/apps/landing/src/app/[locale]/(main)/page.tsx
@@ -22,6 +22,7 @@ import {
   SectionTitle,
 } from "@/components/section";
 import { getTranslation } from "@/i18n/server";
+import { getAlternates } from "@/lib/alternates";
 import { getMonthlyPollCount, getMonthlyVoterCount } from "@/lib/data";
 
 export default async function Page(props: {
@@ -395,6 +396,7 @@ export async function generateMetadata(props: {
   const { locale } = await props.params;
   const { t } = await getTranslation(locale, "home");
   return {
+    alternates: getAlternates({ locale }),
     title: t("metaTitle", {
       defaultValue: "Rallly: Free Group Meeting Scheduling Tool",
       ns: "home",

--- a/apps/landing/src/app/[locale]/(main)/pricing/page.tsx
+++ b/apps/landing/src/app/[locale]/(main)/pricing/page.tsx
@@ -32,6 +32,7 @@ import {
   SectionTitle,
 } from "@/components/section";
 import { getTranslation } from "@/i18n/server";
+import { getAlternates } from "@/lib/alternates";
 import { getMonthlyPollCount, getMonthlyVoterCount } from "@/lib/data";
 import { linkToApp } from "@/lib/linkToApp";
 
@@ -933,6 +934,7 @@ export async function generateMetadata(props: {
   const { locale } = await props.params;
   const { t } = await getTranslation(locale, ["common", "pricing"]);
   return {
+    alternates: getAlternates({ locale, path: "/pricing" }),
     title: t("pricing", { ns: "common", defaultValue: "Pricing" }),
     description: t("pricingDescription", {
       ns: "pricing",

--- a/apps/landing/src/app/sitemap.ts
+++ b/apps/landing/src/app/sitemap.ts
@@ -1,10 +1,7 @@
-import { supportedLngs } from "@rallly/languages";
 import { absoluteUrl } from "@rallly/utils/absolute-url";
 import type { MetadataRoute } from "next";
-
+import { getAlternateLanguages } from "@/lib/alternates";
 import { getAllPosts } from "@/lib/api";
-
-const alternateLanguages = supportedLngs.filter((lng) => lng !== "en");
 
 const seoPages = [
   "/best-doodle-alternative",
@@ -16,13 +13,6 @@ const seoPages = [
   "/free-scheduling-poll",
   "/when2meet-alternative",
 ];
-
-const getAlternateLanguages = (path: string) => {
-  return alternateLanguages.reduce<Record<string, string>>((acc, locale) => {
-    acc[locale] = absoluteUrl(`/${locale}${path}`);
-    return acc;
-  }, {});
-};
 
 export default async function Sitemap(): Promise<MetadataRoute.Sitemap> {
   const posts = getAllPosts(["slug"]);

--- a/apps/landing/src/lib/alternates.ts
+++ b/apps/landing/src/lib/alternates.ts
@@ -1,0 +1,30 @@
+import { supportedLngs } from "@rallly/languages";
+import { absoluteUrl } from "@rallly/utils/absolute-url";
+import type { Metadata } from "next";
+
+const localizedUrl = (locale: string, path: string) =>
+  // `/en/*` redirects to `/*`, so English lives at the unprefixed URL
+  locale === "en" ? absoluteUrl(path) : absoluteUrl(`/${locale}${path}`);
+
+export function getAlternateLanguages(path = "/") {
+  const languages: Record<string, string> = {
+    "x-default": absoluteUrl(path),
+  };
+  for (const locale of supportedLngs) {
+    languages[locale] = localizedUrl(locale, path);
+  }
+  return languages;
+}
+
+export function getAlternates({
+  locale,
+  path = "/",
+}: {
+  locale: string;
+  path?: string;
+}): Metadata["alternates"] {
+  return {
+    canonical: localizedUrl(locale, path),
+    languages: getAlternateLanguages(path),
+  };
+}


### PR DESCRIPTION
## Problem

Ahrefs flagged three hreflang issues on the landing site, all confirmed against production:

- **Missing self-referencing link** — the sitemap's alternates list was built with `supportedLngs.filter((lng) => lng !== "en")`, so no URL referenced itself.
- **Missing x-default** — not declared anywhere.
- **Pages missing hreflang links to the rest of their group** — hreflang existed only in the sitemap, and only English URLs were sitemap entries. Localized URLs (`/de`, `/fr/pricing`, …) carried zero annotations, so no group had valid return links and the whole annotation set was invalid.

## Fix

- New shared helper `apps/landing/src/lib/alternates.ts` that builds the full language map: `en` self-reference (unprefixed URL, since `/en/*` redirects to `/*`), all supported locales, and `x-default` pointing at the English URL. `getAlternates` additionally returns a per-locale canonical.
- Every localized variant of the home, pricing, blog index and the 8 SEO pages now emits the full `<link rel="alternate" hreflang>` set plus canonical via `generateMetadata`, satisfying the reciprocal return-link requirement.
- The sitemap reuses the same helper so both sources agree exactly.

Legal pages (terms, privacy, cookie policy) are deliberately left out: their content is hardcoded English, so declaring translations would be incorrect.

## Verified

Rendered output checked on a local dev server: `/`, `/de/pricing`, `/fr/when2meet-alternative` and `sitemap.xml` all emit the complete group (17 locales + x-default), self-references included, canonical per locale.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added localized alternate-language and canonical URL metadata across key landing, blog, pricing, and SEO pages.
  * Added support for English, translated locale paths, and a default language URL in page metadata.

* **Bug Fixes**
  * Improved sitemap language URL generation to align with the site’s localized URL structure.

* **SEO**
  * Enhanced search engine discovery and international page indexing through consistent alternate-language links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->