### PR TITLE
💄 Show the yearly billing arrow on small screens

### DIFF
--- a/apps/landing/src/app/[locale]/(main)/pricing/billing-interval.tsx
+++ b/apps/landing/src/app/[locale]/(main)/pricing/billing-interval.tsx
@@ -57,7 +57,7 @@ export function BillingIntervalSwitch({
           <svg
             aria-hidden="true"
             viewBox="0 0 48 32"
-            className="pointer-events-none absolute top-0 -right-16 hidden h-9 w-16 text-gray-400 sm:block"
+            className="pointer-events-none absolute top-0 -right-16 h-9 w-16 text-gray-400"
             fill="none"
           >
             <path


### PR DESCRIPTION
## Summary

The curved arrow pointing from the free months badge to the yearly option on the pricing page was hidden below the `sm` breakpoint (`hidden sm:block`). #3031 added that guard on the assumption that the row had no room for it. It has room, so the guard is removed and the arrow renders at every width.

## Verification

Measured with `getBoundingClientRect` on a local dev server, arrow extends 64px right of the centered badge:

| Viewport | Locale | Badge | Arrow | Yearly label | Overflow |
| --- | --- | --- | --- | --- | --- |
| 375px | English | 141 to 234 | 234 to 298 | 224 to 294 | none |
| 320px | German (longest badge string) | 95 to 225 | 225 to 289 | 196 to 298 | none |

The arrow tip lands on the yearly label in both cases. `document.documentElement.scrollWidth` equals the viewport width, so no horizontal scroll is introduced. Biome passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - The decorative arrow badge in the billing interval switch now remains visible on all screen sizes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->