### PR TITLE
✨ Return the documented JSON error envelope from every /api/v1 failure

### DIFF
--- a/apps/web/src/app/api/middleware/api-error.ts
+++ b/apps/web/src/app/api/middleware/api-error.ts
@@ -1,3 +1,53 @@
-export const apiError = (code: string, message: string) => ({
-  error: { code, message },
+import type { Context } from "hono";
+
+export type ApiErrorDetail = { path: string; message: string };
+
+export const apiError = (
+  code: string,
+  message: string,
+  details?: ApiErrorDetail[],
+) => ({
+  error: { code, message, ...(details ? { details } : {}) },
 });
+
+type ValidationIssue = {
+  readonly message: string;
+  readonly path?: ReadonlyArray<PropertyKey | { key: PropertyKey }> | undefined;
+};
+
+type ValidationResult =
+  | { success: true }
+  | { success: false; error: readonly ValidationIssue[] };
+
+const issuePath = (issue: ValidationIssue) =>
+  (issue.path ?? [])
+    .map((segment) =>
+      typeof segment === "object" && segment !== null
+        ? String(segment.key)
+        : String(segment),
+    )
+    .join(".");
+
+/**
+ * Hook for every `validator(...)` call. The standard-validator default
+ * response is `{ success, error, data }` with the request body echoed back,
+ * which both breaks the documented envelope and copies client input into
+ * logs and proxies. This replaces it with the envelope plus a `details`
+ * array built from the issues.
+ */
+export const validationHook = (result: ValidationResult, c: Context) => {
+  if (result.success) {
+    return;
+  }
+  return c.json(
+    apiError(
+      "VALIDATION_ERROR",
+      "The request did not match the expected schema. See details.",
+      result.error.map((issue) => ({
+        path: issuePath(issue),
+        message: issue.message,
+      })),
+    ),
+    400,
+  );
+};

--- a/apps/web/src/app/api/middleware/api-error.ts
+++ b/apps/web/src/app/api/middleware/api-error.ts
@@ -1,13 +1,7 @@
 import type { Context } from "hono";
 
-export type ApiErrorDetail = { path: string; message: string };
-
-export const apiError = (
-  code: string,
-  message: string,
-  details?: ApiErrorDetail[],
-) => ({
-  error: { code, message, ...(details ? { details } : {}) },
+export const apiError = (code: string, message: string) => ({
+  error: { code, message },
 });
 
 type ValidationIssue = {
@@ -20,29 +14,24 @@ type ValidationResult =
   | { success: false; error: readonly ValidationIssue[] };
 
 // zod emits plain keys; the Standard Schema `{ key }` segment form never occurs.
-const issuePath = (issue: ValidationIssue) =>
-  (issue.path ?? []).map(String).join(".");
+const describeIssue = (issue: ValidationIssue) => {
+  const path = (issue.path ?? []).map(String).join(".");
+  return path ? `${path}: ${issue.message}` : issue.message;
+};
 
 /**
  * Hook for every `validator(...)` call. The standard-validator default
  * response is `{ success, error, data }` with the request body echoed back,
  * which both breaks the documented envelope and copies client input into
- * logs and proxies. This replaces it with the envelope plus a `details`
- * array built from the issues.
+ * logs and proxies. This replaces it with the envelope, one issue per
+ * sentence in `message`.
  */
 export const validationHook = (result: ValidationResult, c: Context) => {
   if (result.success) {
     return;
   }
   return c.json(
-    apiError(
-      "VALIDATION_ERROR",
-      "The request did not match the expected schema. See details.",
-      result.error.map((issue) => ({
-        path: issuePath(issue),
-        message: issue.message,
-      })),
-    ),
+    apiError("VALIDATION_ERROR", result.error.map(describeIssue).join("; ")),
     400,
   );
 };

--- a/apps/web/src/app/api/middleware/api-error.ts
+++ b/apps/web/src/app/api/middleware/api-error.ts
@@ -19,14 +19,9 @@ type ValidationResult =
   | { success: true }
   | { success: false; error: readonly ValidationIssue[] };
 
+// zod emits plain keys; the Standard Schema `{ key }` segment form never occurs.
 const issuePath = (issue: ValidationIssue) =>
-  (issue.path ?? [])
-    .map((segment) =>
-      typeof segment === "object" && segment !== null
-        ? String(segment.key)
-        : String(segment),
-    )
-    .join(".");
+  (issue.path ?? []).map(String).join(".");
 
 /**
  * Hook for every `validator(...)` call. The standard-validator default

--- a/apps/web/src/app/api/middleware/api-key.ts
+++ b/apps/web/src/app/api/middleware/api-key.ts
@@ -161,12 +161,3 @@ export const spaceApiKeyAuth = every(
   }),
   requireProSpace,
 );
-
-/**
- * The frozen `/api/private` route keeps hono's plain-text `Unauthorized` /
- * `Bad Request` bodies. Not for new routes.
- */
-export const legacySpaceApiKeyAuth = every(
-  bearerAuth({ verifyToken }),
-  requireProSpace,
-);

--- a/apps/web/src/app/api/middleware/api-key.ts
+++ b/apps/web/src/app/api/middleware/api-key.ts
@@ -1,6 +1,7 @@
 import crypto from "node:crypto";
 import type { SpaceTier } from "@rallly/database";
 import { prisma } from "@rallly/database";
+import type { Context } from "hono";
 import { bearerAuth } from "hono/bearer-auth";
 import { every } from "hono/combine";
 import { createMiddleware } from "hono/factory";
@@ -17,108 +18,106 @@ import { apiError } from "./api-error";
 
 const LAST_USED_AT_WRITE_INTERVAL_MS = 60_000;
 
-const verifyKey = bearerAuth({
-  verifyToken: async (rawKey, c) => {
-    const prefix = extractApiKeyPrefix(rawKey);
-    const prefixBuffer = Buffer.from(prefix);
+const verifyToken = async (rawKey: string, c: Context) => {
+  const prefix = extractApiKeyPrefix(rawKey);
+  const prefixBuffer = Buffer.from(prefix);
 
-    // Query candidate keys to avoid timing attack via database lookup
-    // We use a partial prefix match to narrow the search space
-    const now = new Date();
-    const candidateKeys = await prisma.spaceApiKey.findMany({
-      where: {
-        prefix: {
-          startsWith: prefix.slice(0, Math.min(4, prefix.length)),
-        },
-        revokedAt: null,
-        OR: [{ expiresAt: null }, { expiresAt: { gt: now } }],
+  // Query candidate keys to avoid timing attack via database lookup
+  // We use a partial prefix match to narrow the search space
+  const now = new Date();
+  const candidateKeys = await prisma.spaceApiKey.findMany({
+    where: {
+      prefix: {
+        startsWith: prefix.slice(0, Math.min(4, prefix.length)),
       },
-      select: {
-        id: true,
-        prefix: true,
-        spaceId: true,
-        hashedKey: true,
-        lastUsedAt: true,
-        expiresAt: true,
-        revokedAt: true,
-        space: {
-          select: {
-            ownerId: true,
-            tier: true,
-          },
+      revokedAt: null,
+      OR: [{ expiresAt: null }, { expiresAt: { gt: now } }],
+    },
+    select: {
+      id: true,
+      prefix: true,
+      spaceId: true,
+      hashedKey: true,
+      lastUsedAt: true,
+      expiresAt: true,
+      revokedAt: true,
+      space: {
+        select: {
+          ownerId: true,
+          tier: true,
         },
       },
-    });
+    },
+  });
 
-    let apiKeyId: string | null = null;
-    let spaceId: string | null = null;
-    let spaceOwnerId: string | null = null;
-    let spaceTier: SpaceTier | null = null;
-    let lastUsedAt: Date | null = null;
-    let needsRehash = false;
-    for (const candidate of candidateKeys) {
-      // Timing-safe prefix comparison
-      const candidateBuffer = Buffer.from(candidate.prefix);
-      if (
-        prefixBuffer.length === candidateBuffer.length &&
-        crypto.timingSafeEqual(prefixBuffer, candidateBuffer)
-      ) {
-        // Verify the full key hash
-        const isValid = await verifyApiKey(rawKey, candidate.hashedKey);
-        if (isValid) {
-          apiKeyId = candidate.id;
-          spaceId = candidate.spaceId;
-          spaceOwnerId = candidate.space.ownerId;
-          spaceTier = candidate.space.tier;
-          lastUsedAt = candidate.lastUsedAt;
-          needsRehash = isLegacyApiKeyHash(candidate.hashedKey);
-        }
+  let apiKeyId: string | null = null;
+  let spaceId: string | null = null;
+  let spaceOwnerId: string | null = null;
+  let spaceTier: SpaceTier | null = null;
+  let lastUsedAt: Date | null = null;
+  let needsRehash = false;
+  for (const candidate of candidateKeys) {
+    // Timing-safe prefix comparison
+    const candidateBuffer = Buffer.from(candidate.prefix);
+    if (
+      prefixBuffer.length === candidateBuffer.length &&
+      crypto.timingSafeEqual(prefixBuffer, candidateBuffer)
+    ) {
+      // Verify the full key hash
+      const isValid = await verifyApiKey(rawKey, candidate.hashedKey);
+      if (isValid) {
+        apiKeyId = candidate.id;
+        spaceId = candidate.spaceId;
+        spaceOwnerId = candidate.space.ownerId;
+        spaceTier = candidate.space.tier;
+        lastUsedAt = candidate.lastUsedAt;
+        needsRehash = isLegacyApiKeyHash(candidate.hashedKey);
       }
     }
+  }
 
-    if (!apiKeyId || !spaceId || !spaceOwnerId || !spaceTier) {
-      return false;
-    }
+  if (!apiKeyId || !spaceId || !spaceOwnerId || !spaceTier) {
+    return false;
+  }
 
-    const effectiveTier = resolveSpaceTier(spaceTier);
+  const effectiveTier = resolveSpaceTier(spaceTier);
 
-    c.set("apiAuth", {
-      spaceId: spaceId as AuthorizedSpaceId,
-      spaceOwnerId,
-      spaceTier: effectiveTier,
-      apiKeyId,
-    });
+  c.set("apiAuth", {
+    spaceId: spaceId as AuthorizedSpaceId,
+    spaceOwnerId,
+    spaceTier: effectiveTier,
+    apiKeyId,
+  });
 
-    // Lazily migrate deprecated scrypt hashes to sha256 — we only hold the
-    // raw key during verification, so this is the one place we can re-hash.
-    const rehashedKey = needsRehash ? hashApiKey(rawKey) : null;
+  // Lazily migrate deprecated scrypt hashes to sha256 — we only hold the
+  // raw key during verification, so this is the one place we can re-hash.
+  const rehashedKey = needsRehash ? hashApiKey(rawKey) : null;
 
-    // lastUsedAt is only read at coarse precision, so throttle the write
-    // rather than issue an UPDATE on every request. Concurrent requests
-    // racing past this check are harmless (the write is idempotent).
-    const isLastUsedAtStale =
-      !lastUsedAt ||
-      now.getTime() - lastUsedAt.getTime() > LAST_USED_AT_WRITE_INTERVAL_MS;
+  // lastUsedAt is only read at coarse precision, so throttle the write
+  // rather than issue an UPDATE on every request. Concurrent requests
+  // racing past this check are harmless (the write is idempotent).
+  const isLastUsedAtStale =
+    !lastUsedAt ||
+    now.getTime() - lastUsedAt.getTime() > LAST_USED_AT_WRITE_INTERVAL_MS;
 
-    // Skip the write for non-Pro spaces: requireProSpace rejects them with
-    // 403, so bumping lastUsedAt would misreport a blocked key as active and
-    // waste a DB write on rejected traffic. Without billing every space
-    // resolves to Pro here.
-    if (effectiveTier === "pro" && (rehashedKey || isLastUsedAtStale)) {
-      after(() =>
-        prisma.spaceApiKey.update({
-          where: { id: apiKeyId },
-          data: {
-            lastUsedAt: new Date(),
-            ...(rehashedKey ? { hashedKey: rehashedKey } : {}),
-          },
-        }),
-      );
-    }
+  // Skip the write for non-Pro spaces: requireProSpace rejects them with
+  // 403, so bumping lastUsedAt would misreport a blocked key as active and
+  // waste a DB write on rejected traffic. Without billing every space
+  // resolves to Pro here.
+  if (effectiveTier === "pro" && (rehashedKey || isLastUsedAtStale)) {
+    after(() =>
+      prisma.spaceApiKey.update({
+        where: { id: apiKeyId },
+        data: {
+          lastUsedAt: new Date(),
+          ...(rehashedKey ? { hashedKey: rehashedKey } : {}),
+        },
+      }),
+    );
+  }
 
-    return true;
-  },
-});
+  return true;
+};
 
 // hono/bearer-auth can only turn a failed verifyToken into a 401, so the
 // tier check runs as a follow-up middleware to respond with a 403 instead.
@@ -137,4 +136,37 @@ const requireProSpace = createMiddleware<{
   await next();
 });
 
-export const spaceApiKeyAuth = every(verifyKey, requireProSpace);
+/**
+ * Bearer auth whose failure bodies are the documented JSON envelope. The
+ * `WWW-Authenticate` challenge headers keep hono's defaults.
+ */
+export const spaceApiKeyAuth = every(
+  bearerAuth({
+    verifyToken,
+    noAuthenticationHeader: {
+      message: apiError(
+        "UNAUTHORIZED",
+        "Missing API key. Send it as `Authorization: Bearer <key>`.",
+      ),
+    },
+    invalidAuthenticationHeader: {
+      message: apiError(
+        "INVALID_AUTHORIZATION_HEADER",
+        "Malformed Authorization header. Expected `Bearer <key>`.",
+      ),
+    },
+    invalidToken: {
+      message: apiError("UNAUTHORIZED", "Invalid, expired or revoked API key."),
+    },
+  }),
+  requireProSpace,
+);
+
+/**
+ * The frozen `/api/private` route keeps hono's plain-text `Unauthorized` /
+ * `Bad Request` bodies. Not for new routes.
+ */
+export const legacySpaceApiKeyAuth = every(
+  bearerAuth({ verifyToken }),
+  requireProSpace,
+);

--- a/apps/web/src/app/api/middleware/api-key.ts
+++ b/apps/web/src/app/api/middleware/api-key.ts
@@ -1,7 +1,6 @@
 import crypto from "node:crypto";
 import type { SpaceTier } from "@rallly/database";
 import { prisma } from "@rallly/database";
-import type { Context } from "hono";
 import { bearerAuth } from "hono/bearer-auth";
 import { every } from "hono/combine";
 import { createMiddleware } from "hono/factory";
@@ -18,106 +17,123 @@ import { apiError } from "./api-error";
 
 const LAST_USED_AT_WRITE_INTERVAL_MS = 60_000;
 
-const verifyToken = async (rawKey: string, c: Context) => {
-  const prefix = extractApiKeyPrefix(rawKey);
-  const prefixBuffer = Buffer.from(prefix);
+const verifyKey = bearerAuth({
+  verifyToken: async (rawKey, c) => {
+    const prefix = extractApiKeyPrefix(rawKey);
+    const prefixBuffer = Buffer.from(prefix);
 
-  // Query candidate keys to avoid timing attack via database lookup
-  // We use a partial prefix match to narrow the search space
-  const now = new Date();
-  const candidateKeys = await prisma.spaceApiKey.findMany({
-    where: {
-      prefix: {
-        startsWith: prefix.slice(0, Math.min(4, prefix.length)),
+    // Query candidate keys to avoid timing attack via database lookup
+    // We use a partial prefix match to narrow the search space
+    const now = new Date();
+    const candidateKeys = await prisma.spaceApiKey.findMany({
+      where: {
+        prefix: {
+          startsWith: prefix.slice(0, Math.min(4, prefix.length)),
+        },
+        revokedAt: null,
+        OR: [{ expiresAt: null }, { expiresAt: { gt: now } }],
       },
-      revokedAt: null,
-      OR: [{ expiresAt: null }, { expiresAt: { gt: now } }],
-    },
-    select: {
-      id: true,
-      prefix: true,
-      spaceId: true,
-      hashedKey: true,
-      lastUsedAt: true,
-      expiresAt: true,
-      revokedAt: true,
-      space: {
-        select: {
-          ownerId: true,
-          tier: true,
+      select: {
+        id: true,
+        prefix: true,
+        spaceId: true,
+        hashedKey: true,
+        lastUsedAt: true,
+        expiresAt: true,
+        revokedAt: true,
+        space: {
+          select: {
+            ownerId: true,
+            tier: true,
+          },
         },
       },
-    },
-  });
+    });
 
-  let apiKeyId: string | null = null;
-  let spaceId: string | null = null;
-  let spaceOwnerId: string | null = null;
-  let spaceTier: SpaceTier | null = null;
-  let lastUsedAt: Date | null = null;
-  let needsRehash = false;
-  for (const candidate of candidateKeys) {
-    // Timing-safe prefix comparison
-    const candidateBuffer = Buffer.from(candidate.prefix);
-    if (
-      prefixBuffer.length === candidateBuffer.length &&
-      crypto.timingSafeEqual(prefixBuffer, candidateBuffer)
-    ) {
-      // Verify the full key hash
-      const isValid = await verifyApiKey(rawKey, candidate.hashedKey);
-      if (isValid) {
-        apiKeyId = candidate.id;
-        spaceId = candidate.spaceId;
-        spaceOwnerId = candidate.space.ownerId;
-        spaceTier = candidate.space.tier;
-        lastUsedAt = candidate.lastUsedAt;
-        needsRehash = isLegacyApiKeyHash(candidate.hashedKey);
+    let apiKeyId: string | null = null;
+    let spaceId: string | null = null;
+    let spaceOwnerId: string | null = null;
+    let spaceTier: SpaceTier | null = null;
+    let lastUsedAt: Date | null = null;
+    let needsRehash = false;
+    for (const candidate of candidateKeys) {
+      // Timing-safe prefix comparison
+      const candidateBuffer = Buffer.from(candidate.prefix);
+      if (
+        prefixBuffer.length === candidateBuffer.length &&
+        crypto.timingSafeEqual(prefixBuffer, candidateBuffer)
+      ) {
+        // Verify the full key hash
+        const isValid = await verifyApiKey(rawKey, candidate.hashedKey);
+        if (isValid) {
+          apiKeyId = candidate.id;
+          spaceId = candidate.spaceId;
+          spaceOwnerId = candidate.space.ownerId;
+          spaceTier = candidate.space.tier;
+          lastUsedAt = candidate.lastUsedAt;
+          needsRehash = isLegacyApiKeyHash(candidate.hashedKey);
+        }
       }
     }
-  }
 
-  if (!apiKeyId || !spaceId || !spaceOwnerId || !spaceTier) {
-    return false;
-  }
+    if (!apiKeyId || !spaceId || !spaceOwnerId || !spaceTier) {
+      return false;
+    }
 
-  const effectiveTier = resolveSpaceTier(spaceTier);
+    const effectiveTier = resolveSpaceTier(spaceTier);
 
-  c.set("apiAuth", {
-    spaceId: spaceId as AuthorizedSpaceId,
-    spaceOwnerId,
-    spaceTier: effectiveTier,
-    apiKeyId,
-  });
+    c.set("apiAuth", {
+      spaceId: spaceId as AuthorizedSpaceId,
+      spaceOwnerId,
+      spaceTier: effectiveTier,
+      apiKeyId,
+    });
 
-  // Lazily migrate deprecated scrypt hashes to sha256 — we only hold the
-  // raw key during verification, so this is the one place we can re-hash.
-  const rehashedKey = needsRehash ? hashApiKey(rawKey) : null;
+    // Lazily migrate deprecated scrypt hashes to sha256 — we only hold the
+    // raw key during verification, so this is the one place we can re-hash.
+    const rehashedKey = needsRehash ? hashApiKey(rawKey) : null;
 
-  // lastUsedAt is only read at coarse precision, so throttle the write
-  // rather than issue an UPDATE on every request. Concurrent requests
-  // racing past this check are harmless (the write is idempotent).
-  const isLastUsedAtStale =
-    !lastUsedAt ||
-    now.getTime() - lastUsedAt.getTime() > LAST_USED_AT_WRITE_INTERVAL_MS;
+    // lastUsedAt is only read at coarse precision, so throttle the write
+    // rather than issue an UPDATE on every request. Concurrent requests
+    // racing past this check are harmless (the write is idempotent).
+    const isLastUsedAtStale =
+      !lastUsedAt ||
+      now.getTime() - lastUsedAt.getTime() > LAST_USED_AT_WRITE_INTERVAL_MS;
 
-  // Skip the write for non-Pro spaces: requireProSpace rejects them with
-  // 403, so bumping lastUsedAt would misreport a blocked key as active and
-  // waste a DB write on rejected traffic. Without billing every space
-  // resolves to Pro here.
-  if (effectiveTier === "pro" && (rehashedKey || isLastUsedAtStale)) {
-    after(() =>
-      prisma.spaceApiKey.update({
-        where: { id: apiKeyId },
-        data: {
-          lastUsedAt: new Date(),
-          ...(rehashedKey ? { hashedKey: rehashedKey } : {}),
-        },
-      }),
-    );
-  }
+    // Skip the write for non-Pro spaces: requireProSpace rejects them with
+    // 403, so bumping lastUsedAt would misreport a blocked key as active and
+    // waste a DB write on rejected traffic. Without billing every space
+    // resolves to Pro here.
+    if (effectiveTier === "pro" && (rehashedKey || isLastUsedAtStale)) {
+      after(() =>
+        prisma.spaceApiKey.update({
+          where: { id: apiKeyId },
+          data: {
+            lastUsedAt: new Date(),
+            ...(rehashedKey ? { hashedKey: rehashedKey } : {}),
+          },
+        }),
+      );
+    }
 
-  return true;
-};
+    return true;
+  },
+  noAuthenticationHeader: {
+    message: apiError(
+      "UNAUTHORIZED",
+      "Missing API key. Send it as `Authorization: Bearer <key>`.",
+    ),
+  },
+  invalidAuthenticationHeader: {
+    message: apiError(
+      "INVALID_AUTHORIZATION_HEADER",
+      "Malformed Authorization header. Expected `Bearer <key>`.",
+    ),
+  },
+  invalidToken: {
+    message: apiError("UNAUTHORIZED", "Invalid, expired or revoked API key."),
+  },
+});
 
 // hono/bearer-auth can only turn a failed verifyToken into a 401, so the
 // tier check runs as a follow-up middleware to respond with a 403 instead.
@@ -136,28 +152,4 @@ const requireProSpace = createMiddleware<{
   await next();
 });
 
-/**
- * Bearer auth whose failure bodies are the documented JSON envelope. The
- * `WWW-Authenticate` challenge headers keep hono's defaults.
- */
-export const spaceApiKeyAuth = every(
-  bearerAuth({
-    verifyToken,
-    noAuthenticationHeader: {
-      message: apiError(
-        "UNAUTHORIZED",
-        "Missing API key. Send it as `Authorization: Bearer <key>`.",
-      ),
-    },
-    invalidAuthenticationHeader: {
-      message: apiError(
-        "INVALID_AUTHORIZATION_HEADER",
-        "Malformed Authorization header. Expected `Bearer <key>`.",
-      ),
-    },
-    invalidToken: {
-      message: apiError("UNAUTHORIZED", "Invalid, expired or revoked API key."),
-    },
-  }),
-  requireProSpace,
-);
+export const spaceApiKeyAuth = every(verifyKey, requireProSpace);

--- a/apps/web/src/app/api/private/[...route]/route.ts
+++ b/apps/web/src/app/api/private/[...route]/route.ts
@@ -28,7 +28,7 @@ import {
 import { isMaintenanceModeEnabled } from "@/lib/maintenance";
 import { flushPostHog, identifyGroup, track } from "@/lib/posthog";
 import { apiError } from "../../middleware/api-error";
-import { legacySpaceApiKeyAuth as spaceApiKeyAuth } from "../../middleware/api-key";
+import { spaceApiKeyAuth } from "../../middleware/api-key";
 import {
   RATE_LIMIT_PER_DAY,
   RATE_LIMIT_PER_MINUTE,

--- a/apps/web/src/app/api/private/[...route]/route.ts
+++ b/apps/web/src/app/api/private/[...route]/route.ts
@@ -28,7 +28,7 @@ import {
 import { isMaintenanceModeEnabled } from "@/lib/maintenance";
 import { flushPostHog, identifyGroup, track } from "@/lib/posthog";
 import { apiError } from "../../middleware/api-error";
-import { spaceApiKeyAuth } from "../../middleware/api-key";
+import { legacySpaceApiKeyAuth as spaceApiKeyAuth } from "../../middleware/api-key";
 import {
   RATE_LIMIT_PER_DAY,
   RATE_LIMIT_PER_MINUTE,

--- a/apps/web/src/app/api/v1/[...route]/route.test.ts
+++ b/apps/web/src/app/api/v1/[...route]/route.test.ts
@@ -74,6 +74,7 @@ vi.mock("@/lib/posthog", () => ({
   flushPostHog: vi.fn(),
 }));
 
+import { logger } from "@rallly/logger";
 import { after } from "next/server";
 import { hashApiKey, verifyApiKey } from "@/features/api-keys/utils";
 import { MAX_SLOT_GENERATION_DAYS } from "@/lib/datetime/slot-generator";
@@ -88,6 +89,7 @@ import {
   createPollInputSchema,
   createPollSuccessResponseSchema,
   deletePollSuccessResponseSchema,
+  errorResponseSchema,
   getPollParticipantsSuccessResponseSchema,
   getPollResultsSuccessResponseSchema,
   getPollSuccessResponseSchema,
@@ -105,6 +107,24 @@ const expectMatchesContract = (
   const result = schema.safeParse(body);
   expect(result.error).toBeUndefined();
   expect(result.success).toBe(true);
+};
+
+// Every failure must be the documented `{ error: { code, message } }` JSON
+// envelope, whichever layer produced it (bearer auth, validator, handler,
+// notFound, onError).
+const expectErrorEnvelope = async (
+  res: Response,
+  { status, code }: { status: number; code: string },
+) => {
+  expect(res.status).toBe(status);
+  expect(res.headers.get("content-type")).toMatch(/^application\/json/);
+  const json = await res.json();
+  expectMatchesContract(errorResponseSchema, json);
+  expect(json.error.code).toBe(code);
+  expect(typeof json.error.message).toBe("string");
+  return json as {
+    error: { code: string; message: string; details?: unknown };
+  };
 };
 
 // Pre-generated test API key fixture. The stored hash deliberately uses the
@@ -173,7 +193,8 @@ describe("API v1 - /polls", () => {
         }),
       });
 
-      expect(res.status).toBe(401);
+      await expectErrorEnvelope(res, { status: 401, code: "UNAUTHORIZED" });
+      expect(res.headers.get("WWW-Authenticate")).not.toBeNull();
     });
 
     it("should return 401 with invalid API key", async () => {
@@ -191,7 +212,8 @@ describe("API v1 - /polls", () => {
         }),
       });
 
-      expect(res.status).toBe(401);
+      await expectErrorEnvelope(res, { status: 401, code: "UNAUTHORIZED" });
+      expect(res.headers.get("WWW-Authenticate")).not.toBeNull();
     });
 
     it("should return 401 with revoked API key", async () => {
@@ -210,7 +232,8 @@ describe("API v1 - /polls", () => {
         }),
       });
 
-      expect(res.status).toBe(401);
+      await expectErrorEnvelope(res, { status: 401, code: "UNAUTHORIZED" });
+      expect(res.headers.get("WWW-Authenticate")).not.toBeNull();
     });
 
     it("should return 401 with expired API key", async () => {
@@ -229,7 +252,8 @@ describe("API v1 - /polls", () => {
         }),
       });
 
-      expect(res.status).toBe(401);
+      await expectErrorEnvelope(res, { status: 401, code: "UNAUTHORIZED" });
+      expect(res.headers.get("WWW-Authenticate")).not.toBeNull();
     });
   });
 
@@ -781,12 +805,14 @@ describe("API v1 - /polls", () => {
       // (e.g. TOO_MANY_OPTIONS) can't mask a regression.
       expect(res.status).toBe(400);
       expect(mockCreatePoll).not.toHaveBeenCalled();
-      const json = await res.json();
-      const issue = json.error.find((e: { path: (string | number)[] }) =>
-        e.path.includes("endDate"),
-      );
-      expect(issue).toBeDefined();
-      expect(issue.message).toContain(String(MAX_SLOT_GENERATION_DAYS));
+      const json = await expectErrorEnvelope(res, {
+        status: 400,
+        code: "VALIDATION_ERROR",
+      });
+      const issue = (
+        json.error.details as { path: string; message: string }[]
+      ).find((d) => d.path.endsWith("endDate"));
+      expect(issue?.message).toContain(String(MAX_SLOT_GENERATION_DAYS));
     });
 
     it("should reject a slot generator range where endDate precedes startDate", async () => {
@@ -816,10 +842,13 @@ describe("API v1 - /polls", () => {
 
       expect(res.status).toBe(400);
       expect(mockCreatePoll).not.toHaveBeenCalled();
-      const json = await res.json();
-      const issue = json.error.find((e: { path: (string | number)[] }) =>
-        e.path.includes("endDate"),
-      );
+      const json = await expectErrorEnvelope(res, {
+        status: 400,
+        code: "VALIDATION_ERROR",
+      });
+      const issue = (
+        json.error.details as { path: string; message: string }[]
+      ).find((d) => d.path.endsWith("endDate"));
       expect(issue).toBeDefined();
     });
 
@@ -1885,6 +1914,175 @@ describe("API v1 - /polls", () => {
       });
 
       expect(res.status).toBe(401);
+    });
+  });
+
+  describe("Error envelope", () => {
+    const authed = { Authorization: `Bearer ${testApiKey}` };
+
+    it("should return 400 INVALID_AUTHORIZATION_HEADER as JSON for a malformed Authorization header", async () => {
+      const res = await app.request("/api/v1/polls", {
+        method: "GET",
+        headers: { Authorization: "Basic not-a-bearer-token" },
+      });
+
+      await expectErrorEnvelope(res, {
+        status: 400,
+        code: "INVALID_AUTHORIZATION_HEADER",
+      });
+      expect(res.headers.get("WWW-Authenticate")).toContain("invalid_request");
+    });
+
+    it("should return 400 VALIDATION_ERROR with details and no echoed body for an invalid JSON body", async () => {
+      const res = await app.request("/api/v1/polls", {
+        method: "POST",
+        headers: { ...authed, "Content-Type": "application/json" },
+        body: JSON.stringify({ dates: ["not-a-date"], secret: "do-not-echo" }),
+      });
+
+      const json = await expectErrorEnvelope(res, {
+        status: 400,
+        code: "VALIDATION_ERROR",
+      });
+      expect(json.error.details).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ path: "title" }),
+          expect.objectContaining({ path: "dates.0" }),
+        ]),
+      );
+      for (const detail of json.error.details as unknown[]) {
+        expect(Object.keys(detail as object).sort()).toEqual([
+          "message",
+          "path",
+        ]);
+      }
+      expect(JSON.stringify(json)).not.toContain("do-not-echo");
+      expect(json).not.toHaveProperty("success");
+      expect(json).not.toHaveProperty("data");
+      expect(mockCreatePoll).not.toHaveBeenCalled();
+    });
+
+    it("should return 400 VALIDATION_ERROR as JSON for an invalid query string", async () => {
+      const res = await app.request("/api/v1/polls?limit=9999", {
+        method: "GET",
+        headers: authed,
+      });
+
+      const json = await expectErrorEnvelope(res, {
+        status: 400,
+        code: "VALIDATION_ERROR",
+      });
+      expect(json.error.details).toEqual([
+        expect.objectContaining({ path: "limit" }),
+      ]);
+      expect(mockListPolls).not.toHaveBeenCalled();
+    });
+
+    it("should return 400 VALIDATION_ERROR as JSON for a PATCH body that fails validation", async () => {
+      const res = await app.request("/api/v1/polls/test-poll-id", {
+        method: "PATCH",
+        headers: { ...authed, "Content-Type": "application/json" },
+        body: JSON.stringify({ status: "archived" }),
+      });
+
+      const json = await expectErrorEnvelope(res, {
+        status: 400,
+        code: "VALIDATION_ERROR",
+      });
+      expect(json.error.details).toEqual([
+        expect.objectContaining({ path: "status" }),
+      ]);
+      expect(json).not.toHaveProperty("data");
+    });
+
+    it("should return 400 VALIDATION_ERROR as JSON for a malformed JSON body", async () => {
+      const res = await app.request("/api/v1/polls", {
+        method: "POST",
+        headers: { ...authed, "Content-Type": "application/json" },
+        body: "{not json",
+      });
+
+      await expectErrorEnvelope(res, { status: 400, code: "VALIDATION_ERROR" });
+    });
+
+    it("should return 404 NOT_FOUND as JSON for an unknown route", async () => {
+      const res = await app.request("/api/v1/nope", {
+        method: "GET",
+        headers: authed,
+      });
+
+      await expectErrorEnvelope(res, { status: 404, code: "NOT_FOUND" });
+    });
+
+    it("should return 404 NOT_FOUND as JSON for an unsupported method on a known route", async () => {
+      const res = await app.request("/api/v1/polls", {
+        method: "PUT",
+        headers: authed,
+      });
+
+      await expectErrorEnvelope(res, { status: 404, code: "NOT_FOUND" });
+    });
+
+    it("should return 500 INTERNAL_ERROR as JSON and log the error when a handler behind the rate limiter throws", async () => {
+      const errorSpy = vi.spyOn(logger, "error").mockImplementation(() => {});
+      mockGetPollWithOptions.mockRejectedValue(new TypeError("db exploded"));
+
+      const res = await app.request("/api/v1/polls/test-poll-id", {
+        method: "GET",
+        headers: authed,
+      });
+
+      const json = await expectErrorEnvelope(res, {
+        status: 500,
+        code: "INTERNAL_ERROR",
+      });
+      // Never leak the underlying error message to the client.
+      expect(json.error.message).not.toContain("db exploded");
+      // The request was counted by the limiter before the handler threw.
+      expect(res.headers.get("RateLimit-Limit")).not.toBeNull();
+
+      expect(errorSpy).toHaveBeenCalledTimes(1);
+      expect(errorSpy.mock.calls[0][0]).toMatchObject({
+        service: "api-v1",
+        statusCode: 500,
+        errorType: "TypeError",
+        errorMessage: "db exploded",
+        spaceId: "test-space-id",
+      });
+      errorSpy.mockRestore();
+    });
+
+    it("should document the details array and the full error code list in the spec", async () => {
+      const res = await app.request("/api/v1/openapi");
+      const json = await res.json();
+
+      const errorSchema =
+        json.paths["/api/v1/polls"].post.responses["400"].content[
+          "application/json"
+        ].schema;
+      expect(errorSchema.properties.error.properties.details.type).toBe(
+        "array",
+      );
+      expect(errorSchema.properties.error.required).not.toContain("details");
+
+      for (const code of [
+        "VALIDATION_ERROR",
+        "UNAUTHORIZED",
+        "INVALID_AUTHORIZATION_HEADER",
+        "SPACE_NOT_PRO",
+        "RATE_LIMIT_EXCEEDED",
+        "NOT_FOUND",
+        "POLL_NOT_FOUND",
+        "ORGANIZER_NOT_MEMBER",
+        "TOO_MANY_OPTIONS",
+        "DUPLICATE_DATES",
+        "NO_OPTIONS_GENERATED",
+        "TRANSITION_NOT_AVAILABLE",
+        "SERVICE_UNAVAILABLE",
+        "INTERNAL_ERROR",
+      ]) {
+        expect(json.info.description).toContain(`\`${code}\``);
+      }
     });
   });
 });

