### PR TITLE
📝 Link Vercel to its trust center on the security page and DPA

### DIFF
--- a/apps/landing/src/app/[locale]/(main)/dpa/page.tsx
+++ b/apps/landing/src/app/[locale]/(main)/dpa/page.tsx
@@ -396,7 +396,7 @@ export default async function DataProcessingAgreement() {
               <tr>
                 <td>
                   <a
-                    href="https://vercel.com/security"
+                    href="https://security.vercel.com/"
                     target="_blank"
                     rel="noreferrer noopener"
                   >

--- a/apps/landing/src/app/[locale]/(main)/security/page.tsx
+++ b/apps/landing/src/app/[locale]/(main)/security/page.tsx
@@ -57,7 +57,7 @@ const europeanUnion = { code: "EU", label: "European Union" };
 const providers = [
   {
     name: "Vercel",
-    href: "https://vercel.com/security",
+    href: "https://security.vercel.com/",
     purpose: "Application hosting",
     location: unitedStates,
     logo: {


### PR DESCRIPTION
## What changed

The Vercel entry on the landing security page provider grid and in Annex 2 of the DPA now links to Vercel's trust center at https://security.vercel.com/ instead of the marketing page at vercel.com/security.

## Why

The security page FAQ tells enterprise buyers that our providers' SOC 2 and ISO attestations are available from each provider. The trust center is where those reports actually live; the marketing page is not. Both pages are updated together so the two sub-processor lists stay in agreement.

## Reviewer notes

- Copy only, no logic changes. The URL returns 200.
- Neon, Stripe and Upstash still link to marketing or docs pages on both surfaces. Left as is for a separate decision.
- Annex 2 lists Sentry; the security page provider grid does not. Also out of scope here, flagged for follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Vercel security links in the Data Processing Agreement and Security pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->