### PR TITLE
✨ Add nightly cleanup of stale Neon preview branches

### DIFF
--- a/.github/workflows/delete-stale-preview-branches.yml
+++ b/.github/workflows/delete-stale-preview-branches.yml
@@ -1,0 +1,48 @@
+name: Delete stale preview branches
+# -----------------------------------------------------------------
+# Workflow Purpose:
+#   Preview deployments get a Neon branch containing a copy of
+#   production data. This job deletes any preview/* branch older
+#   than the TTL so those copies never outlive the retention
+#   commitments in our DPA. The Vercel integration recreates a
+#   branch (with fresh data) on the next push to that git branch.
+# Trigger: Nightly at 03:30 UTC, or manually.
+# Secrets: NEON_API_KEY (project-scoped), NEON_PROJECT_ID
+# -----------------------------------------------------------------
+on:
+  schedule:
+    - cron: "30 3 * * *"
+  workflow_dispatch:
+
+env:
+  TTL_DAYS: 7
+
+jobs:
+  delete-stale-preview-branches:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Delete preview branches older than TTL
+        env:
+          NEON_API_KEY: ${{ secrets.NEON_API_KEY }}
+          NEON_PROJECT_ID: ${{ secrets.NEON_PROJECT_ID }}
+        run: |
+          set -euo pipefail
+          cutoff=$(date -u -d "${TTL_DAYS} days ago" +%Y-%m-%dT%H:%M:%SZ)
+          branches=$(curl -sf "https://console.neon.tech/api/v2/projects/${NEON_PROJECT_ID}/branches" \
+            -H "Authorization: Bearer ${NEON_API_KEY}" -H "Accept: application/json")
+          stale=$(echo "$branches" | jq -r --arg cutoff "$cutoff" '
+            .branches[]
+            | select(.name | startswith("preview/"))
+            | select(.default == false and .protected == false)
+            | select(.created_at < $cutoff)
+            | .id + " " + .name')
+          if [ -z "$stale" ]; then
+            echo "No preview branches older than ${TTL_DAYS} days."
+            exit 0
+          fi
+          echo "$stale" | while read -r id name; do
+            echo "Deleting $name ($id, older than ${TTL_DAYS} days)"
+            curl -sf -X DELETE \
+              "https://console.neon.tech/api/v2/projects/${NEON_PROJECT_ID}/branches/${id}" \
+              -H "Authorization: Bearer ${NEON_API_KEY}" -H "Accept: application/json" > /dev/null
+          done

--- a/.github/workflows/delete-stale-preview-branches.yml
+++ b/.github/workflows/delete-stale-preview-branches.yml
@@ -20,6 +20,7 @@ env:
 jobs:
   delete-stale-preview-branches:
     runs-on: ubuntu-latest
+    permissions: {}
     steps:
       - name: Delete preview branches older than TTL
         env:
@@ -27,22 +28,39 @@ jobs:
           NEON_PROJECT_ID: ${{ vars.NEON_PROJECT_ID }}
         run: |
           set -euo pipefail
+          base="https://console.neon.tech/api/v2/projects/${NEON_PROJECT_ID}"
           cutoff=$(date -u -d "${TTL_DAYS} days ago" +%Y-%m-%dT%H:%M:%SZ)
-          branches=$(curl -sf "https://console.neon.tech/api/v2/projects/${NEON_PROJECT_ID}/branches" \
-            -H "Authorization: Bearer ${NEON_API_KEY}" -H "Accept: application/json")
-          stale=$(echo "$branches" | jq -r --arg cutoff "$cutoff" '
-            .branches[]
-            | select(.name | startswith("preview/"))
-            | select(.default == false and .protected == false)
-            | select(.created_at < $cutoff)
-            | .id + " " + .name')
-          if [ -z "$stale" ]; then
+
+          stale=""
+          cursor=""
+          while :; do
+            page=$(curl -sfG "${base}/branches" \
+              --data-urlencode "limit=200" \
+              ${cursor:+--data-urlencode "cursor=${cursor}"} \
+              -H "Authorization: Bearer ${NEON_API_KEY}" -H "Accept: application/json")
+            stale+=$(echo "$page" | jq -r --arg cutoff "$cutoff" '
+              .branches[]
+              | select(.name | startswith("preview/"))
+              | select(.default == false and .protected == false)
+              | select(.created_at < $cutoff)
+              | .id + " " + .name')$'\n'
+            cursor=$(echo "$page" | jq -r '.pagination.next // empty')
+            [ -n "$cursor" ] || break
+          done
+
+          if ! grep -q '[^[:space:]]' <<< "$stale"; then
             echo "No preview branches older than ${TTL_DAYS} days."
             exit 0
           fi
-          echo "$stale" | while read -r id name; do
+
+          failed=0
+          while read -r id name; do
+            [ -n "$id" ] || continue
             echo "Deleting $name ($id, older than ${TTL_DAYS} days)"
-            curl -sf -X DELETE \
-              "https://console.neon.tech/api/v2/projects/${NEON_PROJECT_ID}/branches/${id}" \
-              -H "Authorization: Bearer ${NEON_API_KEY}" -H "Accept: application/json" > /dev/null
-          done
+            if ! curl -sf -X DELETE "${base}/branches/${id}" \
+              -H "Authorization: Bearer ${NEON_API_KEY}" -H "Accept: application/json" > /dev/null; then
+              echo "::error::Failed to delete $name ($id); continuing"
+              failed=1
+            fi
+          done <<< "$stale"
+          exit "$failed"

--- a/.github/workflows/delete-stale-preview-branches.yml
+++ b/.github/workflows/delete-stale-preview-branches.yml
@@ -7,7 +7,7 @@ name: Delete stale preview branches
 #   commitments in our DPA. The Vercel integration recreates a
 #   branch (with fresh data) on the next push to that git branch.
 # Trigger: Nightly at 03:30 UTC, or manually.
-# Secrets: NEON_API_KEY (project-scoped), NEON_PROJECT_ID
+# Config: NEON_API_KEY secret (project-scoped), NEON_PROJECT_ID variable
 # -----------------------------------------------------------------
 on:
   schedule:
@@ -24,7 +24,7 @@ jobs:
       - name: Delete preview branches older than TTL
         env:
           NEON_API_KEY: ${{ secrets.NEON_API_KEY }}
-          NEON_PROJECT_ID: ${{ secrets.NEON_PROJECT_ID }}
+          NEON_PROJECT_ID: ${{ vars.NEON_PROJECT_ID }}
         run: |
           set -euo pipefail
           cutoff=$(date -u -d "${TTL_DAYS} days ago" +%Y-%m-%dT%H:%M:%SZ)


### PR DESCRIPTION
Keeps the integration's default preview branching (copies of production data, branched from the default branch) but bounds their lifetime: a nightly job deletes any `preview/*` Neon branch older than **7 days**. The Vercel integration recreates the branch with fresh data on the next push to that git branch, so open PRs self-heal; a deleted branch only means a stale PR's preview link errors until its next push.

Guards: only branches named `preview/*`, never default or protected branches.

**Requires two repo secrets before merge** (Settings → Secrets → Actions):
- `NEON_API_KEY` — create a project-scoped key for the rallly project
- `NEON_PROJECT_ID` — `young-darkness-17034295`

Compliance context: preview deployments are already behind Vercel Authentication (SSO, all non-custom domains), so with this TTL the posture is "production data in previews: access-restricted, auto-deleted ≤7 days." The DPA (#3104) gets a matching sentence so its deletion commitments cover these copies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added automated cleanup of stale preview branches.
  * Preview branches older than seven days are removed nightly, with an option to run cleanup manually.
  * Protected, default, and non-preview branches are excluded from cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->