### PR TITLE
✨ Remember the currency picked in the pay wall

### DIFF
--- a/apps/web/src/features/billing/client.tsx
+++ b/apps/web/src/features/billing/client.tsx
@@ -1,7 +1,9 @@
 "use client";
 
 import type { PricesByCurrency } from "@rallly/billing";
+import { CURRENCY_COOKIE_NAME } from "@rallly/billing";
 import { posthog } from "@rallly/posthog/client";
+import Cookies from "js-cookie";
 import React from "react";
 import { create } from "zustand";
 import type { SpaceTier } from "@/features/space/schema";
@@ -77,3 +79,14 @@ export type PayWallPricing = {
   prices: PricesByCurrency;
   defaultCurrency: string;
 };
+
+// Same cookie the pricing page writes, so a currency picked in either place
+// is what the other opens in. Shared across subdomains via the cookie domain.
+export function setCurrencyCookie(currency: string) {
+  Cookies.set(CURRENCY_COOKIE_NAME, currency, {
+    path: "/",
+    sameSite: "lax",
+    domain: process.env.NEXT_PUBLIC_COOKIE_DOMAIN,
+    expires: 365,
+  });
+}

--- a/apps/web/src/features/billing/components/pay-wall-dialog.tsx
+++ b/apps/web/src/features/billing/components/pay-wall-dialog.tsx
@@ -41,7 +41,7 @@ import { spaceTierSchema } from "@/features/space/schema";
 import { Trans, useTranslation } from "@/i18n/client";
 import { useDateTimeConfig } from "@/lib/datetime/client";
 import type { PayWallPricing, PayWallTrigger } from "../client";
-import { usePayWallStore } from "../client";
+import { setCurrencyCookie, usePayWallStore } from "../client";
 import { PLAN_NAMES } from "../constants";
 
 function KeyBenefits({ children }: { children?: React.ReactNode }) {
@@ -297,6 +297,7 @@ export function PayWallDialog({
                     onValueChange={(value) => {
                       if (value) {
                         setSelectedCurrency(value);
+                        setCurrencyCookie(value);
                       }
                     }}
                   >

--- a/apps/web/src/features/billing/components/pay-wall-dialog.tsx
+++ b/apps/web/src/features/billing/components/pay-wall-dialog.tsx
@@ -265,9 +265,10 @@ export function PayWallDialog({
       onOpenChange={(open) => {
         onOpenChange(open);
         if (!open) {
+          // Plan and interval are per attempt; the currency is a persisted
+          // preference (cookie) and must survive close and reopen.
           setSelectedPlan("pro");
           setIsAnnual(true);
-          setSelectedCurrency(defaultCurrency);
         }
       }}
     >


### PR DESCRIPTION
## Summary

Follow-up to #3208 and #3209. Changing the currency in the pay wall now writes the same `rallly_currency` cookie the pricing page writes, so the two surfaces open in whichever currency the visitor chose last. The pay wall loader already reads that cookie before the country header.

- `setCurrencyCookie` in `features/billing/client.tsx`, using `js-cookie` (already an app dependency) with the app's cookie domain and a one year expiry, matching the datetime cookies.
- Called from the pay wall's currency select alongside the local state update.

## Verified

Driven login against a local server with the price map stubbed (the dev Stripe key is rejected), as a UK visitor:

| Step | Result |
|---|---|
| Open pay wall | no cookie, select shows £ GBP from the country |
| Pick EUR | `rallly_currency=eur`, expires in 365 days |
| Reload and reopen | select shows € EUR |

Root type check, Biome clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Currency selections made in the billing dialog are now saved and carried over when opening the pricing page.
  - Currency preferences persist across pages for up to one year.
  - Reopening the billing dialog retains the previously selected currency, while plan and billing interval selections continue to reset for each new purchase attempt.
  - Currency settings now remain consistent between the billing dialog and pricing page.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->