### PR TITLE
✨ Merge testimonial and press mentions into one social proof section

### DIFF
--- a/apps/landing/public/locales/en/home.json
+++ b/apps/landing/public/locales/en/home.json
@@ -47,6 +47,8 @@
   "eaFinalCtaTitle": "Ready to get that meeting in the diary?",
   "eaMetaDescription": "Rallly is a free scheduling tool for executive assistants. Coordinate meetings across busy calendars and time zones with one link. No account needed to respond.",
   "eaMetaTitle": "Scheduling for Executive Assistants | Free Meeting Poll Tool",
+  "eaSocialProofDescription": "When scheduling is your job, simplicity matters. Here's what assistants and the press have to say.",
+  "eaSocialProofTitle": "Loved by executive assistants",
   "eaTitle": "Scheduling for executive assistants",
   "ericJobTitle": "Executive Assistant at MIT",
   "ericQuote": "“If your scheduling workflow lives in emails, I strongly encourage you to try and let Rallly simplify your scheduling tasks for a more organized and less stressful workday.”",

--- a/apps/landing/public/locales/en/home.json
+++ b/apps/landing/public/locales/en/home.json
@@ -47,8 +47,6 @@
   "eaFinalCtaTitle": "Ready to get that meeting in the diary?",
   "eaMetaDescription": "Rallly is a free scheduling tool for executive assistants. Coordinate meetings across busy calendars and time zones with one link. No account needed to respond.",
   "eaMetaTitle": "Scheduling for Executive Assistants | Free Meeting Poll Tool",
-  "eaSocialProofDescription": "When scheduling is your job, simplicity matters. Here's what assistants and the press have to say.",
-  "eaSocialProofTitle": "Loved by executive assistants",
   "eaTitle": "Scheduling for executive assistants",
   "ericJobTitle": "Executive Assistant at MIT",
   "ericQuote": "“If your scheduling workflow lives in emails, I strongly encourage you to try and let Rallly simplify your scheduling tasks for a more organized and less stressful workday.”",

--- a/apps/landing/public/locales/en/home.json
+++ b/apps/landing/public/locales/en/home.json
@@ -195,6 +195,8 @@
   "pressKitScreenshotsDescription": "High-resolution product screenshots that you can use in your coverage.",
   "pressKitScreenshotsTitle": "Screenshots",
   "pressKitScreenshotVoting": "Voting on a poll",
+  "socialProofDescription": "Ask anyone who's used it. The fastest way to schedule a group is also the simplest.",
+  "socialProofTitle": "Loved for its simplicity",
   "sportsClubsDescription": "Find out which nights your squad can actually make. Share one link with players, parents and coaches, see the numbers for every session, and book the pitch once. Free, with no limit on how many people you ask.",
   "sportsClubsFaqBranding": "Can polls carry our club badge?",
   "sportsClubsFaqBrandingAnswer": "With <0>Rallly Pro</0> you can add your own logo and colours and remove Rallly attribution, so a poll you send out looks like it came from the club. Everything else is free to use.",

--- a/apps/landing/src/app/[locale]/(main)/(seo)/best-doodle-alternative/page.tsx
+++ b/apps/landing/src/app/[locale]/(main)/(seo)/best-doodle-alternative/page.tsx
@@ -2,7 +2,6 @@
 
 import type { Metadata } from "next";
 import { cacheLife } from "next/cache";
