### PR TITLE
🔧 Lower preview branch TTL to 6 days

### DIFF
--- a/.github/workflows/delete-stale-preview-branches.yml
+++ b/.github/workflows/delete-stale-preview-branches.yml
@@ -15,7 +15,7 @@ on:
   workflow_dispatch:
 
 env:
-  TTL_DAYS: 7
+  TTL_DAYS: 6
 
 jobs:
   delete-stale-preview-branches:


### PR DESCRIPTION
Section 9.4 of the DPA (#3104) commits to deleting preview copies within 7 days. The nightly job deletes branches older than `TTL_DAYS`, so a branch created just after a run can reach almost `TTL_DAYS + 1` days old before deletion. Setting the TTL to 6 keeps the worst case just under 7 days, making the contractual commitment true by construction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Preview branches are now automatically deleted after 6 days of inactivity instead of 7.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->