### PR TITLE
🐛 Hard delete responses so their invite reverts to pending

### DIFF
--- a/apps/web/src/trpc/routers/polls/participants.ts
+++ b/apps/web/src/trpc/routers/polls/participants.ts
@@ -237,13 +237,13 @@ export const participants = router({
           },
         });
 
-        await tx.participant.update({
+        // Hard delete: votes cascade, the invite's SetNull FK reverts it to
+        // pending, and the response frees the token it took from that invite
+        // so the next response through the same link can take it again. The
+        // activity row above is the historical record.
+        await tx.participant.delete({
           where: {
             id: participantId,
-          },
-          data: {
-            deleted: true,
-            deletedAt: new Date(),
           },
         });
 

--- a/apps/web/tests/email-invites.spec.ts
+++ b/apps/web/tests/email-invites.spec.ts
@@ -65,6 +65,26 @@ async function renameThroughInviteLink(
   }
 }
 
+/**
+ * The poll holds one response, so the menu resolves without disambiguation.
+ */
+async function deleteResponse(page: Page, name: string) {
+  await page.getByTestId("participant-menu").click();
+  await page.getByRole("menuitem", { name: "Delete" }).click();
+  const dialog = page.getByRole("dialog", { name: `Delete ${name}?` });
+  await dialog.getByRole("button", { name: "Delete" }).click();
+  await expect(dialog).toBeHidden();
+  // The list update is optimistic, so wait for the row to actually be gone
+  // before reading the invite it released.
+  await expect
+    .poll(async () =>
+      prisma.participant.count({
+        where: { name, poll: { title: POLL_TITLE } },
+      }),
+    )
+    .toBe(0);
+}
+
 async function reopenShareDialog(page: Page) {
   await page.reload();
   await page.getByRole("button", { name: "Share" }).click();
@@ -211,6 +231,41 @@ test.describe("Email invites", () => {
     });
     await page.reload();
     await expect(page.getByText("Renamed Guest")).toBeVisible();
+
+    // Deleting the response reverts the invite to pending: the row goes back
+    // to Opened, and the link keeps working because the response released
+    // the token it had taken from the invite.
+    await deleteResponse(page, "Renamed Guest");
+    const revertedRow = (await reopenShareDialog(page))
+      .getByRole("listitem")
+      .filter({ hasText: INVITEE });
+    await expect(revertedRow.getByText("Opened")).toBeVisible();
+    await page.keyboard.press("Escape");
+
+    const reverted = await prisma.pollInvite.findUniqueOrThrow({
+      where: { id: invite.id },
+      select: { participantId: true, token: true, revokedAt: true },
+    });
+    expect(reverted.participantId).toBeNull();
+    expect(reverted.revokedAt).toBeNull();
+    expect(reverted.token).toBe(converted.token);
+
+    // Responding through the same link a second time converts it again and
+    // takes the token back.
+    const second = await openAsGuest(browser as Browser, emailedUrl as string);
+    await new InvitePage(second.guestPage).addParticipant("Second Response");
+    await second.close();
+
+    const reconverted = await prisma.pollInvite.findUniqueOrThrow({
+      where: { id: invite.id },
+      select: { token: true, participant: { select: { token: true } } },
+    });
+    expect(reconverted.participant?.token).toBe(reconverted.token);
+
+    const respondedAgainRow = (await reopenShareDialog(page))
+      .getByRole("listitem")
+      .filter({ hasText: INVITEE });
+    await expect(respondedAgainRow.getByText("Responded")).toBeVisible();
   });
 
   test("creation opens the dialog and leaves the URL clean", async ({

--- a/packages/database/prisma/models/poll.prisma
+++ b/packages/database/prisma/models/poll.prisma
@@ -104,7 +104,7 @@ model PollInvite {
 
   openedAt   DateTime? @map("opened_at")
   remindedAt DateTime? @map("reminded_at")
-  /// Revocation is always explicit: set when the host removes a pending invite, never as a side effect of close, schedule or reopen. Deleting a response clears participantId instead, reverting the invite to pending with its token intact. Cleared only by re-inviting (reactivation), which also rotates the token
+  /// Revocation is always explicit: set when the host removes a pending invite, never as a side effect of close, schedule or reopen. Deleting a response instead hard deletes the participant, so the SetNull FK clears participantId and reverts the invite to pending with its token intact — the token the deleted response held is freed with it, so the next response through the same link can take it again. Cleared only by re-inviting (reactivation), which also rotates the token
   revokedAt  DateTime? @map("revoked_at")
 
   /// Conversion join, merges invite history into the response timeline. Set only when the invitee responds via their token: a typed email is unverified, so a generic link response never claims an invite


### PR DESCRIPTION
## Description

Fixes [RAL-1619](https://linear.app/rallly/issue/RAL-1619).

The legacy `participants.delete` procedure soft deleted: it set `deleted` and `deletedAt` on the participant row. `PollInvite.participantId` is a `SetNull` FK, which only fires on a hard delete, so an invite whose response was deleted stayed converted — contradicting the schema comment on `PollInvite.revokedAt`, which already promised the opposite.

What that meant in practice:

- The host's Share dialog kept showing the invite as **Responded** after the response was gone.
- Opening the emailed link again showed no response to edit (`listParticipantIdsByToken` filters `deleted: false`), and responding again could not reattach (`findPendingPollInvite` requires `participantId: null`). The invitee was locked out of their own invite.

Since #3166 the response takes the invite's token at creation, which makes this sharper: clearing `participantId` alone would not have been enough, because the soft deleted row still held the token and a second response through the same link would have collided on the unique index on `participants.token`.

### The fix

Hard delete, as RAL-1494 already decided for the Poll Admin mutation. Votes cascade, the FK reverts the invite to pending, and the token is freed for the next response. The activity snapshot is taken before the delete, so the `response_deleted` row still carries the name and vote snapshot and nothing historical is lost.

### Two things worth a reviewer's attention

**The reverted invite shows "Opened", not "Sent".** The issue's test description asks for "Sent again", but `derivePollInviteStatus` returns `opened` when `openedAt` is set and `participantId` is null — and `openedAt` correctly survives, because the invitee genuinely did open the link. "Opened" is the truthful state, so the test asserts that rather than changing the derivation to match the issue's wording.

**The `deleted: false` read filters stay.** Rows soft deleted since #3160 shipped still exist and must stay hidden until RAL-1494's purge runs. `Participant.deleted` / `deletedAt` now have no writer anywhere in the app; dropping the columns belongs to RAL-1494, not here.

No migration — the only schema change is the `revokedAt` doc comment, updated to state the hard-delete mechanism rather than implying it.

### Verification

- Extended the existing `email-invites.spec.ts` pro-host test: delete the response, assert the row reverts to Opened with `participantId` null and the token unchanged, then respond through the same link a second time and assert it flips back to Responded with the token retaken. Reusing that test avoids rebuilding the whole invite/convert setup.
- **Negative check**: stashed the fix and re-ran — the test fails on the old soft-delete code at exactly the right assertion, so it genuinely exercises the change.
- `type-check`, `check`, `check:structure`, `check:cascades`, 602 unit tests, and the 3 email-invites specs all pass.
- One `house-keeping.spec.ts` failure appeared in a batched run; it passes in isolation, and a baseline run with the change stashed showed the same 11 specs green. Pre-existing ordering flake, unrelated to this change.

## Checklist

- [x] I have performed a self-review of my code
- [x] My code follows the code style of this project
- [x] I have commented my code, particularly in hard-to-understand areas

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Deleting a poll response now fully removes it.
  - The associated invitation returns to a pending state while retaining its link.
  - The same invitation link can be used to submit a new response again.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->