### PR TITLE
🐛 Wrap long descriptions in the landing hero demo

### DIFF
--- a/apps/landing/src/components/home/hero-demo/desktop-demo.tsx
+++ b/apps/landing/src/components/home/hero-demo/desktop-demo.tsx
@@ -45,7 +45,9 @@ export const DesktopDemo = ({
   return (
     <DemoFrame>
       <DemoScreen className="bg-gray-100 p-4 sm:p-6">
-        <div className="mx-auto w-fit space-y-3 text-left">
+        {/* Pinned to the grid width (235px + 8 × 84px) so a long description
+            wraps instead of stretching the card past the table. */}
+        <div className="mx-auto w-[907px] space-y-3 text-left">
           <div className="overflow-hidden rounded-xl border border-gray-200/60 bg-white">
             <div className="h-1.5 bg-linear-to-r from-indigo-500 to-violet-500" />
             <div className="space-y-3 p-4 sm:p-5">


### PR DESCRIPTION
## What changed

The hero demo card in `apps/landing/src/components/home/hero-demo/desktop-demo.tsx` is now pinned to the width of the poll grid (235px name column + 8 × 84px slots = 907px) instead of `w-fit`.

## Why

The wrapper was `w-fit` inside the hero's `w-max` zoom container, so nothing constrained the card to the table. Its width became whichever child was widest at max-content. A description longer than the grid stretched the card to a single line instead of wrapping. The English copy is shorter than the grid so it never surfaced; French (and likely other locales) exposed it, e.g. `/fr/scheduling-for/committees`.

## Reviewer notes

- Verified in the browser: the French committees page wraps the description onto two lines with the card flush with the table; the English page renders identically to before.
- The value is documented in a comment next to the grid columns it mirrors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the desktop demo card layout so long descriptions wrap within the table instead of expanding beyond its boundaries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->