### PR TITLE
🗑️ Purge legacy soft-deleted participants

### DIFF
--- a/packages/database/prisma/migrations/20260906090000_purge_soft_deleted_participants/migration.sql
+++ b/packages/database/prisma/migrations/20260906090000_purge_soft_deleted_participants/migration.sql
@@ -1,0 +1,28 @@
+-- Response deletion became a hard delete in #3191, so nothing writes
+-- `deleted = true` any more and this backlog is closed ended.
+--
+-- It is purged rather than left to age out. Inactivity poll deletion only
+-- collects polls that have gone quiet, so a poll kept in use for years never
+-- reaches it and accumulates soft deleted responses indefinitely: names and
+-- emails retained on responses their authors explicitly deleted, and ghost
+-- rows that leak into counts and scores wherever a read forgets its
+-- `deleted = false` filter.
+--
+-- Cloud's backlog was drained by hand before this shipped, so here it clears
+-- the remainder. On a self hosted instance, which has no scheduler and never
+-- ran the manual drain, this is the whole purge — those backlogs are small
+-- and finish in well under a second. Measured at ~2.6ms per response
+-- including cascade, so no chunking: a few thousand rows is seconds, and
+-- keeping it one statement means it either applies or rolls back cleanly.
+--
+-- Votes cascade. `poll_invites.participant_id` is SetNull, so an invite whose
+-- response is purged reverts to pending with its token intact — the rule the
+-- column documents. `poll_activities.participant_id` is a soft reference with
+-- no FK, so the `response_deleted` rows that are these responses' historical
+-- record survive untouched.
+--
+-- The activity feed is deliberately not backfilled for rows deleted before
+-- `response_deleted` existed: there is no true timestamp for those events,
+-- and dating them today would put invented history at the top of hosts' feeds
+-- for polls they settled long ago.
+DELETE FROM "participants" WHERE "deleted" = true;


### PR DESCRIPTION
## Description

Part of [RAL-1494](https://linear.app/rallly/issue/RAL-1494). Follow-on from #3191.

Response deletion became a hard delete in #3191, so nothing writes `Participant.deleted` any more and the backlog is closed ended. This migration clears what is left of it.

```sql
DELETE FROM "participants" WHERE "deleted" = true;
```

### Why purge rather than let them age out

That was my first instinct and it was wrong. Inactivity poll deletion only collects polls that have gone **quiet** — it requires no edits, no participant activity and no comments for 30 days. A poll kept in continuous use for years never satisfies that, so it accumulates soft deleted responses indefinitely:

- **PII.** Names and emails retained forever on responses their authors explicitly deleted, against a delete dialog that says "This action cannot be undone."
- **Correctness.** Ghost rows leak into counts and scores wherever a read forgets its `deleted = false` filter — and on a long-lived active poll, that is a poll someone is looking at today.

### Why a migration

Self hosted instances have no scheduler: the crons live in `vercel.json`, which they never read, and `CRON_SECRET` is not documented, so the house-keeping routes have never run there. `prisma migrate deploy` runs on every container start (`scripts/docker-start.sh`), which makes a migration the only delivery mechanism that reaches those instances.

Cloud's backlog was reduced by hand before this shipped, so on cloud this clears the remainder.

### Why one statement

Measured at ~2.6ms per response including cascade, so the remaining few thousand rows take seconds. Keeping it atomic means it either applies or rolls back cleanly, and re-running is a no-op. Chunking was considered and dropped as unnecessary machinery at this size.

### Verification

Applied through `prisma migrate deploy` against a database seeded to exercise every cascade:

| Check | Result |
| --- | --- |
| Soft deleted purged, live responses untouched | ✅ |
| Votes cascaded, zero orphaned vote rows | ✅ |
| Converted invite reverted: `participant_id` null, `revoked_at` still null, token intact | ✅ |
| `response_deleted` activity rows survive as the historical record | ✅ |
| Re-running the migration is a no-op | ✅ |

The activity feed is deliberately **not** backfilled for rows deleted before `response_deleted` existed: there is no true timestamp for those events, and dating them today would put invented history at the top of hosts' feeds for polls they settled long ago.

### Scope

This does not close RAL-1494. Step 3 — dropping the `deleted` / `deletedAt` columns and removing the ~10 `deleted: false` filters — stays gated on legacy-admin cutover. The step 2 note about purging *before* invites shipped is moot: no invite had a soft deleted response behind it, confirmed against production.

## Checklist

- [x] I have performed a self-review of my code
- [x] My code follows the code style of this project
- [x] I have commented my code, particularly in hard-to-understand areas

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Data Management**
  - Permanently removes participants marked for deletion.
  - Removes associated votes.
  - Resets related poll invitations to pending while retaining their tokens.
  - Preserves activity records linked to removed participants.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->