### PR TITLE
💄 Restyle policy pages to match the landing design system

### DIFF
--- a/apps/landing/src/app/[locale]/(main)/blog/[slug]/page.tsx
+++ b/apps/landing/src/app/[locale]/(main)/blog/[slug]/page.tsx
@@ -108,7 +108,7 @@ export default async function Page(props: {
               </div>
             </dl>
           </aside>
-          <article className="blog-content min-w-0 max-w-2xl lg:order-1">
+          <article className="longform min-w-0 max-w-2xl lg:order-1">
             <MDXRemote source={post.content} />
           </article>
         </div>

--- a/apps/landing/src/app/[locale]/(main)/cookie-policy/page.tsx
+++ b/apps/landing/src/app/[locale]/(main)/cookie-policy/page.tsx
@@ -1,64 +1,69 @@
 "use cache";
 
 import { cacheLife } from "next/cache";
+import { Section } from "@/components/section";
 
 export default async function CookiePolicy() {
   cacheLife("max");
   return (
-    <div className="prose mx-auto max-w-3xl">
-      <h1>Cookie Policy</h1>
-      <p>Last updated: 4 April 2026</p>
-      <p>
-        This Policy explains how we use cookies and other similar technologies
-        on our website, and your options to control them.
-      </p>
+    <Section>
+      <h1 className="max-w-2xl text-balance font-medium text-3xl text-gray-800 tracking-tight sm:text-4xl">
+        Cookie policy
+      </h1>
+      <p className="mt-4 text-gray-500 text-sm">Last updated: 4 April 2026</p>
+      <div className="longform mt-8 max-w-2xl">
+        <p>
+          This Policy explains how we use cookies and other similar technologies
+          on our website, and your options to control them.
+        </p>
 
-      <h2>What are cookies?</h2>
-      <p>
-        Cookies are small text files that are placed on your device (e.g.
-        computer, tablet, or smartphone) when you visit a website. Cookies are
-        widely used by website owners to make their websites work, or to work
-        more efficiently, as well as to provide reporting information.
-      </p>
+        <h2>What are cookies?</h2>
+        <p>
+          Cookies are small text files that are placed on your device (e.g.
+          computer, tablet, or smartphone) when you visit a website. Cookies are
+          widely used by website owners to make their websites work, or to work
+          more efficiently, as well as to provide reporting information.
+        </p>
 
-      <h2>How we use cookies</h2>
-      <p>We use the following types of cookies on our website:</p>
-      <h3>Essential cookies</h3>
-      <p>
-        These cookies are necessary for our website to function properly and
-        enable you to access secure areas of the website. They cannot be
-        disabled.
-      </p>
-      <h3>Analytics cookies</h3>
-      <p>
-        We use PostHog to collect anonymous analytics data that helps us
-        understand how visitors use our website and identify areas for
-        improvement. PostHog sets cookies to distinguish between users and
-        sessions. The data collected includes pages visited, events triggered,
-        device type, and IP address (used for approximate geolocation only).
-        This information is stored on PostHog&apos;s EU-based servers and is not
-        used for advertising or shared with third parties.
-      </p>
+        <h2>How we use cookies</h2>
+        <p>We use the following types of cookies on our website:</p>
+        <h3>Essential cookies</h3>
+        <p>
+          These cookies are necessary for our website to function properly and
+          enable you to access secure areas of the website. They cannot be
+          disabled.
+        </p>
+        <h3>Analytics cookies</h3>
+        <p>
+          We use PostHog to collect anonymous analytics data that helps us
+          understand how visitors use our website and identify areas for
+          improvement. PostHog sets cookies to distinguish between users and
+          sessions. The data collected includes pages visited, events triggered,
+          device type, and IP address (used for approximate geolocation only).
+          This information is stored on PostHog&apos;s EU-based servers and is
+          not used for advertising or shared with third parties.
+        </p>
 
-      <h2>Your options</h2>
-      <p>
-        Most web browsers allow you to control cookies through their settings
-        preferences. You can also opt out of analytics cookies by enabling the{" "}
-        <a href="https://globalprivacycontrol.org/" rel="noopener noreferrer">
-          Global Privacy Control
-        </a>{" "}
-        signal in your browser. Please be aware that disabling essential cookies
-        may prevent you from accessing certain parts of our website.
-      </p>
+        <h2>Your options</h2>
+        <p>
+          Most web browsers allow you to control cookies through their settings
+          preferences. You can also opt out of analytics cookies by enabling the{" "}
+          <a href="https://globalprivacycontrol.org/" rel="noopener noreferrer">
+            Global Privacy Control
+          </a>{" "}
+          signal in your browser. Please be aware that disabling essential
+          cookies may prevent you from accessing certain parts of our website.
+        </p>
 
-      <h2>Changes to this policy</h2>
-      <p>
-        We may update this Cookie Policy from time to time to reflect changes in
-        our website or relevant regulations. We encourage you to review this
-        policy regularly to stay informed about how we use cookies on our
-        website.
-      </p>
-    </div>
+        <h2>Changes to this policy</h2>
+        <p>
+          We may update this Cookie Policy from time to time to reflect changes
+          in our website or relevant regulations. We encourage you to review
+          this policy regularly to stay informed about how we use cookies on our
+          website.
+        </p>
+      </div>
+    </Section>
   );
 }
 

--- a/apps/landing/src/app/[locale]/(main)/privacy-policy/page.tsx
+++ b/apps/landing/src/app/[locale]/(main)/privacy-policy/page.tsx
@@ -1,181 +1,188 @@
 "use cache";
 
 import { cacheLife } from "next/cache";
+import { Section } from "@/components/section";
 
 export default async function PrivacyPolicy() {
   cacheLife("max");
   return (
-    <div className="prose mx-auto max-w-3xl">
-      <h1>Privacy Policy</h1>
-      <p>Last updated: 27 August 2026</p>
-      <p>
-        At rallly.co, we take your privacy seriously. This privacy policy
-        explains how we collect, use, and disclose your personal data, and your
-        rights in relation to your personal data under the General Data
-        Protection Regulation (GDPR).
-      </p>
+    <Section>
+      <h1 className="max-w-2xl text-balance font-medium text-3xl text-gray-800 tracking-tight sm:text-4xl">
+        Privacy policy
+      </h1>
+      <p className="mt-4 text-gray-500 text-sm">Last updated: 27 August 2026</p>
+      <div className="longform mt-8 max-w-2xl">
+        <p>
+          At rallly.co, we take your privacy seriously. This privacy policy
+          explains how we collect, use, and disclose your personal data, and
+          your rights in relation to your personal data under the General Data
+          Protection Regulation (GDPR).
+        </p>
 
-      <h2>Information we collect</h2>
+        <h2>Information we collect</h2>
 
-      <p>
-        We store personal data (names and email addresses) in a database hosted
-        by DigitalOcean on servers located in the United States. We also use
-        Upstash to store session data and rate limiting data in the United
-        States. The reason for storing data in the US is to improve performance
-        for users by having the data stored closer to where our compute services
-        are running. By using our services, you acknowledge that your personal
-        data may be transferred to and stored in the United States.
-      </p>
+        <p>
+          We store personal data (names and email addresses) in a database
+          hosted by DigitalOcean on servers located in the United States. We
+          also use Upstash to store session data and rate limiting data in the
+          United States. The reason for storing data in the US is to improve
+          performance for users by having the data stored closer to where our
+          compute services are running. By using our services, you acknowledge
+          that your personal data may be transferred to and stored in the United
+          States.
+        </p>
 
-      <p>
-        We collect this information to enable the functionality of our website,
-        and to provide support and communication to our users. We also use
-        Posthog as a data processor to analyze trends and debug issues.
-      </p>
+        <p>
+          We collect this information to enable the functionality of our
+          website, and to provide support and communication to our users. We
+          also use Posthog as a data processor to analyze trends and debug
+          issues.
+        </p>
 
-      <p>
-        Posthog collects certain properties automatically, such as device
-        information and IP address, to help us understand how the website is
-        being used and to identify and resolve any issues. This information is
-        stored securely on Posthog&apos;s EU based servers and is used solely
-        for the purpose of providing and improving the functionality of the
-        website.
-      </p>
+        <p>
+          Posthog collects certain properties automatically, such as device
+          information and IP address, to help us understand how the website is
+          being used and to identify and resolve any issues. This information is
+          stored securely on Posthog&apos;s EU based servers and is used solely
+          for the purpose of providing and improving the functionality of the
+          website.
+        </p>
 
-      <h2>Optional information about your work</h2>
+        <h2>Optional information about your work</h2>
 
-      <p>
-        If you set up an account for work, we ask for two further pieces of
-        information about you:
-      </p>
+        <p>
+          If you set up an account for work, we ask for two further pieces of
+          information about you:
+        </p>
 
-      <ul>
-        <li>
-          Your role — self-declared, chosen from a list or described in your own
-          words.
-        </li>
-        <li>
-          The sector your organisation works in — suggested by us, and yours to
-          confirm or change.
-        </li>
-      </ul>
+        <ul>
+          <li>
+            Your role — self-declared, chosen from a list or described in your
+            own words.
+          </li>
+          <li>
+            The sector your organisation works in — suggested by us, and yours
+            to confirm or change.
+          </li>
+        </ul>
 
-      <p>
-        We use this to understand which professional groups use Rallly, so we
-        can improve the product for them and focus our documentation and
-        marketing on the people it is written for. This information is also
-        shared with Posthog, our analytics processor, for the same purpose.
-      </p>
+        <p>
+          We use this to understand which professional groups use Rallly, so we
+          can improve the product for them and focus our documentation and
+          marketing on the people it is written for. This information is also
+          shared with Posthog, our analytics processor, for the same purpose.
+        </p>
 
-      <p>
-        The sector field is suggested for you: we guess it from your email
-        address&apos;s domain and the organisation name you enter, so that the
-        field arrives filled in rather than blank. The guess is only a
-        suggestion. Nothing is recorded until you submit the form, and you can
-        change it to any other option, or to &quot;Prefer not to say&quot;,
-        before you do.
-      </p>
+        <p>
+          The sector field is suggested for you: we guess it from your email
+          address&apos;s domain and the organisation name you enter, so that the
+          field arrives filled in rather than blank. The guess is only a
+          suggestion. Nothing is recorded until you submit the form, and you can
+          change it to any other option, or to &quot;Prefer not to say&quot;,
+          before you do.
+        </p>
 
-      <p>
-        Both fields are optional. You can skip either one when setting up your
-        account, and neither is required to use Rallly — skipping them has no
-        effect on the service you receive. To change or remove an answer you
-        have already given, email us at{" "}
-        <a href="mailto:support@rallly.co">support@rallly.co</a> and we will
-        update or erase it.
-      </p>
+        <p>
+          Both fields are optional. You can skip either one when setting up your
+          account, and neither is required to use Rallly — skipping them has no
+          effect on the service you receive. To change or remove an answer you
+          have already given, email us at{" "}
+          <a href="mailto:support@rallly.co">support@rallly.co</a> and we will
+          update or erase it.
+        </p>
 
-      <h2>Legal basis for processing</h2>
+        <h2>Legal basis for processing</h2>
 
-      <p>
-        We process your personal data on the legal bases of consent and
-        contract. By using our website, you consent to the collection and use of
-        your personal data as described in this privacy policy. We process your
-        personal data to provide you with our services, and to fulfill our
-        contractual obligations to you.
-      </p>
+        <p>
+          We process your personal data on the legal bases of consent and
+          contract. By using our website, you consent to the collection and use
+          of your personal data as described in this privacy policy. We process
+          your personal data to provide you with our services, and to fulfill
+          our contractual obligations to you.
+        </p>
 
-      <p>
-        Your role and your organisation&apos;s sector are processed on the basis
-        of consent alone, since they are optional and are not needed to deliver
-        the service. You give that consent by submitting the setup form with a
-        value in either field — including a suggested sector you choose to leave
-        as it is. Choosing &quot;Prefer not to say&quot;, or leaving a field
-        unanswered, gives no consent and stores nothing. You can withdraw
-        consent at any time by asking us to erase the answer.
-      </p>
+        <p>
+          Your role and your organisation&apos;s sector are processed on the
+          basis of consent alone, since they are optional and are not needed to
+          deliver the service. You give that consent by submitting the setup
+          form with a value in either field — including a suggested sector you
+          choose to leave as it is. Choosing &quot;Prefer not to say&quot;, or
+          leaving a field unanswered, gives no consent and stores nothing. You
+          can withdraw consent at any time by asking us to erase the answer.
+        </p>
 
-      <h2>Retention of personal data</h2>
+        <h2>Retention of personal data</h2>
 
-      <p>
-        We retain your personal data only for as long as necessary to provide
-        our services to you, and for as long as required by law. We will delete
-        your personal data when you delete your account or when it is no longer
-        necessary for the purposes for which it was collected.
-      </p>
+        <p>
+          We retain your personal data only for as long as necessary to provide
+          our services to you, and for as long as required by law. We will
+          delete your personal data when you delete your account or when it is
+          no longer necessary for the purposes for which it was collected.
+        </p>
 
-      <h2>Sharing of personal data</h2>
+        <h2>Sharing of personal data</h2>
 
-      <p>
-        We do not share your personal data with any third parties for marketing
-        or commercial purposes. We may share your personal data with third
-        parties to provide you with our services, to comply with applicable laws
-        and regulations, to respond to a subpoena, search warrant or other
-        lawful request for information we receive, or to otherwise protect our
-        rights.
-      </p>
+        <p>
+          We do not share your personal data with any third parties for
+          marketing or commercial purposes. We may share your personal data with
+          third parties to provide you with our services, to comply with
+          applicable laws and regulations, to respond to a subpoena, search
+          warrant or other lawful request for information we receive, or to
+          otherwise protect our rights.
+        </p>
 
-      <p>
-        For example, we use Featurebase to make it easy for users to submit
-        feedback. Your name and email may be shared with Featurbase to provide a
-        seamless transition between the two services.
-      </p>
+        <p>
+          For example, we use Featurebase to make it easy for users to submit
+          feedback. Your name and email may be shared with Featurbase to provide
+          a seamless transition between the two services.
+        </p>
 
-      <h2>Your rights</h2>
+        <h2>Your rights</h2>
 
-      <p>You have the following rights in relation to your personal data:</p>
+        <p>You have the following rights in relation to your personal data:</p>
 
-      <ul>
-        <li>
-          Right to access: You have the right to access the personal data we
-          hold about you.
-        </li>
-        <li>
-          Right to rectification: You have the right to have inaccurate personal
-          data corrected or completed if it is incomplete.
-        </li>
-        <li>
-          Right to erasure: You have the right to request that we delete your
-          personal data.
-        </li>
-        <li>
-          Right to restrict processing: You have the right to request that we
-          restrict the processing of your personal data.
-        </li>
-        <li>
-          Right to data portability: You have the right to receive the personal
-          data we hold about you in a structured, commonly used, and
-          machine-readable format, and to transmit it to another controller.
-        </li>
-        <li>
-          Right to object: You have the right to object to the processing of
-          your personal data in certain circumstances.
-        </li>
-      </ul>
+        <ul>
+          <li>
+            Right to access: You have the right to access the personal data we
+            hold about you.
+          </li>
+          <li>
+            Right to rectification: You have the right to have inaccurate
+            personal data corrected or completed if it is incomplete.
+          </li>
+          <li>
+            Right to erasure: You have the right to request that we delete your
+            personal data.
+          </li>
+          <li>
+            Right to restrict processing: You have the right to request that we
+            restrict the processing of your personal data.
+          </li>
+          <li>
+            Right to data portability: You have the right to receive the
+            personal data we hold about you in a structured, commonly used, and
+            machine-readable format, and to transmit it to another controller.
+          </li>
+          <li>
+            Right to object: You have the right to object to the processing of
+            your personal data in certain circumstances.
+          </li>
+        </ul>
 
-      <p>
-        To exercise any of these rights, please contact us at{" "}
-        <a href="mailto:support@rallly.co">support@rallly.co</a>.
-      </p>
+        <p>
+          To exercise any of these rights, please contact us at{" "}
+          <a href="mailto:support@rallly.co">support@rallly.co</a>.
+        </p>
 
-      <h2>Contact</h2>
+        <h2>Contact</h2>
 
-      <p>
-        If you have any questions or concerns about our privacy policy or our
-        practices with regards to your personal data, please contact us at{" "}
-        <a href="mailto:support@rallly.co">support@rallly.co</a>.
-      </p>
-    </div>
+        <p>
+          If you have any questions or concerns about our privacy policy or our
+          practices with regards to your personal data, please contact us at{" "}
+          <a href="mailto:support@rallly.co">support@rallly.co</a>.
+        </p>
+      </div>
+    </Section>
   );
 }
 

--- a/apps/landing/src/app/[locale]/(main)/terms-of-use/page.tsx
+++ b/apps/landing/src/app/[locale]/(main)/terms-of-use/page.tsx
@@ -2,237 +2,252 @@
 
 import type { Metadata } from "next";
 import { cacheLife } from "next/cache";
+import { Section } from "@/components/section";
 
 export default async function TermsOfUse() {
   cacheLife("max");
   return (
-    <div className="prose mx-auto max-w-3xl">
-      <h1>Terms of Use</h1>
-      <p>
-        <strong>Last updated:</strong> 3 December 2025
+    <Section>
+      <h1 className="max-w-2xl text-balance font-medium text-3xl text-gray-800 tracking-tight sm:text-4xl">
+        Terms of use
+      </h1>
+      <p className="mt-4 text-gray-500 text-sm">
+        Last updated: 3 December 2025
       </p>
-      <p>
-        This website and the Rallly software and services are operated by Stack
-        Snap Ltd. References to &quot;we&quot;, &quot;us&quot; or
-        &quot;our&quot; refer to Stack Snap Ltd.
-      </p>
-      <p>
-        We provide you with this website and the Rallly software, including the
-        hosted service at rallly.co and any self‑hosted enterprise editions,
-        subject to your acceptance of these Terms of Use (&quot;Terms&quot;).
-      </p>
-      <p>
-        By accessing or using our website, our hosted service, or a self‑hosted
-        installation of Rallly obtained from us, you agree to be bound by these
-        Terms.
-      </p>
+      <div className="longform mt-8 max-w-2xl">
+        <p>
+          This website and the Rallly software and services are operated by
+          Stack Snap Ltd. References to &quot;we&quot;, &quot;us&quot; or
+          &quot;our&quot; refer to Stack Snap Ltd.
+        </p>
+        <p>
+          We provide you with this website and the Rallly software, including
+          the hosted service at rallly.co and any self‑hosted enterprise
+          editions, subject to your acceptance of these Terms of Use
+          (&quot;Terms&quot;).
+        </p>
+        <p>
+          By accessing or using our website, our hosted service, or a
+          self‑hosted installation of Rallly obtained from us, you agree to be
+          bound by these Terms.
+        </p>
 
-      <hr />
+        <hr />
 
-      <h2>1. Scope</h2>
-      <p>1.1 These Terms apply to:</p>
-      <ul>
-        <li>
-          Your use of the <strong>website</strong> at rallly.co.
-        </li>
-        <li>
-          Your use of the <strong>hosted Rallly service</strong> at rallly.co
-          (if you create an account).
-        </li>
-        <li>
-          Where explicitly stated, your use of{" "}
-          <strong>self‑hosted / enterprise licenses</strong> of the Rallly
-          software that you purchase from us (for example, a &quot;Rallly v4
-          Enterprise License&quot;).
-        </li>
-      </ul>
-      <p>
-        1.2 Additional or different terms may apply to self‑hosted, on‑premise,
-        or enterprise licenses as set out in Section 5 below or in a separate
-        written agreement between you and us. If there is a conflict between
-        these Terms and a signed agreement, the signed agreement will control.
-      </p>
+        <h2>1. Scope</h2>
+        <p>1.1 These Terms apply to:</p>
+        <ul>
+          <li>
+            Your use of the <strong>website</strong> at rallly.co.
+          </li>
+          <li>
+            Your use of the <strong>hosted Rallly service</strong> at rallly.co
+            (if you create an account).
+          </li>
+          <li>
+            Where explicitly stated, your use of{" "}
+            <strong>self‑hosted / enterprise licenses</strong> of the Rallly
+            software that you purchase from us (for example, a &quot;Rallly v4
+            Enterprise License&quot;).
+          </li>
+        </ul>
+        <p>
+          1.2 Additional or different terms may apply to self‑hosted,
+          on‑premise, or enterprise licenses as set out in Section 5 below or in
+          a separate written agreement between you and us. If there is a
+          conflict between these Terms and a signed agreement, the signed
+          agreement will control.
+        </p>
 
-      <hr />
+        <hr />
 
-      <h2>2. Use of Website and Hosted Service</h2>
-      <p>
-        2.1 You may use this website and the hosted Rallly service only for
-        lawful purposes and in accordance with these Terms.
-      </p>
-      <p>2.2 You must not use the website or hosted service in any way that:</p>
-      <ul>
-        <li>Causes or may cause damage to the website or service,</li>
-        <li>
-          Impairs the availability or accessibility of the website or service,
-          or
-        </li>
-        <li>
-          Is unlawful, fraudulent, harmful, or infringes the rights of others.
-        </li>
-      </ul>
-      <p>
-        2.3 You are responsible for keeping your account credentials
-        confidential and for all activity under your account.
-      </p>
+        <h2>2. Use of website and hosted service</h2>
+        <p>
+          2.1 You may use this website and the hosted Rallly service only for
+          lawful purposes and in accordance with these Terms.
+        </p>
+        <p>
+          2.2 You must not use the website or hosted service in any way that:
+        </p>
+        <ul>
+          <li>Causes or may cause damage to the website or service,</li>
+          <li>
+            Impairs the availability or accessibility of the website or service,
+            or
+          </li>
+          <li>
+            Is unlawful, fraudulent, harmful, or infringes the rights of others.
+          </li>
+        </ul>
+        <p>
+          2.3 You are responsible for keeping your account credentials
+          confidential and for all activity under your account.
+        </p>
 
-      <hr />
+        <hr />
 
-      <h2>3. Purchases, Payments and No‑Refund Policy</h2>
-      <p>
-        3.1 All purchases and transactions made through this website or directly
-        with us for Rallly licenses or services are{" "}
-        <strong>final and non‑refundable</strong>, unless we are required to
-        offer a refund under applicable law.
-      </p>
-      <p>
-        3.2 By making a purchase or engaging in a transaction with us, you
-        acknowledge and agree to this no‑refund policy.
-      </p>
-      <p>
-        3.3 For certain products (including Rallly v4 Enterprise), we may
-        require <strong>payment in advance</strong> before delivery of license
-        keys or access details. Any such payment terms will be stated in our
-        quote or invoice.
-      </p>
+        <h2>3. Purchases, payments and no‑refund policy</h2>
+        <p>
+          3.1 All purchases and transactions made through this website or
+          directly with us for Rallly licenses or services are{" "}
+          <strong>final and non‑refundable</strong>, unless we are required to
+          offer a refund under applicable law.
+        </p>
+        <p>
+          3.2 By making a purchase or engaging in a transaction with us, you
+          acknowledge and agree to this no‑refund policy.
+        </p>
+        <p>
+          3.3 For certain products (including Rallly v4 Enterprise), we may
+          require <strong>payment in advance</strong> before delivery of license
+          keys or access details. Any such payment terms will be stated in our
+          quote or invoice.
+        </p>
 
-      <hr />
+        <hr />
 
-      <h2>4. Links to Third‑Party Websites</h2>
-      <p>
-        This website may contain links to third‑party websites that are not
-        owned or controlled by Stack Snap Ltd. We have no control over, and
-        assume no responsibility for, the content, privacy policies, or
-        practices of any third‑party websites.
-      </p>
+        <h2>4. Links to third‑party websites</h2>
+        <p>
+          This website may contain links to third‑party websites that are not
+          owned or controlled by Stack Snap Ltd. We have no control over, and
+          assume no responsibility for, the content, privacy policies, or
+          practices of any third‑party websites.
+        </p>
 
-      <hr />
+        <hr />
 
-      <h2>5. Self‑Hosted</h2>
-      <p>
-        This section applies <strong>only</strong> to customers who have
-        purchased a separate self‑hosted or enterprise license from us (for
-        example, a &quot;Rallly v4 Enterprise License&quot;). It does{" "}
-        <strong>not</strong> apply to users of the hosted service at rallly.co
-        unless expressly agreed in writing.
-      </p>
+        <h2>5. Self‑hosted</h2>
+        <p>
+          This section applies <strong>only</strong> to customers who have
+          purchased a separate self‑hosted or enterprise license from us (for
+          example, a &quot;Rallly v4 Enterprise License&quot;). It does{" "}
+          <strong>not</strong> apply to users of the hosted service at rallly.co
+          unless expressly agreed in writing.
+        </p>
 
-      <h3>5.1 License grant</h3>
-      <p>
-        Subject to your timely payment of all applicable fees, Stack Snap Ltd.
-        grants you a non‑exclusive, non‑transferable, non‑sublicensable license
-        to install and run the Rallly v4 software on your own infrastructure for
-        use by your organization.
-      </p>
+        <h3>5.1 License grant</h3>
+        <p>
+          Subject to your timely payment of all applicable fees, Stack Snap Ltd.
+          grants you a non‑exclusive, non‑transferable, non‑sublicensable
+          license to install and run the Rallly v4 software on your own
+          infrastructure for use by your organization.
+        </p>
 
-      <h3>5.2 Perpetual license scope</h3>
-      <p>If you purchase a Rallly v4 License on a perpetual basis:</p>
-      <ul>
-        <li>
-          The license is perpetual for the purchased major version (v4.x).
-        </li>
-        <li>
-          You are entitled to receive updates, bug fixes and minor releases
-          within the v4.x product line at no additional license fee.
-        </li>
-        <li>
-          Access to future major versions (for example, v5.x) may require a new
-          license or an upgrade fee.
-        </li>
-      </ul>
+        <h3>5.2 Perpetual license scope</h3>
+        <p>If you purchase a Rallly v4 License on a perpetual basis:</p>
+        <ul>
+          <li>
+            The license is perpetual for the purchased major version (v4.x).
+          </li>
+          <li>
+            You are entitled to receive updates, bug fixes and minor releases
+            within the v4.x product line at no additional license fee.
+          </li>
+          <li>
+            Access to future major versions (for example, v5.x) may require a
+            new license or an upgrade fee.
+          </li>
+        </ul>
 
-      <h3>5.3 Restrictions</h3>
-      <p>Unless we agree otherwise in writing, you must not:</p>
-      <ul>
-        <li>
-          Resell, redistribute, or provide the self‑hosted software as a hosted
-          service to third parties.
-        </li>
-        <li>Sublicense, rent, or lease the software to third parties.</li>
-        <li>
-          Attempt to circumvent any technical restrictions in the software.
-        </li>
-      </ul>
-      <p>
-        These restrictions do not limit any rights you have under the applicable
-        open‑source licenses for the Rallly project codebase itself.
-      </p>
+        <h3>5.3 Restrictions</h3>
+        <p>Unless we agree otherwise in writing, you must not:</p>
+        <ul>
+          <li>
+            Resell, redistribute, or provide the self‑hosted software as a
+            hosted service to third parties.
+          </li>
+          <li>Sublicense, rent, or lease the software to third parties.</li>
+          <li>
+            Attempt to circumvent any technical restrictions in the software.
+          </li>
+        </ul>
+        <p>
+          These restrictions do not limit any rights you have under the
+          applicable open‑source licenses for the Rallly project codebase
+          itself.
+        </p>
 
-      <h3>5.4 Open‑source components</h3>
-      <p>
-        Rallly includes open‑source components that are licensed under their own
-        terms. To the extent of any conflict between these Terms and the
-        applicable open‑source licenses, the open‑source licenses will govern
-        your use of those components.
-      </p>
+        <h3>5.4 Open‑source components</h3>
+        <p>
+          Rallly includes open‑source components that are licensed under their
+          own terms. To the extent of any conflict between these Terms and the
+          applicable open‑source licenses, the open‑source licenses will govern
+          your use of those components.
+        </p>
 
-      <h3>5.5 Support</h3>
-      <p>Unless otherwise agreed in writing:</p>
-      <ul>
-        <li>
-          A Rallly v4 Enterprise License includes email support for installation
-          and configuration issues.
-        </li>
-        <li>We do not guarantee specific response times or service levels.</li>
-        <li>No on‑site support is included.</li>
-      </ul>
+        <h3>5.5 Support</h3>
+        <p>Unless otherwise agreed in writing:</p>
+        <ul>
+          <li>
+            A Rallly v4 Enterprise License includes email support for
+            installation and configuration issues.
+          </li>
+          <li>
+            We do not guarantee specific response times or service levels.
+          </li>
+          <li>No on‑site support is included.</li>
+        </ul>
 
-      <h3>5.6 Hosted‑service‑specific terms not automatically applicable</h3>
-      <p>
-        Sections of these Terms that relate specifically to the hosted service
-        (such as account registration or data stored on our servers) do not
-        apply to your self‑hosted installation, except where they are inherently
-        relevant (for example, intellectual property, limitation of liability).
-      </p>
+        <h3>5.6 Hosted‑service‑specific terms not automatically applicable</h3>
+        <p>
+          Sections of these Terms that relate specifically to the hosted service
+          (such as account registration or data stored on our servers) do not
+          apply to your self‑hosted installation, except where they are
+          inherently relevant (for example, intellectual property, limitation of
+          liability).
+        </p>
 
-      <hr />
+        <hr />
 
-      <h2>6. Limitation of Liability</h2>
-      <p>
-        To the maximum extent permitted by law, we will not be liable for any
-        damages arising from the use or inability to use this website, the
-        hosted service, or any self‑hosted installation of Rallly, including but
-        not limited to direct, indirect, incidental, consequential, or punitive
-        damages.
-      </p>
-      <p>
-        Nothing in these Terms limits or excludes any liability that cannot be
-        limited or excluded under applicable law.
-      </p>
+        <h2>6. Limitation of liability</h2>
+        <p>
+          To the maximum extent permitted by law, we will not be liable for any
+          damages arising from the use or inability to use this website, the
+          hosted service, or any self‑hosted installation of Rallly, including
+          but not limited to direct, indirect, incidental, consequential, or
+          punitive damages.
+        </p>
+        <p>
+          Nothing in these Terms limits or excludes any liability that cannot be
+          limited or excluded under applicable law.
+        </p>
 
-      <hr />
+        <hr />
 
-      <h2>7. Modifications to These Terms</h2>
-      <p>
-        We reserve the right to modify these Terms at any time, without prior
-        notice to you. The &quot;Last updated&quot; date above will be revised
-        when we make changes. Your continued use of the website, hosted service,
-        or self‑hosted enterprise license after any modifications will
-        constitute your acceptance of such modifications.
-      </p>
+        <h2>7. Modifications to these terms</h2>
+        <p>
+          We reserve the right to modify these Terms at any time, without prior
+          notice to you. The &quot;Last updated&quot; date above will be revised
+          when we make changes. Your continued use of the website, hosted
+          service, or self‑hosted enterprise license after any modifications
+          will constitute your acceptance of such modifications.
+        </p>
 
-      <hr />
+        <hr />
 
-      <h2>8. Contact</h2>
-      <p>If you have any questions about these Terms, please contact us at:</p>
-      <p>
-        <strong>Email:</strong>{" "}
-        <a href="mailto:support@rallly.co">support@rallly.co</a>
-      </p>
-      <p>
-        <strong>Post:</strong>
-        <br />
-        Stack Snap Ltd.
-        <br />
-        The Gallery
-        <br />
-        14 Upland Road
-        <br />
-        London SE22 9EE
-        <br />
-        United Kingdom
-      </p>
-    </div>
+        <h2>8. Contact</h2>
+        <p>
+          If you have any questions about these Terms, please contact us at:
+        </p>
+        <p>
+          <strong>Email:</strong>{" "}
+          <a href="mailto:support@rallly.co">support@rallly.co</a>
+        </p>
+        <p>
+          <strong>Post:</strong>
+          <br />
+          Stack Snap Ltd.
+          <br />
+          The Gallery
+          <br />
+          14 Upland Road
+          <br />
+          London SE22 9EE
+          <br />
+          United Kingdom
+        </p>
+      </div>
+    </Section>
   );
 }
 

--- a/apps/landing/src/app/[locale]/globals.css
+++ b/apps/landing/src/app/[locale]/globals.css
@@ -7,8 +7,8 @@ body {
   @apply bg-gray-100;
 }
 
-/* Blog post content styles */
-.blog-content {
+/* Long-form content styles (blog posts, policy pages) */
+.longform {
   h2,
   h3,
   h4 {


### PR DESCRIPTION
## What changed

Follow-up to #3092 — brings the privacy policy, cookie policy, and terms of use pages in line with the landing design system.

- Dropped the Tailwind typography plugin's stock `prose` class, which had its own font sizes, colors, and rhythm unrelated to the rest of the site.
- Each page now follows the blog post pattern: `Section` wrapper for vertical rhythm, system heading style on the `h1`, a muted "Last updated" line (normalized across all three pages), and body content at `max-w-2xl`, left-aligned like the blog.
- Renamed `.blog-content` to `.longform` in `globals.css` since it now styles legal pages too, and updated the one usage in the blog post page. The class already covers everything these pages need (heading hierarchy, lists, `hr` spacing for the terms dividers, link styling).
- Sentence-cased page and section headings per the copy standards. Body prose and SEO `<title>` metadata untouched.

## Notes for review

- No `Cta` block at the bottom, unlike blog posts — a marketing CTA on legal documents felt wrong.
- Verified all three pages plus a blog post in the browser; `tsc` passes for the landing app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated blog and policy pages with a consistent long-form content layout.
  * Refined headings, “Last updated” text, spacing, and responsive typography.
  * Standardized policy page widths and sentence-case section headings.

* **Bug Fixes**
  * Preserved all existing blog, cookie policy, privacy policy, and terms content while improving presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->