### PR TITLE
✨ Animate how it works steps on scroll with a relay cursor

### DIFF
--- a/apps/landing/src/components/home/how-it-works/create-step-demo.tsx
+++ b/apps/landing/src/components/home/how-it-works/create-step-demo.tsx
@@ -2,10 +2,13 @@
 
 import { cn } from "@rallly/ui";
 import * as m from "motion/react-m";
+import * as React from "react";
 import { DemoScreen } from "../hero-demo/demo-frame";
 import { ACCENT } from "./accent";
+import type { CursorStop } from "./demo-cursor";
+import { DemoCursor } from "./demo-cursor";
 import type { Playback } from "./motion";
-import { EASE_OUT, EXIT, STAGGER } from "./motion";
+import { EASE_OUT, EXIT } from "./motion";
 import { PressButton } from "./press-button";
 
 // A textless mock of the poll creation form: title field and a month
@@ -13,8 +16,8 @@ import { PressButton } from "./press-button";
 // it doesn't compete with the section text. Sized to fit the 4:3 artboard on
 // the how it works section.
 //
-// On play the picked dates land one at a time in the order listed, then the
-// submit button presses.
+// On play the cursor hops through the dates, each one lighting as it is
+// clicked, then carries on to the submit button and presses it.
 const WEEKS = 4;
 const START_OFFSET = 2;
 
@@ -23,98 +26,126 @@ const START_OFFSET = 2;
 // happen to suit. Indices are cells in the WEEKS x 7 grid, listed in the
 // order they get picked, which is deliberately not left to right.
 const SELECTED = [10, 4, 17, 23, 12, 27];
