### PR TITLE
💄 Truncate hero announcement text to one line

### DIFF
--- a/apps/landing/src/components/home/hero.tsx
+++ b/apps/landing/src/components/home/hero.tsx
@@ -16,14 +16,14 @@ export function HeroAnnouncement({
     <Link
       href={href}
       prefetch={false}
-      className="group -ml-1 inline-flex items-center gap-x-2 rounded-full bg-gray-200/50 p-1 pr-3 text-sm transition-all hover:bg-gray-200"
+      className="group -ml-1 inline-flex max-w-full items-center gap-x-2 rounded-full bg-gray-200/50 p-1 pr-3 text-sm transition-all hover:bg-gray-200"
     >
-      <Badge variant="primary" className="rounded-full">
+      <Badge variant="primary" className="shrink-0 rounded-full">
         {badge}
       </Badge>
-      <span className="flex items-center gap-x-1">{children}</span>
+      <span className="min-w-0 truncate">{children}</span>
       <ArrowRightIcon
-        className="size-3 text-gray-500 transition-transform group-hover:translate-x-0.5 group-active:translate-x-0.5"
+        className="size-3 shrink-0 text-gray-500 transition-transform group-hover:translate-x-0.5 group-active:translate-x-0.5"
         aria-hidden="true"
       />
     </Link>


### PR DESCRIPTION
The blog announcement link in the landing page hero wrapped onto a second line when the text didn't fit, instead of truncating.

`HeroAnnouncement` is `inline-flex`, so it shrink-wraps its content and never constrains the text. Three changes:

- `max-w-full` on the link — without it the element grows past its container rather than truncating.
- `min-w-0 truncate` on the text span — `min-w-0` overrides the flex-item default `min-width: auto`, which otherwise refuses to shrink below content width.
- `shrink-0` on the badge and arrow so the ellipsis only eats the announcement text.

Also dropped `flex items-center gap-x-1` from the text span: a flex container's children don't inherit text ellipsis, so it's incompatible with `truncate`. The current callsite passes plain text. Any future announcement needing inline elements there would need them inline rather than as flex children.

## Verification

`pnpm check` passes on the changed file. Two lint failures exist elsewhere on `main` and are untouched here (`.claude/settings.local.json` formatting, a stale suppression in `packages/ui/src/rich-text-editor.tsx`).

Not visually verified in a browser — this is a CSS-only change reasoned through rather than rendered. Worth an eyeball on the deploy preview at a narrow viewport.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved announcement link layout and text truncation on narrow screens.
  * Prevented the announcement badge and arrow icon from shrinking or overlapping content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->