### PR TITLE
📝 Drop vendor comparison from security page intro

### DIFF
--- a/apps/landing/src/app/[locale]/(main)/security/page.tsx
+++ b/apps/landing/src/app/[locale]/(main)/security/page.tsx
@@ -113,8 +113,7 @@ export default async function Security(props: {
           <SectionTitle>Secure by design</SectionTitle>
           <SectionDescription>
             How we run the service, where your data lives, and what we commit
-            to. Where most vendors ask you to take their word for it, we publish
-            the evidence.
+            to, backed by evidence you can verify yourself.
           </SectionDescription>
         </SectionHeading>
         <SectionContent>

--- a/apps/landing/src/app/[locale]/(main)/security/page.tsx
+++ b/apps/landing/src/app/[locale]/(main)/security/page.tsx
@@ -112,8 +112,9 @@ export default async function Security(props: {
         <SectionHeading>
           <SectionTitle>Secure by design</SectionTitle>
           <SectionDescription>
-            How we run the service, where your data lives, and what we commit
-            to, backed by evidence you can verify yourself.
+            Rallly is built in the open. The source code is public, uptime is
+            independently measured, and this page lists exactly where your data
+            lives.
           </SectionDescription>
         </SectionHeading>
         <SectionContent>


### PR DESCRIPTION
## Description

Rewords the "Secure by design" section description on the security page. The previous copy ("Where most vendors ask you to take their word for it, we publish the evidence.") disparaged other vendors, which isn't how we talk. The evidence-first positioning stays, stated positively.

## Checklist

- [x] I have performed a self-review of my code
- [x] My code follows the code style of this project
- [x] I have commented my code, particularly in hard-to-understand areas

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the security page to highlight Rallly’s open-source nature, independently measured uptime, and available data-location information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->