### PR TITLE
📈 Attribute signups to the originating landing page

### DIFF
--- a/apps/landing/src/app/[locale]/(main)/mobile-menu.tsx
+++ b/apps/landing/src/app/[locale]/(main)/mobile-menu.tsx
@@ -8,6 +8,7 @@ import React from "react";
 import { CtaButton } from "@/components/home/cta-button";
 import { LinkBase } from "@/i18n/client/link";
 import { linkToApp } from "@/lib/linkToApp";
+import { getRefSlug } from "@/lib/ref-slug";
 
 const PANEL_ID = "mobile-menu-panel";
 // Matches the `lg:hidden` on the panel below. Tailwind's default `lg`.
@@ -113,7 +114,7 @@ export const MobileMenu = ({
         </nav>
         <div className="flex flex-col gap-3 border-t px-4 py-6 sm:px-6">
           <LinkBase
-            href={linkToApp("/login")}
+            href={linkToApp("/login", { ref: getRefSlug(pathname) })}
             className={buttonVariants({
               variant: "default",
               size: "lg",

--- a/apps/landing/src/app/[locale]/(main)/pricing/page.tsx
+++ b/apps/landing/src/app/[locale]/(main)/pricing/page.tsx
@@ -164,7 +164,7 @@ export default async function Page(props: {
               </PlanCardPrice>
               <div>
                 <Link
-                  href={linkToApp("/")}
+                  href={linkToApp("/", { ref: "pricing" })}
                   className={buttonVariants({
                     className: "w-full",
                   })}
@@ -270,7 +270,7 @@ export default async function Page(props: {
               </PlanCardPrice>
               <div>
                 <Link
-                  href={linkToApp("/settings/billing")}
+                  href={linkToApp("/settings/billing", { ref: "pricing" })}
                   className={buttonVariants({
                     variant: "primary",
                     className: "w-full",
@@ -782,7 +782,9 @@ export default async function Page(props: {
                     a: (
                       <Link
                         className={faqLinkClassName}
-                        href={linkToApp("/settings/billing")}
+                        href={linkToApp("/settings/billing", {
+                          ref: "pricing",
+                        })}
                       />
                     ),
                     b: <strong />,
@@ -808,7 +810,9 @@ export default async function Page(props: {
                     a: (
                       <Link
                         className={faqLinkClassName}
-                        href={linkToApp("/settings/billing")}
+                        href={linkToApp("/settings/billing", {
+                          ref: "pricing",
+                        })}
                       />
                     ),
                     b: <strong />,

--- a/apps/landing/src/components/home/cta-button.tsx
+++ b/apps/landing/src/components/home/cta-button.tsx
@@ -4,6 +4,7 @@ import { buttonVariants, cn } from "@rallly/ui";
 import Link from "next/link";
 import type React from "react";
 import { linkToApp } from "@/lib/linkToApp";
+import { useRefSlug } from "@/lib/use-ref-slug";
 
 export function CtaButton({
   captureEvent,
@@ -16,9 +17,10 @@ export function CtaButton({
   className?: string;
   children: React.ReactNode;
 }) {
+  const ref = useRefSlug();
   return (
     <Link
-      href={linkToApp("/new")}
+      href={linkToApp("/new", { ref })}
       className={buttonVariants({
         size,
         variant: "primary",

--- a/apps/landing/src/components/home/hero-demo/vote-actions.tsx
+++ b/apps/landing/src/components/home/hero-demo/vote-actions.tsx
@@ -7,12 +7,14 @@ import * as React from "react";
 import { Trans } from "@/i18n/client/trans";
 import { useTranslation } from "@/i18n/client/use-translation";
 import { linkToApp } from "@/lib/linkToApp";
+import { useRefSlug } from "@/lib/use-ref-slug";
 
 // The action bar of the phone demo, plus the confirmation it opens. The
 // surrounding poll layout stays on the server. Must be a direct child of the
 // relative DemoScreen so the confirmation overlay covers the whole screen.
 export const VoteActions = () => {
   const { t } = useTranslation("home");
+  const ref = useRefSlug();
   const [submitted, setSubmitted] = React.useState(false);
 
   return (
@@ -108,7 +110,7 @@ export const VoteActions = () => {
               className="mt-4"
             >
               <Link
-                href={linkToApp("/new")}
+                href={linkToApp("/new", { ref })}
                 onClick={() => {
                   posthog?.capture("landing:hero_demo_modal_cta_click");
                 }}

--- a/apps/landing/src/components/login-button.tsx
+++ b/apps/landing/src/components/login-button.tsx
@@ -4,11 +4,13 @@ import { buttonVariants } from "@rallly/ui";
 import Link from "next/link";
 import { Trans } from "@/i18n/client/trans";
 import { linkToApp } from "@/lib/linkToApp";
+import { useRefSlug } from "@/lib/use-ref-slug";
 
 export const LoginButton = () => {
+  const ref = useRefSlug();
   return (
     <Link
-      href={linkToApp("/login")}
+      href={linkToApp("/login", { ref })}
       className={buttonVariants({ variant: "ghost" })}
     >
       <Trans i18nKey="login" defaults="Login" />

--- a/apps/landing/src/lib/linkToApp.ts
+++ b/apps/landing/src/lib/linkToApp.ts
@@ -1,4 +1,7 @@
-export const linkToApp = (path = "") => {
+export const linkToApp = (path = "", options?: { ref?: string }) => {
   const url = new URL(path, process.env.NEXT_PUBLIC_APP_BASE_URL);
+  if (options?.ref) {
+    url.searchParams.set("ref", options.ref);
+  }
   return url.href;
 };

--- a/apps/landing/src/lib/ref-slug.ts
+++ b/apps/landing/src/lib/ref-slug.ts
@@ -1,0 +1,16 @@
+import { languages } from "@/i18n/settings";
+
+// Cross-domain referrers don't survive the hop from rallly.co to the app, so
+// CTA links carry the originating page as a ?ref=<slug> query param instead.
+// The slug is always a locale-independent page path — never personal data.
+export function getRefSlug(pathname: string) {
+  let path = pathname;
+  const locale = languages.find(
+    (lng) => path === `/${lng}` || path.startsWith(`/${lng}/`),
+  );
+  if (locale) {
+    path = path.slice(locale.length + 1) || "/";
+  }
+  const slug = path.replace(/^\/+|\/+$/g, "");
+  return slug === "" ? "home" : slug;
+}

--- a/apps/landing/src/lib/use-ref-slug.ts
+++ b/apps/landing/src/lib/use-ref-slug.ts
@@ -1,0 +1,8 @@
+"use client";
+
+import { usePathname } from "next/navigation";
+import { getRefSlug } from "@/lib/ref-slug";
+
+export function useRefSlug() {
+  return getRefSlug(usePathname());
+}

--- a/apps/web/src/lib/acquisition.ts
+++ b/apps/web/src/lib/acquisition.ts
@@ -1,0 +1,34 @@
+import type { NextRequest, NextResponse } from "next/server";
+
+// Landing CTAs append ?ref=<page-slug> because cross-domain referrers don't
+// survive the hop from rallly.co to the app. The proxy persists the slug in a
+// cookie so it is still available when registration completes requests later
+// (signup spans redirects and, for OAuth, a round trip to the provider).
+export const REF_COOKIE_NAME = "rallly_ref";
+
+const REF_COOKIE_MAX_AGE = 60 * 60 * 24 * 30;
+
+// Page slugs only (e.g. "home", "blog/is-doodle-still-free") — the param is
+// visitor-controlled, so reject anything else before it reaches analytics.
+const REF_PATTERN = /^[a-z0-9][a-z0-9/_-]{0,63}$/;
+
+export function parseRefParam(value: string | null | undefined) {
+  if (!value || !REF_PATTERN.test(value)) {
+    return undefined;
+  }
+  return value;
+}
+
+export function setRefCookie(req: NextRequest, res: NextResponse) {
+  const ref = parseRefParam(req.nextUrl.searchParams.get("ref"));
+  if (!ref) {
+    return;
+  }
+  res.cookies.set(REF_COOKIE_NAME, ref, {
+    httpOnly: true,
+    sameSite: "lax",
+    path: "/",
+    secure: req.nextUrl.protocol === "https:",
+    maxAge: REF_COOKIE_MAX_AGE,
+  });
+}

--- a/apps/web/src/lib/auth.ts
+++ b/apps/web/src/lib/auth.ts
@@ -31,6 +31,7 @@ import type { UserDTO } from "@/features/user/schema";
 import { jobTitleFieldSchema } from "@/features/user/schema";
 import { getTranslation } from "@/i18n/server";
 import { getLocale } from "@/i18n/server/get-locale";
+import { parseRefParam, REF_COOKIE_NAME } from "@/lib/acquisition";
 import { SESSION_TTL_SECONDS } from "@/lib/auth-config";
 import { hostOnlyCookieCleanup } from "@/lib/auth-plugins/host-only-cookie-cleanup";
 import { redis } from "@/lib/kv";
@@ -479,10 +480,11 @@ export const authLib = betterAuth({
   databaseHooks: {
     user: {
       create: {
-        after: async (user) => {
+        after: async (user, ctx) => {
           if (user.isAnonymous) {
             return;
           }
+          const ref = parseRefParam(ctx?.getCookie(REF_COOKIE_NAME));
           // No space is created here — /setup owns space creation, and the
           // active-space gate keeps redirecting there until it happens.
           track(
@@ -491,6 +493,7 @@ export const authLib = betterAuth({
               event: "register",
               properties: {
                 method: user.lastLoginMethod,
+                ref,
                 $set: {
                   name: user.name,
                   email: user.email,
@@ -498,6 +501,7 @@ export const authLib = betterAuth({
                   timeZone: user.timeZone ?? undefined,
                   locale: user.locale ?? undefined,
                 },
+                ...(ref && { $set_once: { initial_ref: ref } }),
               },
             },
           );

--- a/apps/web/src/proxy.ts
+++ b/apps/web/src/proxy.ts
@@ -1,5 +1,6 @@
 import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
+import { setRefCookie } from "@/lib/acquisition";
 import { getLocaleFromRequest, setLocaleCookie } from "@/lib/locale/server";
 import {
   hashBypassToken,
@@ -65,6 +66,8 @@ export const proxy = async (req: NextRequest) => {
   const res = NextResponse.rewrite(newUrl);
 
   setLocaleCookie(req, res, locale);
+
+  setRefCookie(req, res);
 
   res.headers.set("x-locale", locale);
 


### PR DESCRIPTION
## Problem

Cross-domain referrer data dies between rallly.co and app.rallly.co: ~99.9% of `register` events (June–Aug 2026) have an empty/direct `$initial_referring_domain`, so there is no way to tell whether SEO pages (e.g. /best-doodle-alternative, ~14.5k Google visitors/60d) convert to signups or paid.

## Approach

**Landing** — CTAs into the app now carry `?ref=<page-slug>`:
- `linkToApp(path, { ref })` appends the param; `getRefSlug(pathname)` derives a locale-independent slug from the current page (`/` → `home`, `/de/blog/is-doodle-still-free` → `blog/is-doodle-still-free`).
- Wired through the central components (`CtaButton`, `LoginButton`, mobile menu login link, hero demo link) via a `useRefSlug()` hook, so every page using `Cta`/the header gets it for free. Pricing page's direct links pass `ref: "pricing"`.
- Only page slugs, never personal data.

**Web** — the slug has to survive signup's redirects (and the OAuth round trip), so:
- The proxy persists a validated ref (`^[a-z0-9][a-z0-9/_-]{0,63}$` — visitor-controlled input, anything else is dropped) into an httpOnly `rallly_ref` cookie (30d).
- The Better-Auth `user.create.after` hook reads the cookie from the request context and adds `ref` to the `register` event plus `initial_ref` as a `$set_once` person property. No new events.

## Verification (local, landing on :3022 → web on :3021)

- Landing SSR output: `/` renders `/new?ref=home`, `/best-doodle-alternative` → `ref=best-doodle-alternative`, `/de/blog/is-doodle-still-free` → `ref=blog%2Fis-doodle-still-free`, `/pricing` → `ref=pricing` on all four app links.
- `curl -I /login?ref=best-doodle-alternative` sets the cookie; a `<script>` value is rejected; the encoded blog slug round-trips (better-call's cookie parser decodes it).
- Full OTP signup through the UI with PostHog pointed at a local sink — captured payload:

```json
{
  "event": "register",
  "properties": {
    "ref": "best-doodle-alternative",
    "$set": { "email": "...", "tier": "hobby" },
    "$set_once": { "initial_ref": "best-doodle-alternative" }
  }
}
```

- `pnpm type-check` and `pnpm check` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added referral-aware links across navigation, login, pricing, calls to action, and poll creation.
  - Referral information is now preserved as visitors move through the site and complete sign-up.
  - Added support for retaining referral details through redirects and authentication flows.

- **Bug Fixes**
  - Improved consistency of referral attribution across landing-page entry points and account creation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->