### PR TITLE
🐛 Fix muted icon color on the invite member button

### DIFF
--- a/apps/web/src/app/[locale]/(space)/(dashboard)/members/components/invite-member-button.tsx
+++ b/apps/web/src/app/[locale]/(space)/(dashboard)/members/components/invite-member-button.tsx
@@ -2,7 +2,6 @@
 
 import { Button } from "@rallly/ui/button";
 import { useDialog } from "@rallly/ui/dialog";
-import { Icon } from "@rallly/ui/icon";
 import { toast } from "@rallly/ui/sonner";
 import { UserPlusIcon } from "lucide-react";
 import { Trans, useTranslation } from "@/i18n/client";
@@ -34,9 +33,7 @@ export function InviteMemberButton({
           }
         }}
       >
-        <Icon>
-          <UserPlusIcon />
-        </Icon>
+        <UserPlusIcon data-icon="inline-start" />
         <Trans i18nKey="inviteMember" defaults="Invite member" />
       </Button>
       <InviteMemberDialog {...inviteMemberDialog.dialogProps} />


### PR DESCRIPTION
## Description

The icon in the **Invite member** button on the members page rendered muted gray instead of white.

Root cause: the `Icon` wrapper paints icons `text-muted-foreground` and relies on a `group-[.bg-primary]:text-primary-foreground` override to recolor them inside primary buttons. Since the Base UI button migration (ed96e4377), the primary variant uses `bg-primary/90` (dark: `bg-primary/80`), so the literal `.bg-primary` class selector never matches and the compensation never applies.

Fix: drop the `Icon` wrapper and use a bare lucide icon with `data-icon="inline-start"`, matching the convention used elsewhere — the button's own `[&_svg]` rules size it and it inherits `text-primary-foreground` via currentColor. This also aligns with the ongoing deprecation of the `Icon` component.

Blast radius: swept all `variant="primary"` and `variant="destructive"` buttons across the repo — this was the only `Icon`-in-primary-button call site. Destructive buttons still carry the bare `bg-destructive` token, so their override still matches. Verified in the browser: rendered svg computes to `rgb(255, 255, 255)` at 16×16.

## Checklist

- [x] I have performed a self-review of my code
- [x] My code follows the code style of this project
- [x] I have commented my code, particularly in hard-to-understand areas

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified the invite member button’s icon rendering.
  * Removed unused code without changing the button’s functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->