### PR TITLE
💄 Keep the legal index font weight fixed when a section is active

### DIFF
--- a/apps/landing/src/components/legal-page-index.tsx
+++ b/apps/landing/src/components/legal-page-index.tsx
@@ -70,7 +70,7 @@ export function LegalPageIndex({
                 className={cn(
                   "-ml-px block border-l py-1 pl-3 text-sm transition-colors",
                   isActive
-                    ? "border-gray-800 font-medium text-gray-800"
+                    ? "border-gray-800 text-gray-800"
                     : "border-transparent text-gray-500 hover:text-gray-800",
                 )}
               >


### PR DESCRIPTION
## What changed

The contents index in the legal page sidebar switched the active link to `font-medium`. Because the sidebar is sticky and the active item changes as the reader scrolls, the label widening and narrowing caused visible layout shifts. The active link now keeps the base weight.

## Why

The active state was already carried by the darker left border and text color, so the weight change added nothing except the reflow.

## Review notes

One line in `apps/landing/src/components/legal-page-index.tsx`. No copy or behavior changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the active legal-page index link styling so it no longer appears bold, while retaining its gray border and text color.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->