### PR TITLE
♻️ Use locale-aware link for hero announcement

### DIFF
--- a/apps/landing/src/components/home/hero.tsx
+++ b/apps/landing/src/components/home/hero.tsx
@@ -1,7 +1,7 @@
 import { Badge } from "@rallly/ui/badge";
 import { ArrowRightIcon } from "lucide-react";
-import Link from "next/link";
 import type * as React from "react";
+import { LinkBase } from "@/i18n/client/link";
 
 export function HeroAnnouncement({
   href,
@@ -13,7 +13,7 @@ export function HeroAnnouncement({
   children: React.ReactNode;
 }) {
   return (
-    <Link
+    <LinkBase
       href={href}
       prefetch={false}
       className="group -ml-1 inline-flex max-w-full items-center gap-x-2 rounded-full bg-gray-200/50 p-1 pr-3 text-sm transition-all hover:bg-gray-200"
@@ -26,7 +26,7 @@ export function HeroAnnouncement({
         className="size-3 shrink-0 text-gray-500 transition-transform group-hover:translate-x-0.5 group-active:translate-x-0.5"
         aria-hidden="true"
       />
-    </Link>
+    </LinkBase>
   );
 }
 

--- a/apps/landing/src/i18n/client/link.tsx
+++ b/apps/landing/src/i18n/client/link.tsx
@@ -8,10 +8,12 @@ export const LinkBase = ({
   href,
   children,
   className,
+  prefetch,
 }: {
   href: string;
   children?: React.ReactNode;
   className?: string;
+  prefetch?: boolean;
 }) => {
   const { i18n } = useTranslation();
   const locale =
@@ -19,7 +21,7 @@ export const LinkBase = ({
   const newHref = href.startsWith("/") ? `${locale}${href}` : href;
 
   return (
-    <Link className={className} href={newHref}>
+    <Link className={className} href={newHref} prefetch={prefetch}>
       {children}
     </Link>
   );


### PR DESCRIPTION
## Summary

`HeroAnnouncement` in `apps/landing/src/components/home/hero.tsx` rendered its href with a raw `next/link` `Link`, so a visitor on a locale-prefixed page (e.g. `/de`) lost the locale prefix when clicking the hero announcement. Both call sites pass internal blog hrefs (homepage → `/blog/individual-work-or-team-collaboration`, Doodle alternative page → `/blog/is-doodle-still-free`).

- Converted the announcement link to `LinkBase`, matching the rest of the landing app's internal links (#3134, #3136)
- Added an optional `prefetch` pass-through to `LinkBase` so the announcement keeps `prefetch={false}` — no reason to prefetch the blog bundle for every homepage visitor. Existing `LinkBase` call sites are unaffected (`prefetch={undefined}` is the `next/link` default)

## Verification

- `tsc --noEmit` clean in `apps/landing`
- `biome check` clean on touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)