-const SUBMIT_DELAY = SELECTED.length * STAGGER + 0.12;
+
+// The cells light on the cursor's cadence rather than a fast burst: it
+// reaches the first date half a second in, hops between dates from there,
+// then travels down to the submit button.
+const PICK_START = 0.5;
+const PICK_STEP = 0.16;
+const pickAt = (index: number) => PICK_START + index * PICK_STEP;
+const SUBMIT_DELAY = pickAt(SELECTED.length - 1) + 0.35;
 
 export const CreateStepDemo = ({ playback }: { playback: Playback }) => {
   const on = playback !== "idle";
   const instant = playback === "done";
+  const cellRefs = React.useRef(
+    SELECTED.map(() => React.createRef<HTMLDivElement>()),
+  ).current;
+  const submitRef = React.useRef<HTMLDivElement>(null);
+  const stops = React.useMemo<CursorStop[]>(
+    () => [
+      ...SELECTED.map((_, index) => ({
+        ref: cellRefs[index],
+        at: pickAt(index),
+        click: true,
+      })),
+      { ref: submitRef, at: SUBMIT_DELAY, click: true },
+    ],
+    [cellRefs],
+  );
   return (
-    <DemoScreen className="space-y-2 p-4">
-      <div className="space-y-1.5">
-        <div className="h-1.5 w-8 rounded-full bg-gray-300" />
-        <div className="flex h-6 items-center rounded-md border border-gray-200 px-2">
-          <div className="h-1.5 w-24 rounded-full bg-gray-300" />
+    <>
+      <DemoScreen className="space-y-2 p-4">
+        <div className="space-y-1.5">
+          <div className="h-1.5 w-8 rounded-full bg-gray-300" />
+          <div className="flex h-6 items-center rounded-md border border-gray-200 px-2">
+            <div className="h-1.5 w-24 rounded-full bg-gray-300" />
+          </div>
         </div>
-      </div>
-      <div className="space-y-1.5">
-        <div className="flex items-center justify-between">
-          <div className="h-1.5 w-14 rounded-full bg-gray-300" />
-          <div className="h-1.5 w-10 rounded-full bg-gray-200" />
-        </div>
-        <div className="grid grid-cols-7 gap-1">
-          {Array.from({ length: 7 }, (_, index) => (
-            <div
-              // biome-ignore lint/suspicious/noArrayIndexKey: weekday header cells are positional
-              key={index}
-              className="flex justify-center py-0.5"
-            >
-              <div className="h-1 w-2 rounded-full bg-gray-200" />
-            </div>
-          ))}
-          {Array.from({ length: WEEKS * 7 }, (_, index) => {
-            if (index < START_OFFSET) {
-              return (
-                <div
-                  // biome-ignore lint/suspicious/noArrayIndexKey: calendar cells are positional
-                  key={index}
-                />
-              );
-            }
-            const pickedAt = SELECTED.indexOf(index);
-            if (pickedAt === -1) {
-              return (
-                <div
-                  // biome-ignore lint/suspicious/noArrayIndexKey: calendar cells are positional
-                  key={index}
-                  className="h-3.5 rounded bg-gray-100"
-                />
-              );
-            }
-            return (
-              <m.div
-                // biome-ignore lint/suspicious/noArrayIndexKey: calendar cells are positional
+        <div className="space-y-1.5">
+          <div className="flex items-center justify-between">
+            <div className="h-1.5 w-14 rounded-full bg-gray-300" />
+            <div className="h-1.5 w-10 rounded-full bg-gray-200" />
+          </div>
+          <div className="grid grid-cols-7 gap-1">
+            {Array.from({ length: 7 }, (_, index) => (
+              <div
+                // biome-ignore lint/suspicious/noArrayIndexKey: weekday header cells are positional
                 key={index}
-                className="h-3.5 rounded bg-gray-100"
-                initial={false}
-                animate={
-                  on
-                    ? {
-                        backgroundColor: "#d1d5db",
-                        scale: instant ? 1 : [0.88, 1],
-                      }
-                    : { backgroundColor: "#f3f4f6", scale: 1 }
-                }
-                transition={
-                  instant
-                    ? { duration: 0 }
-                    : on
+                className="flex justify-center py-0.5"
+              >
+                <div className="h-1 w-2 rounded-full bg-gray-200" />
+              </div>
+            ))}
+            {Array.from({ length: WEEKS * 7 }, (_, index) => {
+              if (index < START_OFFSET) {
+                return (
+                  <div
+                    // biome-ignore lint/suspicious/noArrayIndexKey: calendar cells are positional
+                    key={index}
+                  />
+                );
+              }
+              const pickedAt = SELECTED.indexOf(index);
+              if (pickedAt === -1) {
+                return (
+                  <div
+                    // biome-ignore lint/suspicious/noArrayIndexKey: calendar cells are positional
+                    key={index}
+                    className="h-3.5 rounded bg-gray-100"
+                  />
+                );
+              }
+              return (
+                <m.div
+                  // biome-ignore lint/suspicious/noArrayIndexKey: calendar cells are positional
+                  key={index}
+                  ref={cellRefs[pickedAt]}
+                  className="h-3.5 rounded bg-gray-100"
+                  initial={false}
+                  animate={
+                    on
                       ? {
-                          backgroundColor: {
-                            duration: 0.22,
-                            ease: EASE_OUT,
-                            delay: pickedAt * STAGGER,
-                          },
-                          scale: {
-                            type: "spring",
-                            duration: 0.44,
-                            bounce: 0.42,
-                            delay: pickedAt * STAGGER,
-                          },
+                          backgroundColor: "#d1d5db",
+                          scale: instant ? 1 : [0.88, 1],
                         }
-                      : EXIT
-                }
-              />
-            );
-          })}
+                      : { backgroundColor: "#f3f4f6", scale: 1 }
+                  }
+                  transition={
+                    instant
+                      ? { duration: 0 }
+                      : on
+                        ? {
+                            backgroundColor: {
+                              duration: 0.22,
+                              ease: EASE_OUT,
+                              delay: pickAt(pickedAt),
+                            },
+                            scale: {
+                              type: "spring",
+                              duration: 0.44,
+                              bounce: 0.42,
+                              delay: pickAt(pickedAt),
+                            },
+                          }
+                        : EXIT
+                  }
+                />
+              );
+            })}
+          </div>
         </div>
-      </div>
-      <div className="flex justify-end border-gray-200/60 border-t pt-2">
-        <PressButton
-          playback={playback}
-          delay={SUBMIT_DELAY}
-          className={cn("h-7 w-14 rounded-md", ACCENT)}
-        />
-      </div>
-    </DemoScreen>
+        <div className="flex justify-end border-gray-200/60 border-t pt-2">
+          <div ref={submitRef}>
+            <PressButton
+              playback={playback}
+              delay={SUBMIT_DELAY}
+              className={cn("h-7 w-14 rounded-md", ACCENT)}
+            />
+          </div>
+        </div>
+      </DemoScreen>
+      <DemoCursor playback={playback} stops={stops} />
+    </>
   );
 };

--- a/apps/landing/src/components/home/how-it-works/decide-step-demo.tsx
+++ b/apps/landing/src/components/home/how-it-works/decide-step-demo.tsx
@@ -3,8 +3,11 @@
 import { cn } from "@rallly/ui";
 import { VoteIcon } from "@rallly/ui/vote-icon";
 import * as m from "motion/react-m";
+import * as React from "react";
 import { DemoScreen } from "../hero-demo/demo-frame";
 import { ACCENT, ACCENT_EDGE } from "./accent";
+import type { CursorStop } from "./demo-cursor";
+import { DemoCursor } from "./demo-cursor";
 import type { Playback } from "./motion";
 import { EASE_OUT, EXIT } from "./motion";
 
