### PR TITLE
🔧 Add DATABASE_URL_UNPOOLED fallback for Prisma migrations

### DIFF
--- a/packages/database/prisma.config.ts
+++ b/packages/database/prisma.config.ts
@@ -14,6 +14,9 @@ export default defineConfig({
     seed: "tsx prisma/seed.ts",
   },
   datasource: {
-    url: process.env.DIRECT_DATABASE_URL || process.env.DATABASE_URL,
+    url:
+      process.env.DIRECT_DATABASE_URL ||
+      process.env.DATABASE_URL_UNPOOLED ||
+      process.env.DATABASE_URL,
   },
 });


### PR DESCRIPTION
## What

Adds `DATABASE_URL_UNPOOLED` to the Prisma datasource URL fallback chain in `packages/database/prisma.config.ts`:

`DIRECT_DATABASE_URL` → `DATABASE_URL_UNPOOLED` → `DATABASE_URL`

## Why

Production now runs on Neon. The Neon Vercel previews integration injects `DATABASE_URL` (pooled) and `DATABASE_URL_UNPOOLED` into preview deployments, and `prisma migrate deploy` (run by `pnpm db:deploy` in the Vercel build) must not go through the transaction pooler. With this fallback, preview builds migrate their per-PR Neon branch over the direct connection automatically.

## Notes for review

- Production is unaffected: it sets `DIRECT_DATABASE_URL` explicitly, which stays first in the chain.
- Local dev is unaffected: neither new variable is set, so behavior falls through to `DATABASE_URL` as before.
- Prerequisite for installing the Neon Vercel previews integration (branch-per-preview).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved database connectivity by adding fallback options when the preferred connection setting is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->