### PR TITLE
💄 Constrain testimonial attribution width so long titles wrap

### DIFF
--- a/apps/landing/src/components/home/testimonial.tsx
+++ b/apps/landing/src/components/home/testimonial.tsx
@@ -20,11 +20,11 @@ export function Testimonial({
       className="flex flex-col gap-8 sm:flex-row sm:items-start sm:justify-between sm:gap-16"
     >
       <p className="max-w-2xl text-lg leading-normal sm:text-2xl">{children}</p>
-      <div className="flex shrink-0 flex-col gap-y-4 sm:items-end sm:text-right">
+      <div className="flex shrink-0 flex-col gap-y-4 sm:w-64 sm:items-end sm:text-right">
         {logo}
         <div>
           <div className="font-semibold">{name}</div>
-          <div className="text-gray-600 text-sm">{title}</div>
+          <div className="text-balance text-gray-600 text-sm">{title}</div>
         </div>
         {avatar}
       </div>


### PR DESCRIPTION
## Description

The testimonial attribution column in `apps/landing/src/components/home/testimonial.tsx` had `shrink-0` with no width, so it sized to its content. On the Russian home page, Eric Fletcher's job title ("Исполнительный помощник в Массачусетском технологическом институте", 66 characters) stretched the column across the entire row, squeezing the quote.

This adds `sm:w-64` to the column and `text-balance` to the title. Verified in the browser: the Russian title wraps to 3 balanced lines in a 256px column; English stays on one line (174px), so no regression at the source locale. Both changes are `sm:`-scoped or line-count neutral on mobile, where the column stacks full-width.

The Russian translation itself is correct (proper prepositional case, standard Russian name for MIT) — the length is inherent to the language, so this is purely a layout fix; no locale JSON touched. `text-balance` over `text-pretty` because it equalizes line lengths on a short right-aligned block rather than only preventing orphans.

## Checklist

- [x] I have performed a self-review of my code
- [x] My code follows the code style of this project
- [x] I have commented my code, particularly in hard-to-understand areas

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved testimonial layout consistency on small screens.
  * Enhanced author title text wrapping for better readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->