### PR TITLE
🗑️ Drop the participant soft-delete columns

### DIFF
--- a/apps/landing/src/lib/data.ts
+++ b/apps/landing/src/lib/data.ts
@@ -14,7 +14,6 @@ export const getMonthlyPollCount = async () => {
       participants: {
         some: {
           createdAt: { gte: new Date(Date.now() - THIRTY_DAYS_MS) },
-          deleted: false,
         },
       },
     },
@@ -27,7 +26,6 @@ export const getMonthlyVoterCount = async () => {
   return prisma.participant.count({
     where: {
       createdAt: { gte: new Date(Date.now() - THIRTY_DAYS_MS) },
-      deleted: false,
     },
   });
 };

--- a/apps/web/src/features/poll/data.ts
+++ b/apps/web/src/features/poll/data.ts
@@ -296,9 +296,6 @@ export const getPolls = async ({
           },
         },
         participants: {
-          where: {
-            deletedAt: null,
-          },
           select: {
             id: true,
             name: true,

--- a/packages/database/prisma/migrations/20260906120000_drop_participant_soft_delete_columns/migration.sql
+++ b/packages/database/prisma/migrations/20260906120000_drop_participant_soft_delete_columns/migration.sql
@@ -1,0 +1,16 @@
+-- Response deletion became a hard delete in #3191, the backlog was purged in
+-- #3192, and the last read that filtered on these columns was removed in
+-- #3193. Nothing writes them and nothing reads them, so they come out.
+--
+-- Ordering matters and is what makes this safe. On cloud the filter removal
+-- was deployed before this migration ships, so no running instance queries
+-- the dropped columns. On self hosted, migrations run in order at container
+-- start before the server boots, so an instance upgrading across all four
+-- changes applies the purge and this drop against code that already stopped
+-- referencing them.
+--
+-- `response_deleted` PollActivity rows are the historical record of deleted
+-- responses and are untouched: they hold their own name and vote snapshot and
+-- reference the participant by a soft id with no FK.
+ALTER TABLE "participants" DROP COLUMN "deleted",
+DROP COLUMN "deleted_at";

--- a/packages/database/prisma/models/poll.prisma
+++ b/packages/database/prisma/models/poll.prisma
@@ -81,8 +81,6 @@ model Participant {
   timeZone  String?   @map("time_zone")
   createdAt DateTime  @default(now()) @map("created_at")
   updatedAt DateTime? @updatedAt @map("updated_at")
-  deleted   Boolean   @default(false)
-  deletedAt DateTime? @map("deleted_at")
 
   votes  Vote[]
   invite PollInvite?


### PR DESCRIPTION
## Description

Closes [RAL-1494](https://linear.app/rallly/issue/RAL-1494), the last step. Completes the chain #3191 → #3192 → #3193.

Response deletion became a hard delete in #3191, the backlog was purged in #3192, and the reads that filtered on these columns were removed in #3193. Nothing writes them and nothing reads them, so `Participant.deleted` and `deletedAt` come out of the Prisma model and the table.

```sql
ALTER TABLE "participants" DROP COLUMN "deleted", DROP COLUMN "deleted_at";
```

### A filter #3193 missed

`getPolls` (the space poll list) scoped its participant select with `where: { deletedAt: null }` rather than `deleted: false`, so it did not match that PR's sweep. This PR removes it.

It selected no rows either way once the purge had run, so nothing was visibly wrong in production — but the column drop would have broken the query, which is how it surfaced: `tsc` failed on the whole `select` block after the model change. Worth noting as a lesson for the next soft-delete removal: **grep for the column names, not for one filter spelling.**

A second miss, caught by CI rather than by me: `apps/landing/src/lib/data.ts` filtered participants on `deleted: false` in both homepage stat queries. My sweep only covered `apps/web`, and `type-check` passes either way — the generated client's types come from the schema, but an unknown `where` argument is a *runtime* Prisma error, so it only surfaces when a page running the query is prerendered. The Vercel landing build failed with `Unknown argument 'deleted'`; fixed in c9eae681d and verified by running `pnpm build:landing` against a database with the migration applied.

Every other `deleted` / `deletedAt` reference in the codebase is `Poll`-scoped. Polls still soft delete and are deliberately untouched — verified individually, including `Prisma.PollWhereInput` and every `prisma.poll.*` call.

### Why this is safe to drop now

Ordering, not timing:

- **Cloud** — #3193's production deploy (`6b30747e`) completed before this ships, so no running instance queries the dropped columns. Dropping them before that deploy landed would have errored on poll reads during the rollover, which is why this waited.
- **Self hosted** — migrations run in order at container start, *before* the server boots. An instance upgrading across all four changes applies the purge and this drop against code that has already stopped referencing the columns.

### What is preserved

`response_deleted` PollActivity rows are unaffected. They carry their own name and vote snapshot and reference the participant by a soft id with no FK, so the historical record of every deleted response survives the column drop — as it survived the purge.

### Verification

- Full migration chain applied to a fresh database via `prisma migrate deploy`.
- **No schema drift**: the migrated `participants` table has exactly 11 columns, matching the 11 scalar fields on the model one-to-one, with `deleted` and `deleted_at` absent from both.
- `type-check`, `check`, `check:structure`, `check:cascades` and 602 unit tests pass.
- Integration: `email-invites`, `vote-and-comment`, `legacy-edit-link` and `house-keeping` — **12 passed**. House-keeping is included deliberately: it exercises poll soft delete, confirming that path is undisturbed.

## Checklist

- [x] I have performed a self-review of my code
- [x] My code follows the code style of this project
- [x] I have commented my code, particularly in hard-to-understand areas

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Poll participant lists now consistently include all participants, including those previously marked as deleted.
* **Data Updates**
  * Removed obsolete participant soft-deletion tracking from the system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
