### PR TITLE
🔥 Remove comments phase-out notice and legacy badge

### DIFF
--- a/apps/web/public/locales/en/app.json
+++ b/apps/web/public/locales/en/app.json
@@ -149,8 +149,6 @@
   "commentPlaceholder": "Leave a comment on this poll (visible to everyone)",
   "comments": "Comments",
   "commentsSettingDescription": "Allow participants to post public comments on the poll.",
-  "commentsSettingLegacyBadge": "Legacy",
-  "commentsSettingPhaseOutHint": "Comments are being phased out. Participants can include a note with their response instead.",
   "commentsSettingTitle": "Comments",
   "commentsSheetDescription": "View and add comments on this poll",
   "commentsSheetEmpty": "No comments yet",

--- a/apps/web/src/features/poll/components/forms/poll-settings.test.tsx
+++ b/apps/web/src/features/poll/components/forms/poll-settings.test.tsx
@@ -32,39 +32,21 @@ function TestForm({ enableComments = false }: { enableComments?: boolean }) {
 }
 
 describe("PollSettingsForm comments setting", () => {
-  it("shows comments off by default with a legacy badge and no hint", () => {
+  it("shows comments off by default", () => {
     render(<TestForm />);
-    const commentsSwitch = screen.getByRole("switch", { name: /comments/i });
-    expect(commentsSwitch).not.toBeChecked();
-    expect(screen.getByText("Legacy")).toBeInTheDocument();
-    expect(
-      screen.queryByText(/comments are being phased out/i),
-    ).not.toBeInTheDocument();
+    expect(screen.getByRole("switch", { name: /comments/i })).not.toBeChecked();
   });
 
-  it("reveals the phase out hint when comments are switched on", async () => {
+  it("can be switched on", async () => {
     const user = userEvent.setup();
     render(<TestForm />);
     const commentsSwitch = screen.getByRole("switch", { name: /comments/i });
     await user.click(commentsSwitch);
     expect(commentsSwitch).toBeChecked();
-    expect(
-      screen.getByText(/participants can include a note with their response/i),
-    ).toBeInTheDocument();
   });
 
-  it("shows the hint immediately for polls that already have comments enabled", () => {
+  it("reflects polls that already have comments enabled", () => {
     render(<TestForm enableComments={true} />);
     expect(screen.getByRole("switch", { name: /comments/i })).toBeChecked();
-    expect(
-      screen.getByText(/comments are being phased out/i),
-    ).toBeInTheDocument();
-  });
-
-  it("renders the phase out hint as an alert", () => {
-    render(<TestForm enableComments={true} />);
-    expect(screen.getByRole("alert")).toHaveTextContent(
-      /comments are being phased out/i,
-    );
   });
 });

--- a/apps/web/src/features/poll/components/forms/poll-settings.tsx
+++ b/apps/web/src/features/poll/components/forms/poll-settings.tsx
@@ -1,8 +1,6 @@
 "use client";
 
 import { posthog } from "@rallly/posthog/client";
-import { Alert, AlertDescription } from "@rallly/ui/alert";
-import { Badge } from "@rallly/ui/badge";
 import { Card, CardContent, CardTitle } from "@rallly/ui/card";
 import {
   Field,
@@ -15,7 +13,6 @@ import { FormField } from "@rallly/ui/form";
 import { Switch } from "@rallly/ui/switch";
 import {
   BarChart2Icon,
-  InfoIcon,
   MailIcon,
   MessageCircleIcon,
   VenetianMaskIcon,
@@ -161,54 +158,32 @@ export const PollSettingsForm = ({ children }: React.PropsWithChildren) => {
             control={form.control}
             name="enableComments"
             render={({ field }) => (
-              <div className="flex flex-col gap-3">
-                <Field orientation="horizontal">
-                  <SettingIcon>
-                    <MessageCircleIcon />
-                  </SettingIcon>
-                  <FieldContent>
-                    <FieldLabel htmlFor="enable-comments">
-                      <Trans
-                        i18nKey="commentsSettingTitle"
-                        defaults="Comments"
-                      />
-                      <Badge size="sm">
-                        <Trans
-                          i18nKey="commentsSettingLegacyBadge"
-                          defaults="Legacy"
-                        />
-                      </Badge>
-                    </FieldLabel>
-                    <FieldDescription>
-                      <Trans
-                        i18nKey="commentsSettingDescription"
-                        defaults="Allow participants to post public comments on the poll."
-                      />
-                    </FieldDescription>
-                  </FieldContent>
-                  <Switch
-                    id="enable-comments"
-                    checked={!!field.value}
-                    onCheckedChange={(checked) => {
-                      field.onChange(checked);
-                      posthog?.capture("poll_settings:comments_toggle_click", {
-                        enabled: checked,
-                      });
-                    }}
-                  />
-                </Field>
-                {field.value ? (
-                  <Alert variant="info">
-                    <InfoIcon />
-                    <AlertDescription>
-                      <Trans
-                        i18nKey="commentsSettingPhaseOutHint"
-                        defaults="Comments are being phased out. Participants can include a note with their response instead."
-                      />
-                    </AlertDescription>
-                  </Alert>
-                ) : null}
-              </div>
+              <Field orientation="horizontal">
+                <SettingIcon>
+                  <MessageCircleIcon />
+                </SettingIcon>
+                <FieldContent>
+                  <FieldLabel htmlFor="enable-comments">
+                    <Trans i18nKey="commentsSettingTitle" defaults="Comments" />
+                  </FieldLabel>
+                  <FieldDescription>
+                    <Trans
+                      i18nKey="commentsSettingDescription"
+                      defaults="Allow participants to post public comments on the poll."
+                    />
+                  </FieldDescription>
+                </FieldContent>
+                <Switch
+                  id="enable-comments"
+                  checked={!!field.value}
+                  onCheckedChange={(checked) => {
+                    field.onChange(checked);
+                    posthog?.capture("poll_settings:comments_toggle_click", {
+                      enabled: checked,
+                    });
+                  }}
+                />
+              </Field>
             )}
           />
         </FieldGroup>


### PR DESCRIPTION
## Context

Comments are opt-in (off by default since #2790-era work) and the removal decision is still pending the gate review (RAL-1471). The settings UI currently shows a "Legacy" badge and, when the toggle is on, an alert saying comments are being phased out.

Announcing a phase-out before the decision is made:
- pre-commits us publicly to a removal we may not do — recent conversion analysis on the gate review issue shows spaces with peer discussion convert to paid at 6.58% vs 1.20% for equally busy spaces without it
- suppresses the opt-in adoption data the gate review is scoped to evaluate (nobody enables a feature the UI says is dying)
- is already generating support mail from participants about a removal that hasn't happened

## Changes

- Remove the phase-out alert and "Legacy" badge from the comments setting; keep the default-off toggle and neutral description
- Slim the unit test to toggle behavior
- `pnpm i18n:scan` drops the two now-unused keys

If the gate review later decides on removal, we re-announce with a concrete date instead of an open-ended notice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **UI Updates**
  - Removed the “Legacy” badge and phase-out messaging from the comments setting.
  - The comments option now appears as a straightforward toggle.

- **Bug Fixes**
  - Preserved existing comment-setting behavior, including default-off, enabling comments, and retaining an enabled state.
  - Continued tracking changes to the comments setting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->