### PR TITLE
🔥 Remove dead bg-primary group override from Icon

### DIFF
--- a/packages/ui/src/icon.tsx
+++ b/packages/ui/src/icon.tsx
@@ -45,7 +45,7 @@ export function Icon({
     props: {
       className: cn(
         iconVariants({ size, variant }),
-        "group shrink-0 group-[.bg-destructive]:text-destructive-foreground group-[.bg-primary]:text-primary-foreground",
+        "group shrink-0 group-[.bg-destructive]:text-destructive-foreground",
         className,
       ),
     },


### PR DESCRIPTION
## What changed

Removed `group-[.bg-primary]:text-primary-foreground` from the `Icon` component's class list in `packages/ui/src/icon.tsx`.

## Why

Since the Base UI button migration (ed96e4377), the primary button variant uses `bg-primary/90` (dark: `bg-primary/80`), so the literal `.bg-primary` class selector never matches a button. This dead rule already masked a real bug once: icons rendered gray on primary buttons (fixed at the call site in `invite-member-button.tsx` by dropping the `Icon` wrapper).

The only remaining bare `bg-primary` + `group` combination in the repo is `Badge`'s primary variant, and no `Icon` renders inside a primary badge, so this removal changes nothing rendered.

## Reviewer notes

- The `group-[.bg-destructive]:text-destructive-foreground` override is intentionally kept: destructive buttons still carry the literal `bg-destructive` token alongside `group` and rely on it for icon contrast.
- Full `Icon` deprecation (39 importing files) is tracked separately; this is just the dead-code trim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved icon color behavior by removing an unintended primary-background color override.
  * Preserved correct styling for destructive states and layout consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->