### PR TITLE
🐛 Restore dark mode muted text hierarchy on popover surfaces

### DIFF
--- a/packages/tailwind-config/shared-styles.css
+++ b/packages/tailwind-config/shared-styles.css
@@ -98,7 +98,7 @@
 
   --popover: var(--color-gray-800);
   --popover-border: var(--color-gray-700);
-  --popover-foreground: var(--color-gray-300);
+  --popover-foreground: var(--color-gray-100);
   --popover-accent: var(--color-gray-700);
 
   --card: oklch(0.24 0.006 286.033);

--- a/packages/ui/src/command.tsx
+++ b/packages/ui/src/command.tsx
@@ -76,7 +76,7 @@ const CommandInput = React.forwardRef<
     <CommandPrimitive.Input
       ref={ref}
       className={cn(
-        "flex h-11 w-full rounded-md bg-transparent py-3 text-sm outline-hidden placeholder:text-foreground-muted focus:ring-0 disabled:cursor-not-allowed disabled:opacity-50",
+        "flex h-11 w-full rounded-md bg-transparent py-3 text-sm outline-hidden placeholder:text-muted-foreground focus:ring-0 disabled:cursor-not-allowed disabled:opacity-50",
         className,
       )}
       {...props}


### PR DESCRIPTION
## Description

Dark mode's `--popover-foreground` and `--muted-foreground` both resolved to `gray-300`, so `text-muted-foreground` was a visual no-op inside any surface that sets `text-popover-foreground` (dropdowns, popovers, sheets, comboboxes, toasts) — labels, descriptions, timestamps and item icons rendered at the same color as primary text, flattening the type hierarchy.

The collision was accidental: #2087 shipped them distinct (`gray-300` vs `gray-400`), then #2950 bumped `muted-foreground` to `gray-300` for event card contrast without touching `popover-foreground`.

**Changes:**
- Dark `--popover-foreground`: `gray-300` → `gray-100`. Mirrors light mode (where `popover-foreground` equals `foreground`) and matches the existing dark values for `sidebar-foreground`, `accent-foreground` and `input-foreground`.
- `packages/ui/src/command.tsx`: `placeholder:text-foreground-muted` → `placeholder:text-muted-foreground` — `foreground-muted` is not a token, so the class generated no rule and placeholders rendered at full text color.

**Reviewer notes:** dark mode only (light tokens are `gray-800` vs `gray-600`, no collision). All dark popover-family surfaces get slightly brighter primary text, including toasts (sonner maps `--normal-text` to this token). Verified in the browser: dropdown item text and sheet comment bodies compute to zinc-100, labels/timestamps/icons to zinc-300.

## Checklist

- [x] I have performed a self-review of my code
- [x] My code follows the code style of this project
- [x] I have commented my code, particularly in hard-to-understand areas

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved readability of popover text in dark mode with a brighter foreground color.
  * Updated command input placeholder styling for more consistent muted text appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->