### PR TITLE
📝 Correct deletion and export claims in security page FAQ

### DIFF
--- a/apps/landing/src/app/[locale]/(main)/security/page.tsx
+++ b/apps/landing/src/app/[locale]/(main)/security/page.tsx
@@ -371,7 +371,7 @@ export default async function Security(props: {
               retention schedule. Inactive polls are automatically scheduled for
               deletion with a 30 day grace period and advance notice. On
               request, we delete an organization&apos;s data and confirm
-              deletion in writing, and we provide an export of your data.
+              deletion in writing.
             </FaqItem>
             <FaqItem question="Do you hold SOC 2 or ISO 27001 certification?">
               Not currently. Our infrastructure providers are SOC 2 Type 2

--- a/apps/landing/src/app/[locale]/(main)/security/page.tsx
+++ b/apps/landing/src/app/[locale]/(main)/security/page.tsx
@@ -365,12 +365,13 @@ export default async function Security(props: {
             </FaqItem>
             <FaqItem question="How long do you keep data, and can we delete it?">
               Data is retained while your account is active. You can delete
-              polls and your account at any time, and account deletion takes
-              effect immediately. Inactive polls are automatically scheduled for
+              polls and your account at any time. Account deletion starts a 7
+              day recovery window, after which your data is permanently erased
+              and remaining backup copies expire on our database provider&apos;s
+              retention schedule. Inactive polls are automatically scheduled for
               deletion with a 30 day grace period and advance notice. On
               request, we delete an organization&apos;s data and confirm
-              deletion in writing, and your data is exportable in standard
-              formats at any time.
+              deletion in writing, and we provide an export of your data.
             </FaqItem>
             <FaqItem question="Do you hold SOC 2 or ISO 27001 certification?">
               Not currently. Our infrastructure providers are SOC 2 Type 2


### PR DESCRIPTION
Fixes two claims in the security page FAQ that don't match how the product works today (RAL-1590):

1. **"account deletion takes effect immediately"** — on cloud, deletion is scheduled with a 7 day recovery window (`ACCOUNT_DELETION_GRACE_DAYS`) and executed by the remove-deleted-users cron; immediate deletion only exists on self-hosted. The copy now describes the actual mechanics: a 7 day recovery window, then permanent erasure, with remaining backup copies expiring on the database provider's retention schedule.
2. **"your data is exportable in standard formats at any time"** — no self-serve user data export exists (the poll results CSV exports participants' responses to the host, the inverse of a data subject export). The export claim is removed entirely; the FAQ makes no statement about data export until RAL-1591 ships.

Prose only, no logic changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the data-retention FAQ to explain the 7-day recovery window after account deletion.
  * Clarified that remaining backup copies are removed according to the database provider’s retention schedule.
  * Removed the statement that data can be exported in standard formats at any time.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->