@@ -30,11 +33,25 @@ const ROWS: { votes: ("yes" | "ifNeedBe" | "no")[]; winner: boolean }[] = [
 // stamping four cells at once.
 const VOTER_STAGGER = 0.09;
 const ROW_STAGGER = 0.02;
-const WINNER_DELAY = ROWS[0].votes.length * VOTER_STAGGER + 0.12;
+const VOTES_DONE = ROWS[0].votes.length * VOTER_STAGGER + 0.12;
+// The cursor picks the winner once the votes are in, and the accent follows
+// the click, so the highlight reads as chosen rather than announced.
+const CLICK_AT = VOTES_DONE + 0.07;
+const WINNER_DELAY = CLICK_AT + 0.06;
+
+// Where the cursor crosses into frame: the height step 2's cursor left at
+// (its copy button, in stage coordinates), so the two read as one pointer
+// crossing the gap between the cards.
+const ENTER_Y = 51;
 
 export const DecideStepDemo = ({ playback }: { playback: Playback }) => {
   const on = playback !== "idle";
   const instant = playback === "done";
+  const winnerRef = React.useRef<HTMLDivElement>(null);
+  const stops = React.useMemo<CursorStop[]>(
+    () => [{ ref: winnerRef, at: CLICK_AT, click: true }],
+    [],
+  );
   // Every part of the winner's accent — edge, wash, label — arrives on the
   // same beat, so the row reads as one thing lighting up.
   const accentIn = instant
@@ -43,106 +60,110 @@ export const DecideStepDemo = ({ playback }: { playback: Playback }) => {
       ? { duration: 0.34, ease: EASE_OUT, delay: WINNER_DELAY }
       : EXIT;
   return (
-    <DemoScreen className="space-y-1.5 p-4">
-      {ROWS.map((row, rowIndex) => (
-        <div
-          // biome-ignore lint/suspicious/noArrayIndexKey: static wireframe rows
-          key={rowIndex}
-          // A gradient cannot live in border-color, so the edge is a padded
-          // backdrop behind the surface. Every row keeps the same shape, and
-          // the winner's gradient edge cross-fades over the grey one.
-          className="relative rounded-md bg-gray-200 p-px"
-        >
-          {row.winner ? (
-            <m.div
-              className={cn(
-                "pointer-events-none absolute inset-0 rounded-md",
-                ACCENT_EDGE,
-              )}
-              initial={false}
-              animate={{ opacity: on ? 1 : 0 }}
-              transition={accentIn}
-            />
-          ) : null}
-          <div className="relative overflow-hidden rounded-[5px] bg-white">
+    <>
+      <DemoScreen className="space-y-1.5 p-4">
+        {ROWS.map((row, rowIndex) => (
+          <div
+            // biome-ignore lint/suspicious/noArrayIndexKey: static wireframe rows
+            key={rowIndex}
+            ref={row.winner ? winnerRef : undefined}
+            // A gradient cannot live in border-color, so the edge is a padded
+            // backdrop behind the surface. Every row keeps the same shape, and
+            // the winner's gradient edge cross-fades over the grey one.
+            className="relative rounded-md bg-gray-200 p-px"
+          >
             {row.winner ? (
               <m.div
-                className={cn("pointer-events-none absolute inset-0", ACCENT)}
+                className={cn(
+                  "pointer-events-none absolute inset-0 rounded-md",
+                  ACCENT_EDGE,
+                )}
                 initial={false}
-                animate={{ opacity: on ? 0.08 : 0 }}
+                animate={{ opacity: on ? 1 : 0 }}
                 transition={accentIn}
               />
             ) : null}
-            <div className="relative flex items-center justify-between gap-3 px-2.5 py-2">
-              <div className="min-w-0 space-y-1.5">
-                <div className="relative h-1.5 w-16 overflow-hidden rounded-full bg-gray-300">
-                  {row.winner ? (
-                    <m.div
-                      className={cn("absolute inset-0", ACCENT)}
-                      initial={false}
-                      animate={{ opacity: on ? 1 : 0 }}
-                      transition={accentIn}
-                    />
-                  ) : null}
+            <div className="relative overflow-hidden rounded-[5px] bg-white">
+              {row.winner ? (
+                <m.div
+                  className={cn("pointer-events-none absolute inset-0", ACCENT)}
+                  initial={false}
+                  animate={{ opacity: on ? 0.08 : 0 }}
+                  transition={accentIn}
+                />
+              ) : null}
+              <div className="relative flex items-center justify-between gap-3 px-2.5 py-2">
+                <div className="min-w-0 space-y-1.5">
+                  <div className="relative h-1.5 w-16 overflow-hidden rounded-full bg-gray-300">
+                    {row.winner ? (
+                      <m.div
+                        className={cn("absolute inset-0", ACCENT)}
+                        initial={false}
+                        animate={{ opacity: on ? 1 : 0 }}
+                        transition={accentIn}
+                      />
+                    ) : null}
+                  </div>
+                  <div className="flex items-center gap-2">
+                    <div className="h-1.5 w-10 rounded-full bg-gray-200" />
+                    {row.winner ? (
+                      <m.div
+                        className={cn("h-1.5 w-12 rounded-full", ACCENT)}
+                        initial={false}
+                        animate={{ opacity: on ? 1 : 0, scaleX: on ? 1 : 0.4 }}
+                        style={{ originX: 0 }}
+                        transition={
+                          instant
+                            ? { duration: 0 }
+                            : on
+                              ? {
+                                  type: "spring",
+                                  duration: 0.5,
+                                  bounce: 0.24,
+                                  delay: WINNER_DELAY + 0.08,
+                                }
+                              : EXIT
+                        }
+                      />
+                    ) : null}
+                  </div>
                 </div>
-                <div className="flex items-center gap-2">
-                  <div className="h-1.5 w-10 rounded-full bg-gray-200" />
-                  {row.winner ? (
+                <div className="flex shrink-0 items-center gap-1">
+                  {row.votes.map((vote, voteIndex) => (
                     <m.div
-                      className={cn("h-1.5 w-12 rounded-full", ACCENT)}
+                      // biome-ignore lint/suspicious/noArrayIndexKey: static wireframe votes
+                      key={voteIndex}
                       initial={false}
-                      animate={{ opacity: on ? 1 : 0, scaleX: on ? 1 : 0.4 }}
-                      style={{ originX: 0 }}
+                      animate={
+                        on
+                          ? { opacity: 1, scale: 1, y: 0 }
+                          : { opacity: 0, scale: 0.82, y: -3 }
+                      }
                       transition={
                         instant
                           ? { duration: 0 }
                           : on
                             ? {
                                 type: "spring",
-                                duration: 0.5,
-                                bounce: 0.24,
-                                delay: WINNER_DELAY + 0.08,
+                                duration: 0.46,
+                                bounce: 0.38,
+                                delay:
+                                  voteIndex * VOTER_STAGGER +
+                                  rowIndex * ROW_STAGGER,
                               }
                             : EXIT
                       }
-                    />
-                  ) : null}
+                    >
+                      <VoteIcon type={vote} className="size-3.5" />
+                    </m.div>
+                  ))}
                 </div>
-              </div>
-              <div className="flex shrink-0 items-center gap-1">
-                {row.votes.map((vote, voteIndex) => (
-                  <m.div
-                    // biome-ignore lint/suspicious/noArrayIndexKey: static wireframe votes
-                    key={voteIndex}
-                    initial={false}
-                    animate={
-                      on
-                        ? { opacity: 1, scale: 1, y: 0 }
-                        : { opacity: 0, scale: 0.82, y: -3 }
-                    }
-                    transition={
-                      instant
-                        ? { duration: 0 }
-                        : on
-                          ? {
-                              type: "spring",
-                              duration: 0.46,
-                              bounce: 0.38,
-                              delay:
-                                voteIndex * VOTER_STAGGER +
-                                rowIndex * ROW_STAGGER,
-                            }
-                          : EXIT
-                    }
-                  >
-                    <VoteIcon type={vote} className="size-3.5" />
-                  </m.div>
-                ))}
               </div>
             </div>
           </div>
-        </div>
-      ))}
-    </DemoScreen>
+        ))}
+      </DemoScreen>
+      <DemoCursor playback={playback} stops={stops} enterY={ENTER_Y} />
+    </>
   );
 };

--- a/apps/landing/src/components/home/how-it-works/demo-cursor.tsx
+++ b/apps/landing/src/components/home/how-it-works/demo-cursor.tsx
@@ -1,0 +1,186 @@
+"use client";
+
+import * as m from "motion/react-m";
+import * as React from "react";
+import type { Playback } from "./motion";
+import { EASE_OUT, EXIT } from "./motion";
+
+// One pointer appears to drive the whole walkthrough. Each step owns its own
+// cursor, but they are choreographed as a single actor: every cursor sweeps
+// in from the left, clicks its way through the step, and leaves through the
+// right edge — and the next step's cursor enters at the same height the
+// previous one left at, so the eye reads one cursor crossing the cards.
+//
+// Stops are element refs rather than coordinates because the demos are
+// fluid: the overlay measures each target against itself, so the cursor
+// lands on the real pixels at any card width.
+
+// How far past the stage edge the cursor parks, so entering and leaving read
+// as coming from and going to somewhere, not popping at the border.
+const OFFSTAGE = 32;
+// The beat between the last click and departure: long enough to see the
+// click land, short enough that leaving still belongs to the same gesture.
+const HOLD = 0.12;
+const EXIT_DUR = 0.35;
+// The click dip. Kept shorter than the fastest hop between stops so
+// back-to-back clicks never overlap.
+const DIP = 0.14;
+
+export type CursorStop = {
+  ref: React.RefObject<HTMLElement | null>;
+  // Seconds into the step's sequence when the cursor arrives here.
+  at: number;
+  click?: boolean;
+};
+
+export const DemoCursor = ({
+  playback,
+  stops,
+  enterY,
+}: {
+  playback: Playback;
+  stops: CursorStop[];
+  // Stage y where the cursor crosses into frame — the previous step's exit
+  // height, for continuity. Defaults to the first stop's own height.
+  enterY?: number;
+}) => {
+  const overlayRef = React.useRef<HTMLDivElement>(null);
+  const [frame, setFrame] = React.useState<{
+    width: number;
+    points: { x: number; y: number }[];
+  } | null>(null);
+
+  React.useLayoutEffect(() => {
+    const overlay = overlayRef.current;
+    if (!overlay) {
+      return;
+    }
+    const measure = () => {
+      const o = overlay.getBoundingClientRect();
+      if (o.width === 0) {
+        return;
+      }
+      const points = stops.map((stop) => {
+        const r = stop.ref.current?.getBoundingClientRect();
+        return r
+          ? { x: r.x + r.width / 2 - o.x, y: r.y + r.height / 2 - o.y }
+          : null;
+      });
+      if (points.every((point) => point !== null)) {
+        setFrame({ width: o.width, points });
+      }
+    };
+    measure();
+    const observer = new ResizeObserver(measure);
+    observer.observe(overlay);
+    return () => observer.disconnect();
+  }, [stops]);
+
+  const path = React.useMemo(() => {
+    if (!frame) {
+      return null;
+    }
+    const { width, points } = frame;
+    const last = stops[stops.length - 1];
+    const lastPoint = points[points.length - 1];
+    const total = last.at + HOLD + EXIT_DUR;
+    // Enter offstage left, visit every stop, dwell, leave offstage right.
+    const xs = [
+      -OFFSTAGE,
+      ...points.map((p) => p.x),
+      lastPoint.x,
+      width + OFFSTAGE,
+    ];
+    const ys = [
+      enterY ?? points[0].y,
+      ...points.map((p) => p.y),
+      lastPoint.y,
+      lastPoint.y,
+    ];
+    const times = [
+      0,
+      ...stops.map((stop) => stop.at / total),
+      (last.at + HOLD) / total,
+      1,
+    ];
+    // A dip per click, anchored so the scale sits at rest between them.
+    const scales = [1];
+    const scaleTimes = [0];
+    for (const stop of stops) {
+      if (stop.click) {
+        scales.push(1, 0.85, 1);
+        scaleTimes.push(
+          stop.at / total,
+          (stop.at + DIP * 0.4) / total,
+          (stop.at + DIP) / total,
+        );
+      }
+    }
+    scales.push(1);
+    scaleTimes.push(1);
+    return { xs, ys, times, scales, scaleTimes, total };
+  }, [frame, stops, enterY]);
+
+  return (
+    <div
+      ref={overlayRef}
+      aria-hidden="true"
+      className="pointer-events-none absolute inset-0 overflow-hidden"
+    >
+      {path ? (
+        <m.div
+          className="absolute top-0 left-0"
+          initial={false}
+          animate={
+            playback === "play"
+              ? { x: path.xs, y: path.ys, scale: path.scales }
+              : playback === "done"
+                ? // The finished frame includes the cursor having left.
+                  {
+                    x: path.xs[path.xs.length - 1],
+                    y: path.ys[path.ys.length - 1],
+                    scale: 1,
+                  }
+                : { x: path.xs[0], y: path.ys[0], scale: 1 }
+          }
+          transition={
+            playback === "done"
+              ? { duration: 0 }
+              : playback === "play"
+                ? {
+                    x: {
+                      duration: path.total,
+                      times: path.times,
+                      ease: EASE_OUT,
+                    },
+                    y: {
+                      duration: path.total,
+                      times: path.times,
+                      ease: EASE_OUT,
+                    },
+                    scale: {
+                      duration: path.total,
+                      times: path.scaleTimes,
+                      ease: EASE_OUT,
+                    },
+                  }
+                : EXIT
+          }
+        >
+          <CursorIcon />
+        </m.div>
+      ) : null}
+    </div>
+  );
+};
+
+const CursorIcon = () => (
+  <svg
+    aria-hidden="true"
+    viewBox="0 0 12 12"
+    className="size-4 fill-gray-900 stroke-white drop-shadow-sm"
+    strokeWidth="1"
+  >
+    <path d="M1 1 L1 10 L3.5 7.6 L5.3 11 L7 10.1 L5.2 6.9 L8.6 6.7 Z" />
+  </svg>
+);

--- a/apps/landing/src/components/home/how-it-works/share-step-demo.tsx
+++ b/apps/landing/src/components/home/how-it-works/share-step-demo.tsx
@@ -3,10 +3,13 @@
 import { cn } from "@rallly/ui";
 import { MailIcon, MessageCircleIcon, SendIcon } from "lucide-react";
 import * as m from "motion/react-m";
+import * as React from "react";
 import { DemoScreen } from "../hero-demo/demo-frame";
 import { ACCENT } from "./accent";
+import type { CursorStop } from "./demo-cursor";
+import { DemoCursor } from "./demo-cursor";
 import type { Playback } from "./motion";
-import { EASE_OUT, EXIT } from "./motion";
+import { EASE_OUT } from "./motion";
 import { PressButton } from "./press-button";
 
 // A textless mock of the invite step: a link field with a copy button, ways
@@ -14,9 +17,8 @@ import { PressButton } from "./press-button";
 // doesn't compete with the section text. Fills the 4:3 frame on the how it
 // works section.
 //
-// On play a pointer travels to the copy button, presses it, and the link field
-// flips to a confirmation. The pointer is drawn rather than implied so the
-// button dip reads as a click.
+// On play the copy button presses and the link field flips to a
+// confirmation.
 const CHANNELS = [
   { key: "email", icon: MailIcon, width: "w-20" },
   { key: "chat", icon: MessageCircleIcon, width: "w-14" },
@@ -26,6 +28,11 @@ const CHANNELS = [
 const PRESS_AT = 0.42;
 const COPIED_AT = PRESS_AT + 0.1;
 
+// Where the cursor crosses into frame: the height step 1's cursor left at
+// (its submit button, in stage coordinates), so the two read as one pointer
+// crossing the gap between the cards.
+const ENTER_Y = 205;
+
 // Copying recolors the url in place rather than swapping it for a shorter
 // confirmation, so the field keeps the same block at the same width and the
 // accent is what signals the copy.
@@ -34,96 +41,73 @@ const SWAP = { duration: 0.2, ease: EASE_OUT } as const;
 export const ShareStepDemo = ({ playback }: { playback: Playback }) => {
   const on = playback !== "idle";
   const instant = playback === "done";
+  const copyRef = React.useRef<HTMLDivElement>(null);
+  const stops = React.useMemo<CursorStop[]>(
+    () => [{ ref: copyRef, at: PRESS_AT, click: true }],
+    [],
+  );
   return (
-    <DemoScreen className="space-y-2 p-4">
-      <div className="space-y-1.5">
-        <div className="h-1.5 w-12 rounded-full bg-gray-300" />
-        <div className="flex items-center gap-2">
-          <div className="flex h-7 min-w-0 flex-1 items-center rounded-md border border-gray-200 bg-gray-50 px-2">
-            {/* The accent fades over the resting bar rather than replacing its
+    <>
+      <DemoScreen className="space-y-2 p-4">
+        <div className="space-y-1.5">
+          <div className="h-1.5 w-12 rounded-full bg-gray-300" />
+          <div className="flex items-center gap-2">
+            <div className="flex h-7 min-w-0 flex-1 items-center rounded-md border border-gray-200 bg-gray-50 px-2">
+              {/* The accent fades over the resting bar rather than replacing its
               class, so the recolor transitions instead of snapping. */}
-            <div className="relative h-1.5 w-28 shrink-0 overflow-hidden rounded-full bg-gray-300">
-              <m.div
-                className={cn("absolute inset-0", ACCENT)}
-                initial={false}
-                animate={{ opacity: on ? 1 : 0 }}
-                transition={
-                  instant
-                    ? { duration: 0 }
-                    : { ...SWAP, delay: on ? COPIED_AT : 0 }
-                }
+              <div className="relative h-1.5 w-28 shrink-0 overflow-hidden rounded-full bg-gray-300">
+                <m.div
+                  className={cn("absolute inset-0", ACCENT)}
+                  initial={false}
+                  animate={{ opacity: on ? 1 : 0 }}
+                  transition={
+                    instant
+                      ? { duration: 0 }
+                      : { ...SWAP, delay: on ? COPIED_AT : 0 }
+                  }
+                />
+              </div>
+            </div>
+            <div ref={copyRef} className="shrink-0">
+              <PressButton
+                playback={playback}
+                delay={PRESS_AT}
+                className={cn("h-7 w-14 rounded-md", ACCENT)}
               />
             </div>
           </div>
-          <div className="relative shrink-0">
-            <PressButton
-              playback={playback}
-              delay={PRESS_AT}
-              className={cn("h-7 w-14 rounded-md", ACCENT)}
-            />
-            <m.div
-              className="pointer-events-none absolute top-4 left-6"
-              initial={false}
-              animate={
-                on ? { opacity: 1, x: 0, y: 0 } : { opacity: 0, x: 28, y: 24 }
-              }
-              transition={
-                instant
-                  ? { duration: 0 }
-                  : on
-                    ? {
-                        x: { type: "spring", duration: 0.5, bounce: 0.2 },
-                        y: { type: "spring", duration: 0.5, bounce: 0.2 },
-                        opacity: { duration: 0.14, ease: EASE_OUT },
-                      }
-                    : { ...EXIT, opacity: { duration: 0.12 } }
-              }
-            >
-              <CursorIcon />
-            </m.div>
-          </div>
         </div>
-      </div>
-      <div className="space-y-1.5">
-        {CHANNELS.map((channel) => (
-          <div
-            key={channel.key}
-            className="flex items-center gap-2 rounded-md border border-gray-200 px-2 py-1.5"
-          >
-            <div className="flex size-5 shrink-0 items-center justify-center rounded bg-gray-100">
-              <channel.icon className="size-3 text-gray-400" />
+        <div className="space-y-1.5">
+          {CHANNELS.map((channel) => (
+            <div
+              key={channel.key}
+              className="flex items-center gap-2 rounded-md border border-gray-200 px-2 py-1.5"
+            >
+              <div className="flex size-5 shrink-0 items-center justify-center rounded bg-gray-100">
+                <channel.icon className="size-3 text-gray-400" />
+              </div>
+              <div
+                className={cn("h-1.5 rounded-full bg-gray-300", channel.width)}
+              />
             </div>
-            <div
-              className={cn("h-1.5 rounded-full bg-gray-300", channel.width)}
-            />
-          </div>
-        ))}
-      </div>
-      <div className="flex items-center gap-3 border-gray-200/60 border-t pt-3">
-        <div className="flex shrink-0 -space-x-1.5">
-          {[0, 1, 2, 3].map((participant) => (
-            <div
-              key={participant}
-              className="size-6 rounded-full bg-gray-300 ring-2 ring-white"
-            />
           ))}
         </div>
-        <div className="min-w-0 flex-1 space-y-1.5">
-          <div className="h-1.5 max-w-32 rounded-full bg-gray-200" />
-          <div className="h-1.5 max-w-20 rounded-full bg-gray-200" />
+        <div className="flex items-center gap-3 border-gray-200/60 border-t pt-3">
+          <div className="flex shrink-0 -space-x-1.5">
+            {[0, 1, 2, 3].map((participant) => (
+              <div
+                key={participant}
+                className="size-6 rounded-full bg-gray-300 ring-2 ring-white"
+              />
+            ))}
+          </div>
+          <div className="min-w-0 flex-1 space-y-1.5">
+            <div className="h-1.5 max-w-32 rounded-full bg-gray-200" />
+            <div className="h-1.5 max-w-20 rounded-full bg-gray-200" />
+          </div>
         </div>
-      </div>
-    </DemoScreen>
+      </DemoScreen>
+      <DemoCursor playback={playback} stops={stops} enterY={ENTER_Y} />
+    </>
   );
 };
-
-const CursorIcon = () => (
-  <svg
-    aria-hidden="true"
-    viewBox="0 0 12 12"
-    className="size-4 fill-gray-900 stroke-white drop-shadow-sm"
-    strokeWidth="1"
-  >
-    <path d="M1 1 L1 10 L3.5 7.6 L5.3 11 L7 10.1 L5.2 6.9 L8.6 6.7 Z" />
-  </svg>
-);

--- a/apps/landing/src/components/home/how-it-works/step-stage.tsx
+++ b/apps/landing/src/components/home/how-it-works/step-stage.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { cn } from "@rallly/ui";
 import { useInView, useReducedMotion } from "motion/react";
 import * as React from "react";
 import { CreateStepDemo } from "./create-step-demo";
@@ -18,10 +19,12 @@ const DEMOS = {
 
 export type StepKey = keyof typeof DEMOS;
 
-// Each step waits its turn so the three read as one walkthrough rather than
-// three things happening at once. Roughly the length of a step's own sequence,
-// so the next one starts as the previous settles.
-const STEP_STAGGER = 900;
+// When each step starts, so the three read as one walkthrough rather than
+// three things happening at once. Not a uniform stagger: each boundary sits
+// where the previous step's cursor leaves the frame, so the next cursor
+// enters as the last one exits — the first step runs long because its cursor
+// walks through six dates before submitting.
+const STEP_STARTS = [0, 2000, 2900];
 
 // When the section came into view, so a step can tell how much of its slot in
 // the walkthrough is left. Null until it does.
@@ -39,14 +42,14 @@ export const StepCue = ({
   // the instant the first pixel appears. Deliberately no amount threshold: the
   // strip can be taller than the viewport, where a fraction like 0.4 would
   // never be reached and the section would never play.
-  const started = useInView(ref, { once: true, margin: "0px 0px -15% 0px" });
+  const inView = useInView(ref, { margin: "0px 0px -15% 0px" });
   const [startedAt, setStartedAt] = React.useState<number | null>(null);
 
+  // Each visit is a fresh cue: leaving clears the clock so coming back starts
+  // a new staggered walkthrough instead of replaying against a stale one.
   React.useEffect(() => {
-    if (started) {
-      setStartedAt(performance.now());
-    }
-  }, [started]);
+    setStartedAt(inView ? performance.now() : null);
+  }, [inView]);
 
   return (
     <div ref={ref} className={className}>
@@ -72,7 +75,11 @@ export const StepStage = ({
   // the side long after the section itself is on screen. Waiting for the stage
   // itself means a demo never plays out of sight; half of it keeps the card
   // peeking in past the gutter from counting as arrived.
-  const arrived = useInView(ref, { once: true, amount: 0.5 });
+  const arrived = useInView(ref, { amount: 0.5 });
+  // Arriving and leaving use different thresholds on purpose: playing waits
+  // for half the stage, but resetting waits for the last pixel, so a demo
+  // never undoes itself while the user can still see it.
+  const visible = useInView(ref);
   const [play, setPlay] = React.useState(false);
   const reduceMotion = useReducedMotion();
   const Demo = DEMOS[step];
@@ -81,24 +88,31 @@ export const StepStage = ({
   const playback: Playback = reduceMotion ? "done" : play ? "play" : "idle";
 
   React.useEffect(() => {
+    // Fully out of sight resets the demo, so the walkthrough replays on the
+    // next visit rather than sitting on its finished frame.
+    if (!visible) {
+      setPlay(false);
+      return;
+    }
     if (startedAt === null || !arrived) {
       return;
     }
-    // The stagger orders steps that arrive together: what is left of this
+    // The schedule orders steps that arrive together: what is left of this
     // step's slot, and nothing at all for a step scrolled to later, which is
     // its own cue and should play as it lands.
     const delay = Math.max(
       0,
-      index * STEP_STAGGER - (performance.now() - startedAt),
+      (STEP_STARTS[index] ?? 0) - (performance.now() - startedAt),
     );
-    // Plays once and holds: the finished state says more than the empty one,
-    // so there is nothing to gain from resetting it.
     const timer = setTimeout(() => setPlay(true), delay);
     return () => clearTimeout(timer);
-  }, [startedAt, arrived, index]);
+  }, [startedAt, arrived, visible, index]);
 
   return (
-    <div ref={ref} aria-hidden="true" className={className}>
+    // Relative so each demo's cursor overlay spans the whole stage: the
+    // cursor travels in stage coordinates, which are the same across the
+    // three steps, making the entry and exit heights line up between cards.
+    <div ref={ref} aria-hidden="true" className={cn("relative", className)}>
       <div className="w-full max-w-64">
         <Demo playback={playback} />
       </div>


### PR DESCRIPTION
## Description

Makes the landing page's how it works section play as one choreographed walkthrough:

- **Scroll-triggered playback with replay.** The step demos play when the section comes into view and reset once it fully leaves, so the walkthrough runs again on the next visit. A step starts playing at 50% visible but only resets when its last pixel leaves the viewport, so a demo never undoes itself while still on screen.
- **Sequenced steps.** Steps that arrive together run on a schedule (`STEP_STARTS`) rather than all at once. The boundaries sit where each step's cursor leaves the frame, so the next one picks up as the previous settles. Steps scrolled to later (the mobile horizontal scroller) play as they land.
- **A single relay cursor.** Each demo is driven by a shared `DemoCursor`: it sweeps in from the left, clicks through the step — picking each calendar date and submitting in step 1, copying the link in step 2, choosing the winning row in step 3 (the accent now follows the click) — and exits through the right edge. Each cursor enters at the same height the previous one left at, so it reads as one pointer crossing the cards.
- Cursor stops are element refs measured against a stage-spanning overlay (with a ResizeObserver), so the path lands on real pixels at any card width. Reduced motion still jumps straight to the finished frame with the cursor already gone.

Verified headless (Playwright): stagger order, handoff heights matching exactly between cards, reset on scroll-away, and staggered replay on return.

## Checklist

- [x] I have performed a self-review of my code
- [x] My code follows the code style of this project
- [x] I have commented my code, particularly in hard-to-understand areas

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added animated cursor interactions to the “How it works” walkthrough, including calendar selections, voting, submission, and sharing actions.
  * Improved cursor movement and click feedback across demo steps.
* **Bug Fixes**
  * Walkthrough animations now restart when revisiting a step and reset when it leaves the viewport.
  * Improved animation timing and positioning for more consistent playback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->