### PR TITLE
💄 Show the footer external link arrow without animating it

### DIFF
--- a/apps/landing/src/app/[locale]/(main)/footer.tsx
+++ b/apps/landing/src/app/[locale]/(main)/footer.tsx
@@ -28,7 +28,7 @@ function FooterExternalLink({
       {children}
       <ArrowUpRightIcon
         aria-hidden="true"
-        className="size-3.5 opacity-0 transition-opacity duration-150 group-hover:opacity-100 group-focus-visible:opacity-100 motion-reduce:transition-none"
+        className="size-3.5 opacity-0 group-hover:opacity-100 group-focus-visible:opacity-100"
       />
     </a>
   );

--- a/apps/landing/src/app/[locale]/(main)/footer.tsx
+++ b/apps/landing/src/app/[locale]/(main)/footer.tsx
@@ -28,7 +28,7 @@ function FooterExternalLink({
       {children}
       <ArrowUpRightIcon
         aria-hidden="true"
-        className="size-3.5 -translate-x-0.5 translate-y-0.5 opacity-0 transition-[opacity,transform] duration-150 group-hover:translate-x-0 group-hover:translate-y-0 group-hover:opacity-100 group-focus-visible:translate-x-0 group-focus-visible:translate-y-0 group-focus-visible:opacity-100 motion-reduce:transition-none"
+        className="size-3.5 opacity-0 transition-opacity duration-150 group-hover:opacity-100 group-focus-visible:opacity-100 motion-reduce:transition-none"
       />
     </a>
   );


### PR DESCRIPTION
## What changed

The up-right arrow on the landing footer's external links (Discussions, Support) now appears instantly on hover and focus. The slide and fade transitions from #3197 are removed.

## Why

The motion added nothing; the arrow only needs to be visible while hovering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated the footer’s external-link icon interaction so it remains stationary on hover and focus, with only its opacity changing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->