### PR TITLE
♻️ Replace clsx + tailwind-merge with cn

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -32,8 +32,8 @@
     "@tiptap/react": "3.27.3",
     "@tiptap/starter-kit": "3.27.3",
     "class-variance-authority": "^0.7.1",
-    "clsx": "^1.2.1",
     "cmdk": "^1.1.1",
+    "cn": "^0.2.4",
     "date-fns": "^4.4.0",
     "input-otp": "^1.4.2",
     "lucide-react": "^0.479.0",
@@ -48,8 +48,7 @@
     "react-markdown": "^10.1.0",
     "rehype-sanitize": "^6.0.0",
     "remark-breaks": "^4.0.0",
-    "sonner": "^2.0.6",
-    "tailwind-merge": "^3.6.0"
+    "sonner": "^2.0.6"
   },
   "devDependencies": {
     "@rallly/tsconfig": "workspace:*",

--- a/packages/ui/src/lib/utils.ts
+++ b/packages/ui/src/lib/utils.ts
@@ -1,7 +1,1 @@
-import type { ClassValue } from "clsx";
-import clsx from "clsx";
-import { twMerge } from "tailwind-merge";
-
-export function cn(...inputs: ClassValue[]) {
-  return twMerge(clsx(inputs));
-}
+export { cn } from "cn";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -815,12 +815,12 @@ importers:
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
-      clsx:
-        specifier: ^1.2.1
-        version: 1.2.1
       cmdk:
         specifier: ^1.1.1
         version: 1.1.1(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      cn:
+        specifier: ^0.2.4
+        version: 0.2.4
       date-fns:
         specifier: ^4.4.0
         version: 4.4.0
@@ -866,9 +866,6 @@ importers:
       sonner:
         specifier: ^2.0.6
         version: 2.0.7(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      tailwind-merge:
-        specifier: ^3.6.0
-        version: 3.6.0
     devDependencies:
       '@rallly/tsconfig':
         specifier: workspace:*
@@ -7095,10 +7092,6 @@ packages:
     resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
     engines: {node: '>=12'}
 
-  clsx@1.2.1:
-    resolution: {integrity: sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg==}
-    engines: {node: '>=6'}
-
   clsx@2.1.1:
     resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
     engines: {node: '>=6'}
@@ -7108,6 +7101,11 @@ packages:
     peerDependencies:
       react: ^18 || ^19 || ^19.0.0-rc
       react-dom: ^18 || ^19 || ^19.0.0-rc
+
+  cn@0.2.4:
+    resolution: {integrity: sha512-SzQvoh5FwizWtQg9+JueKdjWhlfCZMdu5DqNHm9q1wUlRVmKb9WXlepR9bTTbPwzEOyX1ujJ6lcCppmn3bNUCg==}
+    engines: {node: '>=20'}
+    hasBin: true
 
   code-excerpt@4.0.0:
     resolution: {integrity: sha512-xxodCmBen3iy2i0WtAK8FlFNrRzjUqjRsMfho58xT/wvZU1YTM3fCnRjcy1gJPMepaRlgm/0e6w8SpWHpn3/cA==}
@@ -10992,9 +10990,6 @@ packages:
   tagged-tag@1.0.0:
     resolution: {integrity: sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==}
     engines: {node: '>=20'}
-
-  tailwind-merge@3.6.0:
-    resolution: {integrity: sha512-uxL7qAVQriqRQPAyK3pj66VqskWqoZ37PW94jwOTwNfq/z9oyu1V+eqrZqtR2+fCiXdYOZe/Modt8GtvqNzu+w==}
 
   tailwind-scrollbar@4.0.2:
     resolution: {integrity: sha512-wAQiIxAPqk0MNTPptVe/xoyWi27y+NRGnTwvn4PQnbvB9kp8QUBiGl/wsfoVBHnQxTmhXJSNt9NHTmcz9EivFA==}
@@ -19439,8 +19434,6 @@ snapshots:
       strip-ansi: 6.0.1
       wrap-ansi: 7.0.0
 
-  clsx@1.2.1: {}
-
   clsx@2.1.1: {}
 
   cmdk@1.1.1(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
@@ -19454,6 +19447,8 @@ snapshots:
     transitivePeerDependencies:
       - '@types/react'
       - '@types/react-dom'
+
+  cn@0.2.4: {}
 
   code-excerpt@4.0.0:
     dependencies:
@@ -24540,8 +24535,6 @@ snapshots:
   tabbable@6.4.0: {}
 
   tagged-tag@1.0.0: {}
-
-  tailwind-merge@3.6.0: {}
 
   tailwind-scrollbar@4.0.2(react@19.2.6)(tailwindcss@4.1.18):
     dependencies:


### PR DESCRIPTION
## What

Swaps the `cn()` implementation in `@rallly/ui` from `clsx` + `tailwind-merge` to the [`cn`](https://github.com/shadcn-ui/cn) package from shadcn, which bundles both behind one optimized merge engine with zero runtime dependencies.

- `packages/ui/src/lib/utils.ts` now re-exports `cn` from the package. Every call site imports through `@rallly/ui`, so no component changes.
- `clsx` and `tailwind-merge` are removed from `packages/ui`. No other workspace package depended on either.

## Why

Same API and output, smaller dependency surface, and the shadcn CLI is moving all shadcn projects onto this package.

## Verification

- Differential test against tailwind-merge 3.6.0: every class token used in `packages/ui` and `apps/web` (2,259 tokens) compared across all 5.1M ordered pairs, plus the 78 multi-argument `cn(...)` call sites in the repo. Zero differences.
- Existing `utils.test.ts` edge cases pass (`min-h-svh` vs `min-h-full`, `text-pretty` not treated as a color).
- `pnpm type-check` and `pnpm test:unit` pass across all workspaces.

## Reviewer notes

- The package is pre-1.0 and two days old. The cache is bounded (two-generation, 8,192 entries, same design as tailwind-merge). If a merge bug turns up, reverting is restoring the three-line wrapper and two dependencies.
- `experimentalParseClassName` is the only tailwind-merge feature not supported; we do not use it.
- Did not run `npx shadcn migrate cn`; it would rewrite ~55 imports to pull from the package directly with no behavioral gain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated internal class-name utility handling to use a shared utility package.
  * No user-facing functionality or behavior changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->