### PR TITLE
♻️ Drop the participant soft-delete filters from poll reads

### DIFF
--- a/apps/web/src/features/poll/data.ts
+++ b/apps/web/src/features/poll/data.ts
@@ -63,9 +63,7 @@ export async function getPollResults({
         },
         _count: {
           select: {
-            participants: {
-              where: { deleted: false },
-            },
+            participants: true,
           },
         },
       },
@@ -74,7 +72,6 @@ export async function getPollResults({
       by: ["optionId", "type"],
       where: {
         pollId,
-        participant: { deleted: false },
       },
       _count: true,
     }),
@@ -157,7 +154,6 @@ export async function getPollParticipants({
     select: {
       id: true,
       participants: {
-        where: { deleted: false },
         select: {
           id: true,
           name: true,
@@ -225,9 +221,7 @@ export async function listPolls({
       },
       _count: {
         select: {
-          participants: {
-            where: { deleted: false },
-          },
+          participants: true,
         },
       },
     },
@@ -465,7 +459,7 @@ export async function getParticipant({
   participantId: string;
 }) {
   return prisma.participant.findFirst({
-    where: { id: participantId, deleted: false },
+    where: { id: participantId },
     select: { id: true, pollId: true, userId: true },
   });
 }
@@ -494,7 +488,6 @@ export async function listParticipantIdsByToken({
       where: {
         pollId,
         userId: payload.userId,
-        deleted: false,
         email: { not: null },
       },
       select: { id: true },
@@ -503,7 +496,7 @@ export async function listParticipantIdsByToken({
   }
 
   const participant = await prisma.participant.findFirst({
-    where: { pollId, token, deleted: false },
+    where: { pollId, token },
     select: { id: true },
   });
   return participant ? [participant.id] : [];

--- a/apps/web/src/features/poll/invite/mutations.ts
+++ b/apps/web/src/features/poll/invite/mutations.ts
@@ -90,7 +90,6 @@ export async function sendPollInvite({
   const participant = await prisma.participant.findFirst({
     where: {
       pollId,
-      deleted: false,
       email: { equals: email, mode: "insensitive" },
     },
     select: { id: true },

--- a/apps/web/src/trpc/routers/polls.ts
+++ b/apps/web/src/trpc/routers/polls.ts
@@ -577,9 +577,7 @@ export const polls = router({
           muted: true,
           _count: {
             select: {
-              participants: {
-                where: { deleted: false },
-              },
+              participants: true,
               comments: true,
               options: true,
             },
@@ -888,7 +886,6 @@ export const polls = router({
             },
           },
           participants: {
-            where: { deleted: false },
             select: {
               id: true,
               name: true,

--- a/apps/web/src/trpc/routers/polls/participants.ts
+++ b/apps/web/src/trpc/routers/polls/participants.ts
@@ -131,7 +131,6 @@ export const participants = router({
       const rawParticipants = await prisma.participant.findMany({
         where: {
           pollId,
-          deleted: false,
         },
         include: {
           votes: {
@@ -305,7 +304,6 @@ export const participants = router({
         const participantCount = await prisma.participant.count({
           where: {
             pollId,
-            deleted: false,
           },
         });
 


### PR DESCRIPTION
## Description

Part of [RAL-1494](https://linear.app/rallly/issue/RAL-1494), step 3 — the first half. Follows #3191 and #3192.

Nothing writes `Participant.deleted` after #3191 made response deletion a hard delete, and #3192 purged the backlog (verified: zero soft-deleted participants in production). Every `deleted: false` on a participant query now matches every row, so removing them changes no result.

### What changed

Twelve call sites across four files:

- `features/poll/data.ts` — participant list, response lookup by id and by token (both the legacy-seal and token paths), the vote aggregation's `participant: { deleted: false }` relation filter, and two `_count` selects
- `features/poll/invite/mutations.ts` — the duplicate-response check behind invite sending
- `trpc/routers/polls.ts` — a `_count` select and a participants select
- `trpc/routers/polls/participants.ts` — the participant list and the `MAX_PARTICIPANTS` count

The `deleted: false` filters on **`Poll`** are a separate concern — polls still soft delete — and are deliberately untouched. Every remaining occurrence in the codebase is on `prisma.poll`.

### Why the columns stay for now

Dropping `deleted` / `deletedAt` in this same release would break any instance still running the old code during a rolling deploy: it would keep issuing `WHERE deleted = false` against a column that no longer exists, erroring on the hottest read path in the app.

Self-hosted adds a second reason. Those instances upgrade on their own schedule, and one that has not yet taken #3192 still holds soft-deleted rows. Migrations run in order at container start, so an instance crossing both releases gets the purge *before* this change — but only if the two stay in separate releases.

The column drop follows in a later release and closes RAL-1494.

### Verification

- `type-check`, `check`, `check:structure` and 602 unit tests pass.
- Integration: `email-invites.spec.ts`, `vote-and-comment.spec.ts` and `legacy-edit-link.spec.ts` — 8 passed. These cover every touched read path: participant lists, counts, vote aggregation, token lookup (both variants) and the invite duplicate check.
- The three unit tests that assert on `deleted: false` are all `Poll`-scoped and unaffected.

## Checklist

- [x] I have performed a self-review of my code
- [x] My code follows the code style of this project
- [x] I have commented my code, particularly in hard-to-understand areas

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Behavior Changes**
  - Poll participant lists and lookups now include records marked as deleted.
  - Participant counts, poll results, vote totals, attendee calculations, and participant-limit checks now include deleted records.
  - Invitation matching recognizes existing participant records regardless of deletion status, affecting invitations sent to previously deleted participant email addresses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->