### PR TITLE
🐛 Skip drawing the perimeter when the canvas has no size

### DIFF
--- a/apps/landing/src/components/home/perimeter.tsx
+++ b/apps/landing/src/components/home/perimeter.tsx
@@ -93,6 +93,11 @@ export function Perimeter({ className }: { className?: string }) {
     };
 
     const draw = (now: number, dt: number, animate: boolean) => {
+      // A hidden canvas measures 0x0, which would make the grid step 0 and
+      // the loops below never terminate.
+      if (width <= 0 || height <= 0) {
+        return;
+      }
       const radius = height / 2;
       const cx = width / 2;
       const cy = height / 2;


### PR DESCRIPTION
## What

Follow-up to #3174. Guards the perimeter's `draw` against a zero-sized canvas.

## Why

Below the `lg` breakpoint the visual's wrapper is `display: none`, so the canvas measures 0×0 and the grid step works out to 0. The animated path was safe because the intersection observer never reports a hidden canvas as visible, but the reduced motion path draws straight from `render` and from the resize observer, so a phone with reduced motion enabled looped forever in the grid loop and froze the page.

## Verification

Headless Chromium, checking the page stays responsive and whether the canvas painted:

| Viewport | Reduced motion | Result |
| -- | -- | -- |
| 390 | on | responsive, nothing painted |
| 1440 | on | responsive, still frame painted |
| 1440 | off | responsive, animated frame painted |

Lint and the landing type check pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented the perimeter visualization from becoming unresponsive when its display area has zero width or height.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->