### PR TITLE
💄 Rename landing footer heading to "Use cases"

### DIFF
--- a/apps/landing/public/locales/en/common.json
+++ b/apps/landing/public/locales/en/common.json
@@ -38,7 +38,6 @@
   "privacyPolicy": "Privacy policy",
   "product": "Product",
   "resources": "Resources",
-  "schedulingFor": "Scheduling for",
   "schedulingPoll": "Scheduling poll",
   "security": "Security",
   "sportsClubs": "Sports clubs",
@@ -46,5 +45,6 @@
   "support": "Support",
   "termsOfUse": "Terms of use",
   "thesisDefense": "Thesis defenses",
+  "useCases": "Use cases",
   "when2MeetAlternative": "When2Meet alternative"
 }

--- a/apps/landing/src/app/[locale]/(main)/footer.tsx
+++ b/apps/landing/src/app/[locale]/(main)/footer.tsx
@@ -209,12 +209,7 @@ export const Footer = async ({ locale }: { locale: string }) => {
         </div>
         <div>
           <div className="mb-6 font-medium text-gray-800 text-sm uppercase tracking-wide">
-            <Trans
-              t={t}
-              ns="common"
-              i18nKey="schedulingFor"
-              defaults="Scheduling for"
-            />
+            <Trans t={t} ns="common" i18nKey="useCases" defaults="Use cases" />
           </div>
           <ul className="grid gap-3 text-sm">
             <li>


### PR DESCRIPTION
## Summary
- Replace the "Scheduling for" footer column heading on the landing page with "Use cases"
- "Scheduling for" was a dangling fragment that only made sense combined with the link labels below it, which made it untranslatable in isolation (e.g. Hungarian rendered it as "Ütemezés ennek:"). "Use cases" is a self-contained noun phrase that translates cleanly.
- New i18n key `useCases` added via `pnpm i18n:scan`; the old `schedulingFor` key was pruned from the English source. Leftover translations in cs/hu/de will be cleaned up by Crowdin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Renamed the footer’s “Scheduling for” section to “Use cases”.
  * Updated the English translation to reflect the new section label.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->