### PR TITLE
✨ Require an edit token on every response

### DIFF
--- a/packages/database/prisma/migrations/20260905170000_require_participant_token/migration.sql
+++ b/packages/database/prisma/migrations/20260905170000_require_participant_token/migration.sql
@@ -1,0 +1,8 @@
+-- Rows inserted by the previous release between the backfill and its
+-- promotion still carry no token. Same fill as the backfill.
+UPDATE "participants"
+SET "token" = replace(gen_random_uuid()::text, '-', '')
+WHERE "token" IS NULL;
+
+-- AlterTable
+ALTER TABLE "participants" ALTER COLUMN "token" SET NOT NULL;

--- a/packages/database/prisma/models/poll.prisma
+++ b/packages/database/prisma/models/poll.prisma
@@ -73,8 +73,8 @@ model Participant {
   name      String
   email     String?
   note      String?
-  /// Per response edit link: grants edit access to this response without a session. App minted at creation, CSPRNG alphanumeric ≥32 chars (nanoid customAlphabet — url safe with no linkifier edge cases, unlike base64url); never a DB default. A response created through an emailed invite takes the invite's token. Rows that predate minting were backfilled with gen_random_uuid() hex. Nullable only until the minting code is live everywhere: until then a code path that forgets to mint inserts NULL; once the follow-up migration makes the column required, it fails loudly instead
-  token     String?   @unique
+  /// Per response edit link: grants edit access to this response without a session. App minted at creation, CSPRNG alphanumeric ≥32 chars (nanoid customAlphabet — url safe with no linkifier edge cases, unlike base64url); never a DB default so a code path that forgets to mint fails loudly. A response created through an emailed invite takes the invite's token. Rows that predate minting were backfilled with gen_random_uuid() hex
+  token     String    @unique
   userId    String?   @map("user_id")
   pollId    String    @map("poll_id")
   locale    String?


### PR DESCRIPTION
Part of RAL-1601. Step two of three, after #3166 (backfill and mint). Step three makes both emailed links resolve to the token.

## What

- `Participant.token` becomes required. The Prisma type flips to `String`; no code reads the token yet, so nothing else changes.
- The migration first fills any rows the previous release inserted between the backfill and its promotion (a handful, same UUID hex fill), then sets NOT NULL.

## Migration

`SET NOT NULL` scans the table once under an exclusive lock, on the order of a second for 853k rows. Reads and writes queue for that second. The straggler UPDATE touches only the null rows.

Do not merge until the #3166 build is promoted and serving: any release still inserting null tokens would fail on the constraint. Production has been on the minting code since 2026-09-05 16:16 UTC.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Ensured every poll participant has a unique token.
  * Existing participants without tokens are automatically assigned valid tokens.
  * Participant token requirements are now enforced consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->