### PR TITLE
✨ Add a contents index to the legal page sidebar

### DIFF
--- a/apps/landing/src/app/[locale]/globals.css
+++ b/apps/landing/src/app/[locale]/globals.css
@@ -15,7 +15,7 @@ body {
     @apply mb-4 mt-8;
   }
   h2 {
-    @apply text-2xl font-medium tracking-tight text-gray-800;
+    @apply scroll-mt-24 text-2xl font-medium tracking-tight text-gray-800;
   }
   h3 {
     @apply text-xl font-medium tracking-tight text-gray-800;

--- a/apps/landing/src/components/legal-page-index.tsx
+++ b/apps/landing/src/components/legal-page-index.tsx
@@ -1,0 +1,85 @@
+"use client";
+
+import { cn } from "@rallly/ui";
+import * as React from "react";
+
+// Matches the sticky header offset (`scroll-mt-24`) with a little slack, so a
+// heading that has just been scrolled to by hash counts as the current one.
+const ACTIVE_OFFSET = 100;
+
+export function LegalPageIndex({
+  items,
+}: {
+  items: { id: string; title: string }[];
+}) {
+  const [activeId, setActiveId] = React.useState<string | null>(null);
+
+  React.useEffect(() => {
+    const headings = items
+      .map((item) => document.getElementById(item.id))
+      .filter((el): el is HTMLElement => el !== null);
+    let frame = 0;
+
+    const update = () => {
+      frame = 0;
+      const doc = document.documentElement;
+      const atBottom =
+        window.innerHeight + window.scrollY >= doc.scrollHeight - 1;
+      let current: HTMLElement | null = null;
+      if (atBottom) {
+        current = headings[headings.length - 1] ?? null;
+      } else {
+        for (const heading of headings) {
+          if (heading.getBoundingClientRect().top <= ACTIVE_OFFSET) {
+            current = heading;
+          }
+        }
+      }
+      setActiveId(current?.id ?? null);
+    };
+
+    const schedule = () => {
+      if (!frame) {
+        frame = requestAnimationFrame(update);
+      }
+    };
+
+    update();
+    window.addEventListener("scroll", schedule, { passive: true });
+    window.addEventListener("resize", schedule);
+    return () => {
+      cancelAnimationFrame(frame);
+      window.removeEventListener("scroll", schedule);
+      window.removeEventListener("resize", schedule);
+    };
+  }, [items]);
+
+  return (
+    <nav aria-labelledby="legal-page-index-label">
+      <p id="legal-page-index-label" className="text-gray-500 text-sm">
+        Contents
+      </p>
+      <ul className="mt-2 border-gray-200 border-l">
+        {items.map((item) => {
+          const isActive = item.id === activeId;
+          return (
+            <li key={item.id}>
+              <a
+                href={`#${item.id}`}
+                aria-current={isActive ? "location" : undefined}
+                className={cn(
+                  "-ml-px block border-l py-1 pl-3 text-sm transition-colors",
+                  isActive
+                    ? "border-gray-800 font-medium text-gray-800"
+                    : "border-transparent text-gray-500 hover:text-gray-800",
+                )}
+              >
+                {item.title}
+              </a>
+            </li>
+          );
+        })}
+      </ul>
+    </nav>
+  );
+}

--- a/apps/landing/src/components/legal-page-layout.tsx
+++ b/apps/landing/src/components/legal-page-layout.tsx
@@ -26,6 +26,15 @@ function slugify(title: string) {
 
 function indexHeadings(children: React.ReactNode) {
   const items: { id: string; title: string }[] = [];
+  const used = new Set<string>();
+  const uniqueId = (base: string) => {
+    let id = base;
+    for (let n = 2; used.has(id); n++) {
+      id = `${base}-${n}`;
+    }
+    used.add(id);
+    return id;
+  };
   const content = React.Children.map(children, (child) => {
     if (
       !React.isValidElement<{ id?: string; children?: React.ReactNode }>(
@@ -36,7 +45,10 @@ function indexHeadings(children: React.ReactNode) {
       return child;
     }
     const title = textOf(child.props.children);
-    const id = child.props.id ?? slugify(title);
+    if (child.props.id) {
+      used.add(child.props.id);
+    }
+    const id = child.props.id ?? uniqueId(slugify(title));
     items.push({ id, title });
     return React.cloneElement(child, { id });
   });

--- a/apps/landing/src/components/legal-page-layout.tsx
+++ b/apps/landing/src/components/legal-page-layout.tsx
@@ -1,4 +1,47 @@
+import * as React from "react";
 import DateFormatter from "@/components/blog/date-formatter";
+import { LegalPageIndex } from "@/components/legal-page-index";
+
+function textOf(node: React.ReactNode): string {
+  if (typeof node === "string" || typeof node === "number") {
+    return String(node);
+  }
+  if (Array.isArray(node)) {
+    return node.map(textOf).join("");
+  }
+  if (React.isValidElement<{ children?: React.ReactNode }>(node)) {
+    return textOf(node.props.children);
+  }
+  return "";
+}
+
+// Drops leading section numbers so anchors survive renumbering.
+function slugify(title: string) {
+  return title
+    .toLowerCase()
+    .replace(/^\d+\.\s*/, "")
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+}
+
+function indexHeadings(children: React.ReactNode) {
+  const items: { id: string; title: string }[] = [];
+  const content = React.Children.map(children, (child) => {
+    if (
+      !React.isValidElement<{ id?: string; children?: React.ReactNode }>(
+        child,
+      ) ||
+      child.type !== "h2"
+    ) {
+      return child;
+    }
+    const title = textOf(child.props.children);
+    const id = child.props.id ?? slugify(title);
+    items.push({ id, title });
+    return React.cloneElement(child, { id });
+  });
+  return { items, content };
+}
 
 export function LegalPageLayout({
   title,
@@ -9,13 +52,19 @@ export function LegalPageLayout({
   lastUpdated: string;
   children: React.ReactNode;
 }) {
+  const { items, content } = indexHeadings(children);
   return (
     <>
       <h1 className="max-w-2xl text-balance font-medium text-3xl text-gray-800 tracking-tight sm:text-4xl">
         {title}
       </h1>
       <div className="mt-8 flex flex-col gap-8 lg:flex-row lg:items-start lg:justify-between lg:gap-16">
-        <aside className="lg:sticky lg:top-24 lg:order-2 lg:w-56 lg:shrink-0">
+        <aside className="flex flex-col gap-8 lg:sticky lg:top-24 lg:order-2 lg:w-56 lg:shrink-0">
+          {items.length > 0 ? (
+            <div className="hidden lg:block">
+              <LegalPageIndex items={items} />
+            </div>
+          ) : null}
           <dl className="flex flex-wrap gap-x-12 gap-y-6 lg:flex-col">
             <div>
               <dt className="text-gray-500 text-sm">Last updated</dt>
@@ -25,7 +74,7 @@ export function LegalPageLayout({
             </div>
           </dl>
         </aside>
-        <div className="longform min-w-0 max-w-2xl lg:order-1">{children}</div>
+        <div className="longform min-w-0 max-w-2xl lg:order-1">{content}</div>
       </div>
     </>
   );


### PR DESCRIPTION
## What changed

The sticky aside on the four legal pages (privacy policy, cookie policy, terms of use, DPA) now shows a "Contents" list of every top-level section. Clicking an entry jumps to that section, and the entry for the section currently in view is highlighted.

- `LegalPageLayout` walks its children on the server, assigns each `h2` an id derived from its text, and renders the index. The page files are untouched: they stay plain HTML with bare `<h2>` headings.
- Existing ids are preserved, so `/dpa#annex-2` (linked from the security page) still resolves. Leading section numbers are dropped from generated slugs so renumbering a section does not break its anchor.
- `LegalPageIndex` is a small client component that tracks the last heading scrolled past the sticky header and marks it with `aria-current="location"`, a heavier weight, and a dark left rail. At the bottom of the page the final section wins, so short closing sections still highlight. Scroll work is throttled to one animation frame.
- `.longform h2` gains `scroll-mt-24` so hash jumps land below the sticky header on every page.

## Decisions a reviewer may want to revisit

- The index is hidden below the `lg` breakpoint. On mobile the aside renders above the content, and a 14-entry list would push the DPA text a full screen down.
- Only `h2` headings are indexed. The terms and cookie pages have a few `h3` subsections that are left out to keep the list scannable.

## Verification

- Checked all four pages in the dev server: ids present in the server-rendered HTML, no client render bailouts, no console errors, and the highlight follows both hash navigation and scrolling.
- Biome and the landing type check pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a table of contents to legal pages with links to each section.
  * The index highlights the section currently in view and remains visible while scrolling.
  * Legal page headings now support stable anchor links for easier navigation, including when headings share similar titles.

* **Style**
  * Improved scrolling to anchored legal page headings by adding spacing above headings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->