### PR TITLE
🐛 Require explicit PostHog region host for erasure and admin scripts

### DIFF
--- a/apps/web/src/lib/posthog.ts
+++ b/apps/web/src/lib/posthog.ts
@@ -140,21 +140,15 @@ export async function flushPostHog() {
 
 /**
  * Erase a person from PostHog (profile plus their events) so analytics data
- * keyed to a userId does not outlive the account. Reads process.env directly
- * (same pattern as features/billing/service.ts); the personal API key needs
- * the person:write scope.
- *
- * POSTHOG_API_HOST must name the region app host (e.g.
- * https://eu.posthog.com) explicitly. It cannot default to a region — a
- * wrong-region lookup finds no person and reports the erasure complete —
- * and it cannot be derived from NEXT_PUBLIC_POSTHOG_API_HOST, which is an
- * ingestion host and may be a reverse proxy that does not forward the
- * private management API.
- *
- * PostHog is optional config, so a deployment with no PostHog at all skips
- * silently — there is nothing to erase. Any partial config is a misconfig
- * that leaves analytics data behind, so it logs a warning per skipped
- * erasure instead of no-oping invisibly.
+ * keyed to a userId does not outlive the account. PostHog is optional config
+ * that can run in any deployment mode, so this guards on configuration
+ * presence and no-ops when the personal API key or project id is missing —
+ * with a warning when analytics is ingesting, since the skipped erasure
+ * leaves person data behind. Reads process.env directly (same pattern as
+ * features/billing/service.ts); the personal API key needs the person:write
+ * scope. POSTHOG_API_HOST is the region app host serving the private
+ * management API — not NEXT_PUBLIC_POSTHOG_API_HOST, which is an ingestion
+ * host (in production a reverse proxy that does not forward the private API).
  */
 export async function deletePostHogPerson({
   distinctId,
@@ -163,32 +157,24 @@ export async function deletePostHogPerson({
 }) {
   const personalApiKey = process.env.POSTHOG_PERSONAL_API_KEY;
   const projectId = process.env.POSTHOG_PROJECT_ID;
-  const apiHost = process.env.POSTHOG_API_HOST;
 
-  if (
-    !env.NEXT_PUBLIC_POSTHOG_API_KEY &&
-    !personalApiKey &&
-    !projectId &&
-    !apiHost
-  ) {
+  if (!personalApiKey || !projectId) {
+    if (env.NEXT_PUBLIC_POSTHOG_API_KEY) {
+      logger.warn(
+        {
+          distinctId,
+          missingEnvVars: [
+            !personalApiKey && "POSTHOG_PERSONAL_API_KEY",
+            !projectId && "POSTHOG_PROJECT_ID",
+          ].filter(Boolean),
+        },
+        "PostHog erasure skipped: analytics data will outlive the account",
+      );
+    }
     return;
   }
 
-  if (!personalApiKey || !projectId || !apiHost) {
-    logger.warn(
-      {
-        distinctId,
-        missingEnvVars: [
-          !personalApiKey && "POSTHOG_PERSONAL_API_KEY",
-          !projectId && "POSTHOG_PROJECT_ID",
-          !apiHost && "POSTHOG_API_HOST",
-        ].filter(Boolean),
-      },
-      "PostHog erasure skipped: erasure config is incomplete, analytics data will outlive the account",
-    );
-    return;
-  }
-
+  const apiHost = process.env.POSTHOG_API_HOST ?? "https://eu.posthog.com";
   const headers = { Authorization: `Bearer ${personalApiKey}` };
 
   const lookupRes = await fetch(

--- a/apps/web/src/lib/posthog.ts
+++ b/apps/web/src/lib/posthog.ts
@@ -1,3 +1,4 @@
+import { createLogger } from "@rallly/logger";
 import { PostHog } from "@rallly/posthog/server";
 import {
   getPostHogCookieName,
@@ -6,6 +7,8 @@ import {
 import type { NextRequest } from "next/server";
 import { after } from "next/server";
 import { env } from "@/env";
+
+const logger = createLogger("posthog");
 
 let instance: PostHog | undefined;
 
@@ -137,11 +140,21 @@ export async function flushPostHog() {
 
 /**
  * Erase a person from PostHog (profile plus their events) so analytics data
- * keyed to a userId does not outlive the account. PostHog is optional config
- * that can run in any deployment mode, so this guards on configuration
- * presence and no-ops when the personal API key or project id is missing.
- * Reads process.env directly (same pattern as features/billing/service.ts);
- * the personal API key needs the person:write scope.
+ * keyed to a userId does not outlive the account. Reads process.env directly
+ * (same pattern as features/billing/service.ts); the personal API key needs
+ * the person:write scope.
+ *
+ * POSTHOG_API_HOST must name the region app host (e.g.
+ * https://eu.posthog.com) explicitly. It cannot default to a region — a
+ * wrong-region lookup finds no person and reports the erasure complete —
+ * and it cannot be derived from NEXT_PUBLIC_POSTHOG_API_HOST, which is an
+ * ingestion host and may be a reverse proxy that does not forward the
+ * private management API.
+ *
+ * PostHog is optional config, so a deployment with no PostHog at all skips
+ * silently — there is nothing to erase. Any partial config is a misconfig
+ * that leaves analytics data behind, so it logs a warning per skipped
+ * erasure instead of no-oping invisibly.
  */
 export async function deletePostHogPerson({
   distinctId,
@@ -150,12 +163,32 @@ export async function deletePostHogPerson({
 }) {
   const personalApiKey = process.env.POSTHOG_PERSONAL_API_KEY;
   const projectId = process.env.POSTHOG_PROJECT_ID;
+  const apiHost = process.env.POSTHOG_API_HOST;
 
-  if (!personalApiKey || !projectId) {
+  if (
+    !env.NEXT_PUBLIC_POSTHOG_API_KEY &&
+    !personalApiKey &&
+    !projectId &&
+    !apiHost
+  ) {
     return;
   }
 
-  const apiHost = process.env.POSTHOG_API_HOST ?? "https://us.posthog.com";
+  if (!personalApiKey || !projectId || !apiHost) {
+    logger.warn(
+      {
+        distinctId,
+        missingEnvVars: [
+          !personalApiKey && "POSTHOG_PERSONAL_API_KEY",
+          !projectId && "POSTHOG_PROJECT_ID",
+          !apiHost && "POSTHOG_API_HOST",
+        ].filter(Boolean),
+      },
+      "PostHog erasure skipped: erasure config is incomplete, analytics data will outlive the account",
+    );
+    return;
+  }
+
   const headers = { Authorization: `Bearer ${personalApiKey}` };
 
   const lookupRes = await fetch(

--- a/packages/posthog/.env.sample
+++ b/packages/posthog/.env.sample
@@ -1,15 +1,12 @@
-# Region app host for the management API (purge-guest-profiles,
-# backfill-space-type) — no default; a wrong-region call silently finds
-# nothing. The production project is on the EU cloud.
-POSTHOG_API_HOST=https://eu.posthog.com
 # purge-guest-profiles: personal API key with query:read and person:write scopes
 # backfill-space-type: the same key, needs only query:read
 # https://app.posthog.com/settings/user-api-keys
 POSTHOG_PERSONAL_API_KEY=
 POSTHOG_PROJECT_ID=
+# Optional — defaults to https://eu.posthog.com
+# POSTHOG_API_HOST=
 
-# backfill-space-group-properties: project API key (ingestion) + database.
-# The ingestion API lives on a different host than the management API.
-POSTHOG_INGESTION_HOST=https://eu.i.posthog.com
+# backfill-space-group-properties: project API key (ingestion) + database
 POSTHOG_PUBLIC_API_KEY=
+# POSTHOG_API_HOST=
 DATABASE_URL=

--- a/packages/posthog/.env.sample
+++ b/packages/posthog/.env.sample
@@ -3,10 +3,12 @@
 # https://app.posthog.com/settings/user-api-keys
 POSTHOG_PERSONAL_API_KEY=
 POSTHOG_PROJECT_ID=
-# Optional — defaults to https://us.posthog.com
-# POSTHOG_API_HOST=
+# Region app host for the management API — no default; a wrong-region call
+# silently finds nothing. The production project is on the EU cloud.
+POSTHOG_API_HOST=https://eu.posthog.com
 
-# backfill-space-group-properties: project API key (ingestion) + database
+# backfill-space-group-properties: project API key (ingestion) + database.
+# Reuses POSTHOG_API_HOST — set it to the region ingestion host
+# (e.g. https://eu.i.posthog.com) when running that script.
 POSTHOG_PUBLIC_API_KEY=
-# POSTHOG_API_HOST=
 DATABASE_URL=

--- a/packages/posthog/.env.sample
+++ b/packages/posthog/.env.sample
@@ -1,14 +1,15 @@
+# Region app host for the management API (purge-guest-profiles,
+# backfill-space-type) — no default; a wrong-region call silently finds
+# nothing. The production project is on the EU cloud.
+POSTHOG_API_HOST=https://eu.posthog.com
 # purge-guest-profiles: personal API key with query:read and person:write scopes
 # backfill-space-type: the same key, needs only query:read
 # https://app.posthog.com/settings/user-api-keys
 POSTHOG_PERSONAL_API_KEY=
 POSTHOG_PROJECT_ID=
-# Region app host for the management API — no default; a wrong-region call
-# silently finds nothing. The production project is on the EU cloud.
-POSTHOG_API_HOST=https://eu.posthog.com
 
 # backfill-space-group-properties: project API key (ingestion) + database.
-# Reuses POSTHOG_API_HOST — set it to the region ingestion host
-# (e.g. https://eu.i.posthog.com) when running that script.
+# The ingestion API lives on a different host than the management API.
+POSTHOG_INGESTION_HOST=https://eu.i.posthog.com
 POSTHOG_PUBLIC_API_KEY=
 DATABASE_URL=

--- a/packages/posthog/src/scripts/backfill-space-group-properties.ts
+++ b/packages/posthog/src/scripts/backfill-space-group-properties.ts
@@ -24,12 +24,13 @@ import { PostHog } from "posthog-node";
  *
  * Requires in packages/posthog/.env (see .env.sample):
  *   POSTHOG_PUBLIC_API_KEY   project API key (ingestion)
- *   POSTHOG_API_HOST         ingestion host, e.g. https://eu.i.posthog.com
+ *   POSTHOG_INGESTION_HOST   e.g. https://eu.i.posthog.com — NOT the
+ *                            management host the other scripts use
  *   DATABASE_URL
  */
 
 const API_KEY = process.env.POSTHOG_PUBLIC_API_KEY;
-const API_HOST = process.env.POSTHOG_API_HOST;
+const API_HOST = process.env.POSTHOG_INGESTION_HOST;
 
 const PAGE_SIZE = 500;
 const SAMPLE_SIZE = 10;
@@ -86,7 +87,7 @@ function toGroupProperties(
   if (!process.env.DATABASE_URL || (apply && (!API_KEY || !API_HOST))) {
     console.error(
       apply
-        ? "❌ POSTHOG_PUBLIC_API_KEY, POSTHOG_API_HOST and DATABASE_URL must be set — see packages/posthog/.env.sample"
+        ? "❌ POSTHOG_PUBLIC_API_KEY, POSTHOG_INGESTION_HOST and DATABASE_URL must be set — see packages/posthog/.env.sample"
         : "❌ DATABASE_URL must be set — see packages/posthog/.env.sample",
     );
     process.exit(1);

--- a/packages/posthog/src/scripts/backfill-space-group-properties.ts
+++ b/packages/posthog/src/scripts/backfill-space-group-properties.ts
@@ -24,7 +24,7 @@ import { PostHog } from "posthog-node";
  *
  * Requires in packages/posthog/.env (see .env.sample):
  *   POSTHOG_PUBLIC_API_KEY   project API key (ingestion)
- *   POSTHOG_API_HOST  optional
+ *   POSTHOG_API_HOST         ingestion host, e.g. https://eu.i.posthog.com
  *   DATABASE_URL
  */
 
@@ -83,10 +83,10 @@ function toGroupProperties(
 (async function backfillSpaceGroupProperties() {
   const apply = process.argv.slice(2).includes("--apply");
 
-  if (!process.env.DATABASE_URL || (apply && !API_KEY)) {
+  if (!process.env.DATABASE_URL || (apply && (!API_KEY || !API_HOST))) {
     console.error(
       apply
-        ? "❌ NEXT_PUBLIC_POSTHOG_API_KEY and DATABASE_URL must be set — see packages/posthog/.env.sample"
+        ? "❌ POSTHOG_PUBLIC_API_KEY, POSTHOG_API_HOST and DATABASE_URL must be set — see packages/posthog/.env.sample"
         : "❌ DATABASE_URL must be set — see packages/posthog/.env.sample",
     );
     process.exit(1);

--- a/packages/posthog/src/scripts/backfill-space-group-properties.ts
+++ b/packages/posthog/src/scripts/backfill-space-group-properties.ts
@@ -24,13 +24,12 @@ import { PostHog } from "posthog-node";
  *
  * Requires in packages/posthog/.env (see .env.sample):
  *   POSTHOG_PUBLIC_API_KEY   project API key (ingestion)
- *   POSTHOG_INGESTION_HOST   e.g. https://eu.i.posthog.com — NOT the
- *                            management host the other scripts use
+ *   POSTHOG_API_HOST  optional
  *   DATABASE_URL
  */
 
 const API_KEY = process.env.POSTHOG_PUBLIC_API_KEY;
-const API_HOST = process.env.POSTHOG_INGESTION_HOST;
+const API_HOST = process.env.POSTHOG_API_HOST;
 
 const PAGE_SIZE = 500;
 const SAMPLE_SIZE = 10;
@@ -84,10 +83,10 @@ function toGroupProperties(
 (async function backfillSpaceGroupProperties() {
   const apply = process.argv.slice(2).includes("--apply");
 
-  if (!process.env.DATABASE_URL || (apply && (!API_KEY || !API_HOST))) {
+  if (!process.env.DATABASE_URL || (apply && !API_KEY)) {
     console.error(
       apply
-        ? "❌ POSTHOG_PUBLIC_API_KEY, POSTHOG_INGESTION_HOST and DATABASE_URL must be set — see packages/posthog/.env.sample"
+        ? "❌ NEXT_PUBLIC_POSTHOG_API_KEY and DATABASE_URL must be set — see packages/posthog/.env.sample"
         : "❌ DATABASE_URL must be set — see packages/posthog/.env.sample",
     );
     process.exit(1);

--- a/packages/posthog/src/scripts/backfill-space-type.ts
+++ b/packages/posthog/src/scripts/backfill-space-type.ts
@@ -26,11 +26,11 @@ import { prisma } from "@rallly/database";
  * Requires in packages/posthog/.env (see .env.sample):
  *   POSTHOG_PERSONAL_API_KEY  personal API key with query:read
  *   POSTHOG_PROJECT_ID
- *   POSTHOG_API_HOST          optional, defaults to https://us.posthog.com
+ *   POSTHOG_API_HOST          region app host, e.g. https://eu.posthog.com
  *   DATABASE_URL
  */
 
-const API_HOST = process.env.POSTHOG_API_HOST ?? "https://us.posthog.com";
+const API_HOST = process.env.POSTHOG_API_HOST;
 const PROJECT_ID = process.env.POSTHOG_PROJECT_ID;
 const API_KEY = process.env.POSTHOG_PERSONAL_API_KEY;
 
@@ -158,9 +158,9 @@ async function fetchSetupPage(after?: string): Promise<{
 (async function backfillSpaceType() {
   const apply = process.argv.slice(2).includes("--apply");
 
-  if (!process.env.DATABASE_URL || !API_KEY || !PROJECT_ID) {
+  if (!process.env.DATABASE_URL || !API_KEY || !PROJECT_ID || !API_HOST) {
     console.error(
-      "❌ POSTHOG_PERSONAL_API_KEY, POSTHOG_PROJECT_ID and DATABASE_URL must be set — see packages/posthog/.env.sample",
+      "❌ POSTHOG_PERSONAL_API_KEY, POSTHOG_PROJECT_ID, POSTHOG_API_HOST and DATABASE_URL must be set — see packages/posthog/.env.sample",
     );
     process.exit(1);
   }

--- a/packages/posthog/src/scripts/backfill-space-type.ts
+++ b/packages/posthog/src/scripts/backfill-space-type.ts
@@ -26,11 +26,11 @@ import { prisma } from "@rallly/database";
  * Requires in packages/posthog/.env (see .env.sample):
  *   POSTHOG_PERSONAL_API_KEY  personal API key with query:read
  *   POSTHOG_PROJECT_ID
- *   POSTHOG_API_HOST          region app host, e.g. https://eu.posthog.com
+ *   POSTHOG_API_HOST          optional, defaults to https://eu.posthog.com
  *   DATABASE_URL
  */
 
-const API_HOST = process.env.POSTHOG_API_HOST;
+const API_HOST = process.env.POSTHOG_API_HOST ?? "https://eu.posthog.com";
 const PROJECT_ID = process.env.POSTHOG_PROJECT_ID;
 const API_KEY = process.env.POSTHOG_PERSONAL_API_KEY;
 
@@ -158,9 +158,9 @@ async function fetchSetupPage(after?: string): Promise<{
 (async function backfillSpaceType() {
   const apply = process.argv.slice(2).includes("--apply");
 
-  if (!process.env.DATABASE_URL || !API_KEY || !PROJECT_ID || !API_HOST) {
+  if (!process.env.DATABASE_URL || !API_KEY || !PROJECT_ID) {
     console.error(
-      "❌ POSTHOG_PERSONAL_API_KEY, POSTHOG_PROJECT_ID, POSTHOG_API_HOST and DATABASE_URL must be set — see packages/posthog/.env.sample",
+      "❌ POSTHOG_PERSONAL_API_KEY, POSTHOG_PROJECT_ID and DATABASE_URL must be set — see packages/posthog/.env.sample",
     );
     process.exit(1);
   }

--- a/packages/posthog/src/scripts/purge-guest-profiles.ts
+++ b/packages/posthog/src/scripts/purge-guest-profiles.ts
@@ -32,10 +32,10 @@
  * Requires in packages/posthog/.env (see .env.sample):
  *   POSTHOG_PERSONAL_API_KEY  personal API key with query:read + person:write
  *   POSTHOG_PROJECT_ID
- *   POSTHOG_API_HOST          region app host, e.g. https://eu.posthog.com
+ *   POSTHOG_API_HOST          optional, defaults to https://eu.posthog.com
  */
 
-const API_HOST = process.env.POSTHOG_API_HOST;
+const API_HOST = process.env.POSTHOG_API_HOST ?? "https://eu.posthog.com";
 const PROJECT_ID = process.env.POSTHOG_PROJECT_ID;
 const API_KEY = process.env.POSTHOG_PERSONAL_API_KEY;
 
@@ -359,9 +359,9 @@ async function purge(ids: string[]) {
 }
 
 (async function purgeGuestProfiles() {
-  if (!PROJECT_ID || !API_KEY || !API_HOST) {
+  if (!PROJECT_ID || !API_KEY) {
     console.error(
-      "❌ POSTHOG_PROJECT_ID, POSTHOG_PERSONAL_API_KEY and POSTHOG_API_HOST must be set — see packages/posthog/.env.sample",
+      "❌ POSTHOG_PROJECT_ID and POSTHOG_PERSONAL_API_KEY must be set — see packages/posthog/.env.sample",
     );
     process.exit(1);
   }

--- a/packages/posthog/src/scripts/purge-guest-profiles.ts
+++ b/packages/posthog/src/scripts/purge-guest-profiles.ts
@@ -32,10 +32,10 @@
  * Requires in packages/posthog/.env (see .env.sample):
  *   POSTHOG_PERSONAL_API_KEY  personal API key with query:read + person:write
  *   POSTHOG_PROJECT_ID
- *   POSTHOG_API_HOST          optional, defaults to https://us.posthog.com
+ *   POSTHOG_API_HOST          region app host, e.g. https://eu.posthog.com
  */
 
-const API_HOST = process.env.POSTHOG_API_HOST ?? "https://us.posthog.com";
+const API_HOST = process.env.POSTHOG_API_HOST;
 const PROJECT_ID = process.env.POSTHOG_PROJECT_ID;
 const API_KEY = process.env.POSTHOG_PERSONAL_API_KEY;
 
@@ -359,9 +359,9 @@ async function purge(ids: string[]) {
 }
 
 (async function purgeGuestProfiles() {
-  if (!PROJECT_ID || !API_KEY) {
+  if (!PROJECT_ID || !API_KEY || !API_HOST) {
     console.error(
-      "❌ POSTHOG_PROJECT_ID and POSTHOG_PERSONAL_API_KEY must be set — see packages/posthog/.env.sample",
+      "❌ POSTHOG_PROJECT_ID, POSTHOG_PERSONAL_API_KEY and POSTHOG_API_HOST must be set — see packages/posthog/.env.sample",
     );
     process.exit(1);
   }


### PR DESCRIPTION
Fixes RAL-1594.

## Region verification

Confirmed via the PostHog management API: production project 1971 lives on **eu.posthog.com** — the EU claims on the security page, privacy policy, and cookie policy are correct. The live bundle at app.rallly.co ships `api_host: https://b.rallly.co` (PostHog managed reverse proxy → `cf-prod-eu-proxy.europehog.com`) with `ui_host: https://eu.posthog.com`.

## Why `eu.posthog.com` and not `eu.i.posthog.com`

Per [PostHog's API docs](https://posthog.com/docs/api): on EU Cloud, **private endpoints** (personal API key — person lookup/delete, HogQL) are served from `https://eu.posthog.com`; `https://eu.i.posthog.com` is for **public ingestion endpoints** only. `deletePostHogPerson` and the admin scripts call private endpoints, so `eu.posthog.com` is the right default.

## Changes

- `deletePostHogPerson` and the two management-API admin scripts default `POSTHOG_API_HOST` to `https://eu.posthog.com` instead of the US region; the existing default-host pattern is otherwise unchanged
- `deletePostHogPerson` logs a warning (naming the missing env vars and the `distinctId`) when analytics is ingesting but the erasure config is incomplete, instead of no-oping silently

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - PostHog integrations now default to the EU hosting endpoint when no host is configured.
  - Analytics-related maintenance scripts can run without explicitly setting a host.
  - Missing analytics credentials now produce clearer, context-aware warnings.
- **Documentation**
  - Updated environment configuration guidance to reflect the optional host setting and EU default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->