### PR TITLE
✨ Link the DPA from the footer and privacy policy

### DIFF
--- a/apps/landing/public/locales/en/common.json
+++ b/apps/landing/public/locales/en/common.json
@@ -11,6 +11,7 @@
   "cookiePolicy": "Cookie policy",
   "discussions": "Discussions",
   "doodleAlternative": "Doodle alternative",
+  "dpa": "DPA",
   "executiveAssistants": "Executive assistants",
   "footerDiscordLabel": "Join us on Discord",
   "footerGithubLabel": "View our GitHub repository",

--- a/apps/landing/src/app/[locale]/(main)/footer.tsx
+++ b/apps/landing/src/app/[locale]/(main)/footer.tsx
@@ -310,6 +310,14 @@ export const Footer = async ({ locale }: { locale: string }) => {
                 <Trans t={t} ns="common" i18nKey="termsOfUse" />
               </LinkBase>
             </li>
+            <li>
+              <LinkBase
+                href="/dpa"
+                className="inline-block font-normal text-gray-600 hover:text-gray-800 hover:no-underline"
+              >
+                <Trans t={t} ns="common" i18nKey="dpa" defaults="DPA" />
+              </LinkBase>
+            </li>
           </ul>
         </div>
         <div className="flex flex-wrap items-center gap-4">

--- a/apps/landing/src/app/[locale]/(main)/privacy-policy/page.tsx
+++ b/apps/landing/src/app/[locale]/(main)/privacy-policy/page.tsx
@@ -10,7 +10,9 @@ export default async function PrivacyPolicy() {
       <h1 className="max-w-2xl text-balance font-medium text-3xl text-gray-800 tracking-tight sm:text-4xl">
         Privacy policy
       </h1>
-      <p className="mt-4 text-gray-500 text-sm">Last updated: 30 August 2026</p>
+      <p className="mt-4 text-gray-500 text-sm">
+        Last updated: 1 September 2026
+      </p>
       <div className="longform mt-8 max-w-2xl">
         <p>
           At rallly.co, we take your privacy seriously. This privacy policy
@@ -135,6 +137,16 @@ export default async function PrivacyPolicy() {
           For example, we use Featurebase to make it easy for users to submit
           feedback. Your name and email may be shared with Featurbase to provide
           a seamless transition between the two services.
+        </p>
+
+        <h2>Processing on behalf of organizations</h2>
+
+        <p>
+          Where we process personal data on behalf of an organization using
+          Rallly, for example the details of people invited to that
+          organization&apos;s polls and events, we act as a processor and that
+          processing is governed by our{" "}
+          <a href="/dpa">Data Processing Agreement</a>.
         </p>
 
         <h2>Your rights</h2>

--- a/apps/landing/src/app/[locale]/(main)/privacy-policy/page.tsx
+++ b/apps/landing/src/app/[locale]/(main)/privacy-policy/page.tsx
@@ -2,6 +2,7 @@
 
 import { cacheLife } from "next/cache";
 import { Section } from "@/components/section";
+import { LinkBase } from "@/i18n/client/link";
 
 export default async function PrivacyPolicy() {
   cacheLife("max");
@@ -146,7 +147,7 @@ export default async function PrivacyPolicy() {
           Rallly, for example the details of people invited to that
           organization&apos;s polls and events, we act as a processor and that
           processing is governed by our{" "}
-          <a href="/dpa">Data Processing Agreement</a>.
+          <LinkBase href="/dpa">Data Processing Agreement</LinkBase>.
         </p>
 
         <h2>Your rights</h2>


### PR DESCRIPTION
The DPA published in #3104 was only reachable via the terms and the security page FAQ. This adds the two places procurement reviewers actually look:

- **Footer legal row**: `DPA` alongside Privacy policy / Cookie policy / Terms of use (new `dpa` key via i18n:scan, initialism so it survives translation untouched).
- **Privacy policy**: a "Processing on behalf of organizations" section pointing processor-side questions at the DPA, so the two documents reference each other. Last-updated bumped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a localized Data Processing Agreement (DPA) link to the website footer.
  - Added locale-aware navigation to the DPA page.
  - Added privacy policy information about processing personal data on behalf of organizations.

- **Documentation**
  - Updated the privacy policy’s “Last updated” date to 1 September 2026.
  - Added a reference to the DPA in the privacy policy.
  - Corrected the “When2meet alternative” label capitalization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->