### PR TITLE
⚡️ Refresh pricing page stats hourly

### DIFF
--- a/apps/landing/src/app/[locale]/(main)/pricing/page.tsx
+++ b/apps/landing/src/app/[locale]/(main)/pricing/page.tsx
@@ -70,7 +70,7 @@ const faqLinkClassName =
 export default async function Page(props: {
   params: Promise<{ locale: string }>;
 }) {
-  cacheLife("days");
+  cacheLife("hours");
   const { locale } = await props.params;
   const { t } = await getTranslation(locale, ["common", "pricing", "home"]);
   const [pollCount, voterCount] = await Promise.all([


### PR DESCRIPTION
## Description

Changed the pricing page's body `cacheLife` from `"days"` to `"hours"`. The page body caches the monthly poll and voter counts shown on the pricing page, so with a `days` profile those stats could lag up to a day behind; an `hours` profile keeps them reasonably fresh without giving up caching.

`generateMetadata` keeps `cacheLife("max")` — the title, description and alternates are static.

## Checklist

- [x] I have performed a self-review of my code
- [x] My code follows the code style of this project
- [x] I have commented my code, particularly in hard-to-understand areas

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Pricing page updates now become visible more frequently by shortening its cache duration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->