### PR TITLE
💄 Dock the create poll action bar at the container bottom

### DIFF
--- a/apps/web/src/features/poll/components/create-poll.tsx
+++ b/apps/web/src/features/poll/components/create-poll.tsx
@@ -145,6 +145,22 @@ export const CreatePoll = ({ nav }: { nav?: React.ReactNode }) => {
   const { user, createGuestIfNeeded } = useUser();
   const isLoggedIn = !!user && !user.isGuest;
   const [createdPollId, setCreatedPollId] = React.useState<string | null>(null);
+  // There is no CSS selector for "sticky element is stuck": a sentinel after
+  // the bar tells us when it has settled into its natural resting position.
+  const [isDocked, setIsDocked] = React.useState(false);
+  const sentinelRef = React.useRef<HTMLDivElement>(null);
+
+  React.useEffect(() => {
+    const sentinel = sentinelRef.current;
+    if (!sentinel) {
+      return;
+    }
+    const observer = new IntersectionObserver((entries) => {
+      setIsDocked(entries[entries.length - 1].isIntersecting);
+    });
+    observer.observe(sentinel);
+    return () => observer.disconnect();
+  }, []);
   const [, copy] = useCopyToClipboard();
   const [didCopy, setDidCopy] = React.useState(false);
 
@@ -280,8 +296,15 @@ export const CreatePoll = ({ nav }: { nav?: React.ReactNode }) => {
             <PollSettingsForm />
           </div>
         </form>
-        <div className="pointer-events-none sticky bottom-0 z-20 flex justify-center pt-4 pb-6">
-          <div className="pointer-events-auto flex w-full max-w-md items-center justify-between gap-x-4 rounded-full border border-popover-border bg-popover py-2 pr-2 pl-5 shadow-2xl shadow-black/40">
+        <div className="pointer-events-none sticky bottom-0 z-20 flex justify-center pt-4 pb-6 lg:pb-16">
+          <div
+            className={cn(
+              "pointer-events-auto flex w-full items-center justify-between gap-x-4 rounded-full border border-popover-border bg-popover py-2 pr-2 pl-5 transition-[max-width,box-shadow] duration-300",
+              isDocked
+                ? "max-w-full shadow-none"
+                : "max-w-md shadow-2xl shadow-black/40",
+            )}
+          >
             <p className="min-w-0 truncate text-muted-foreground text-sm">
               <SelectedOptionsCount />
             </p>
@@ -290,6 +313,10 @@ export const CreatePoll = ({ nav }: { nav?: React.ReactNode }) => {
             </div>
           </div>
         </div>
+        {/* Overlaps the bar's bottom padding: a hairline sentinel sitting
+            exactly on the viewport edge misses intersection under fractional
+            scaling, so give it height inside the resting zone. */}
+        <div ref={sentinelRef} className="-mt-6 h-6" aria-hidden="true" />
       </main>
       <Dialog open={!!createdPollId}>
         <DialogContent showCloseButton={false}>


### PR DESCRIPTION
## Description

Polish for the floating action bar on the create poll page:

- On `lg:` screens the bar sits higher — 64px off the viewport bottom instead of 24px (mobile unchanged).
- When the user scrolls to the bottom of the form, the bar expands from the floating pill (`max-w-md`) to the full container width and the shadow fades out, so it reads as part of the page rather than an overlay. Both properties animate over 300ms.

CSS has no selector for "sticky element is stuck", so a sentinel div after the sticky wrapper drives the state via IntersectionObserver: sentinel visible means the bar has settled into its natural resting position. Two details a reviewer should know:

- The sentinel is 24px tall and pulled up into the wrapper's bottom padding with `-mt-6` (net zero layout impact). A 1px sentinel sitting exactly on the viewport edge misses intersection under fractional scaling.
- The observer callback reads the latest batched entry rather than the first, so a fast scroll flutter can't latch a stale state.

Verified in the browser at 1280px and 375px: pill with shadow while scrolling, full-width shadowless bar at rest, contracts again on scroll up.

## Checklist

- [x] I have performed a self-review of my code
- [x] My code follows the code style of this project
- [x] I have commented my code, particularly in hard-to-understand areas

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved the create-poll action bar’s responsive behavior while scrolling.
  * The bar expands to full width and removes its shadow when docked, then returns to its compact appearance when undocked.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->