### PR TITLE
🐛 Gate space branding and attribution removal on the resolved tier

### DIFF
--- a/apps/web/src/app/[locale]/(optional-space)/new/page.tsx
+++ b/apps/web/src/app/[locale]/(optional-space)/new/page.tsx
@@ -14,6 +14,7 @@ import { BrandStyle } from "@/features/branding/components/brand-style";
 import { loadInstancePolicy } from "@/features/instance-policy/loaders";
 import { CreatePoll } from "@/features/poll/components/create-poll";
 import { getActiveSpaceForUser } from "@/features/space/data";
+import { isSpaceBrandingActive } from "@/features/space/utils";
 import { Trans } from "@/i18n/client";
 import { getTranslation } from "@/i18n/server";
 import { getSession } from "@/lib/auth";
@@ -30,9 +31,11 @@ export default async function Page() {
   }
 
   const primaryColor =
-    space?.showBranding &&
-    space.primaryColor &&
-    (await loadInstancePolicy()).spaceBrandingAllowed
+    space?.primaryColor &&
+    isSpaceBrandingActive({
+      ...space,
+      spaceBrandingAllowed: (await loadInstancePolicy()).spaceBrandingAllowed,
+    })
       ? space.primaryColor
       : null;
 

--- a/apps/web/src/emails/branding.ts
+++ b/apps/web/src/emails/branding.ts
@@ -3,7 +3,10 @@ import type { EmailBranding } from "@rallly/emails";
 import { getInstanceBrandingConfig } from "@/features/branding/data";
 import { getInstancePolicy } from "@/features/instance-policy/data";
 import type { SpaceTier } from "@/features/space/schema";