-import Image from "next/image";
 import Link from "next/link";
 import { Trans } from "react-i18next/TransWithoutContext";
 import {
@@ -19,9 +18,8 @@ import { Faq, FaqItem } from "@/components/home/faq";
 import { Hero } from "@/components/home/hero";
 import { HeroDemo } from "@/components/home/hero-demo/hero-demo";
 import { HowItWorks } from "@/components/home/how-it-works/how-it-works";
-import { Mention, Mentions } from "@/components/home/mentions";
+import { SocialProof } from "@/components/home/social-proof";
 import { Stats } from "@/components/home/stats";
-import { Testimonial } from "@/components/home/testimonial";
 import {
   Section,
   SectionContent,
@@ -232,127 +230,7 @@ export default async function Page(props: {
           </CompareTable>
         </SectionContent>
       </Section>
-      <Section>
-        <Testimonial
-          logo={
-            <Image
-              src="/static/images/mit-logo.svg"
-              width={54}
-              height={28}
-              alt=""
-            />
-          }
-          avatar={
-            <Image
-              className="rounded-full"
-              src="/static/images/eric.png"
-              width={48}
-              height={48}
-              alt=""
-            />
-          }
-          name="Eric Fletcher"
-          title={
-            <Trans
-              t={t}
-              ns="home"
-              i18nKey="ericJobTitle"
-              defaults="Executive Assistant at MIT"
-            />
-          }
-        >
-          <Trans
-            t={t}
-            ns="home"
-            i18nKey="ericQuote"
-            defaults="“If your scheduling workflow lives in emails, I strongly encourage you to try and let Rallly simplify your scheduling tasks for a more organized and less stressful workday.”"
-          />
-        </Testimonial>
-      </Section>
-      <Section>
-        <Mentions locale={locale}>
-          <Mention
-            delay={0.25}
-            logo={
-              <div className="relative h-8 w-14">
-                <Image
-                  src="/static/images/pcmag-logo.svg"
-                  alt="PCMag"
-                  fill
-                  style={{ objectFit: "contain" }}
-                />
-              </div>
-            }
-          >
-            <Trans
-              t={t}
-              ns="home"
-              i18nKey="pcmagQuote"
-              defaults="“Set up a scheduling poll in as little time as possible.”"
-            />
-          </Mention>
-          <Mention
-            delay={0.5}
-            logo={
-              <div className="relative h-8 w-24">
-                <Image
-                  src="/static/images/hubspot-logo.svg"
-                  alt="HubSpot"
-                  fill
-                  style={{ objectFit: "contain" }}
-                />
-              </div>
-            }
-          >
-            <Trans
-              t={t}
-              ns="home"
-              i18nKey="hubspotQuote"
-              defaults="“The simplest choice for availability polling for large groups.”"
-            />
-          </Mention>
-          <Mention
-            delay={0.75}
-            logo={
-              <div className="relative h-8 w-32">
-                <Image
-                  src="/static/images/goodfirms-logo.svg"
-                  alt="Goodfirms"
-                  fill
-                  style={{ objectFit: "contain" }}
-                />
-              </div>
-            }
-          >
-            <Trans
-              t={t}
-              ns="home"
-              i18nKey="goodfirmsQuote"
-              defaults="“Unique in its simplicity and requires minimum interaction time.”"
-            />
-          </Mention>
-          <Mention
-            delay={1}
-            logo={
-              <div className="relative h-8 w-20">
-                <Image
-                  src="/static/images/popsci-logo.svg"
-                  alt="PopSci"
-                  fill
-                  style={{ objectFit: "contain" }}
-                />
-              </div>
-            }
-          >
-            <Trans
-              t={t}
-              ns="home"
-              i18nKey="popsciQuote"
-              defaults="“The perfect pick if you want to keep your RSVPs simple.”"
-            />
-          </Mention>
-        </Mentions>
-      </Section>
+      <SocialProof locale={locale} />
       <div>
         <Section>
           <SectionHeading>

--- a/apps/landing/src/app/[locale]/(main)/(seo)/free-scheduling-poll/page.tsx
+++ b/apps/landing/src/app/[locale]/(main)/(seo)/free-scheduling-poll/page.tsx
@@ -2,7 +2,6 @@
 
 import type { Metadata } from "next";
 import { cacheLife } from "next/cache";
-import Image from "next/image";
 import Link from "next/link";
 import { Trans } from "react-i18next/TransWithoutContext";
 import { PeopleBadge, PollsBadge } from "@/components/home/animated-number";
@@ -11,9 +10,8 @@ import { Faq, FaqItem } from "@/components/home/faq";
 import { Hero } from "@/components/home/hero";
 import { HeroDemo } from "@/components/home/hero-demo/hero-demo";
 import { HowItWorks } from "@/components/home/how-it-works/how-it-works";
-import { Mention, Mentions } from "@/components/home/mentions";
+import { SocialProof } from "@/components/home/social-proof";
 import { Stats } from "@/components/home/stats";
-import { Testimonial } from "@/components/home/testimonial";
 import {
   Section,
   SectionContent,
@@ -63,127 +61,7 @@ export default async function Page(props: {
         </Stats>
       </Section>
       <HowItWorks locale={locale} />
-      <Section>
-        <Testimonial
-          logo={
-            <Image
-              src="/static/images/mit-logo.svg"
-              width={54}
-              height={28}
-              alt=""
-            />
-          }
-          avatar={
-            <Image
-              className="rounded-full"
-              src="/static/images/eric.png"
-              width={48}
-              height={48}
-              alt=""
-            />
-          }
-          name="Eric Fletcher"
-          title={
-            <Trans
-              t={t}
-              ns="home"
-              i18nKey="ericJobTitle"
-              defaults="Executive Assistant at MIT"
-            />
-          }
-        >
-          <Trans
-            t={t}
-            ns="home"
-            i18nKey="ericQuote"
-            defaults="“If your scheduling workflow lives in emails, I strongly encourage you to try and let Rallly simplify your scheduling tasks for a more organized and less stressful workday.”"
-          />
-        </Testimonial>
-      </Section>
-      <Section>
-        <Mentions locale={locale}>
-          <Mention
-            delay={0.25}
-            logo={
-              <div className="relative h-8 w-14">
-                <Image
-                  src="/static/images/pcmag-logo.svg"
-                  alt="PCMag"
-                  fill
-                  style={{ objectFit: "contain" }}
-                />
-              </div>
-            }
-          >
-            <Trans
-              t={t}
-              ns="home"
-              i18nKey="pcmagQuote"
-              defaults="“Set up a scheduling poll in as little time as possible.”"
-            />
-          </Mention>
-          <Mention
-            delay={0.5}
-            logo={
-              <div className="relative h-8 w-24">
-                <Image
-                  src="/static/images/hubspot-logo.svg"
-                  alt="HubSpot"
-                  fill
-                  style={{ objectFit: "contain" }}
-                />
-              </div>
-            }
-          >
-            <Trans
-              t={t}
-              ns="home"
-              i18nKey="hubspotQuote"
-              defaults="“The simplest choice for availability polling for large groups.”"
-            />
-          </Mention>
-          <Mention
-            delay={0.75}
-            logo={
-              <div className="relative h-8 w-32">
-                <Image
-                  src="/static/images/goodfirms-logo.svg"
-                  alt="Goodfirms"
-                  fill
-                  style={{ objectFit: "contain" }}
-                />
-              </div>
-            }
-          >
-            <Trans
-              t={t}
-              ns="home"
-              i18nKey="goodfirmsQuote"
-              defaults="“Unique in its simplicity and requires minimum interaction time.”"
-            />
-          </Mention>
-          <Mention
-            delay={1}
-            logo={
-              <div className="relative h-8 w-20">
-                <Image
-                  src="/static/images/popsci-logo.svg"
-                  alt="PopSci"
-                  fill
-                  style={{ objectFit: "contain" }}
-                />
-              </div>
-            }
-          >
-            <Trans
-              t={t}
-              ns="home"
-              i18nKey="popsciQuote"
-              defaults="“The perfect pick if you want to keep your RSVPs simple.”"
-            />
-          </Mention>
-        </Mentions>
-      </Section>
+      <SocialProof locale={locale} />
       <div>
         <Section>
           <SectionHeading>

--- a/apps/landing/src/app/[locale]/(main)/(seo)/scheduling-for/committees/page.tsx
+++ b/apps/landing/src/app/[locale]/(main)/(seo)/scheduling-for/committees/page.tsx
@@ -2,7 +2,6 @@
 
 import type { Metadata } from "next";
 import { cacheLife } from "next/cache";
-import Image from "next/image";
 import Link from "next/link";
 import { Trans } from "react-i18next/TransWithoutContext";
 import { PeopleBadge, PollsBadge } from "@/components/home/animated-number";
@@ -11,9 +10,8 @@ import { Faq, FaqItem } from "@/components/home/faq";
 import { Hero } from "@/components/home/hero";
 import { HeroDemo } from "@/components/home/hero-demo/hero-demo";
 import { HowItWorks } from "@/components/home/how-it-works/how-it-works";
-import { Mention, Mentions } from "@/components/home/mentions";
+import { SocialProof } from "@/components/home/social-proof";
 import { Stats } from "@/components/home/stats";
-import { Testimonial } from "@/components/home/testimonial";
 import {
   Section,
   SectionContent,
@@ -66,127 +64,7 @@ export default async function Page(props: {
         </Stats>
       </Section>
       <HowItWorks locale={locale} />
-      <Section>
-        <Testimonial
-          logo={
-            <Image
-              src="/static/images/mit-logo.svg"
-              width={54}
-              height={28}
-              alt=""
-            />
-          }
-          avatar={
-            <Image
-              className="rounded-full"
-              src="/static/images/eric.png"
-              width={48}
-              height={48}
-              alt=""
-            />
-          }
-          name="Eric Fletcher"
-          title={
-            <Trans
-              t={t}
-              ns="home"
-              i18nKey="ericJobTitle"
-              defaults="Executive Assistant at MIT"
-            />
-          }
-        >
-          <Trans
-            t={t}
-            ns="home"
-            i18nKey="ericQuote"
-            defaults="“If your scheduling workflow lives in emails, I strongly encourage you to try and let Rallly simplify your scheduling tasks for a more organized and less stressful workday.”"
-          />
-        </Testimonial>
-      </Section>
-      <Section>
-        <Mentions locale={locale}>
-          <Mention
-            delay={0.25}
-            logo={
-              <div className="relative h-8 w-14">
-                <Image
-                  src="/static/images/pcmag-logo.svg"
-                  alt="PCMag"
-                  fill
-                  style={{ objectFit: "contain" }}
-                />
-              </div>
-            }
-          >
-            <Trans
-              t={t}
-              ns="home"
-              i18nKey="pcmagQuote"
-              defaults="“Set up a scheduling poll in as little time as possible.”"
-            />
-          </Mention>
-          <Mention
-            delay={0.5}
-            logo={
-              <div className="relative h-8 w-24">
-                <Image
-                  src="/static/images/hubspot-logo.svg"
-                  alt="HubSpot"
-                  fill
-                  style={{ objectFit: "contain" }}
-                />
-              </div>
-            }
-          >
-            <Trans
-              t={t}
-              ns="home"
-              i18nKey="hubspotQuote"
-              defaults="“The simplest choice for availability polling for large groups.”"
-            />
-          </Mention>
-          <Mention
-            delay={0.75}
-            logo={
-              <div className="relative h-8 w-32">
-                <Image
-                  src="/static/images/goodfirms-logo.svg"
-                  alt="Goodfirms"
-                  fill
-                  style={{ objectFit: "contain" }}
-                />
-              </div>
-            }
-          >
-            <Trans
-              t={t}
-              ns="home"
-              i18nKey="goodfirmsQuote"
-              defaults="“Unique in its simplicity and requires minimum interaction time.”"
-            />
-          </Mention>
-          <Mention
-            delay={1}
-            logo={
-              <div className="relative h-8 w-20">
-                <Image
-                  src="/static/images/popsci-logo.svg"
-                  alt="PopSci"
-                  fill
-                  style={{ objectFit: "contain" }}
-                />
-              </div>
-            }
-          >
-            <Trans
-              t={t}
-              ns="home"
-              i18nKey="popsciQuote"
-              defaults="“The perfect pick if you want to keep your RSVPs simple.”"
-            />
-          </Mention>
-        </Mentions>
-      </Section>
+      <SocialProof locale={locale} />
       <div>
         <Section>
           <SectionHeading>

--- a/apps/landing/src/app/[locale]/(main)/(seo)/scheduling-for/executive-assistants/page.tsx
+++ b/apps/landing/src/app/[locale]/(main)/(seo)/scheduling-for/executive-assistants/page.tsx
@@ -2,7 +2,6 @@
 
 import type { Metadata } from "next";
 import { cacheLife } from "next/cache";
-import Image from "next/image";
 import Link from "next/link";
 import { Trans } from "react-i18next/TransWithoutContext";
 import { PeopleBadge, PollsBadge } from "@/components/home/animated-number";
@@ -11,9 +10,8 @@ import { Faq, FaqItem } from "@/components/home/faq";
 import { Hero } from "@/components/home/hero";
 import { HeroDemo } from "@/components/home/hero-demo/hero-demo";
 import { HowItWorks } from "@/components/home/how-it-works/how-it-works";
-import { Mention, Mentions } from "@/components/home/mentions";
+import { SocialProof } from "@/components/home/social-proof";
 import { Stats } from "@/components/home/stats";
-import { Testimonial } from "@/components/home/testimonial";
 import {
   Section,
   SectionContent,
@@ -66,127 +64,25 @@ export default async function Page(props: {
         </Stats>
       </Section>
       <HowItWorks locale={locale} />
-      <Section>
-        <Testimonial
-          logo={
-            <Image
-              src="/static/images/mit-logo.svg"
-              width={54}
-              height={28}
-              alt=""
-            />
-          }
-          avatar={
-            <Image
-              className="rounded-full"
-              src="/static/images/eric.png"
-              width={48}
-              height={48}
-              alt=""
-            />
-          }
-          name="Eric Fletcher"
-          title={
-            <Trans
-              t={t}
-              ns="home"
-              i18nKey="ericJobTitle"
-              defaults="Executive Assistant at MIT"
-            />
-          }
-        >
+      <SocialProof
+        locale={locale}
+        title={
           <Trans
             t={t}
             ns="home"
-            i18nKey="ericQuote"
-            defaults="“If your scheduling workflow lives in emails, I strongly encourage you to try and let Rallly simplify your scheduling tasks for a more organized and less stressful workday.”"
+            i18nKey="eaSocialProofTitle"
+            defaults="Loved by executive assistants"
           />
-        </Testimonial>
-      </Section>
-      <Section>
-        <Mentions locale={locale}>
-          <Mention
-            delay={0.25}
-            logo={
-              <div className="relative h-8 w-14">
-                <Image
-                  src="/static/images/pcmag-logo.svg"
-                  alt="PCMag"
-                  fill
-                  style={{ objectFit: "contain" }}
-                />
-              </div>
-            }
-          >
-            <Trans
-              t={t}
-              ns="home"
-              i18nKey="pcmagQuote"
-              defaults="“Set up a scheduling poll in as little time as possible.”"
-            />
-          </Mention>
-          <Mention
-            delay={0.5}
-            logo={
-              <div className="relative h-8 w-24">
-                <Image
-                  src="/static/images/hubspot-logo.svg"
-                  alt="HubSpot"
-                  fill
-                  style={{ objectFit: "contain" }}
-                />
-              </div>
-            }
-          >
-            <Trans
-              t={t}
-              ns="home"
-              i18nKey="hubspotQuote"
-              defaults="“The simplest choice for availability polling for large groups.”"
-            />
-          </Mention>
-          <Mention
-            delay={0.75}
-            logo={
-              <div className="relative h-8 w-32">
-                <Image
-                  src="/static/images/goodfirms-logo.svg"
-                  alt="Goodfirms"
-                  fill
-                  style={{ objectFit: "contain" }}
-                />
-              </div>
-            }
-          >
-            <Trans
-              t={t}
-              ns="home"
-              i18nKey="goodfirmsQuote"
-              defaults="“Unique in its simplicity and requires minimum interaction time.”"
-            />
-          </Mention>
-          <Mention
-            delay={1}
-            logo={
-              <div className="relative h-8 w-20">
-                <Image
-                  src="/static/images/popsci-logo.svg"
-                  alt="PopSci"
-                  fill
-                  style={{ objectFit: "contain" }}
-                />
-              </div>
-            }
-          >
-            <Trans
-              t={t}
-              ns="home"
-              i18nKey="popsciQuote"
-              defaults="“The perfect pick if you want to keep your RSVPs simple.”"
-            />
-          </Mention>
-        </Mentions>
-      </Section>
+        }
+        description={
+          <Trans
+            t={t}
+            ns="home"
+            i18nKey="eaSocialProofDescription"
+            defaults="When scheduling is your job, simplicity matters. Here's what assistants and the press have to say."
+          />
+        }
+      />
       <div>
         <Section>
           <SectionHeading>

--- a/apps/landing/src/app/[locale]/(main)/(seo)/scheduling-for/executive-assistants/page.tsx
+++ b/apps/landing/src/app/[locale]/(main)/(seo)/scheduling-for/executive-assistants/page.tsx
@@ -64,25 +64,7 @@ export default async function Page(props: {
         </Stats>
       </Section>
       <HowItWorks locale={locale} />
-      <SocialProof
-        locale={locale}
-        title={
-          <Trans
-            t={t}
-            ns="home"
-            i18nKey="eaSocialProofTitle"
-            defaults="Loved by executive assistants"
-          />
-        }
-        description={
-          <Trans
-            t={t}
-            ns="home"
-            i18nKey="eaSocialProofDescription"
-            defaults="When scheduling is your job, simplicity matters. Here's what assistants and the press have to say."
-          />
-        }
-      />
+      <SocialProof locale={locale} />
       <div>
         <Section>
           <SectionHeading>

--- a/apps/landing/src/app/[locale]/(main)/(seo)/scheduling-for/legal/page.tsx
+++ b/apps/landing/src/app/[locale]/(main)/(seo)/scheduling-for/legal/page.tsx
@@ -2,7 +2,6 @@
 
 import type { Metadata } from "next";
 import { cacheLife } from "next/cache";
-import Image from "next/image";
 import Link from "next/link";
 import { Trans } from "react-i18next/TransWithoutContext";
 import { PeopleBadge, PollsBadge } from "@/components/home/animated-number";
@@ -11,9 +10,8 @@ import { Faq, FaqItem } from "@/components/home/faq";
 import { Hero } from "@/components/home/hero";
 import { HeroDemo } from "@/components/home/hero-demo/hero-demo";
 import { HowItWorks } from "@/components/home/how-it-works/how-it-works";
-import { Mention, Mentions } from "@/components/home/mentions";
+import { SocialProof } from "@/components/home/social-proof";
 import { Stats } from "@/components/home/stats";
-import { Testimonial } from "@/components/home/testimonial";
 import {
   Section,
   SectionContent,
@@ -66,127 +64,7 @@ export default async function Page(props: {
         </Stats>
       </Section>
       <HowItWorks locale={locale} />
-      <Section>
-        <Testimonial
-          logo={
-            <Image
-              src="/static/images/mit-logo.svg"
-              width={54}
-              height={28}
-              alt=""
-            />
-          }
-          avatar={
-            <Image
-              className="rounded-full"
-              src="/static/images/eric.png"
-              width={48}
-              height={48}
-              alt=""
-            />
-          }
-          name="Eric Fletcher"
-          title={
-            <Trans
-              t={t}
-              ns="home"
-              i18nKey="ericJobTitle"
-              defaults="Executive Assistant at MIT"
-            />
-          }
-        >
-          <Trans
-            t={t}
-            ns="home"
-            i18nKey="ericQuote"
-            defaults="“If your scheduling workflow lives in emails, I strongly encourage you to try and let Rallly simplify your scheduling tasks for a more organized and less stressful workday.”"
-          />
-        </Testimonial>
-      </Section>
-      <Section>
-        <Mentions locale={locale}>
-          <Mention
-            delay={0.25}
-            logo={
-              <div className="relative h-8 w-14">
-                <Image
-                  src="/static/images/pcmag-logo.svg"
-                  alt="PCMag"
-                  fill
-                  style={{ objectFit: "contain" }}
-                />
-              </div>
-            }
-          >
-            <Trans
-              t={t}
-              ns="home"
-              i18nKey="pcmagQuote"
-              defaults="“Set up a scheduling poll in as little time as possible.”"
-            />
-          </Mention>
-          <Mention
-            delay={0.5}
-            logo={
-              <div className="relative h-8 w-24">
-                <Image
-                  src="/static/images/hubspot-logo.svg"
-                  alt="HubSpot"
-                  fill
-                  style={{ objectFit: "contain" }}
-                />
-              </div>
-            }
-          >
-            <Trans
-              t={t}
-              ns="home"
-              i18nKey="hubspotQuote"
-              defaults="“The simplest choice for availability polling for large groups.”"
-            />
-          </Mention>
-          <Mention
-            delay={0.75}
-            logo={
-              <div className="relative h-8 w-32">
-                <Image
-                  src="/static/images/goodfirms-logo.svg"
-                  alt="Goodfirms"
-                  fill
-                  style={{ objectFit: "contain" }}
-                />
-              </div>
-            }
-          >
-            <Trans
-              t={t}
-              ns="home"
-              i18nKey="goodfirmsQuote"
-              defaults="“Unique in its simplicity and requires minimum interaction time.”"
-            />
-          </Mention>
-          <Mention
-            delay={1}
-            logo={
-              <div className="relative h-8 w-20">
-                <Image
-                  src="/static/images/popsci-logo.svg"
-                  alt="PopSci"
-                  fill
-                  style={{ objectFit: "contain" }}
-                />
-              </div>
-            }
-          >
-            <Trans
-              t={t}
-              ns="home"
-              i18nKey="popsciQuote"
-              defaults="“The perfect pick if you want to keep your RSVPs simple.”"
-            />
-          </Mention>
-        </Mentions>
-      </Section>
+      <SocialProof locale={locale} />
       <div>
         <Section>
           <SectionHeading>

--- a/apps/landing/src/app/[locale]/(main)/(seo)/scheduling-for/sports-clubs/page.tsx
+++ b/apps/landing/src/app/[locale]/(main)/(seo)/scheduling-for/sports-clubs/page.tsx
@@ -2,7 +2,6 @@
 
 import type { Metadata } from "next";
 import { cacheLife } from "next/cache";
-import Image from "next/image";
 import Link from "next/link";
 import { Trans } from "react-i18next/TransWithoutContext";
 import { PeopleBadge, PollsBadge } from "@/components/home/animated-number";
@@ -11,9 +10,8 @@ import { Faq, FaqItem } from "@/components/home/faq";
 import { Hero } from "@/components/home/hero";
 import { HeroDemo } from "@/components/home/hero-demo/hero-demo";
 import { HowItWorks } from "@/components/home/how-it-works/how-it-works";
-import { Mention, Mentions } from "@/components/home/mentions";
+import { SocialProof } from "@/components/home/social-proof";
 import { Stats } from "@/components/home/stats";
-import { Testimonial } from "@/components/home/testimonial";
 import {
   Section,
   SectionContent,
@@ -66,127 +64,7 @@ export default async function Page(props: {
         </Stats>
       </Section>
       <HowItWorks locale={locale} />
-      <Section>
-        <Testimonial
-          logo={
-            <Image
-              src="/static/images/mit-logo.svg"
-              width={54}
-              height={28}
-              alt=""
-            />
-          }
-          avatar={
-            <Image
-              className="rounded-full"
-              src="/static/images/eric.png"
-              width={48}
-              height={48}
-              alt=""
-            />
-          }
-          name="Eric Fletcher"
-          title={
-            <Trans
-              t={t}
-              ns="home"
-              i18nKey="ericJobTitle"
-              defaults="Executive Assistant at MIT"
-            />
-          }
-        >
-          <Trans
-            t={t}
-            ns="home"
-            i18nKey="ericQuote"
-            defaults="“If your scheduling workflow lives in emails, I strongly encourage you to try and let Rallly simplify your scheduling tasks for a more organized and less stressful workday.”"
-          />
-        </Testimonial>
-      </Section>
-      <Section>
-        <Mentions locale={locale}>
-          <Mention
-            delay={0.25}
-            logo={
-              <div className="relative h-8 w-14">
-                <Image
-                  src="/static/images/pcmag-logo.svg"
-                  alt="PCMag"
-                  fill
-                  style={{ objectFit: "contain" }}
-                />
-              </div>
-            }
-          >
-            <Trans
-              t={t}
-              ns="home"
-              i18nKey="pcmagQuote"
-              defaults="“Set up a scheduling poll in as little time as possible.”"
-            />
-          </Mention>
-          <Mention
-            delay={0.5}
-            logo={
-              <div className="relative h-8 w-24">
-                <Image
-                  src="/static/images/hubspot-logo.svg"
-                  alt="HubSpot"
-                  fill
-                  style={{ objectFit: "contain" }}
-                />
-              </div>
-            }
-          >
-            <Trans
-              t={t}
-              ns="home"
-              i18nKey="hubspotQuote"
-              defaults="“The simplest choice for availability polling for large groups.”"
-            />
-          </Mention>
-          <Mention
-            delay={0.75}
-            logo={
-              <div className="relative h-8 w-32">
-                <Image
-                  src="/static/images/goodfirms-logo.svg"
-                  alt="Goodfirms"
-                  fill
-                  style={{ objectFit: "contain" }}
-                />
-              </div>
-            }
-          >
-            <Trans
-              t={t}
-              ns="home"
-              i18nKey="goodfirmsQuote"
-              defaults="“Unique in its simplicity and requires minimum interaction time.”"
-            />
-          </Mention>
-          <Mention
-            delay={1}
-            logo={
-              <div className="relative h-8 w-20">
-                <Image
-                  src="/static/images/popsci-logo.svg"
-                  alt="PopSci"
-                  fill
-                  style={{ objectFit: "contain" }}
-                />
-              </div>
-            }
-          >
-            <Trans
-              t={t}
-              ns="home"
-              i18nKey="popsciQuote"
-              defaults="“The perfect pick if you want to keep your RSVPs simple.”"
-            />
-          </Mention>
-        </Mentions>
-      </Section>
+      <SocialProof locale={locale} />
       <div>
         <Section>
           <SectionHeading>

--- a/apps/landing/src/app/[locale]/(main)/(seo)/scheduling-for/thesis-defense/page.tsx
+++ b/apps/landing/src/app/[locale]/(main)/(seo)/scheduling-for/thesis-defense/page.tsx
@@ -2,7 +2,6 @@
 
 import type { Metadata } from "next";
 import { cacheLife } from "next/cache";
-import Image from "next/image";
 import Link from "next/link";
 import { Trans } from "react-i18next/TransWithoutContext";
 import { PeopleBadge, PollsBadge } from "@/components/home/animated-number";
@@ -11,9 +10,8 @@ import { Faq, FaqItem } from "@/components/home/faq";
 import { Hero } from "@/components/home/hero";
 import { HeroDemo } from "@/components/home/hero-demo/hero-demo";
 import { HowItWorks } from "@/components/home/how-it-works/how-it-works";
-import { Mention, Mentions } from "@/components/home/mentions";
+import { SocialProof } from "@/components/home/social-proof";
 import { Stats } from "@/components/home/stats";
-import { Testimonial } from "@/components/home/testimonial";
 import {
   Section,
   SectionContent,
@@ -66,127 +64,7 @@ export default async function Page(props: {
         </Stats>
       </Section>
       <HowItWorks locale={locale} />
-      <Section>
-        <Testimonial
-          logo={
-            <Image
-              src="/static/images/mit-logo.svg"
-              width={54}
-              height={28}
-              alt=""
-            />
-          }
-          avatar={
-            <Image
-              className="rounded-full"
-              src="/static/images/eric.png"
-              width={48}
-              height={48}
-              alt=""
-            />
-          }
-          name="Eric Fletcher"
-          title={
-            <Trans
-              t={t}
-              ns="home"
-              i18nKey="ericJobTitle"
-              defaults="Executive Assistant at MIT"
-            />
-          }
-        >
-          <Trans
-            t={t}
-            ns="home"
-            i18nKey="ericQuote"
-            defaults="“If your scheduling workflow lives in emails, I strongly encourage you to try and let Rallly simplify your scheduling tasks for a more organized and less stressful workday.”"
-          />
-        </Testimonial>
-      </Section>
-      <Section>
-        <Mentions locale={locale}>
-          <Mention
-            delay={0.25}
-            logo={
-              <div className="relative h-8 w-14">
-                <Image
-                  src="/static/images/pcmag-logo.svg"
-                  alt="PCMag"
-                  fill
-                  style={{ objectFit: "contain" }}
-                />
-              </div>
-            }
-          >
-            <Trans
-              t={t}
-              ns="home"
-              i18nKey="pcmagQuote"
-              defaults="“Set up a scheduling poll in as little time as possible.”"
-            />
-          </Mention>
-          <Mention
-            delay={0.5}
-            logo={
-              <div className="relative h-8 w-24">
-                <Image
-                  src="/static/images/hubspot-logo.svg"
-                  alt="HubSpot"
-                  fill
-                  style={{ objectFit: "contain" }}
-                />
-              </div>
-            }
-          >
-            <Trans
-              t={t}
-              ns="home"
-              i18nKey="hubspotQuote"
-              defaults="“The simplest choice for availability polling for large groups.”"
-            />
-          </Mention>
-          <Mention
-            delay={0.75}
-            logo={
-              <div className="relative h-8 w-32">
-                <Image
-                  src="/static/images/goodfirms-logo.svg"
-                  alt="Goodfirms"
-                  fill
-                  style={{ objectFit: "contain" }}
-                />
-              </div>
-            }
-          >
-            <Trans
-              t={t}
-              ns="home"
-              i18nKey="goodfirmsQuote"
-              defaults="“Unique in its simplicity and requires minimum interaction time.”"
-            />
-          </Mention>
-          <Mention
-            delay={1}
-            logo={
-              <div className="relative h-8 w-20">
-                <Image
-                  src="/static/images/popsci-logo.svg"
-                  alt="PopSci"
-                  fill
-                  style={{ objectFit: "contain" }}
-                />
-              </div>
-            }
-          >
-            <Trans
-              t={t}
-              ns="home"
-              i18nKey="popsciQuote"
-              defaults="“The perfect pick if you want to keep your RSVPs simple.”"
-            />
-          </Mention>
-        </Mentions>
-      </Section>
+      <SocialProof locale={locale} />
       <div>
         <Section>
           <SectionHeading>

--- a/apps/landing/src/app/[locale]/(main)/(seo)/when2meet-alternative/page.tsx
+++ b/apps/landing/src/app/[locale]/(main)/(seo)/when2meet-alternative/page.tsx
@@ -2,7 +2,6 @@
 
 import type { Metadata } from "next";
 import { cacheLife } from "next/cache";
-import Image from "next/image";
 import Link from "next/link";
 import { Trans } from "react-i18next/TransWithoutContext";
 import { PeopleBadge, PollsBadge } from "@/components/home/animated-number";
@@ -11,9 +10,8 @@ import { Faq, FaqItem } from "@/components/home/faq";
 import { Hero } from "@/components/home/hero";
 import { HeroDemo } from "@/components/home/hero-demo/hero-demo";
 import { HowItWorks } from "@/components/home/how-it-works/how-it-works";
-import { Mention, Mentions } from "@/components/home/mentions";
+import { SocialProof } from "@/components/home/social-proof";
 import { Stats } from "@/components/home/stats";
-import { Testimonial } from "@/components/home/testimonial";
 import {
   Section,
   SectionContent,
@@ -63,127 +61,7 @@ export default async function Page(props: {
         </Stats>
       </Section>
       <HowItWorks locale={locale} />
-      <Section>
-        <Testimonial
-          logo={
-            <Image
-              src="/static/images/mit-logo.svg"
-              width={54}
-              height={28}
-              alt=""
-            />
-          }
-          avatar={
-            <Image
-              className="rounded-full"
-              src="/static/images/eric.png"
-              width={48}
-              height={48}
-              alt=""
-            />
-          }
-          name="Eric Fletcher"
-          title={
-            <Trans
-              t={t}
-              ns="home"
-              i18nKey="ericJobTitle"
-              defaults="Executive Assistant at MIT"
-            />
-          }
-        >
-          <Trans
-            t={t}
-            ns="home"
-            i18nKey="ericQuote"
-            defaults="“If your scheduling workflow lives in emails, I strongly encourage you to try and let Rallly simplify your scheduling tasks for a more organized and less stressful workday.”"
-          />
-        </Testimonial>
-      </Section>
-      <Section>
-        <Mentions locale={locale}>
-          <Mention
-            delay={0.25}
-            logo={
-              <div className="relative h-8 w-14">
-                <Image
-                  src="/static/images/pcmag-logo.svg"
-                  alt="PCMag"
-                  fill
-                  style={{ objectFit: "contain" }}
-                />
-              </div>
-            }
-          >
-            <Trans
-              t={t}
-              ns="home"
-              i18nKey="pcmagQuote"
-              defaults="“Set up a scheduling poll in as little time as possible.”"
-            />
-          </Mention>
-          <Mention
-            delay={0.5}
-            logo={
-              <div className="relative h-8 w-24">
-                <Image
-                  src="/static/images/hubspot-logo.svg"
-                  alt="HubSpot"
-                  fill
-                  style={{ objectFit: "contain" }}
-                />
-              </div>
-            }
-          >
-            <Trans
-              t={t}
-              ns="home"
-              i18nKey="hubspotQuote"
-              defaults="“The simplest choice for availability polling for large groups.”"
-            />
-          </Mention>
-          <Mention
-            delay={0.75}
-            logo={
-              <div className="relative h-8 w-32">
-                <Image
-                  src="/static/images/goodfirms-logo.svg"
-                  alt="Goodfirms"
-                  fill
-                  style={{ objectFit: "contain" }}
-                />
-              </div>
-            }
-          >
-            <Trans
-              t={t}
-              ns="home"
-              i18nKey="goodfirmsQuote"
-              defaults="“Unique in its simplicity and requires minimum interaction time.”"
-            />
-          </Mention>
-          <Mention
-            delay={1}
-            logo={
-              <div className="relative h-8 w-20">
-                <Image
-                  src="/static/images/popsci-logo.svg"
-                  alt="PopSci"
-                  fill
-                  style={{ objectFit: "contain" }}
-                />
-              </div>
-            }
-          >
-            <Trans
-              t={t}
-              ns="home"
-              i18nKey="popsciQuote"
-              defaults="“The perfect pick if you want to keep your RSVPs simple.”"
-            />
-          </Mention>
-        </Mentions>
-      </Section>
+      <SocialProof locale={locale} />
       <div>
         <Section>
           <SectionHeading>

--- a/apps/landing/src/app/[locale]/(main)/page.tsx
+++ b/apps/landing/src/app/[locale]/(main)/page.tsx
@@ -87,125 +87,143 @@ export default async function Page(props: {
       </Section>
       <HowItWorks locale={locale} />
       <Section>
-        <Testimonial
-          logo={
-            <Image
-              src="/static/images/mit-logo.svg"
-              width={54}
-              height={28}
-              alt=""
-            />
-          }
-          avatar={
-            <Image
-              className="rounded-full"
-              src="/static/images/eric.png"
-              width={48}
-              height={48}
-              alt=""
-            />
-          }
-          name="Eric Fletcher"
-          title={
+        <SectionHeading>
+          <SectionTitle>
             <Trans
               t={t}
               ns="home"
-              i18nKey="ericJobTitle"
-              defaults="Executive Assistant at MIT"
+              i18nKey="socialProofTitle"
+              defaults="Loved for its simplicity"
             />
-          }
-        >
-          <Trans
-            t={t}
-            ns="home"
-            i18nKey="ericQuote"
-            defaults="“If your scheduling workflow lives in emails, I strongly encourage you to try and let Rallly simplify your scheduling tasks for a more organized and less stressful workday.”"
-          />
-        </Testimonial>
-      </Section>
-      <Section>
-        <Mentions locale={locale}>
-          <Mention
-            delay={0.25}
+          </SectionTitle>
+          <SectionDescription>
+            <Trans
+              t={t}
+              ns="home"
+              i18nKey="socialProofDescription"
+              defaults="Ask anyone who's used it. The fastest way to schedule a group is also the simplest."
+            />
+          </SectionDescription>
+        </SectionHeading>
+        <SectionContent className="space-y-12 sm:space-y-16">
+          <Testimonial
             logo={
-              <div className="relative h-8 w-14">
-                <Image
-                  src="/static/images/pcmag-logo.svg"
-                  alt="PCMag"
-                  fill
-                  style={{ objectFit: "contain" }}
-                />
-              </div>
+              <Image
+                src="/static/images/mit-logo.svg"
+                width={54}
+                height={28}
+                alt=""
+              />
+            }
+            avatar={
+              <Image
+                className="rounded-full"
+                src="/static/images/eric.png"
+                width={48}
+                height={48}
+                alt=""
+              />
+            }
+            name="Eric Fletcher"
+            title={
+              <Trans
+                t={t}
+                ns="home"
+                i18nKey="ericJobTitle"
+                defaults="Executive Assistant at MIT"
+              />
             }
           >
             <Trans
               t={t}
               ns="home"
-              i18nKey="pcmagQuote"
-              defaults="“Set up a scheduling poll in as little time as possible.”"
+              i18nKey="ericQuote"
+              defaults="“If your scheduling workflow lives in emails, I strongly encourage you to try and let Rallly simplify your scheduling tasks for a more organized and less stressful workday.”"
             />
-          </Mention>
-          <Mention
-            delay={0.5}
-            logo={
-              <div className="relative h-8 w-24">
-                <Image
-                  src="/static/images/hubspot-logo.svg"
-                  alt="HubSpot"
-                  fill
-                  style={{ objectFit: "contain" }}
-                />
-              </div>
-            }
-          >
-            <Trans
-              t={t}
-              ns="home"
-              i18nKey="hubspotQuote"
-              defaults="“The simplest choice for availability polling for large groups.”"
-            />
-          </Mention>
-          <Mention
-            delay={0.75}
-            logo={
-              <div className="relative h-8 w-32">
-                <Image
-                  src="/static/images/goodfirms-logo.svg"
-                  alt="Goodfirms"
-                  fill
-                  style={{ objectFit: "contain" }}
-                />
-              </div>
-            }
-          >
-            <Trans
-              t={t}
-              ns="home"
-              i18nKey="goodfirmsQuote"
-              defaults="“Unique in its simplicity and requires minimum interaction time.”"
-            />
-          </Mention>
-          <Mention
-            delay={1}
-            logo={
-              <div className="relative h-8 w-20">
-                <Image
-                  src="/static/images/popsci-logo.svg"
-                  alt="PopSci"
-                  fill
-                  style={{ objectFit: "contain" }}
-                />
-              </div>
-            }
-          >
-            <Trans
-              t={t}
-              ns="home"
-              i18nKey="popsciQuote"
-              defaults="“The perfect pick if you want to keep your RSVPs simple.”"
-            />
-          </Mention>
-        </Mentions>
+          </Testimonial>
+          <Mentions locale={locale}>
+            <Mention
+              delay={0.25}
+              logo={
+                <div className="relative h-8 w-14">
+                  <Image
+                    src="/static/images/pcmag-logo.svg"
+                    alt="PCMag"
+                    fill
+                    style={{ objectFit: "contain" }}
+                  />
+                </div>
+              }
+            >
+              <Trans
+                t={t}
+                ns="home"
+                i18nKey="pcmagQuote"
+                defaults="“Set up a scheduling poll in as little time as possible.”"
+              />
+            </Mention>
+            <Mention
+              delay={0.5}
+              logo={
+                <div className="relative h-8 w-24">
+                  <Image
+                    src="/static/images/hubspot-logo.svg"
+                    alt="HubSpot"
+                    fill
+                    style={{ objectFit: "contain" }}
+                  />
+                </div>
+              }
+            >
+              <Trans
+                t={t}
+                ns="home"
+                i18nKey="hubspotQuote"
+                defaults="“The simplest choice for availability polling for large groups.”"
+              />
+            </Mention>
+            <Mention
+              delay={0.75}
+              logo={
+                <div className="relative h-8 w-32">
+                  <Image
+                    src="/static/images/goodfirms-logo.svg"
+                    alt="Goodfirms"
+                    fill
+                    style={{ objectFit: "contain" }}
+                  />
+                </div>
+              }
+            >
+              <Trans
+                t={t}
+                ns="home"
+                i18nKey="goodfirmsQuote"
+                defaults="“Unique in its simplicity and requires minimum interaction time.”"
+              />
+            </Mention>
+            <Mention
+              delay={1}
+              logo={
+                <div className="relative h-8 w-20">
+                  <Image
+                    src="/static/images/popsci-logo.svg"
+                    alt="PopSci"
+                    fill
+                    style={{ objectFit: "contain" }}
+                  />
+                </div>
+              }
+            >
+              <Trans
+                t={t}
+                ns="home"
+                i18nKey="popsciQuote"
+                defaults="“The perfect pick if you want to keep your RSVPs simple.”"
+              />
+            </Mention>
+          </Mentions>
+        </SectionContent>
       </Section>
       <div>
         <Section>

--- a/apps/landing/src/app/[locale]/(main)/page.tsx
+++ b/apps/landing/src/app/[locale]/(main)/page.tsx
@@ -2,7 +2,6 @@
 
 import type { Metadata } from "next";
 import { cacheLife } from "next/cache";
-import Image from "next/image";
 import Link from "next/link";
 import { Trans } from "react-i18next/TransWithoutContext";
 import { PeopleBadge, PollsBadge } from "@/components/home/animated-number";
@@ -11,9 +10,8 @@ import { Faq, FaqItem } from "@/components/home/faq";
 import { Hero, HeroAnnouncement } from "@/components/home/hero";
 import { HeroDemo } from "@/components/home/hero-demo/hero-demo";
 import { HowItWorks } from "@/components/home/how-it-works/how-it-works";
-import { Mention, Mentions } from "@/components/home/mentions";
+import { SocialProof } from "@/components/home/social-proof";
 import { Stats } from "@/components/home/stats";
-import { Testimonial } from "@/components/home/testimonial";
 import {
   Section,
   SectionContent,
@@ -86,145 +84,7 @@ export default async function Page(props: {
         </Stats>
       </Section>
       <HowItWorks locale={locale} />
-      <Section>
-        <SectionHeading>
-          <SectionTitle>
-            <Trans
-              t={t}
-              ns="home"
-              i18nKey="socialProofTitle"
-              defaults="Loved for its simplicity"
-            />
-          </SectionTitle>
-          <SectionDescription>
-            <Trans
-              t={t}
-              ns="home"
-              i18nKey="socialProofDescription"
-              defaults="Ask anyone who's used it. The fastest way to schedule a group is also the simplest."
-            />
-          </SectionDescription>
-        </SectionHeading>
-        <SectionContent className="space-y-12 sm:space-y-16">
-          <Testimonial
-            logo={
-              <Image
-                src="/static/images/mit-logo.svg"
-                width={54}
-                height={28}
-                alt=""
-              />
-            }
-            avatar={
-              <Image
-                className="rounded-full"
-                src="/static/images/eric.png"
-                width={48}
-                height={48}
-                alt=""
-              />
-            }
-            name="Eric Fletcher"
-            title={
-              <Trans
-                t={t}
-                ns="home"
-                i18nKey="ericJobTitle"
-                defaults="Executive Assistant at MIT"
-              />
-            }
-          >
-            <Trans
-              t={t}
-              ns="home"
-              i18nKey="ericQuote"
-              defaults="“If your scheduling workflow lives in emails, I strongly encourage you to try and let Rallly simplify your scheduling tasks for a more organized and less stressful workday.”"
-            />
-          </Testimonial>
-          <Mentions locale={locale}>
-            <Mention
-              delay={0.25}
-              logo={
-                <div className="relative h-8 w-14">
-                  <Image
-                    src="/static/images/pcmag-logo.svg"
-                    alt="PCMag"
-                    fill
-                    style={{ objectFit: "contain" }}
-                  />
-                </div>
-              }
-            >
-              <Trans
-                t={t}
-                ns="home"
-                i18nKey="pcmagQuote"
-                defaults="“Set up a scheduling poll in as little time as possible.”"
-              />
-            </Mention>
-            <Mention
-              delay={0.5}
-              logo={
-                <div className="relative h-8 w-24">
-                  <Image
-                    src="/static/images/hubspot-logo.svg"
-                    alt="HubSpot"
-                    fill
-                    style={{ objectFit: "contain" }}
-                  />
-                </div>
-              }
-            >
-              <Trans
-                t={t}
-                ns="home"
-                i18nKey="hubspotQuote"
-                defaults="“The simplest choice for availability polling for large groups.”"
-              />
-            </Mention>
-            <Mention
-              delay={0.75}
-              logo={
-                <div className="relative h-8 w-32">
-                  <Image
-                    src="/static/images/goodfirms-logo.svg"
-                    alt="Goodfirms"
-                    fill
-                    style={{ objectFit: "contain" }}
-                  />
-                </div>
-              }
-            >
-              <Trans
-                t={t}
-                ns="home"
-                i18nKey="goodfirmsQuote"
-                defaults="“Unique in its simplicity and requires minimum interaction time.”"
-              />
-            </Mention>
-            <Mention
-              delay={1}
-              logo={
-                <div className="relative h-8 w-20">
-                  <Image
-                    src="/static/images/popsci-logo.svg"
-                    alt="PopSci"
-                    fill
-                    style={{ objectFit: "contain" }}
-                  />
-                </div>
-              }
-            >
-              <Trans
-                t={t}
-                ns="home"
-                i18nKey="popsciQuote"
-                defaults="“The perfect pick if you want to keep your RSVPs simple.”"
-              />
-            </Mention>
-          </Mentions>
-        </SectionContent>
-      </Section>
+      <SocialProof locale={locale} />
       <div>
         <Section>
           <SectionHeading>

--- a/apps/landing/src/components/home/social-proof.tsx
+++ b/apps/landing/src/components/home/social-proof.tsx
@@ -1,0 +1,173 @@
+import Image from "next/image";
+import { Trans } from "react-i18next/TransWithoutContext";
+import { Mention, Mentions } from "@/components/home/mentions";
+import { Testimonial } from "@/components/home/testimonial";
+import {
+  Section,
+  SectionContent,
+  SectionDescription,
+  SectionHeading,
+  SectionTitle,
+} from "@/components/section";
+import { getTranslation } from "@/i18n/server";
+
+// The social proof section, shared by the home page and the SEO landing
+// pages. Owns its copy, unlike the rest of the landing components, so every
+// page renders the same testimonial and press mentions. Pages aimed at a
+// specific audience can pass their own title and description.
+export const SocialProof = async ({
+  locale,
+  title,
+  description,
+}: {
+  locale: string;
+  title?: React.ReactNode;
+  description?: React.ReactNode;
+}) => {
+  const { t } = await getTranslation<"home">(locale, "home");
+  return (
+    <Section>
+      <SectionHeading>
+        <SectionTitle>
+          {title ?? (
+            <Trans
+              t={t}
+              ns="home"
+              i18nKey="socialProofTitle"
+              defaults="Loved for its simplicity"
+            />
+          )}
+        </SectionTitle>
+        <SectionDescription>
+          {description ?? (
+            <Trans
+              t={t}
+              ns="home"
+              i18nKey="socialProofDescription"
+              defaults="Ask anyone who's used it. The fastest way to schedule a group is also the simplest."
+            />
+          )}
+        </SectionDescription>
+      </SectionHeading>
+      <SectionContent className="space-y-12 sm:space-y-16">
+        <Testimonial
+          logo={
+            <Image
+              src="/static/images/mit-logo.svg"
+              width={54}
+              height={28}
+              alt=""
+            />
+          }
+          avatar={
+            <Image
+              className="rounded-full"
+              src="/static/images/eric.png"
+              width={48}
+              height={48}
+              alt=""
+            />
+          }
+          name="Eric Fletcher"
+          title={
+            <Trans
+              t={t}
+              ns="home"
+              i18nKey="ericJobTitle"
+              defaults="Executive Assistant at MIT"
+            />
+          }
+        >
+          <Trans
+            t={t}
+            ns="home"
+            i18nKey="ericQuote"
+            defaults="“If your scheduling workflow lives in emails, I strongly encourage you to try and let Rallly simplify your scheduling tasks for a more organized and less stressful workday.”"
+          />
+        </Testimonial>
+        <Mentions locale={locale}>
+          <Mention
+            delay={0.25}
+            logo={
+              <div className="relative h-8 w-14">
+                <Image
+                  src="/static/images/pcmag-logo.svg"
+                  alt="PCMag"
+                  fill
+                  style={{ objectFit: "contain" }}
+                />
+              </div>
+            }
+          >
+            <Trans
+              t={t}
+              ns="home"
+              i18nKey="pcmagQuote"
+              defaults="“Set up a scheduling poll in as little time as possible.”"
+            />
+          </Mention>
+          <Mention
+            delay={0.5}
+            logo={
+              <div className="relative h-8 w-24">
+                <Image
+                  src="/static/images/hubspot-logo.svg"
+                  alt="HubSpot"
+                  fill
+                  style={{ objectFit: "contain" }}
+                />
+              </div>
+            }
+          >
+            <Trans
+              t={t}
+              ns="home"
+              i18nKey="hubspotQuote"
+              defaults="“The simplest choice for availability polling for large groups.”"
+            />
+          </Mention>
+          <Mention
+            delay={0.75}
+            logo={
+              <div className="relative h-8 w-32">
+                <Image
+                  src="/static/images/goodfirms-logo.svg"
+                  alt="Goodfirms"
+                  fill
+                  style={{ objectFit: "contain" }}
+                />
+              </div>
+            }
+          >
+            <Trans
+              t={t}
+              ns="home"
+              i18nKey="goodfirmsQuote"
+              defaults="“Unique in its simplicity and requires minimum interaction time.”"
+            />
+          </Mention>
+          <Mention
+            delay={1}
+            logo={
+              <div className="relative h-8 w-20">
+                <Image
+                  src="/static/images/popsci-logo.svg"
+                  alt="PopSci"
+                  fill
+                  style={{ objectFit: "contain" }}
+                />
+              </div>
+            }
+          >
+            <Trans
+              t={t}
+              ns="home"
+              i18nKey="popsciQuote"
+              defaults="“The perfect pick if you want to keep your RSVPs simple.”"
+            />
+          </Mention>
+        </Mentions>
+      </SectionContent>
+    </Section>
+  );
+};


### PR DESCRIPTION
## Description

The landing page showed Eric's testimonial and the press mention quotes as two unrelated bands with no framing, and the same blocks were duplicated verbatim across the home page and all eight SEO pages.

**Commit 1** merges them into a single social proof section on the home page:

- New heading: **"Loved for its simplicity"** with the description *"Ask anyone who's used it. The fastest way to schedule a group is also the simplest."* — chosen because all four press quotes are literally about simplicity/speed, so the content proves the claim.
- Eric Fletcher's testimonial stays featured at the top, with the four press mentions (PCMag, HubSpot, Goodfirms, PopSci) in the existing grid/scroll-strip below.

**Commit 2** extracts the section into a `SocialProof` component and reuses it on all nine pages (home + 8 SEO pages), deleting ~1,100 lines of duplication:

- Follows the `HowItWorks` pattern: an async server component that owns its copy, taking `locale`.
- Optional `title`/`description` props are available for audience-targeted copy on specific pages.

**Commit 3** removes the copy override that commit 2 added on the executive assistants page — the plural title overclaimed what the section shows (one assistant, four press quotes), and Eric's MIT byline does the audience targeting on its own. All pages now use the default copy; the props remain for future use.

The `Testimonial` and `Mentions` components are untouched, so the small-screen scroll bleed and fade-in behavior carry over unchanged. i18n keys were managed via `i18next-cli extract`; the locale diff contains only the two new `socialProof*` keys.

Verified against the dev server: home, executive-assistants, and best-doodle-alternative all render the section with no console errors; landing type-check passes.

## Checklist

- [x] I have performed a self-review of my code
- [x] My code follows the code style of this project
- [x] I have commented my code, particularly in hard-to-understand areas

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a shared social-proof section with customer testimonials and media mentions across landing pages.
  * Added localized social-proof titles and descriptions for broader home and SEO page audiences.
  * Standardized testimonial and press-mention content across scheduling and alternative-product pages for a consistent experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->