### PR TITLE
🐛 Flush PostHog events after every server action

### DIFF
--- a/apps/web/src/app/[locale]/(space)/settings/profile/actions.ts
+++ b/apps/web/src/app/[locale]/(space)/settings/profile/actions.ts
@@ -17,12 +17,7 @@ import { getLocale } from "@/i18n/server/get-locale";
 import { isSelfHosted } from "@/lib/constants";
 import { formatDateTime } from "@/lib/datetime/format";
 import { AppError } from "@/lib/errors/app-error";
-import {
-  deletePostHogPerson,
-  flushPostHog,
-  track,
-  trackSystemEvent,
-} from "@/lib/posthog";
+import { deletePostHogPerson, track, trackSystemEvent } from "@/lib/posthog";
 import {
   authActionClient,
   createRateLimitMiddleware,
@@ -118,7 +113,6 @@ export const deleteAccountAction = authActionClient
 
     // Personless by design — the person this event is about was just erased.
     trackSystemEvent({ event: "account_deletion_complete" });
-    after(() => flushPostHog());
   });
 
 export const cancelAccountDeletionAction = authActionClient

--- a/apps/web/src/lib/safe-action/server.ts
+++ b/apps/web/src/lib/safe-action/server.ts
@@ -2,6 +2,7 @@ import "server-only";
 
 import * as Sentry from "@sentry/nextjs";
 import { APIError } from "better-auth/api";
+import { after } from "next/server";
 import { createMiddleware, createSafeActionClient } from "next-safe-action";
 import * as z from "zod";
 import { defineAbilityFor } from "@/features/user/ability";
@@ -10,6 +11,7 @@ import { signOut } from "@/lib/auth";
 import { AppError } from "@/lib/errors/app-error";
 import { InvalidSessionError } from "@/lib/errors/invalid-session-error";
 import { assertAppAvailable } from "@/lib/maintenance-server";
+import { flushPostHog } from "@/lib/posthog";
 import type { Duration } from "@/lib/rate-limit";
 import { createRatelimit } from "@/lib/rate-limit";
 
@@ -95,10 +97,22 @@ export const actionClient = createSafeActionClient({
 
     return "INTERNAL_SERVER_ERROR" as const;
   },
-}).use(async ({ next }) => {
-  await assertAppAvailable();
-  return next();
-});
+})
+  // The PostHog client only enqueues; a serverless function freezes once the
+  // action response is sent, so the buffer must be flushed here. Route
+  // handlers get the same through withPostHog. Runs in finally so a failed
+  // action's events still flush.
+  .use(async ({ next }) => {
+    try {
+      return await next();
+    } finally {
+      after(() => flushPostHog());
+    }
+  })
+  .use(async ({ next }) => {
+    await assertAppAvailable();
+    return next();
+  });
 
 export const authActionClient = actionClient.use(async ({ next }) => {
   const user = await getCurrentUser();


### PR DESCRIPTION
## Problem

Server-side PostHog events captured inside server actions never reliably reach PostHog in production.

`apps/web/src/lib/posthog.ts` holds a module-level posthog-node client configured with `flushAt: 20` and `flushInterval: 10000`. `track()`, `trackSystemEvent()` and `identifyGroup()` only enqueue. Route handlers are wrapped in `withPostHog`, which schedules `after(() => ph.flush())`, so tRPC, Better-Auth, the private API, the Stripe webhook and house-keeping all drain the buffer before the function freezes.

Server actions had no equivalent. `actionClient` and `authActionClient` in `apps/web/src/lib/safe-action/server.ts` carried no PostHog middleware. On Vercel the function freezes as soon as the action response is sent, so buffered events only reached PostHog if a later route-handler request happened to land on the same warm instance and flushed them as a side effect. The one action that flushed did it by hand (`deleteAccountAction`).

## Fix

- Add a middleware to the base `actionClient` that runs the action and registers `after(() => flushPostHog())` in a `finally` block. Every client (`authActionClient`, `adminActionClient`) derives from `actionClient`, so every action is covered, including ones that throw.
- Remove the hand-written `after(() => flushPostHog())` from `deleteAccountAction`. It ran after `trackSystemEvent` inside the action body, which the middleware now covers.

`after()` is a request-scoped API and the next-safe-action middleware executes inside the server action invocation, so it is in scope (Next 16.3.3).

## Events affected

Every `track()` / `trackSystemEvent()` call inside a safe-action client:

- `poll_share:invite_send`
- `billing:checkout_start`
- `developer:api_key_create`, `developer:api_key_revoke`
- `space_create`, `space_delete`, `space_setup`, `space_update`, `space_update_shared`, `space_update_show_branding`, `space_update_hide_attribution`, `space_set_active`, `space:industry_set`
- `space_member_invite`, `space_member_join`, `space_member_remove`
- `notification_preference_update`
- `password_set`
- `account_deletion_schedule`, `account_deletion_cancel`, `account_deletion_complete`

## Verification

- `pnpm --filter @rallly/web type-check` passes.
- `pnpm check` is clean on the touched files. The two remaining findings (a git-ignored `.claude/settings.local.json` and an unused suppression in `packages/ui/src/rich-text-editor.tsx`) pre-date this change.
- No unit test: mocking posthog-node plus `after()` would test the mock. Coverage is structural: the middleware sits on the base client that all other clients extend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability of usage and activity tracking by ensuring pending analytics events are sent after server actions complete.
  - Analytics events are now flushed even when an action encounters an error.
  - Account deletion continues to remove the account and record completion events without changing the user-facing deletion flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->