### PR TITLE
💄 Replace landing footer status link with OpenStatus badge

### DIFF
--- a/apps/landing/public/locales/en/common.json
+++ b/apps/landing/public/locales/en/common.json
@@ -37,7 +37,7 @@
   "schedulingPoll": "Scheduling poll",
   "security": "Security",
   "sportsClubs": "Sports clubs",
-  "status": "Status",
+  "statusBadgeAlt": "Rallly status",
   "support": "Support",
   "termsOfUse": "Terms of use",
   "thesisDefense": "Thesis defenses",

--- a/apps/landing/src/app/[locale]/(main)/footer.tsx
+++ b/apps/landing/src/app/[locale]/(main)/footer.tsx
@@ -160,14 +160,6 @@ export const Footer = async ({ locale }: { locale: string }) => {
               </a>
             </li>
             <li>
-              <a
-                href="https://rallly.openstatus.dev"
-                className="inline-block font-normal text-gray-600 hover:text-gray-800 hover:no-underline"
-              >
-                <Trans t={t} ns="common" i18nKey="status" defaults="Status" />
-              </a>
-            </li>
-            <li>
               <LinkBase
                 href="/press-kit"
                 className="inline-block font-normal text-gray-600 hover:text-gray-800 hover:no-underline"
@@ -293,7 +285,7 @@ export const Footer = async ({ locale }: { locale: string }) => {
           </ul>
         </div>
       </div>
-      <div className="flex flex-col gap-x-8 gap-y-8 sm:pb-8 lg:flex-row lg:items-center lg:justify-between">
+      <div className="flex flex-col gap-x-8 gap-y-8 sm:pb-8 lg:flex-row lg:flex-wrap lg:items-center lg:justify-between">
         <div className="flex flex-col gap-x-8 gap-y-2 sm:flex-row sm:items-center">
           <p className="whitespace-nowrap text-gray-600 text-sm leading-loose">
             &copy; 2026 Stack Snap Ltd.
@@ -325,7 +317,19 @@ export const Footer = async ({ locale }: { locale: string }) => {
             </li>
           </ul>
         </div>
-        <div className="flex flex-wrap items-center gap-2">
+        <div className="flex flex-wrap items-center gap-4">
+          <a
+            href="https://rallly.openstatus.dev"
+            rel="noopener"
+            className="inline-flex h-9 items-center rounded-lg bg-background/80 px-0.5 ring-1 ring-button-outline ring-inset hover:bg-accent"
+          >
+            {/* biome-ignore lint/performance/noImgElement: dynamic external badge, not optimizable via next/image */}
+            <img
+              src="https://rallly.openstatus.dev/badge/v2"
+              alt={t("statusBadgeAlt", { defaultValue: "Rallly status" })}
+              className="mix-blend-multiply"
+            />
+          </a>
           <div className="w-48">
             <LanguageSelect />
           </div>


### PR DESCRIPTION
## What changed

- Removed the "Status" text link from the footer's Resources column.
- Added the live OpenStatus badge (`rallly.openstatus.dev/badge/v2`) to the footer's bottom row, next to the language select, linking to the status page.
- The badge link is styled with the same box primitives as the language select (`h-9 rounded-lg bg-background/80 ring-1 ring-button-outline ring-inset hover:bg-accent`) so the two controls match exactly (verified via computed styles: same height, radius, background, and ring). The `img` uses `mix-blend-multiply` so the SVG's baked-in white background rect merges into the container — the badge endpoint has no transparent theme.
- The bottom row now wraps at `lg` (`lg:flex-wrap`): in long locales like Russian, the badge + language select drop to a second line instead of crushing the legal links into a stacked column.
- `pnpm i18n:scan` dropped the now-unused `status` key from `en/common.json` and added `statusBadgeAlt` (alt text for the badge image, which also labels the link).

## Notes for review

- `mix-blend-multiply` only hides the badge's white background against light backdrops; if the footer ever goes dark this needs revisiting (e.g. rendering status from the OpenStatus API instead of their image).
- The badge is a plain `img` with a `biome-ignore` for `noImgElement` — it's a dynamic external SVG, so `next/image` optimization doesn't apply.
- Verified in the browser at 800/1024/1440 widths in English and Russian.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a status badge to the footer, linking to the service status page.
  - Improved footer layout and spacing for larger screens.

- **Updates**
  - Removed the separate “Status” link from the Resources section.
  - Updated the English localization label used by the status badge.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->