### PR TITLE
📝 Correct data storage providers in privacy policy

### DIFF
--- a/apps/landing/src/app/[locale]/(main)/privacy-policy/page.tsx
+++ b/apps/landing/src/app/[locale]/(main)/privacy-policy/page.tsx
@@ -7,7 +7,7 @@ export default async function PrivacyPolicy() {
   return (
     <div className="prose mx-auto max-w-3xl">
       <h1>Privacy Policy</h1>
-      <p>Last updated: 21 August 2026</p>
+      <p>Last updated: 27 August 2026</p>
       <p>
         At rallly.co, we take your privacy seriously. This privacy policy
         explains how we collect, use, and disclose your personal data, and your
@@ -18,12 +18,13 @@ export default async function PrivacyPolicy() {
       <h2>Information we collect</h2>
 
       <p>
-        We store personal data (names and email addresses) on Neon&apos;s
-        servers, which are located in the United States. The reason for storing
-        data in the US is to improve performance for users by having the data
-        stored closer to where our compute services are running. By using our
-        services, you acknowledge that your personal data may be transferred to
-        and stored in the United States.
+        We store personal data (names and email addresses) in a database hosted
+        by DigitalOcean on servers located in the United States. We also use
+        Upstash to store session data and rate limiting data in the United
+        States. The reason for storing data in the US is to improve performance
+        for users by having the data stored closer to where our compute services
+        are running. By using our services, you acknowledge that your personal
+        data may be transferred to and stored in the United States.
       </p>
 
       <p>


### PR DESCRIPTION
## What changed

The privacy policy's "Information we collect" section claimed personal data is stored on Neon. It isn't — the database is hosted on DigitalOcean. The paragraph now names DigitalOcean, and also discloses Upstash, which holds auth session data and rate limiting keys (per `env.ts`, `KV_REST_API_URL`). Bumped the "Last updated" date to 27 August 2026.

## For the reviewer

The Upstash storage location is stated as the United States, carried over from the existing US-transfer paragraph. Verify the Upstash database's actual region in the console — if it's EU, that sentence needs correcting before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the privacy policy’s “last updated” date to 27 August 2026.
  * Clarified where personal data, session data, and rate-limiting data are stored.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->