### PR TITLE
🐛 Fix duplicated number in stats badge text extraction

### DIFF
--- a/apps/landing/src/components/home/animated-number.tsx
+++ b/apps/landing/src/components/home/animated-number.tsx
@@ -165,10 +165,15 @@ function AnimatedNumber({
       className="relative inline-block tabular-nums"
     >
       {/* Invisible copy of the final number holds its width for the whole
-          animation so the surrounding text doesn't shift as digits roll in */}
-      <span className="invisible" aria-hidden="true">
-        {sizerText}
-      </span>
+          animation so the surrounding text doesn't shift as digits roll in.
+          Rendered as a pseudo-element rather than a text node so extractors
+          (search snippets, reader mode) don't see the number twice — the
+          readable copy is NumberFlow's own light-DOM text */}
+      <span
+        className="invisible before:content-[attr(data-value)]"
+        data-value={sizerText}
+        aria-hidden="true"
+      />
       {/* NumberFlow's box is taller than the text (mask padding) but
           symmetric around the glyphs, so centering it on the sizer — also
           symmetric — puts both baselines in the same place */}


### PR DESCRIPTION
## Description

Fixes RAL-1587: the hero stats on the security page read "325,326 325,326 people voted on 62,213 62,213 polls" when extracted as text.

The page renders correctly on screen, but the DOM's text layer contained each number twice: once in the invisible width-sizer span inside `AnimatedNumber`, and once in NumberFlow's own server-rendered fallback text. Anything reading `textContent` — search snippets, reader mode, crawlers — saw the duplication.

The fix renders the sizer's text as a CSS pseudo-element (`before:content-[attr(data-value)]`) instead of a text node. It still reserves exactly the same width (measured identical at 83.02px before and after in Chromium), but is no longer document text, so extraction sees the number once — NumberFlow's readable copy.

Verified in Chromium against a local dev server: duplication gone from `textContent`, roll-up animation and live ticking unchanged, badge layout pixel-identical. Also applies to the home and SEO pages, which share the component.

## Checklist

- [x] I have performed a self-review of my code
- [x] My code follows the code style of this project
- [x] I have commented my code, particularly in hard-to-understand areas

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U1aUcQPBFE5xyuT9Pg9BLm

---
_Generated by [Claude Code](https://claude.ai/code/session_01U1aUcQPBFE5xyuT9Pg9BLm)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented animated numbers from appearing twice in search snippets and reader mode.
  - Preserved accessible behavior and visual layout for animated number displays.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->