### PR TITLE
💄 Replace GitHub icon with CodeIcon on security page

### DIFF
--- a/apps/landing/src/app/[locale]/(main)/security/page.tsx
+++ b/apps/landing/src/app/[locale]/(main)/security/page.tsx
@@ -4,13 +4,13 @@ import { buttonVariants } from "@rallly/ui";
 import {
   ActivityIcon,
   ArrowRightIcon,
+  CodeIcon,
   DatabaseIcon,
   EyeOffIcon,
   LockIcon,
   ServerIcon,
 } from "lucide-react";
 import { cacheLife } from "next/cache";
-import GithubIcon from "@/assets/github.svg";
 import { PeopleBadge, PollsBadge } from "@/components/home/animated-number";
 import { Faq, FaqItem } from "@/components/home/faq";
 import { Hero } from "@/components/home/hero";
@@ -120,7 +120,7 @@ export default async function Security(props: {
         <SectionContent>
           <div className="grid gap-x-8 gap-y-10 sm:grid-cols-2 lg:grid-cols-3">
             <SecurityFeature
-              icon={<GithubIcon className="size-4" />}
+              icon={<CodeIcon className="size-4" />}
               title="Open source"
               link={{
                 label: "Browse source code",


### PR DESCRIPTION
Swaps the `github.svg` icon in the security page's "Open source" feature for `CodeIcon` from lucide-react, matching the other feature icons in the grid. The `github.svg` asset stays — the footer still uses it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the security page’s “Open source” feature icon for a more consistent visual style.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->