### PR TITLE
🐛 Match the blog final CTA default to the English source

### DIFF
--- a/apps/landing/src/app/[locale]/(main)/blog/[slug]/page.tsx
+++ b/apps/landing/src/app/[locale]/(main)/blog/[slug]/page.tsx
@@ -130,7 +130,7 @@ export default async function Page(props: {
               i18n={i18n}
               ns="home"
               i18nKey="finalCtaDescription"
-              defaults="Set up your poll in under a minute. No account, no downloads, no chasing people for replies."
+              defaults="Set up your poll in under a minute. No account, no chasing people for replies."
             />
           }
           buttonLabel={


### PR DESCRIPTION
## Summary
- The blog post page's `finalCtaDescription` `defaults` still said "No account, no downloads, no chasing people for replies." while `home.json` and the home page say "No account, no chasing people for replies."
- Updated the blog page `defaults` to match the source string exactly. The home page already matched; no locale JSON touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Content Updates**
  * Updated the final call-to-action message on blog post pages for a shorter, clearer description.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->