### PR TITLE
♻️ Use locale-aware links for landing page internal cross-links

### DIFF
--- a/apps/landing/src/app/[locale]/(main)/dpa/page.tsx
+++ b/apps/landing/src/app/[locale]/(main)/dpa/page.tsx
@@ -3,6 +3,7 @@
 import type { Metadata } from "next";
 import { cacheLife } from "next/cache";
 import { Section } from "@/components/section";
+import { LinkBase } from "@/i18n/client/link";
 
 export default async function DataProcessingAgreement() {
   cacheLife("max");
@@ -15,11 +16,11 @@ export default async function DataProcessingAgreement() {
       <div className="longform mt-8 max-w-2xl">
         <p>
           This Data Processing Agreement (&quot;DPA&quot;) forms part of the{" "}
-          <a href="/terms-of-use">Terms of Use</a> between Stack Snap Ltd
-          (&quot;we&quot;, &quot;us&quot;, &quot;our&quot;) and the customer
-          (&quot;you&quot;, &quot;your&quot;) and governs our processing of
-          personal data on your behalf when we provide the hosted Rallly service
-          at rallly.co.
+          <LinkBase href="/terms-of-use">Terms of Use</LinkBase> between Stack
+          Snap Ltd (&quot;we&quot;, &quot;us&quot;, &quot;our&quot;) and the
+          customer (&quot;you&quot;, &quot;your&quot;) and governs our
+          processing of personal data on your behalf when we provide the hosted
+          Rallly service at rallly.co.
         </p>
         <p>
           This DPA is incorporated into the Terms of Use by reference and
@@ -77,7 +78,7 @@ export default async function DataProcessingAgreement() {
           personal data we process for our own purposes: managing accounts and
           billing, securing and improving the Service, and communicating with
           users. That processing is described in our{" "}
-          <a href="/privacy-policy">Privacy Policy</a>.
+          <LinkBase href="/privacy-policy">Privacy Policy</LinkBase>.
         </p>
         <p>
           2.3 This DPA applies for as long as we process Customer Data. If there
@@ -246,10 +247,10 @@ export default async function DataProcessingAgreement() {
           8.1 We will make available to you the information reasonably necessary
           to demonstrate compliance with this DPA. We support this primarily
           through documentation: this DPA, our{" "}
-          <a href="/security">security page</a>, our publicly auditable source
-          code, our public real-time status page, and the audit reports and
-          certifications of our Sub-processors, which are available from each
-          provider.
+          <LinkBase href="/security">security page</LinkBase>, our publicly
+          auditable source code, our public real-time status page, and the audit
+          reports and certifications of our Sub-processors, which are available
+          from each provider.
         </p>
         <p>
           8.2 Where that documentation is not sufficient to demonstrate
@@ -311,7 +312,8 @@ export default async function DataProcessingAgreement() {
         <h2>Annex 1: Technical and organizational measures</h2>
         <p>
           The measures below describe how we protect Customer Data. Further
-          detail is published on our <a href="/security">security page</a>.
+          detail is published on our{" "}
+          <LinkBase href="/security">security page</LinkBase>.
         </p>
         <ul>
           <li>

--- a/apps/landing/src/app/[locale]/(main)/page.tsx
+++ b/apps/landing/src/app/[locale]/(main)/page.tsx
@@ -2,7 +2,6 @@
 
 import type { Metadata } from "next";
 import { cacheLife } from "next/cache";
-import Link from "next/link";
 import { Trans } from "react-i18next/TransWithoutContext";
 import { PeopleBadge, PollsBadge } from "@/components/home/animated-number";
 import { Cta } from "@/components/home/cta";
@@ -19,6 +18,7 @@ import {
   SectionHeading,
   SectionTitle,
 } from "@/components/section";
+import { LinkBase } from "@/i18n/client/link";
 import { getTranslation } from "@/i18n/server";
 import { getAlternates } from "@/lib/alternates";
 import { getMonthlyPollCount, getMonthlyVoterCount } from "@/lib/data";
@@ -157,7 +157,7 @@ export default async function Page(props: {
                   i18nKey="faqIsFreeAnswer"
                   defaults="Yes. 99% of people use Rallly completely free. Creating polls, sharing them, and collecting votes costs nothing and there is no limit on participants. We also offer <0>Rallly Pro</0>, a paid subscription with features that are useful if you use Rallly professionally, like adding your own branding, removing Rallly attribution from your polls, and keeping polls around indefinitely."
                   components={[
-                    <Link
+                    <LinkBase
                       key="pricing"
                       className="text-gray-800 underline underline-offset-2 hover:text-gray-600"
                       href="/pricing"
@@ -215,7 +215,7 @@ export default async function Page(props: {
                   i18nKey="faqPrivacyAnswer"
                   defaults="Yes. Privacy is central to how we build Rallly. We do not show ads or sell your data, we collect only what we need to run the service, and polls on the free plan are deleted automatically once they become inactive. Rallly is also open source, so anyone can inspect how their data is handled. You can read the details in our <0>privacy policy</0>."
                   components={[
-                    <Link
+                    <LinkBase
                       key="privacy"
                       className="text-gray-800 underline underline-offset-2 hover:text-gray-600"
                       href="/privacy-policy"

--- a/apps/landing/src/app/[locale]/(main)/security/page.tsx
+++ b/apps/landing/src/app/[locale]/(main)/security/page.tsx
@@ -22,6 +22,7 @@ import {
   SectionHeading,
   SectionTitle,
 } from "@/components/section";
+import { LinkBase } from "@/i18n/client/link";
 import { getMonthlyPollCount, getMonthlyVoterCount } from "@/lib/data";
 
 function SecurityFeature({
@@ -383,9 +384,9 @@ export default async function Security(props: {
             </FaqItem>
             <FaqItem question="Do you offer a Data Processing Agreement (DPA)?">
               Yes. Our GDPR Article 28{" "}
-              <a className="text-primary hover:underline" href="/dpa">
+              <LinkBase className="text-primary hover:underline" href="/dpa">
                 Data Processing Agreement
-              </a>{" "}
+              </LinkBase>{" "}
               is published openly and incorporated into our terms of use, so it
               applies automatically without paperwork. It includes our technical
               and organizational measures and the full subprocessor list, and we

--- a/apps/landing/src/app/[locale]/(main)/terms-of-use/page.tsx
+++ b/apps/landing/src/app/[locale]/(main)/terms-of-use/page.tsx
@@ -3,6 +3,7 @@
 import type { Metadata } from "next";
 import { cacheLife } from "next/cache";
 import { Section } from "@/components/section";
+import { LinkBase } from "@/i18n/client/link";
 
 export default async function TermsOfUse() {
   cacheLife("max");
@@ -201,13 +202,13 @@ export default async function TermsOfUse() {
         <p>
           6.1 Where we process personal data on your behalf in providing the
           hosted Rallly service, we do so as a processor under our{" "}
-          <a href="/dpa">Data Processing Agreement</a>, which is incorporated
-          into these Terms by reference and forms part of them.
+          <LinkBase href="/dpa">Data Processing Agreement</LinkBase>, which is
+          incorporated into these Terms by reference and forms part of them.
         </p>
         <p>
           6.2 Our processing of personal data for our own purposes as a
           controller is described in our{" "}
-          <a href="/privacy-policy">Privacy Policy</a>.
+          <LinkBase href="/privacy-policy">Privacy Policy</LinkBase>.
         </p>
 
         <hr />


### PR DESCRIPTION
## Summary

Internal cross-links on the landing app's legal pages used plain `<a href="/...">` anchors, which drop the active locale prefix on navigation — a `/de/` visitor clicking through lands on the unprefixed English-chromed page. PR #3134 converted the privacy policy's DPA link to `LinkBase` (which re-prefixes the locale from i18n context); this converts the remaining internal cross-links the same way.

- **terms-of-use**: `/dpa` and `/privacy-policy` links in section 6
- **dpa**: `/terms-of-use`, `/privacy-policy`, and both `/security` links
- **security**: FAQ link to `/dpa` (className preserved)
- **homepage FAQ**: both `next/link` usages — `/privacy-policy` and `/pricing` — passed to `Trans` `components` arrays had the same locale issue

External links and `mailto:` anchors are unchanged. No file overlap with #3134, so merge order doesn't matter.

## Test plan

- [x] `pnpm exec biome check --write` on touched files
- [x] `tsc --noEmit` in `apps/landing` passes
- [x] No `<a href="/...">` internal anchors remain in landing pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved navigation between the Terms of Use, Privacy Policy, Data Processing Agreement, security, and pricing pages.
  - Internal links on the landing page and legal pages now consistently preserve the selected language and locale.
  - Updated FAQ links to provide more reliable localized navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->