--- a/apps/web/src/app/api/v1/[...route]/route.test.ts
+++ b/apps/web/src/app/api/v1/[...route]/route.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, onTestFinished, vi } from "vitest";
 
 // Mock server-only before any imports that might need it
 vi.mock("server-only", () => ({}));
@@ -2025,6 +2025,7 @@ describe("API v1 - /polls", () => {
 
     it("should return 500 INTERNAL_ERROR as JSON and log the error when a handler behind the rate limiter throws", async () => {
       const errorSpy = vi.spyOn(logger, "error").mockImplementation(() => {});
+      onTestFinished(() => errorSpy.mockRestore());
       mockGetPollWithOptions.mockRejectedValue(new TypeError("db exploded"));
 
       const res = await app.request("/api/v1/polls/test-poll-id", {
@@ -2049,7 +2050,6 @@ describe("API v1 - /polls", () => {
         errorMessage: "db exploded",
         spaceId: "test-space-id",
       });
-      errorSpy.mockRestore();
     });
 
     it("should document the details array and the full error code list in the spec", async () => {

--- a/apps/web/src/app/api/v1/[...route]/route.test.ts
+++ b/apps/web/src/app/api/v1/[...route]/route.test.ts
@@ -122,9 +122,7 @@ const expectErrorEnvelope = async (
   expectMatchesContract(errorResponseSchema, json);
   expect(json.error.code).toBe(code);
   expect(typeof json.error.message).toBe("string");
-  return json as {
-    error: { code: string; message: string; details?: unknown };
-  };
+  return json as { error: { code: string; message: string } };
 };
 
 // Pre-generated test API key fixture. The stored hash deliberately uses the
@@ -809,10 +807,8 @@ describe("API v1 - /polls", () => {
         status: 400,
         code: "VALIDATION_ERROR",
       });
-      const issue = (
-        json.error.details as { path: string; message: string }[]
-      ).find((d) => d.path.endsWith("endDate"));
-      expect(issue?.message).toContain(String(MAX_SLOT_GENERATION_DAYS));
+      expect(json.error.message).toContain("endDate");
+      expect(json.error.message).toContain(String(MAX_SLOT_GENERATION_DAYS));
     });
 
     it("should reject a slot generator range where endDate precedes startDate", async () => {
@@ -846,10 +842,7 @@ describe("API v1 - /polls", () => {
         status: 400,
         code: "VALIDATION_ERROR",
       });
-      const issue = (
-        json.error.details as { path: string; message: string }[]
-      ).find((d) => d.path.endsWith("endDate"));
-      expect(issue).toBeDefined();
+      expect(json.error.message).toContain("endDate");
     });
 
     it("should reject a range spanning exactly MAX_SLOT_GENERATION_DAYS", async () => {
@@ -1933,7 +1926,7 @@ describe("API v1 - /polls", () => {
       expect(res.headers.get("WWW-Authenticate")).toContain("invalid_request");
     });
 
-    it("should return 400 VALIDATION_ERROR with details and no echoed body for an invalid JSON body", async () => {
+    it("should return 400 VALIDATION_ERROR naming the fields, without echoing the body, for an invalid JSON body", async () => {
       const res = await app.request("/api/v1/polls", {
         method: "POST",
         headers: { ...authed, "Content-Type": "application/json" },
@@ -1944,18 +1937,9 @@ describe("API v1 - /polls", () => {
         status: 400,
         code: "VALIDATION_ERROR",
       });
-      expect(json.error.details).toEqual(
-        expect.arrayContaining([
-          expect.objectContaining({ path: "title" }),
-          expect.objectContaining({ path: "dates.0" }),
-        ]),
-      );
-      for (const detail of json.error.details as unknown[]) {
-        expect(Object.keys(detail as object).sort()).toEqual([
-          "message",
-          "path",
-        ]);
-      }
+      expect(json.error.message).toContain("title:");
+      expect(json.error.message).toContain("dates.0:");
+      expect(Object.keys(json.error).sort()).toEqual(["code", "message"]);
       expect(JSON.stringify(json)).not.toContain("do-not-echo");
       expect(json).not.toHaveProperty("success");
       expect(json).not.toHaveProperty("data");
@@ -1972,9 +1956,7 @@ describe("API v1 - /polls", () => {
         status: 400,
         code: "VALIDATION_ERROR",
       });
-      expect(json.error.details).toEqual([
-        expect.objectContaining({ path: "limit" }),
-      ]);
+      expect(json.error.message).toMatch(/^limit: /);
       expect(mockListPolls).not.toHaveBeenCalled();
     });
 
@@ -1989,9 +1971,7 @@ describe("API v1 - /polls", () => {
         status: 400,
         code: "VALIDATION_ERROR",
       });
-      expect(json.error.details).toEqual([
-        expect.objectContaining({ path: "status" }),
-      ]);
+      expect(json.error.message).toMatch(/^status: /);
       expect(json).not.toHaveProperty("data");
     });
 
@@ -2052,18 +2032,9 @@ describe("API v1 - /polls", () => {
       });
     });
 
-    it("should document the details array and the full error code list in the spec", async () => {
+    it("should document the full error code list in the spec", async () => {
       const res = await app.request("/api/v1/openapi");
       const json = await res.json();
-
-      const errorSchema =
-        json.paths["/api/v1/polls"].post.responses["400"].content[
-          "application/json"
-        ].schema;
-      expect(errorSchema.properties.error.properties.details.type).toBe(
-        "array",
-      );
-      expect(errorSchema.properties.error.required).not.toContain("details");
 
       for (const code of [
         "VALIDATION_ERROR",

--- a/apps/web/src/app/api/v1/[...route]/route.ts
+++ b/apps/web/src/app/api/v1/[...route]/route.ts
@@ -204,7 +204,7 @@ async function buildOpenApiSpec() {
           "",
           "## Errors",
           "",
-          'Every failure is `application/json` with the shape `{ "error": { "code", "message" } }`. `code` is stable and safe to branch on; `message` is human-readable and may change. `VALIDATION_ERROR` responses add a `details` array of `{ path, message }`, one entry per issue.',
+          'Every failure is `application/json` with the shape `{ "error": { "code", "message" } }`. `code` is stable and safe to branch on; `message` is human-readable and may change. `VALIDATION_ERROR` messages name each offending field.',
           "",
           "| Status | Code | When |",
           "| --- | --- | --- |",

--- a/apps/web/src/app/api/v1/[...route]/route.ts
+++ b/apps/web/src/app/api/v1/[...route]/route.ts
@@ -1,5 +1,6 @@
 import { absoluteUrl, shortUrl } from "@rallly/utils/absolute-url";
 import { Hono } from "hono";
+import { HTTPException } from "hono/http-exception";
 import { handle } from "hono/vercel";
 import {
   describeRoute,
@@ -27,7 +28,7 @@ import {
 } from "@/lib/datetime/slot-generator";
 import { isMaintenanceModeEnabled } from "@/lib/maintenance";
 import { flushPostHog, identifyGroup, track } from "@/lib/posthog";
-import { apiError } from "../../middleware/api-error";
+import { apiError, validationHook } from "../../middleware/api-error";
 import { spaceApiKeyAuth } from "../../middleware/api-key";
 import {
   RATE_LIMIT_PER_DAY,
@@ -116,6 +117,33 @@ app.use("*", async (c, next) => {
   await next();
 });
 
+app.notFound((c) =>
+  c.json(
+    apiError("NOT_FOUND", `No route matches ${c.req.method} ${c.req.path}.`),
+    404,
+  ),
+);
+
+// The wide event middleware reads `c.error`, which hono sets before calling
+// this handler, so the original error is logged there. The client only ever
+// sees a generic message.
+app.onError((error, c) => {
+  if (error instanceof HTTPException) {
+    // Bearer auth throws with a prebuilt JSON response.
+    if (error.res) {
+      return error.getResponse();
+    }
+    // hono's validator throws a bare 400 for a body it cannot parse.
+    if (error.status === 400) {
+      return c.json(apiError("VALIDATION_ERROR", error.message), 400);
+    }
+  }
+  return c.json(
+    apiError("INTERNAL_ERROR", "Something went wrong. Try again later."),
+    500,
+  );
+});
+
 const spaceNotProResponse = {
   description:
     "The space associated with the API key does not have a Pro subscription",
@@ -173,6 +201,27 @@ async function buildOpenApiSpec() {
           "Every response from an authenticated request includes the standard `RateLimit-*` headers. Responses sent before the limiter runs (`401`, `403`, and the maintenance `503`) do not. `RateLimit-Policy` lists both limits; `RateLimit-Limit`, `RateLimit-Remaining` and `RateLimit-Reset` describe whichever limit is closest to being exhausted. When either limit is exceeded the API responds with `429 Too Many Requests`, a `RATE_LIMIT_EXCEEDED` error body, and a `Retry-After` header indicating how many seconds to wait before retrying.",
           "",
           "If the rate limit store cannot be reached the API fails closed and responds with `503 Service Unavailable`, a `SERVICE_UNAVAILABLE` error body, and a `Retry-After` header.",
+          "",
+          "## Errors",
+          "",
+          'Every failure is `application/json` with the shape `{ "error": { "code", "message" } }`. `code` is stable and safe to branch on; `message` is human-readable and may change. `VALIDATION_ERROR` responses add a `details` array of `{ path, message }`, one entry per issue.',
+          "",
+          "| Status | Code | When |",
+          "| --- | --- | --- |",
+          "| 400 | `VALIDATION_ERROR` | The body or query string did not match the schema, or the body was not valid JSON |",
+          "| 400 | `INVALID_AUTHORIZATION_HEADER` | The `Authorization` header is not `Bearer <key>` |",
+          "| 400 | `ORGANIZER_NOT_MEMBER` | The organizer email is not a member of the space |",
+          "| 400 | `TOO_MANY_OPTIONS` | More than the maximum number of poll options |",
+          "| 400 | `DUPLICATE_DATES` | `dates` contains the same date more than once |",
+          "| 400 | `NO_OPTIONS_GENERATED` | No slot generator produced a valid time slot |",
+          "| 401 | `UNAUTHORIZED` | The API key is missing, invalid, expired or revoked |",
+          "| 403 | `SPACE_NOT_PRO` | The space behind the key has no Pro subscription |",
+          "| 404 | `NOT_FOUND` | No route matches the method and path |",
+          "| 404 | `POLL_NOT_FOUND` | The poll does not exist or belongs to another space |",
+          "| 422 | `TRANSITION_NOT_AVAILABLE` | The requested status change is not supported |",
+          "| 429 | `RATE_LIMIT_EXCEEDED` | A rate limit window is exhausted |",
+          "| 503 | `SERVICE_UNAVAILABLE` | Maintenance, or the rate limit store cannot be reached |",
+          "| 500 | `INTERNAL_ERROR` | Unexpected failure; the request id is logged |",
         ].join("\n"),
       },
       servers: [{ url: absoluteUrl() }],
@@ -255,7 +304,7 @@ app.post(
       503: serviceUnavailableResponse,
     },
   }),
-  validator("json", createPollInputSchema),
+  validator("json", createPollInputSchema, validationHook),
   async (c) => {
     const input = c.req.valid("json");
     const { spaceId, spaceOwnerId } = c.get("apiAuth");
@@ -382,7 +431,10 @@ app.post(
     // Process slots (time-based options)
     if (!input.slots) {
       return c.json(
-        apiError("INVALID_INPUT", "Either 'dates' or 'slots' must be provided"),
+        apiError(
+          "VALIDATION_ERROR",
+          "Either 'dates' or 'slots' must be provided",
+        ),
         400,
       );
     }
@@ -487,7 +539,7 @@ app.get(
       503: serviceUnavailableResponse,
     },
   }),
-  validator("query", listPollsQuerySchema),
+  validator("query", listPollsQuerySchema, validationHook),
   async (c) => {
     const { status, cursor, limit } = c.req.valid("query");
     const { spaceId } = c.get("apiAuth");
@@ -608,7 +660,7 @@ app.patch(
       },
     },
   }),
-  validator("json", patchPollInputSchema),
+  validator("json", patchPollInputSchema, validationHook),
   async (c) => {
     const { pollId } = c.req.param();
     const { status } = c.req.valid("json");

--- a/apps/web/src/app/api/v1/schemas.ts
+++ b/apps/web/src/app/api/v1/schemas.ts
@@ -147,26 +147,10 @@ export const errorResponseSchema = z
         example: "VALIDATION_ERROR",
       }),
       message: z.string().openapi({
-        example: "The request did not match the expected schema. See details.",
+        description:
+          "Human-readable explanation. For `VALIDATION_ERROR` it names each offending field, e.g. `title: Invalid input: expected string, received undefined; dates.0: Invalid ISO date`.",
+        example: "title: Invalid input: expected string, received undefined",
       }),
-      details: z
-        .array(
-          z.object({
-            path: z.string().openapi({
-              description:
-                "Dot-separated path to the offending field. Empty for errors on the whole body.",
-              example: "slots.duration",
-            }),
-            message: z.string().openapi({
-              example: "Invalid input: expected number, received string",
-            }),
-          }),
-        )
-        .optional()
-        .openapi({
-          description:
-            "Present on `VALIDATION_ERROR` only: one entry per issue.",
-        }),
     }),
   })
   .openapi("ErrorResponse");

--- a/apps/web/src/app/api/v1/schemas.ts
+++ b/apps/web/src/app/api/v1/schemas.ts
@@ -141,11 +141,32 @@ export const createPollInputSchema = z
 export const errorResponseSchema = z
   .object({
     error: z.object({
-      code: z.string().openapi({ example: "TIMEZONE_REQUIRED" }),
-      message: z.string().openapi({
-        example:
-          "Timezone is required. Either provide a timezone in the request or set one in your profile.",
+      code: z.string().openapi({
+        description:
+          "Machine-readable error code. The full list is in the API description.",
+        example: "VALIDATION_ERROR",
       }),
+      message: z.string().openapi({
+        example: "The request did not match the expected schema. See details.",
+      }),
+      details: z
+        .array(
+          z.object({
+            path: z.string().openapi({
+              description:
+                "Dot-separated path to the offending field. Empty for errors on the whole body.",
+              example: "slots.duration",
+            }),
+            message: z.string().openapi({
+              example: "Invalid input: expected number, received string",
+            }),
+          }),
+        )
+        .optional()
+        .openapi({
+          description:
+            "Present on `VALIDATION_ERROR` only: one entry per issue.",
+        }),
     }),
   })
   .openapi("ErrorResponse");


### PR DESCRIPTION
## Description

Fixes RAL-1615. Targets `/api/v1`. The only spill-over onto the frozen `/api/private` route is the bearer auth body format, see below.

The spec promises `{ error: { code, message } }` on every failure, but only handler-level errors honoured it. Validation failures returned the standard-validator default (`{ success, error, data }` with the request body echoed back), missing or invalid API keys returned plain-text `Unauthorized`, a malformed `Authorization` header returned plain-text `Bad Request`, and unknown routes and thrown errors returned hono's text 404 and 500. Once clients parse errors this is a breaking change, so it lands before v1 is published.

### What changed

- **Validation** – every `validator(...)` call takes a shared `validationHook` that returns `400 VALIDATION_ERROR` whose message lists each issue as `path: reason` (e.g. `title: Invalid input: expected string, received undefined; dates.0: Invalid ISO date`). The request body is never echoed. The issue proposed a structured `details` array; dropped on review because validation failures only occur while an integration is being built, so a per-field array is machinery nobody reads.
- **Bearer auth** – `spaceApiKeyAuth` now returns the JSON envelope for the 401 (`UNAUTHORIZED`) and 400 (`INVALID_AUTHORIZATION_HEADER`) cases. The `WWW-Authenticate` challenge headers are unchanged. The private route shares the same middleware, so its 401/400 bodies change from plain text to the JSON envelope; status and headers are unchanged and nothing parses the old text.
- **Unknown routes** – `app.notFound` returns `404 NOT_FOUND` as JSON, including for unsupported methods on known paths.
- **Thrown errors** – `app.onError` returns `500 INTERNAL_ERROR` with a generic message. It passes through bearer auth's prebuilt JSON response and maps hono's bare malformed-JSON 400 to `VALIDATION_ERROR`, a path the issue did not list. The wide event logs the original error via `c.error` as before.
- **Spec** – `ErrorResponse` stays `{ code, message }`; the API description now has an "Errors" table listing every code and when it is returned. The dead `INVALID_INPUT` branch in create poll now uses `VALIDATION_ERROR` so the list is exhaustive.

### Rate limiter note

The issue's note about `hono-rate-limiter` swallowing handler exceptions is stale for v1: since RAL-1618 the route uses the custom `rateLimit` middleware, which awaits `next()` without a try/catch. A new test throws from a handler behind the limiter and asserts the JSON 500, the `RateLimit-*` headers, and the wide event's `errorType` / `errorMessage`. Nothing needed wrapping. `hono-rate-limiter` is still used by the licensing route, which is out of scope.

### Tests

The four existing 401 tests now assert `content-type: application/json` and the envelope. A new "Error envelope" block covers a malformed `Authorization` header, an invalid JSON body (fields named in the message, body not echoed, no `success`/`data` keys), an invalid query string, an invalid PATCH body, malformed JSON, an unknown route, an unsupported method, a thrown handler error, and the spec's code list.

### Reviewer note

hono-openapi inlines schemas instead of registering `components.schemas`, so the `.openapi("ErrorResponse")` name and per-field examples do not appear in the generated spec. That is pre-existing and untouched here.

## Checklist

- [x] I have performed a self-review of my code
- [x] My code follows the code style of this project
- [x] I have commented my code, particularly in hard-to-understand areas

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - API errors now use a consistent JSON envelope with standardized error codes and messages.
  - Validation failures report affected field paths and messages in a single error message.
  - Authentication failures provide structured responses for missing, malformed, or invalid API keys.
  - Unknown routes, unsupported methods, and unexpected server errors return consistent responses without exposing sensitive details.
  - Missing date or slot errors are reported as validation errors.

- **Documentation**
  - API documentation now describes standardized error responses and supported error codes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

