### PR TITLE
📝 Replace DigitalOcean with Neon as database subprocessor

### DIFF
--- a/apps/landing/src/app/[locale]/(main)/privacy-policy/page.tsx
+++ b/apps/landing/src/app/[locale]/(main)/privacy-policy/page.tsx
@@ -10,7 +10,7 @@ export default async function PrivacyPolicy() {
       <h1 className="max-w-2xl text-balance font-medium text-3xl text-gray-800 tracking-tight sm:text-4xl">
         Privacy policy
       </h1>
-      <p className="mt-4 text-gray-500 text-sm">Last updated: 27 August 2026</p>
+      <p className="mt-4 text-gray-500 text-sm">Last updated: 30 August 2026</p>
       <div className="longform mt-8 max-w-2xl">
         <p>
           At rallly.co, we take your privacy seriously. This privacy policy
@@ -23,9 +23,9 @@ export default async function PrivacyPolicy() {
 
         <p>
           We store personal data (names and email addresses) in a database
-          hosted by DigitalOcean on servers located in the United States. We
-          also use Upstash to store session data and rate limiting data in the
-          United States. The reason for storing data in the US is to improve
+          hosted by Neon on servers located in the United States. We also use
+          Upstash to store session data and rate limiting data in the United
+          States. The reason for storing data in the US is to improve
           performance for users by having the data stored closer to where our
           compute services are running. By using our services, you acknowledge
           that your personal data may be transferred to and stored in the United

--- a/apps/landing/src/app/[locale]/(main)/security/page.tsx
+++ b/apps/landing/src/app/[locale]/(main)/security/page.tsx
@@ -224,18 +224,18 @@ export default async function Security(props: {
                   <td>
                     <a
                       className="text-gray-800 hover:underline"
-                      href="https://www.digitalocean.com/trust"
+                      href="https://neon.com/security"
                       target="_blank"
                       rel="noreferrer noopener"
                     >
-                      DigitalOcean
+                      Neon
                     </a>
                   </td>
                   <td>Managed PostgreSQL database</td>
                   <td>United States</td>
                   <TransferMechanismCell
-                    href="https://www.digitalocean.com/legal/data-processing-agreement"
-                    fallback="SCCs + UK Addendum fallback"
+                    href="https://www.databricks.com/legal/dpf"
+                    fallback="Certified under Databricks, Inc. · SCCs fallback"
                   >
                     EU-US DPF + UK Extension
                   </TransferMechanismCell>


### PR DESCRIPTION
Production Postgres migrated from DigitalOcean Managed Databases to Neon (AWS us-east-1, United States) on 2026-08-30. The landing site still named DigitalOcean as the database subprocessor in two places.

## Changes

- **Security page subprocessor table**: DigitalOcean row replaced with Neon. Provider link goes to https://neon.com/security (verified live, Neon-branded). Purpose ("Managed PostgreSQL database") and location ("United States") unchanged.
- **Privacy policy**: database hosting vendor changed to Neon; rest of the paragraph (Upstash, US storage rationale) unchanged. "Last updated" bumped to 30 August 2026 since the vendor change is a material edit.

## Transfer mechanism verification

Did not copy DigitalOcean's mechanism blindly. Neon is now **Neon, LLC**, a Databricks subsidiary — neon.com's privacy/legal pages redirect to Databricks legal. The [Databricks DPF notice](https://www.databricks.com/legal/dpf) and [privacy notice](https://www.databricks.com/legal/privacynotice) state the EU-US DPF certification (including the UK Extension and Swiss-US DPF) explicitly lists **Neon, LLC** as a covered entity, with SCCs as the transfer safeguard fallback. The cell therefore keeps "EU-US DPF + UK Extension" but links the Databricks DPF notice and uses the AWS-row pattern for the fallback line: "Certified under Databricks, Inc. · SCCs fallback". (The dataprivacyframework.gov registry is a JS app that can't be fetched headlessly; verification rests on Databricks' own DPF notice, which is FTC-enforceable.)

## Notes

- Both pages are hardcoded English (no i18n/Crowdin involvement), so no translation-clearing risk.
- `next.config.ts` still has a `/partners/digitalocean` referral redirect — left alone, it's not a hosting claim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the privacy policy’s last-updated date.
  * Updated privacy and security documentation to identify Neon as the primary managed database provider.
  * Revised related provider links and fallback transfer-mechanism details; session and rate-limiting data remains hosted by Upstash in the United States.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->