### PR TITLE
🐛 Run Vercel Analytics outside the cookie consent gate

### DIFF
--- a/apps/landing/src/app/[locale]/layout.tsx
+++ b/apps/landing/src/app/[locale]/layout.tsx
@@ -1,6 +1,7 @@
 import "./globals.css";
 
 import languages from "@rallly/languages";
+import { Analytics } from "@vercel/analytics/react";
 import { domAnimation, LazyMotion } from "motion/react";
 import type { Metadata, Viewport } from "next";
 import { cacheLife } from "next/cache";
@@ -37,6 +38,10 @@ export default async function Root(props: {
           <I18nProvider locale={i18n.resolvedLanguage} resources={translations}>
             {children}
             <CookieConsent />
+            {/* Cookieless (daily-rotating server-side hash, nothing stored
+                on the device), so it runs outside the consent gate — same
+                posture as PostHog's pre-consent cookieless capture. */}
+            <Analytics />
           </I18nProvider>
         </LazyMotion>
       </body>

--- a/apps/landing/src/components/cookie-consent.tsx
+++ b/apps/landing/src/components/cookie-consent.tsx
@@ -1,7 +1,6 @@
 "use client";
 import { useCookieConsent } from "@rallly/posthog/client";
 import { Button } from "@rallly/ui/button";
-import { Analytics } from "@vercel/analytics/react";
 import { LinkBase } from "@/i18n/client/link";
 import { Trans } from "@/i18n/client/trans";
 import { useTranslation } from "@/i18n/client/use-translation";
@@ -10,41 +9,40 @@ export function CookieConsent() {
   const { t } = useTranslation();
   const { status, accept, reject } = useCookieConsent();
 
+  if (status !== "pending") {
+    return null;
+  }
+
   return (
-    <>
-      {status === "granted" ? <Analytics /> : null}
-      {status === "pending" ? (
-        <section
-          aria-label={t("cookieConsentLabel", {
-            defaultValue: "Cookie consent",
-          })}
-          className="fixed bottom-4 left-4 z-50 flex max-w-[min(32rem,calc(100vw-2rem))] flex-wrap items-center gap-x-6 gap-y-3 rounded-xl border bg-white p-4 shadow-lg"
-        >
-          <p className="min-w-0 flex-1 basis-56 text-pretty text-sm">
-            <Trans
-              i18nKey="cookieConsentIntro"
-              defaults="We use cookies to improve your experience."
-            />{" "}
-            <Trans
-              i18nKey="cookieConsentPolicy"
-              defaults="Learn more in our <policyLink>cookie policy</policyLink>."
-              components={{
-                policyLink: (
-                  <LinkBase className="underline" href="/cookie-policy" />
-                ),
-              }}
-            />
-          </p>
-          <div className="flex gap-2">
-            <Button onClick={reject}>
-              <Trans i18nKey="cookieConsentOptOut" defaults="Opt out" />
-            </Button>
-            <Button variant="primary" onClick={accept}>
-              <Trans i18nKey="cookieConsentAccept" defaults="Accept" />
-            </Button>
-          </div>
-        </section>
-      ) : null}
-    </>
+    <section
+      aria-label={t("cookieConsentLabel", {
+        defaultValue: "Cookie consent",
+      })}
+      className="fixed bottom-4 left-4 z-50 flex max-w-[min(32rem,calc(100vw-2rem))] flex-wrap items-center gap-x-6 gap-y-3 rounded-xl border bg-white p-4 shadow-lg"
+    >
+      <p className="min-w-0 flex-1 basis-56 text-pretty text-sm">
+        <Trans
+          i18nKey="cookieConsentIntro"
+          defaults="We use cookies to improve your experience."
+        />{" "}
+        <Trans
+          i18nKey="cookieConsentPolicy"
+          defaults="Learn more in our <policyLink>cookie policy</policyLink>."
+          components={{
+            policyLink: (
+              <LinkBase className="underline" href="/cookie-policy" />
+            ),
+          }}
+        />
+      </p>
+      <div className="flex gap-2">
+        <Button onClick={reject}>
+          <Trans i18nKey="cookieConsentOptOut" defaults="Opt out" />
+        </Button>
+        <Button variant="primary" onClick={accept}>
+          <Trans i18nKey="cookieConsentAccept" defaults="Accept" />
+        </Button>
+      </div>
+    </section>
   );
 }


### PR DESCRIPTION
## Problem

The landing site only rendered Vercel's `<Analytics />` after the visitor clicked Accept on the cookie banner. Everyone who ignored or rejected the banner never loaded the script, so Vercel Analytics data collapsed after the banner shipped.

## Fix

Vercel Web Analytics never needed to sit behind the consent gate: it's cookieless — nothing is stored on the device, and visitors are identified by a daily-rotating server-side hash with no cross-day tracking. That's the same privacy posture as PostHog's pre-consent `cookieless_mode: "on_reject"` capture, which already runs unconditionally.

- Moved `<Analytics />` out of `CookieConsent` and rendered it unconditionally in the landing layout, with a comment stating the rationale.
- The banner is now purely the PostHog cookie consent gate; `CookieConsent` uses the same early-return shape as the web app's banner.

Deliberately **not** done: defaulting consent to granted — that would drop PostHog's tracking cookies without user action, which is what the banner exists to prevent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added analytics tracking across localized landing pages.
- **Bug Fixes**
  - Improved cookie-consent behavior so the consent prompt displays directly and consistently while consent is pending.
  - Separated analytics from the cookie-consent interface, ensuring the consent experience remains focused and reliable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->