-import { isSpaceBrandingActive } from "@/features/space/utils";
+import {
+  isSpaceAttributionHidden,
+  isSpaceBrandingActive,
+} from "@/features/space/utils";
 import { resolveStorageUrl } from "@/lib/storage/resolve-storage-url";
 
 /**
@@ -39,7 +42,7 @@ export async function getSpaceBranding(space: {
     // reflected in the instance branding
     hideAttribution:
       instance.hideAttribution ||
-      (spaceAttributionConfigurable && space.hideAttribution),
+      isSpaceAttributionHidden({ ...space, spaceAttributionConfigurable }),
     ...(isSpaceBrandingActive({ ...space, spaceBrandingAllowed })
       ? {
           primaryColor: space.primaryColor ?? instance.primaryColor,

--- a/apps/web/src/emails/branding.ts
+++ b/apps/web/src/emails/branding.ts
@@ -2,6 +2,8 @@ import type { EmailBranding } from "@rallly/emails";
 
 import { getInstanceBrandingConfig } from "@/features/branding/data";
 import { getInstancePolicy } from "@/features/instance-policy/data";
+import type { SpaceTier } from "@/features/space/schema";
+import { isSpaceBrandingActive } from "@/features/space/utils";
 import { resolveStorageUrl } from "@/lib/storage/resolve-storage-url";
 
 /**
@@ -23,6 +25,7 @@ export async function getInstanceBranding(): Promise<EmailBranding> {
  * space's logo/color applied when the space has custom branding enabled.
  */
 export async function getSpaceBranding(space: {
+  tier: SpaceTier;
   showBranding: boolean;
   hideAttribution: boolean;
   primaryColor: string | null;
@@ -37,7 +40,7 @@ export async function getSpaceBranding(space: {
     hideAttribution:
       instance.hideAttribution ||
       (spaceAttributionConfigurable && space.hideAttribution),
-    ...(space.showBranding && spaceBrandingAllowed
+    ...(isSpaceBrandingActive({ ...space, spaceBrandingAllowed })
       ? {
           primaryColor: space.primaryColor ?? instance.primaryColor,
           logoUrl: space.image

--- a/apps/web/src/features/scheduled-event/data.ts
+++ b/apps/web/src/features/scheduled-event/data.ts
@@ -87,6 +87,7 @@ export function getScheduledEventRsvpEmailData(eventId: string) {
       user: { select: { name: true, email: true } },
       space: {
         select: {
+          tier: true,
           showBranding: true,
           hideAttribution: true,
           primaryColor: true,

--- a/apps/web/src/features/space/client.tsx
+++ b/apps/web/src/features/space/client.tsx
@@ -5,6 +5,7 @@ import { getPrimaryColorVars } from "@/features/branding/utils";
 import { useInstancePolicy } from "@/features/instance-policy/client";
 import { defineAbilityForMember } from "@/features/space/member/ability";
 import type { SpaceDTO } from "@/features/space/types";
+import { isSpaceBrandingActive } from "@/features/space/utils";
 import { useAuthedUser } from "@/features/user/client";
 import { defineAbilityForSpace } from "./ability";
 
@@ -46,7 +47,8 @@ export function SpaceProvider({
   const { spaceBrandingAllowed } = useInstancePolicy();
 
   const primaryColorVars =
-    spaceBrandingAllowed && space.showBranding && space.primaryColor
+    isSpaceBrandingActive({ ...space, spaceBrandingAllowed }) &&
+    space.primaryColor
       ? getPrimaryColorVars(space.primaryColor)
       : null;
 

--- a/apps/web/src/features/space/data.ts
+++ b/apps/web/src/features/space/data.ts
@@ -12,7 +12,11 @@ import { cached_getInstanceLicense } from "@/features/licensing/data";
 import type { LicenseType } from "@/features/licensing/schema";
 import type { MemberDTO } from "@/features/space/member/types";
 import { effectiveSpaceMemberWhere } from "@/features/space/member/utils";
-import { createSpaceDTO, fromDBRole } from "@/features/space/utils";
+import {
+  createSpaceDTO,
+  fromDBRole,
+  isSpaceBrandingActive,
+} from "@/features/space/utils";
 import { AppError } from "@/lib/errors/app-error";
 
 const logger = createLogger("space/data");
@@ -171,6 +175,7 @@ export async function getSpaceBranding(spaceId: string) {
     select: {
       name: true,
       image: true,
+      tier: true,
       showBranding: true,
       primaryColor: true,
     },
@@ -182,7 +187,7 @@ export async function getSpaceBranding(spaceId: string) {
 
   const { spaceBrandingAllowed } = await getInstancePolicy();
 
-  if (!spaceBrandingAllowed) {
+  if (!isSpaceBrandingActive({ ...space, spaceBrandingAllowed })) {
     return { ...space, showBranding: false, primaryColor: null };
   }
 

--- a/apps/web/src/features/space/utils.test.ts
+++ b/apps/web/src/features/space/utils.test.ts
@@ -4,6 +4,7 @@ import {
   createSpaceContentScope,
   createSpaceDTO,
   inferIndustry,
+  isSpaceAttributionHidden,
   isSpaceBrandingActive,
 } from "@/features/space/utils";
 
@@ -66,6 +67,48 @@ describe("isSpaceBrandingActive", () => {
         tier: "pro",
         showBranding: true,
         spaceBrandingAllowed: false,
+      }),
+    ).toBe(false);
+  });
+});
+
+describe("isSpaceAttributionHidden", () => {
+  it("hides attribution for a pro space that turned it on", () => {
+    expect(
+      isSpaceAttributionHidden({
+        tier: "pro",
+        hideAttribution: true,
+        spaceAttributionConfigurable: true,
+      }),
+    ).toBe(true);
+  });
+
+  it("ignores the stored setting once the space is on hobby", () => {
+    expect(
+      isSpaceAttributionHidden({
+        tier: "hobby",
+        hideAttribution: true,
+        spaceAttributionConfigurable: true,
+      }),
+    ).toBe(false);
+  });
+
+  it("respects the switch being off", () => {
+    expect(
+      isSpaceAttributionHidden({
+        tier: "pro",
+        hideAttribution: false,
+        spaceAttributionConfigurable: true,
+      }),
+    ).toBe(false);
+  });
+
+  it("defers to instance policy", () => {
+    expect(
+      isSpaceAttributionHidden({
+        tier: "pro",
+        hideAttribution: true,
+        spaceAttributionConfigurable: false,
       }),
     ).toBe(false);
   });

--- a/apps/web/src/features/space/utils.test.ts
+++ b/apps/web/src/features/space/utils.test.ts
@@ -4,6 +4,7 @@ import {
   createSpaceContentScope,
   createSpaceDTO,
   inferIndustry,
+  isSpaceBrandingActive,
 } from "@/features/space/utils";
 
 const spaceId = "space-1" as AuthorizedSpaceId;
@@ -25,6 +26,48 @@ describe("createSpaceContentScope", () => {
         userId: "user-1",
       }),
     ).toEqual({ spaceId, createdBy: "user-1" });
+  });
+});
+
+describe("isSpaceBrandingActive", () => {
+  it("applies branding for a pro space that turned it on", () => {
+    expect(
+      isSpaceBrandingActive({
+        tier: "pro",
+        showBranding: true,
+        spaceBrandingAllowed: true,
+      }),
+    ).toBe(true);
+  });
+
+  it("ignores a stored colour once the space is on hobby", () => {
+    expect(
+      isSpaceBrandingActive({
+        tier: "hobby",
+        showBranding: true,
+        spaceBrandingAllowed: true,
+      }),
+    ).toBe(false);
+  });
+
+  it("respects the switch being off", () => {
+    expect(
+      isSpaceBrandingActive({
+        tier: "pro",
+        showBranding: false,
+        spaceBrandingAllowed: true,
+      }),
+    ).toBe(false);
+  });
+
+  it("defers to instance policy", () => {
+    expect(
+      isSpaceBrandingActive({
+        tier: "pro",
+        showBranding: true,
+        spaceBrandingAllowed: false,
+      }),
+    ).toBe(false);
   });
 });
 

--- a/apps/web/src/features/space/utils.ts
+++ b/apps/web/src/features/space/utils.ts
@@ -95,6 +95,27 @@ export function isSpaceBrandingActive({
 }
 
 /**
+ * Whether the "Powered by" credit is dropped from a space's polls and emails.
+ * Same shape as branding: paid, and the stored setting survives a downgrade
+ * without taking effect until the space is pro again.
+ */
+export function isSpaceAttributionHidden({
+  tier,
+  hideAttribution,
+  spaceAttributionConfigurable,
+}: {
+  tier: SpaceTier;
+  hideAttribution: boolean;
+  spaceAttributionConfigurable: boolean;
+}) {
+  return (
+    spaceAttributionConfigurable &&
+    hideAttribution &&
+    resolveSpaceTier(tier) === "pro"
+  );
+}
+
+/**
  * The visibility scope space-scoped content reads must apply for this
  * member. One rule for all content types and all roles: in an unshared
  * space, reads are restricted to what the member created themselves —

--- a/apps/web/src/features/space/utils.ts
+++ b/apps/web/src/features/space/utils.ts
@@ -9,7 +9,7 @@ import {
   industryDomainRules,
   industryKeywordRules,
 } from "@/features/space/constants";
-import type { MemberRole } from "@/features/space/schema";
+import type { MemberRole, SpaceTier } from "@/features/space/schema";
 import type {
   AuthorizedSpaceId,
   SpaceContentScope,
@@ -71,6 +71,27 @@ export function createSpaceDTO({
     showBranding: space.showBranding,
     hideAttribution: space.hideAttribution,
   };
+}
+
+/**
+ * Whether a space's stored colour and logo are applied wherever the space is
+ * shown (app chrome, poll pages, emails). Custom branding is a paid feature:
+ * the setting may stay on after a downgrade so it comes back on upgrade, but
+ * the stored values must not render until then. Accepts the stored tier;
+ * resolving is idempotent, so an already resolved DTO tier is fine too.
+ */
+export function isSpaceBrandingActive({
+  tier,
+  showBranding,
+  spaceBrandingAllowed,
+}: {
+  tier: SpaceTier;
+  showBranding: boolean;
+  spaceBrandingAllowed: boolean;
+}) {
+  return (
+    spaceBrandingAllowed && showBranding && resolveSpaceTier(tier) === "pro"
+  );
 }
 
 /**

--- a/apps/web/src/trpc/routers/polls.ts
+++ b/apps/web/src/trpc/routers/polls.ts
@@ -19,7 +19,10 @@ import {
 import { MAX_POLL_DESCRIPTION_LENGTH } from "@/features/poll/schema";
 import { formatEventDateTime } from "@/features/scheduled-event/utils";
 import { getActiveSpaceForUser } from "@/features/space/data";
-import { isSpaceBrandingActive } from "@/features/space/utils";
+import {
+  isSpaceAttributionHidden,
+  isSpaceBrandingActive,
+} from "@/features/space/utils";
 import { dayjs } from "@/lib/dayjs";
 import { identifyGroup, track } from "@/lib/posthog";
 import { createIcsEvent } from "@/lib/utils/ics";
@@ -825,8 +828,10 @@ export const polls = router({
               ...res.space,
               showBranding: brandingActive,
               primaryColor: brandingActive ? res.space.primaryColor : null,
-              hideAttribution:
-                spaceAttributionConfigurable && res.space.hideAttribution,
+              hideAttribution: isSpaceAttributionHidden({
+                ...res.space,
+                spaceAttributionConfigurable,
+              }),
             }
           : null,
         canManage,

--- a/apps/web/src/trpc/routers/polls.ts
+++ b/apps/web/src/trpc/routers/polls.ts
@@ -19,6 +19,7 @@ import {
 import { MAX_POLL_DESCRIPTION_LENGTH } from "@/features/poll/schema";
 import { formatEventDateTime } from "@/features/scheduled-event/utils";
 import { getActiveSpaceForUser } from "@/features/space/data";
+import { isSpaceBrandingActive } from "@/features/space/utils";
 import { dayjs } from "@/lib/dayjs";
 import { identifyGroup, track } from "@/lib/posthog";
 import { createIcsEvent } from "@/lib/utils/ics";
@@ -813,16 +814,17 @@ export const polls = router({
 
       const { spaceBrandingAllowed, spaceAttributionConfigurable } =
         await getInstancePolicy();
+      const brandingActive = res.space
+        ? isSpaceBrandingActive({ ...res.space, spaceBrandingAllowed })
+        : false;
 
       return {
         ...res,
         space: res.space
           ? {
               ...res.space,
-              showBranding: res.space.showBranding && spaceBrandingAllowed,
-              primaryColor: spaceBrandingAllowed
-                ? res.space.primaryColor
-                : null,
+              showBranding: brandingActive,
+              primaryColor: brandingActive ? res.space.primaryColor : null,
               hideAttribution:
                 spaceAttributionConfigurable && res.space.hideAttribution,
             }
@@ -865,6 +867,7 @@ export const polls = router({
           hideParticipants: true,
           space: {
             select: {
+              tier: true,
               showBranding: true,
               hideAttribution: true,
               primaryColor: true,

--- a/apps/web/tests/space-branding.spec.ts
+++ b/apps/web/tests/space-branding.spec.ts
@@ -1,0 +1,71 @@
+import type { Page } from "@playwright/test";
+import { expect, test } from "@playwright/test";
+import { prisma } from "@rallly/database";
+import { createTestPoll, createUserInDb } from "./test-utils";
+
+const HOST_EMAIL = "space-branding-host@rallly.co";
+const POLL_ID = "space-branding-poll";
+const STORED_COLOR = "#dc2626";
+
+async function readPrimaryVar(page: Page) {
+  await page.goto(`/invite/${POLL_ID}`);
+  await expect(
+    page.getByRole("heading", { name: "Space branding poll" }),
+  ).toBeVisible();
+  return page.evaluate(() =>
+    getComputedStyle(document.documentElement).getPropertyValue("--primary"),
+  );
+}
+
+test.describe("space branding on the invite page", () => {
+  let spaceId: string;
+  let defaultPrimary: string;
+
+  test.beforeAll(async ({ browser }) => {
+    await prisma.user.deleteMany({ where: { email: HOST_EMAIL } });
+    const host = await createUserInDb({
+      email: HOST_EMAIL,
+      name: "Space branding host",
+    });
+    const space = await prisma.space.findFirstOrThrow({
+      where: { ownerId: host.id },
+    });
+    spaceId = space.id;
+    await createTestPoll({
+      id: POLL_ID,
+      title: "Space branding poll",
+      userId: host.id,
+      spaceId,
+      updatedAt: new Date(),
+      hasFutureOptions: true,
+    });
+
+    const page = await browser.newPage();
+    defaultPrimary = await readPrimaryVar(page);
+    await page.close();
+  });
+
+  test.afterAll(async () => {
+    await prisma.user.deleteMany({ where: { email: HOST_EMAIL } });
+  });
+
+  test("pro space with branding on renders its colour", async ({ page }) => {
+    await prisma.space.update({
+      where: { id: spaceId },
+      data: { tier: "pro", showBranding: true, primaryColor: STORED_COLOR },
+    });
+
+    expect(await readPrimaryVar(page)).not.toBe(defaultPrimary);
+  });
+
+  test("hobby space with a stored colour renders the default primary", async ({
+    page,
+  }) => {
+    await prisma.space.update({
+      where: { id: spaceId },
+      data: { tier: "hobby", showBranding: true, primaryColor: STORED_COLOR },
+    });
+
+    expect(await readPrimaryVar(page)).toBe(defaultPrimary);
+  });
+});

--- a/apps/web/tests/space-branding.spec.ts
+++ b/apps/web/tests/space-branding.spec.ts
@@ -68,4 +68,28 @@ test.describe("space branding on the invite page", () => {
 
     expect(await readPrimaryVar(page)).toBe(defaultPrimary);
   });
+
+  test("pro space with attribution removed hides the footer credit", async ({
+    page,
+  }) => {
+    await prisma.space.update({
+      where: { id: spaceId },
+      data: { tier: "pro", hideAttribution: true },
+    });
+
+    await readPrimaryVar(page);
+    await expect(page.getByText("Powered by")).toBeHidden();
+  });
+
+  test("hobby space with attribution removed still shows the footer credit", async ({
+    page,
+  }) => {
+    await prisma.space.update({
+      where: { id: spaceId },
+      data: { tier: "hobby", hideAttribution: true },
+    });
+
+    await readPrimaryVar(page);
+    await expect(page.getByText("Powered by")).toBeVisible();
+  });
 });


### PR DESCRIPTION
## Description

Custom branding (primary colour, logo) and attribution removal are Pro features, pay-walled in space settings, but none of the display paths checked the tier. A space that stored a colour or hid the credit while Pro, or while the instance ran self-hosted (where `resolveSpaceTier` returns `pro` for everyone), kept rendering it after dropping to hobby.

Reproduced with a hobby space holding `show_branding=true, primary_color=#dc2626`: the poll admin page and invite page rendered red.

### What changed

Each rule now lives in one pure helper in `features/space/utils.ts`, with unit tests:

- `isSpaceBrandingActive({ tier, showBranding, spaceBrandingAllowed })`
- `isSpaceAttributionHidden({ tier, hideAttribution, spaceAttributionConfigurable })`

Both call `resolveSpaceTier` internally (idempotent, so raw row tiers and resolved DTO tiers are both fine) and never key on `isSelfHosted`.

Every read path uses them:

- `polls.get` in the tRPC router masks `showBranding`, `primaryColor` and `hideAttribution` on the wire. This covers the poll admin page, the invite page, the event card and the poll footer without touching those components.
- `SpaceProvider` (app chrome) and the new poll page.
- `getSpaceBranding` in `features/space/data.ts` now selects `tier` and applies the rule, which covers the scheduled event page.
- Email branding requires `tier` on its input and applies both rules. The `book` select and the scheduled event read now include `tier`; the participant router already did.

The stored settings are untouched: turning a setting off is always allowed, and it comes back on upgrade.

### Tests

- Eight unit cases on the two helpers in `features/space/utils.test.ts`.
- New `tests/space-branding.spec.ts` seeds a poll and checks the invite page: a pro space renders its stored colour and hides the credit, a hobby space with the same stored values renders the default primary and shows the credit. All four cases were watched failing before the fix.

## Checklist

- [x] I have performed a self-review of my code
- [x] My code follows the code style of this project
- [x] I have commented my code, particularly in hard-to-understand areas

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Space branding now consistently follows the space’s tier and instance settings.
  * Pro spaces can display custom colors and branding, while hobby spaces use default styling.
  * Attribution hiding is now limited to eligible spaces and configuration settings.
  * Branding behavior is applied consistently across poll pages, invite pages, and RSVP emails.

* **Tests**
  * Added coverage for branding colors, tier-based behavior, and attribution visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->