### PR TITLE
💄 Restyle legal pages with sticky last-updated sidebar

### DIFF
--- a/apps/landing/src/app/[locale]/(main)/cookie-policy/page.tsx
+++ b/apps/landing/src/app/[locale]/(main)/cookie-policy/page.tsx
@@ -1,17 +1,14 @@
 "use cache";
 
 import { cacheLife } from "next/cache";
+import { LegalPageLayout } from "@/components/legal-page-layout";
 import { Section } from "@/components/section";
 
 export default async function CookiePolicy() {
   cacheLife("max");
   return (
     <Section>
-      <h1 className="max-w-2xl text-balance font-medium text-3xl text-gray-800 tracking-tight sm:text-4xl">
-        Cookie policy
-      </h1>
-      <p className="mt-4 text-gray-500 text-sm">Last updated: 4 April 2026</p>
-      <div className="longform mt-8 max-w-2xl">
+      <LegalPageLayout title="Cookie policy" lastUpdated="2026-04-04">
         <p>
           This Policy explains how we use cookies and other similar technologies
           on our website, and your options to control them.
@@ -62,7 +59,7 @@ export default async function CookiePolicy() {
           this policy regularly to stay informed about how we use cookies on our
           website.
         </p>
-      </div>
+      </LegalPageLayout>
     </Section>
   );
 }

--- a/apps/landing/src/app/[locale]/(main)/dpa/page.tsx
+++ b/apps/landing/src/app/[locale]/(main)/dpa/page.tsx
@@ -2,6 +2,7 @@
 
 import type { Metadata } from "next";
 import { cacheLife } from "next/cache";
+import { LegalPageLayout } from "@/components/legal-page-layout";
 import { Section } from "@/components/section";
 import { LinkBase } from "@/i18n/client/link";
 
@@ -9,11 +10,10 @@ export default async function DataProcessingAgreement() {
   cacheLife("max");
   return (
     <Section>
-      <h1 className="max-w-2xl text-balance font-medium text-3xl text-gray-800 tracking-tight sm:text-4xl">
-        Data processing agreement
-      </h1>
-      <p className="mt-4 text-gray-500 text-sm">Last updated: 29 August 2026</p>
-      <div className="longform mt-8 max-w-2xl">
+      <LegalPageLayout
+        title="Data processing agreement"
+        lastUpdated="2026-08-29"
+      >
         <p>
           This Data Processing Agreement (&quot;DPA&quot;) forms part of the{" "}
           <LinkBase href="/terms-of-use">Terms of Use</LinkBase> between Stack
@@ -524,7 +524,7 @@ export default async function DataProcessingAgreement() {
           <br />
           United Kingdom
         </p>
-      </div>
+      </LegalPageLayout>
     </Section>
   );
 }

--- a/apps/landing/src/app/[locale]/(main)/privacy-policy/page.tsx
+++ b/apps/landing/src/app/[locale]/(main)/privacy-policy/page.tsx
@@ -1,6 +1,7 @@
 "use cache";
 
 import { cacheLife } from "next/cache";
+import { LegalPageLayout } from "@/components/legal-page-layout";
 import { Section } from "@/components/section";
 import { LinkBase } from "@/i18n/client/link";
 
@@ -8,13 +9,7 @@ export default async function PrivacyPolicy() {
   cacheLife("max");
   return (
     <Section>
-      <h1 className="max-w-2xl text-balance font-medium text-3xl text-gray-800 tracking-tight sm:text-4xl">
-        Privacy policy
-      </h1>
-      <p className="mt-4 text-gray-500 text-sm">
-        Last updated: 1 September 2026
-      </p>
-      <div className="longform mt-8 max-w-2xl">
+      <LegalPageLayout title="Privacy policy" lastUpdated="2026-09-01">
         <p>
           At rallly.co, we take your privacy seriously. This privacy policy
           explains how we collect, use, and disclose your personal data, and
@@ -194,7 +189,7 @@ export default async function PrivacyPolicy() {
           practices with regards to your personal data, please contact us at{" "}
           <a href="mailto:support@rallly.co">support@rallly.co</a>.
         </p>
-      </div>
+      </LegalPageLayout>
     </Section>
   );
 }

--- a/apps/landing/src/app/[locale]/(main)/terms-of-use/page.tsx
+++ b/apps/landing/src/app/[locale]/(main)/terms-of-use/page.tsx
@@ -2,6 +2,7 @@
 
 import type { Metadata } from "next";
 import { cacheLife } from "next/cache";
+import { LegalPageLayout } from "@/components/legal-page-layout";
 import { Section } from "@/components/section";
 import { LinkBase } from "@/i18n/client/link";
 
@@ -9,11 +10,7 @@ export default async function TermsOfUse() {
   cacheLife("max");
   return (
     <Section>
-      <h1 className="max-w-2xl text-balance font-medium text-3xl text-gray-800 tracking-tight sm:text-4xl">
-        Terms of use
-      </h1>
-      <p className="mt-4 text-gray-500 text-sm">Last updated: 29 August 2026</p>
-      <div className="longform mt-8 max-w-2xl">
+      <LegalPageLayout title="Terms of use" lastUpdated="2026-08-29">
         <p>
           This website and the Rallly software and services are operated by
           Stack Snap Ltd. References to &quot;we&quot;, &quot;us&quot; or
@@ -260,7 +257,7 @@ export default async function TermsOfUse() {
           <br />
           United Kingdom
         </p>
-      </div>
+      </LegalPageLayout>
     </Section>
   );
 }

--- a/apps/landing/src/components/legal-page-layout.tsx
+++ b/apps/landing/src/components/legal-page-layout.tsx
@@ -1,0 +1,32 @@
+import DateFormatter from "@/components/blog/date-formatter";
+
+export function LegalPageLayout({
+  title,
+  lastUpdated,
+  children,
+}: {
+  title: string;
+  lastUpdated: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <>
+      <h1 className="max-w-2xl text-balance font-medium text-3xl text-gray-800 tracking-tight sm:text-4xl">
+        {title}
+      </h1>
+      <div className="mt-8 flex flex-col gap-8 lg:flex-row lg:items-start lg:justify-between lg:gap-16">
+        <aside className="lg:sticky lg:top-24 lg:order-2 lg:w-56 lg:shrink-0">
+          <dl className="flex flex-wrap gap-x-12 gap-y-6 lg:flex-col">
+            <div>
+              <dt className="text-gray-500 text-sm">Last updated</dt>
+              <dd className="mt-1 text-gray-800">
+                <DateFormatter dateString={lastUpdated} />
+              </dd>
+            </div>
+          </dl>
+        </aside>
+        <div className="longform min-w-0 max-w-2xl lg:order-1">{children}</div>
+      </div>
+    </>
+  );
+}


### PR DESCRIPTION
## What

Restyles the four long-form legal pages (privacy policy, cookie policy, terms of use, DPA) to match the blog post layout: content column on the left, a sticky metadata sidebar on the right showing the last-updated date. No author block.

The inline "Last updated: …" paragraph under each h1 is replaced by the sidebar, which reuses `DateFormatter` (so dates now render locale-formatted, e.g. "August 29, 2026") with a semantic `<time>` element inside a `<dl>`.

Since all four pages share the identical shell, it's extracted into a small presentational `LegalPageLayout` component under `apps/landing/src/components/`.

## Verification

- Desktop: sidebar is sticky (`position: sticky; top: 96px`), content column is `max-w-2xl`, no page-level horizontal scroll.
- Mobile: metadata stacks between the heading and the content, matching the blog layout.
- DPA Annex 2 table: still scrolls inside its `overflow-x-auto` wrapper in the narrower column (content 1142px vs 343px column on mobile) without causing body scroll; fits the column at `lg` where `whitespace-normal` applies.
- `biome check` and `tsc --noEmit` pass in `apps/landing`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a consistent layout for legal pages, including page titles, formatted “Last updated” dates, and structured content presentation.
  * Updated the cookie policy, DPA, privacy policy, and terms of use pages to use the shared legal page layout.

* **Style**
  * Improved consistency across legal pages with standardized headings, date displays, and content spacing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->