### PR TITLE
📝 Align privacy policy service providers with the DPA subprocessor annex

### DIFF
--- a/apps/landing/src/app/[locale]/(main)/privacy-policy/page.tsx
+++ b/apps/landing/src/app/[locale]/(main)/privacy-policy/page.tsx
@@ -130,9 +130,36 @@ export default async function PrivacyPolicy() {
         </p>
 
         <p>
-          For example, we use Featurebase to make it easy for users to submit
-          feedback. Your name and email may be shared with Featurbase to provide
-          a seamless transition between the two services.
+          We rely on the following service providers to operate rallly.co, each
+          of which may process personal data for the purpose described:
+        </p>
+
+        <ul>
+          <li>Vercel — application hosting (United States)</li>
+          <li>Neon — managed PostgreSQL database (United States)</li>
+          <li>Upstash — session data and rate limiting (United States)</li>
+          <li>
+            Amazon Web Services — transactional email and object storage (United
+            States)
+          </li>
+          <li>
+            Stripe — payment processing, billing contact data only (United
+            States)
+          </li>
+          <li>PostHog — product analytics (European Union)</li>
+          <li>Sentry — error monitoring (United States)</li>
+        </ul>
+
+        <p>
+          The same providers are listed, with transfer mechanisms, in the
+          Sub-processor annex of our{" "}
+          <LinkBase href="/dpa">Data Processing Agreement</LinkBase>.
+        </p>
+
+        <p>
+          We also use Featurebase to make it easy for users to submit feedback.
+          Your name and email may be shared with Featurebase to provide a
+          seamless transition between the two services.
         </p>
 
         <h2>Processing on behalf of organizations</h2>


### PR DESCRIPTION
## Summary

The privacy policy named only Neon, Upstash and PostHog as third-party providers, while the DPA's Sub-processor annex (and the CSA Group vendor questionnaire) name seven. Enterprise security reviewers cross-reference these documents, so the policy now lists the same seven providers with the same processing purposes as the DPA annex:

- Vercel — application hosting
- Neon — managed PostgreSQL database
- Upstash — session data and rate limiting
- Amazon Web Services — transactional email and object storage
- Stripe — payment processing (billing contact data only)
- PostHog — product analytics (EU)
- Sentry — error monitoring

The list lives in the existing "Sharing of personal data" section and links to the DPA annex for transfer mechanisms. The Featurebase paragraph stays (voluntary feedback sharing, deliberately not in the DPA annex) with its "Featurbase" typo fixed.

## Notes

- No i18n impact: both legal pages are hardcoded English with no Trans components or locale keys, so no Crowdin strings are touched.
- `lastUpdated` already reads 2026-09-01 (today) from the recent legal-page restyle, so it correctly covers this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the privacy policy with a list of service providers, processing purposes, and processing locations.
  * Added a link to the DPA sub-processor annex.
  * Clarified and separated the Featurebase disclosure from the provider list.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->