### PR TITLE
✅ Fix flaky job title select test racing the Base UI popup

### DIFF
--- a/apps/web/src/features/user/components/job-title-select.test.tsx
+++ b/apps/web/src/features/user/components/job-title-select.test.tsx
@@ -21,7 +21,7 @@ function Harness({ initial = null }: { initial?: string | null }) {
 
 async function chooseOther(user: ReturnType<typeof userEvent.setup>) {
   await user.click(screen.getByRole("combobox"));
-  await user.click(screen.getByRole("option", { name: "Other" }));
+  await user.click(await screen.findByRole("option", { name: "Other" }));
 }
 
 describe("JobTitleSelect", () => {
@@ -30,7 +30,7 @@ describe("JobTitleSelect", () => {
     render(<Harness />);
 
     await user.click(screen.getByRole("combobox"));
-    await user.click(screen.getByRole("option", { name: "Recruiter" }));
+    await user.click(await screen.findByRole("option", { name: "Recruiter" }));
 
     await waitFor(() =>
       expect(screen.getByTestId("value")).toHaveTextContent("recruiter"),
@@ -88,7 +88,9 @@ describe("JobTitleSelect", () => {
     render(<Harness initial="recruiter" />);
 
     await user.click(screen.getByRole("combobox"));
-    await user.click(screen.getByRole("option", { name: "Prefer not to say" }));
+    await user.click(
+      await screen.findByRole("option", { name: "Prefer not to say" }),
+    );
 
     await waitFor(() =>
       expect(screen.getByTestId("value")).toHaveTextContent("null"),


### PR DESCRIPTION
## What changed

Swapped the three synchronous `screen.getByRole("option", ...)` queries in `job-title-select.test.tsx` for `await screen.findByRole(...)`.

## Why

Base UI's Select mounts its popup portal with `hidden` and `data-closed` and un-hides it asynchronously after the trigger click. `getByRole` excludes hidden elements and doesn't retry, so the query races the open transition — the failure DOM dump shows every option present in the portal, still hidden.

The race won on CI from #3045 (Aug 22) until the run for #3070 (unrelated landing page change), which made main go red with "Unable to find an accessible element with the role \"option\" and name \"Recruiter\"". Locally it loses most runs (3–4 of 5 tests fail).

`findByRole` retries until the popup opens, which is how `time-zone-select.test.tsx` already handles the same interaction.

## Verification

- The test file passes 5/5 across five consecutive local runs (previously failing nearly every run)
- Full unit suite green: 539/539 tests, 44 files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved option-selection tests to reliably wait for asynchronously rendered choices before making selections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->