### PR TITLE
✨ Add cta param to distinguish landing CTAs in attribution

### DIFF
--- a/apps/landing/src/app/[locale]/(main)/layout.tsx
+++ b/apps/landing/src/app/[locale]/(main)/layout.tsx
@@ -65,7 +65,11 @@ export default async function Root(props: {
               <div className="hidden sm:block">
                 <LoginButton />
               </div>
-              <CtaButton size="default" captureEvent="landing:header_cta_click">
+              <CtaButton
+                size="default"
+                captureEvent="landing:header_cta_click"
+                cta="header"
+              >
                 <Trans
                   t={t}
                   ns="home"

--- a/apps/landing/src/app/[locale]/(main)/mobile-menu.tsx
+++ b/apps/landing/src/app/[locale]/(main)/mobile-menu.tsx
@@ -1,8 +1,10 @@
 "use client";
 
+import { posthog } from "@rallly/posthog/client";
 import { buttonVariants, cn } from "@rallly/ui";
 import { Button } from "@rallly/ui/button";
 import { MenuIcon, XIcon } from "lucide-react";
+import Link from "next/link";
 import { usePathname } from "next/navigation";
 import React from "react";
 import { CtaButton } from "@/components/home/cta-button";
@@ -113,20 +115,30 @@ export const MobileMenu = ({
           ))}
         </nav>
         <div className="flex flex-col gap-3 border-t px-4 py-6 sm:px-6">
-          <LinkBase
-            href={linkToApp("/login", { ref: getRefSlug(pathname) })}
+          <Link
+            href={linkToApp("/login", {
+              ref: getRefSlug(pathname),
+              cta: "mobile_menu_login",
+            })}
             className={buttonVariants({
               variant: "default",
               size: "lg",
               className: "w-full",
             })}
+            onClick={() => {
+              posthog.capture("landing:login_click", {
+                cta: "mobile_menu_login",
+                ref: getRefSlug(pathname),
+              });
+            }}
           >
             {loginLabel}
-          </LinkBase>
+          </Link>
           <CtaButton
             size="lg"
             className="w-full"
             captureEvent="landing:mobile_menu_cta_click"
+            cta="mobile_menu"
           >
             {ctaLabel}
           </CtaButton>

--- a/apps/landing/src/app/[locale]/(main)/pricing/page.tsx
+++ b/apps/landing/src/app/[locale]/(main)/pricing/page.tsx
@@ -164,7 +164,10 @@ export default async function Page(props: {
               </PlanCardPrice>
               <div>
                 <Link
-                  href={linkToApp("/", { ref: "pricing" })}
+                  href={linkToApp("/", {
+                    ref: "pricing",
+                    cta: "pricing_free",
+                  })}
                   className={buttonVariants({
                     className: "w-full",
                   })}
@@ -270,7 +273,10 @@ export default async function Page(props: {
               </PlanCardPrice>
               <div>
                 <Link
-                  href={linkToApp("/settings/billing", { ref: "pricing" })}
+                  href={linkToApp("/settings/billing", {
+                    ref: "pricing",
+                    cta: "pricing_pro",
+                  })}
                   className={buttonVariants({
                     variant: "primary",
                     className: "w-full",
@@ -784,6 +790,7 @@ export default async function Page(props: {
                         className={faqLinkClassName}
                         href={linkToApp("/settings/billing", {
                           ref: "pricing",
+                          cta: "pricing_faq",
                         })}
                       />
                     ),
@@ -812,6 +819,7 @@ export default async function Page(props: {
                         className={faqLinkClassName}
                         href={linkToApp("/settings/billing", {
                           ref: "pricing",
+                          cta: "pricing_faq",
                         })}
                       />
                     ),

--- a/apps/landing/src/components/home/cta-button.tsx
+++ b/apps/landing/src/components/home/cta-button.tsx
@@ -8,11 +8,13 @@ import { useRefSlug } from "@/lib/use-ref-slug";
 
 export function CtaButton({
   captureEvent,
+  cta,
   size = "xl",
   className,
   children,
 }: {
   captureEvent: string;
+  cta: string;
   size?: "default" | "lg" | "xl";
   className?: string;
   children: React.ReactNode;
@@ -20,14 +22,16 @@ export function CtaButton({
   const ref = useRefSlug();
   return (
     <Link
-      href={linkToApp("/new", { ref })}
+      href={linkToApp("/new", { ref, cta })}
       className={buttonVariants({
         size,
         variant: "primary",
         className: cn("shadow-md transition-all active:shadow-none", className),
       })}
       onClick={() => {
-        posthog.capture(captureEvent);
+        // cta is also the link's cta param, so a click here and the signup it
+        // leads to can be joined on one value.
+        posthog.capture(captureEvent, { cta, ref });
       }}
     >
       {children}

--- a/apps/landing/src/components/home/cta.tsx
+++ b/apps/landing/src/components/home/cta.tsx
@@ -26,7 +26,7 @@ export function Cta({
         </p>
       </div>
       <div className="mt-6 flex flex-col items-center gap-4 sm:items-start">
-        <CtaButton size="lg" captureEvent="landing:final_cta_click">
+        <CtaButton size="lg" captureEvent="landing:final_cta_click" cta="final">
           {buttonLabel}
         </CtaButton>
         <p

--- a/apps/landing/src/components/home/hero-demo/vote-actions.tsx
+++ b/apps/landing/src/components/home/hero-demo/vote-actions.tsx
@@ -110,9 +110,12 @@ export const VoteActions = () => {
               className="mt-4"
             >
               <Link
-                href={linkToApp("/new", { ref })}
+                href={linkToApp("/new", { ref, cta: "hero_demo_modal" })}
                 onClick={() => {
-                  posthog?.capture("landing:hero_demo_modal_cta_click");
+                  posthog?.capture("landing:hero_demo_modal_cta_click", {
+                    cta: "hero_demo_modal",
+                    ref,
+                  });
                 }}
                 className="font-medium text-indigo-600 text-xs hover:underline"
               >

--- a/apps/landing/src/components/login-button.tsx
+++ b/apps/landing/src/components/login-button.tsx
@@ -1,17 +1,21 @@
 "use client";
 
+import { posthog } from "@rallly/posthog/client";
 import { buttonVariants } from "@rallly/ui";
 import Link from "next/link";
 import { Trans } from "@/i18n/client/trans";
 import { linkToApp } from "@/lib/linkToApp";
 import { useRefSlug } from "@/lib/use-ref-slug";
 
-export const LoginButton = () => {
+export const LoginButton = ({ cta = "header_login" }: { cta?: string }) => {
   const ref = useRefSlug();
   return (
     <Link
-      href={linkToApp("/login", { ref })}
+      href={linkToApp("/login", { ref, cta })}
       className={buttonVariants({ variant: "ghost" })}
+      onClick={() => {
+        posthog.capture("landing:login_click", { cta, ref });
+      }}
     >
       <Trans i18nKey="login" defaults="Login" />
     </Link>

--- a/apps/landing/src/lib/linkToApp.ts
+++ b/apps/landing/src/lib/linkToApp.ts
@@ -1,7 +1,14 @@
-export const linkToApp = (path = "", options?: { ref?: string }) => {
+export const linkToApp = (
+  path = "",
+  options?: { ref?: string; cta?: string },
+) => {
   const url = new URL(path, process.env.NEXT_PUBLIC_APP_BASE_URL);
   if (options?.ref) {
     url.searchParams.set("ref", options.ref);
+  }
+  // ref says which page the click came from, cta says which button on it.
+  if (options?.cta) {
+    url.searchParams.set("cta", options.cta);
   }
   return url.href;
 };

--- a/apps/web/src/lib/acquisition.test.ts
+++ b/apps/web/src/lib/acquisition.test.ts
@@ -1,0 +1,79 @@
+import { NextRequest, NextResponse } from "next/server";
+import { describe, expect, it } from "vitest";
+
+import {
+  CTA_COOKIE_NAME,
+  parseCtaParam,
+  REF_COOKIE_NAME,
+  setRefCookie,
+} from "./acquisition";
+
+describe("parseCtaParam", () => {
+  it.each([
+    "pricing_free",
+    "pricing_pro",
+    "header",
+    "mobile_menu_login",
+    "a1",
+  ])("accepts cta id %s", (value) => {
+    expect(parseCtaParam(value)).toBe(value);
+  });
+
+  // Visitor-controlled, so anything that isn't a flat snake_case id must be
+  // dropped before it reaches analytics as a property value.
+  it.each([
+    "",
+    "Pricing_Pro",
+    "pricing-pro",
+    "pricing/pro",
+    "_pricing",
+    "pricing pro",
+    "<script>",
+    "a".repeat(65),
+  ])("rejects %s", (value) => {
+    expect(parseCtaParam(value)).toBeUndefined();
+  });
+
+  it("rejects missing values", () => {
+    expect(parseCtaParam(undefined)).toBeUndefined();
+    expect(parseCtaParam(null)).toBeUndefined();
+  });
+});
+
+const setCookies = (url: string) => {
+  const req = new NextRequest(new URL(url));
+  const res = NextResponse.next();
+  setRefCookie(req, res);
+  return res.cookies;
+};
+
+describe("setRefCookie", () => {
+  it("persists both ref and cta", () => {
+    const cookies = setCookies(
+      "https://app.rallly.co/?ref=pricing&cta=pricing_pro",
+    );
+    expect(cookies.get(REF_COOKIE_NAME)?.value).toBe("pricing");
+    expect(cookies.get(CTA_COOKIE_NAME)?.value).toBe("pricing_pro");
+  });
+
+  it("keeps ref but stores no cta when cta is invalid", () => {
+    const cookies = setCookies("https://app.rallly.co/?ref=pricing&cta=NOPE");
+    expect(cookies.get(REF_COOKIE_NAME)?.value).toBe("pricing");
+    // Rejected values take the clear path, so nothing bogus is ever persisted.
+    expect(cookies.get(CTA_COOKIE_NAME)?.value).toBe("");
+  });
+
+  it("ignores cta without a ref", () => {
+    const cookies = setCookies("https://app.rallly.co/?cta=pricing_pro");
+    expect(cookies.getAll()).toHaveLength(0);
+  });
+
+  // A later ref-only click must not inherit the previous click's cta, or the
+  // pair would describe two different visits.
+  it("clears a stale cta when the new ref carries none", () => {
+    const cookies = setCookies("https://app.rallly.co/?ref=home");
+    const cta = cookies.get(CTA_COOKIE_NAME);
+    expect(cta?.value).toBe("");
+    expect(cta?.expires).toEqual(new Date(0));
+  });
+});

--- a/apps/web/src/lib/acquisition.ts
+++ b/apps/web/src/lib/acquisition.ts
@@ -6,11 +6,20 @@ import type { NextRequest, NextResponse } from "next/server";
 // (signup spans redirects and, for OAuth, a round trip to the provider).
 export const REF_COOKIE_NAME = "rallly_ref";
 
+// Which CTA on that page was clicked. Separate from ref so ref keeps meaning
+// exactly one thing (the page) — a page has several CTAs and pricing in
+// particular has both a free and a paid one, which ref alone cannot tell apart.
+export const CTA_COOKIE_NAME = "rallly_cta";
+
 const REF_COOKIE_MAX_AGE = 60 * 60 * 24 * 30;
 
 // Page slugs only (e.g. "home", "blog/is-doodle-still-free") — the param is
 // visitor-controlled, so reject anything else before it reaches analytics.
 const REF_PATTERN = /^[a-z0-9][a-z0-9/_-]{0,63}$/;
+
+// CTA ids are flat snake_case (e.g. "pricing_pro", "header") — no slashes, so
+// they can never be confused with a page slug.
+const CTA_PATTERN = /^[a-z0-9][a-z0-9_]{0,63}$/;
 
 export function parseRefParam(value: string | null | undefined) {
   if (!value || !REF_PATTERN.test(value)) {
@@ -19,16 +28,41 @@ export function parseRefParam(value: string | null | undefined) {
   return value;
 }
 
-export function setRefCookie(req: NextRequest, res: NextResponse) {
-  const ref = parseRefParam(req.nextUrl.searchParams.get("ref"));
-  if (!ref) {
-    return;
+export function parseCtaParam(value: string | null | undefined) {
+  if (!value || !CTA_PATTERN.test(value)) {
+    return undefined;
   }
-  res.cookies.set(REF_COOKIE_NAME, ref, {
+  return value;
+}
+
+function setAcquisitionCookie(
+  req: NextRequest,
+  res: NextResponse,
+  name: string,
+  value: string,
+) {
+  res.cookies.set(name, value, {
     httpOnly: true,
     sameSite: "lax",
     path: "/",
     secure: req.nextUrl.protocol === "https:",
     maxAge: REF_COOKIE_MAX_AGE,
   });
+}
+
+export function setRefCookie(req: NextRequest, res: NextResponse) {
+  const ref = parseRefParam(req.nextUrl.searchParams.get("ref"));
+  if (!ref) {
+    return;
+  }
+  setAcquisitionCookie(req, res, REF_COOKIE_NAME, ref);
+
+  // Always rewritten alongside ref so the pair describes one click: a later
+  // ref without a cta must clear the previous cta rather than inherit it.
+  const cta = parseCtaParam(req.nextUrl.searchParams.get("cta"));
+  if (cta) {
+    setAcquisitionCookie(req, res, CTA_COOKIE_NAME, cta);
+  } else {
+    res.cookies.delete(CTA_COOKIE_NAME);
+  }
 }

--- a/apps/web/src/lib/auth.ts
+++ b/apps/web/src/lib/auth.ts
@@ -31,7 +31,12 @@ import type { UserDTO } from "@/features/user/schema";
 import { jobTitleFieldSchema } from "@/features/user/schema";
 import { getTranslation } from "@/i18n/server";
 import { getLocale } from "@/i18n/server/get-locale";
-import { parseRefParam, REF_COOKIE_NAME } from "@/lib/acquisition";
+import {
+  CTA_COOKIE_NAME,
+  parseCtaParam,
+  parseRefParam,
+  REF_COOKIE_NAME,
+} from "@/lib/acquisition";
 import { SESSION_TTL_SECONDS } from "@/lib/auth-config";
 import { hostOnlyCookieCleanup } from "@/lib/auth-plugins/host-only-cookie-cleanup";
 import { redis } from "@/lib/kv";
@@ -485,6 +490,7 @@ export const authLib = betterAuth({
             return;
           }
           const ref = parseRefParam(ctx?.getCookie(REF_COOKIE_NAME));
+          const cta = parseCtaParam(ctx?.getCookie(CTA_COOKIE_NAME));
           // No space is created here — /setup owns space creation, and the
           // active-space gate keeps redirecting there until it happens.
           track(
@@ -494,6 +500,7 @@ export const authLib = betterAuth({
               properties: {
                 method: user.lastLoginMethod,
                 ref,
+                cta,
                 $set: {
                   name: user.name,
                   email: user.email,
@@ -501,7 +508,12 @@ export const authLib = betterAuth({
                   timeZone: user.timeZone ?? undefined,
                   locale: user.locale ?? undefined,
                 },
-                ...(ref && { $set_once: { initial_ref: ref } }),
+                ...((ref || cta) && {
+                  $set_once: {
+                    ...(ref && { initial_ref: ref }),
+                    ...(cta && { initial_cta: cta }),
+                  },
+                }),
               },
             },
           );


### PR DESCRIPTION
## Problem

The pricing page's **Get started** (free) and **Get Pro** buttons both sent `ref=pricing`, so buyers who clicked Get Pro were indistinguishable from those who clicked the free button. Only 6 of 100 pricing signups ever reached billing settings, and there was no way to tell how many had asked for Pro at all.

The landing app also had two login entry points (header and mobile menu) that fired no click event whatsoever, making returning users invisible.

## Approach: a new `cta` param, not a split `ref`

I deliberately did **not** split `ref` into `pricing_free`/`pricing_pro`. `ref` is documented in two places as *the originating page slug* ([`ref-slug.ts`](../blob/main/apps/landing/src/lib/ref-slug.ts), [`acquisition.ts`](../blob/main/apps/web/src/lib/acquisition.ts)) and is persisted per-person as `initial_ref` via `$set_once`. Overloading it with button identity would have:

- made `initial_ref` mean two different things depending on which page the visitor landed on, and
- silently broken the existing pricing-cohort funnel, which keys on `ref = "pricing"` — splitting the value invalidates that series at the cut-over date.

Adding a separate `cta` dimension keeps every existing insight continuous while giving the button breakdown.

| Button | URL |
| --- | --- |
| Get started (free) | `?ref=pricing&cta=pricing_free` |
| Get Pro | `?ref=pricing&cta=pricing_pro` |
| FAQ billing links | `?ref=pricing&cta=pricing_faq` |

Two FAQ answers also link to billing settings. They get their own id so in-answer clicks don't inflate the Pro button's numbers — that alone may explain part of the 6-of-100.

## What changed

**App (`apps/web`)**
- `lib/acquisition.ts`: `parseCtaParam` + `CTA_COOKIE_NAME`; the proxy persists `cta` in `rallly_cta` alongside `rallly_ref`.
- `lib/auth.ts`: the `register` event now carries `cta`, plus `initial_cta` via `$set_once`, mirroring `initial_ref`.
- `lib/acquisition.test.ts`: 18 new tests covering the parser and cookie semantics.

**Landing (`apps/landing`)**
- `linkToApp` accepts an optional `cta`.
- Pricing CTAs and FAQ links carry distinct `cta` ids.
- `CtaButton` takes a `cta` id, puts it on both the link and the click event.
- Both login entry points now fire `landing:login_click`.
- Hero-demo modal CTA carries a `cta` id.

## Reviewer notes

- **Event names are unchanged.** `CtaButton` already fired events for the header, mobile menu and final CTA, so the original "no CTA click events outside the hero demo" framing was slightly off — the real gap was the login buttons. I added `cta` as a *property* rather than renaming events, because those insight definitions live in the PostHog dashboard, not in this repo, and renaming would break them silently. The nine pages sharing `landing:final_cta_click` were already separable by `$current_url` (`autocapture: false`, no property denylist).
- **Stale-value handling.** `cta` is only written alongside `ref`, and a later `ref`-only click *clears* any previous `cta`. Without this, a `pricing_pro` click weeks earlier would be misattributed to a later homepage signup.
- **Input validation.** `cta` is visitor-controlled and flows into analytics, so `parseCtaParam` enforces `/^[a-z0-9][a-z0-9_]{0,63}$/`. No slashes, so a `cta` can never be confused with a page slug. Invalid values take the clear path rather than being persisted.
- **`initial_cta` only backfills going forward** — existing users have no value, so cohort comparisons need a start date at deploy.
- **One incidental fix:** the mobile-menu login button moved from `LinkBase` to `Link`. `LinkBase` prefixes the locale (already a no-op for absolute app URLs) and doesn't accept `onClick`; plain `Link` is what the other app-bound CTAs use. `LinkBase` is still used for the relative in-site nav links.

## Verification

- `pnpm type-check` — 8/8 tasks pass
- `pnpm test:unit` — 587 pass (50 files), including the 18 new
- `pnpm check` — clean on all touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Landing-page links now include CTA tracking information for sign-ups and logins.
  * Login interactions are tracked with their originating CTA and referral details.
  * Registration analytics now record the initial CTA alongside referral information.

* **Bug Fixes**
  * Invalid or incomplete CTA values are rejected and stale CTA tracking is cleared when appropriate.

* **Tests**
  * Added coverage for CTA validation, cookie persistence, and cleanup behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->