### PR TITLE
🐛 Unshare single-member spaces wrongly marked shared by backfill

### DIFF
--- a/packages/database/prisma/migrations/20260831000000_unshare_single_member_spaces/migration.sql
+++ b/packages/database/prisma/migrations/20260831000000_unshare_single_member_spaces/migration.sql
@@ -1,0 +1,12 @@
+-- The 20260828000000 backfill also marked spaces with pending invites as
+-- shared, on the theory that invites sent before the setting existed carried
+-- shared-visibility expectations. That was wrong: a pending invitee has never
+-- seen any content, so a single-member space being shared changes nothing
+-- observable while telling its owner collaboration is on when they never
+-- chose it. Realign shared with actual membership. Spaces that gained a
+-- second member are left untouched — unsharing those would be observable.
+UPDATE "spaces" SET "shared" = false
+WHERE "shared" = true
+  AND "id" NOT IN (
+    SELECT "space_id" FROM "space_members" GROUP BY "space_id" HAVING count(*) > 1
+  );

--- a/packages/database/prisma/models/space.prisma
+++ b/packages/database/prisma/models/space.prisma
@@ -17,8 +17,8 @@ model Space {
   // everything) or work independently (everyone, admins included, only
   // sees what they create; roles grant administrative capabilities, not
   // visibility). Defaults to not shared — sharing is opt-in; the backfill
-  // kept existing multi-member spaces (and spaces with pending invites)
-  // shared to preserve their behavior. When the org layer lands, shared
+  // kept existing multi-member spaces shared to preserve their behavior.
+  // When the org layer lands, shared
   // spaces map to teams and unshared spaces to organizations.
   shared          Boolean   @default(false)
   createdAt       DateTime  @default(now()) @map("created_at")


### PR DESCRIPTION
## Problem

The `shared` backfill in #3096 (`20260828000000_add_space_shared_setting`) marked spaces with pending invites as shared, in addition to multi-member spaces. That was the wrong rule: a pending invitee has never seen any content, so a single-member space being shared changes nothing observable — while telling its owner that team collaboration is on when they never chose it.

## Fix

Follow-up data migration (the original is deployed and immutable) that sets `shared = false` on every shared space without more than one member. Also updates the schema comment on `Space.shared`.

Deliberate boundary: spaces that gained a second member since launch (e.g. a pending invite accepted after Aug 29) stay shared — unsharing those would be observable to the member who joined. The migration only touches spaces where the flip is invisible.

Self-hosted instances upgrading across both migrations in one run get the intended rule net: only multi-member spaces end up shared.

## Verification

- UPDATE dry-run in a rolled-back transaction against the dev database
- Applied via `prisma migrate deploy` locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected space-sharing status for spaces with only one member.
  - Spaces with two or more members remain shared as expected.
  - Updated sharing guidance to reflect actual membership rather than pending invitations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->