### PR TITLE
📝 Update backup description for Neon's continuous PITR model

### DIFF
--- a/apps/landing/src/app/[locale]/(main)/security/page.tsx
+++ b/apps/landing/src/app/[locale]/(main)/security/page.tsx
@@ -400,7 +400,7 @@ export default async function Security(props: {
               upcoming organization features.
             </FaqItem>
             <FaqItem question="How do you handle backups and recovery?">
-              The production database is backed up automatically every day with
+              The production database is backed up continuously with
               point-in-time recovery, managed by our database provider. The
               application runs on globally distributed serverless infrastructure
               and can be redeployed rapidly.


### PR DESCRIPTION
The security page FAQ still described DigitalOcean's daily backup model. Neon backs up continuously with point-in-time recovery, so the "every day" claim is stale since the 2026-08-30 migration.

One line, mergeable independently of the DPA PR (#3104), which gets the same wording in Annex 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the security FAQ to clarify that production data is continuously backed up and supports point-in-time recovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->