### PR TITLE
💄 Align the landing phone demo to an option column and use the body font in its prompt

### DIFF
--- a/apps/landing/src/components/home/hero-demo/hero-demo.tsx
+++ b/apps/landing/src/components/home/hero-demo/hero-demo.tsx
@@ -65,7 +65,10 @@ const CachedDemo = async ({
           />
         </div>
       </div>
-      <div className="hidden lg:absolute lg:right-6 lg:-bottom-12 lg:block lg:w-[320px]">
+      {/* The grid is centred in the frame, so the phone is anchored to the
+          frame's centre rather than its edge: its screen's left edge lands on
+          the boundary of the sixth option column at any lg viewport width. */}
+      <div className="hidden lg:absolute lg:-bottom-12 lg:left-[calc(50%+197px)] lg:block lg:w-[320px]">
         <TryItPrompt
           text={t("heroDemoTryIt", {
             ns: "home",

--- a/apps/landing/src/components/home/hero-demo/try-it-prompt.tsx
+++ b/apps/landing/src/components/home/hero-demo/try-it-prompt.tsx
@@ -1,6 +1,3 @@
-import { cn } from "@rallly/ui";
-import { handwritten } from "@/fonts/handwritten";
-
 const ScribbleArrow = ({ className }: { className?: string }) => (
   <svg
     viewBox="0 0 30 30"
@@ -17,13 +14,8 @@ const ScribbleArrow = ({ className }: { className?: string }) => (
 );
 
 export const TryItPrompt = ({ text }: { text: string }) => (
-  <div
-    className={cn(
-      "pointer-events-none absolute -top-9 right-2 z-10 flex items-start text-gray-600",
-      handwritten.className,
-    )}
-  >
-    <span className="whitespace-nowrap rounded-full bg-gray-900 px-2.5 py-1 text-sm text-white">
+  <div className="pointer-events-none absolute -top-9 right-2 z-10 flex items-start text-gray-600">
+    <span className="whitespace-nowrap rounded-full bg-gray-900 px-3 py-1 font-medium text-sm text-white">
       {text}
     </span>
     <ScribbleArrow className="mt-2.5 -ml-0.5 size-6 text-gray-900" />

--- a/apps/landing/src/components/home/hero-demo/try-it-prompt.tsx
+++ b/apps/landing/src/components/home/hero-demo/try-it-prompt.tsx
@@ -15,7 +15,7 @@ const ScribbleArrow = ({ className }: { className?: string }) => (
 
 export const TryItPrompt = ({ text }: { text: string }) => (
   <div className="pointer-events-none absolute -top-9 right-2 z-10 flex items-start text-gray-600">
-    <span className="whitespace-nowrap rounded-full bg-gray-900 px-3 py-1 font-medium text-sm text-white">
+    <span className="whitespace-nowrap rounded-full bg-gray-900 px-3 py-1 text-sm text-white">
       {text}
     </span>
     <ScribbleArrow className="mt-2.5 -ml-0.5 size-6 text-gray-900" />


### PR DESCRIPTION
## What changed

- The phone demo on the landing hero was anchored to the wrapper's right edge, so its left edge cut through whichever option column happened to be underneath at a given viewport width. It is now anchored to the desktop frame's centre (which is also the grid's centre) at \`left: calc(50% + 197px)\`, so the opaque screen edge lands on the sixth option column boundary at every \`lg\` width and the 7px bezel sits over the previous column's empty padding.
- The "Go ahead, try voting!" prompt drops the handwritten font and renders in the body font at \`text-sm\`, regular weight.

## Why

The half covered column read as a layout accident rather than a deliberate overlap. Anchoring to the centre keeps the alignment stable across viewport widths instead of depending on the container's centring slack.

## Reviewer notes

- Verified at 1024, 1200 and 1440: the offset between the phone edge and the column boundary is identical at all three, and there is no horizontal overflow at 1024.
- The final CTA hint in \`cta.tsx\` still uses the handwritten font; only the demo prompt changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Improved alignment of the desktop try-it phone container within the hero section.
  - Adjusted the try-it prompt label’s spacing for a cleaner appearance.
  - Simplified prompt styling by removing the handwritten font treatment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->