### PR TITLE
💄 Constrain landing section and hero text widths

### DIFF
--- a/apps/landing/src/app/[locale]/(main)/pricing/page.tsx
+++ b/apps/landing/src/app/[locale]/(main)/pricing/page.tsx
@@ -92,7 +92,7 @@ export default async function Page(props: {
     <div className="divide-y">
       <Section>
         <Hero
-          className="text-center"
+          className="mx-auto max-w-2xl text-center"
           title={t("pricingTitle", {
             ns: "pricing",
             defaultValue: "Get started for free",

--- a/apps/landing/src/app/[locale]/(main)/security/page.tsx
+++ b/apps/landing/src/app/[locale]/(main)/security/page.tsx
@@ -94,7 +94,6 @@ export default async function Security(props: {
     <div className="divide-y">
       <Section>
         <Hero
-          className="max-w-2xl"
           title="Securely scheduling for thousands of organizations"
           description="Every part of Rallly is built to protect your data, on trusted infrastructure with a codebase anyone can audit. Your schedule is nobody's business but yours."
         />

--- a/apps/landing/src/components/home/hero.tsx
+++ b/apps/landing/src/components/home/hero.tsx
@@ -45,10 +45,10 @@ export function Hero({
 }) {
   return (
     <div className={className}>
-      <h1 className="text-balance font-medium text-3xl text-gray-800 tracking-tight sm:text-5xl">
+      <h1 className="max-w-2xl text-balance font-medium text-3xl text-gray-800 tracking-tight sm:text-5xl">
         {title}
       </h1>
-      <p className="mt-4 text-balance font-normal text-base/6 text-gray-500 sm:text-lg sm:leading-relaxed">
+      <p className="mt-4 max-w-2xl text-pretty font-normal text-base/6 text-gray-500 sm:text-lg sm:leading-relaxed">
         {description}
       </p>
       {announcement ? <div className="mt-8">{announcement}</div> : null}

--- a/apps/landing/src/components/section.tsx
+++ b/apps/landing/src/components/section.tsx
@@ -22,7 +22,7 @@ export function SectionTitle({
   return (
     <h2
       className={cn(
-        "text-balance font-medium text-2xl text-gray-800 leading-tight tracking-tight sm:text-4xl",
+        "max-w-2xl text-balance font-medium text-2xl text-gray-800 leading-tight tracking-tight sm:text-4xl",
         className,
       )}
       {...props}
@@ -37,7 +37,7 @@ export function SectionDescription({
   return (
     <p
       className={cn(
-        "max-w-prose text-pretty text-base/6 text-gray-500 sm:text-lg",
+        "max-w-2xl text-pretty text-base/6 text-gray-500 sm:text-lg",
         className,
       )}
       {...props}


### PR DESCRIPTION
## Description

Landing page titles and descriptions had no `max-width`, so headings and body copy ran the full `max-w-6xl` (1152px) container instead of wrapping into a readable measure. This constrains both the section components and the hero.

**`components/section.tsx`**
- `SectionTitle`: added `max-w-2xl` (previously unbounded).
- `SectionDescription`: `max-w-prose` → `max-w-2xl`, so a heading and its description share one measure.

**`components/home/hero.tsx`**
- `h1` and description: added `max-w-2xl`.
- Description: `text-balance` → `text-pretty`. `text-balance` is designed for short headings and browsers cap it around 6 lines; `text-pretty` is the right tool for multi-line body copy, and it matches `SectionDescription`.

`text-balance` on headings was already present throughout and is unchanged.

### Why `max-w-2xl`

It's the existing convention in this app rather than a new value. The legal, privacy, cookie, DPA and blog pages already cap their `h1` at exactly `max-w-2xl text-balance`, and `security/page.tsx` was passing `max-w-2xl` into `Hero` by hand. `max-w-2xl` is the most-used width constraint in `apps/landing`. This makes the shared components match instead of being the outlier.

### Call-site fallout

- **`security/page.tsx`** — dropped its now-redundant `className="max-w-2xl"`.
- **`pricing/page.tsx`** — this is the one non-mechanical part. Its hero was centered with `text-center` alone, which centers text *inside* a full-width block. Once the inner elements are constrained, the block itself has to be centered too, so the wrapper now takes `mx-auto max-w-2xl`.

  Worth calling out: the obvious shortcut is to put `mx-auto` on the `h1`/`p` inside `Hero`. I tried that and it's wrong — it centers the constrained block on *every* page, indenting the ten left-aligned heroes 216px away from the page's left margin and out of alignment with the sections below them. Centering belongs at the call site that actually wants centering.

### Verification

Checked in the browser against the running landing app at 1280px and 375px:

- Hero and section descriptions now wrap at 672px instead of running to 1152px.
- Left-aligned heroes sit at `left: 88`, flush with the first `h2` below them.
- The centered pricing hero measures dead center (block center 640 = viewport center 640).
- All 11 hero pages pick up the constraint.
- No horizontal overflow at either width (`scrollWidth === clientWidth`); mobile renders at 343px in a 375px viewport, unchanged.
- `pnpm type-check` passes.

Biome reports two findings, both pre-existing in files this PR does not touch (`packages/ui/src/rich-text-editor.tsx` and a `.claude` settings JSON).

## Checklist

Please check off all the following items with an "x" in the boxes before requesting a review.

- [x] I have performed a self-review of my code
- [x] My code follows the code style of this project
- [x] I have commented my code, particularly in hard-to-understand areas

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved heading and description widths across landing page sections for more consistent readability.
  * Centered and constrained the pricing page hero content.
  * Updated homepage hero text wrapping for improved presentation.
  * Expanded the security page hero layout by removing its width constraint.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->