### PR TITLE
💄 Give the landing phone demo breathing room from the last visible option

### DIFF
--- a/apps/landing/src/components/home/hero-demo/hero-demo.tsx
+++ b/apps/landing/src/components/home/hero-demo/hero-demo.tsx
@@ -66,9 +66,10 @@ const CachedDemo = async ({
         </div>
       </div>
       {/* The grid is centred in the frame, so the phone is anchored to the
-          frame's centre rather than its edge: its screen's left edge lands on
-          the boundary of the sixth option column at any lg viewport width. */}
-      <div className="hidden lg:absolute lg:-bottom-12 lg:left-[calc(50%+197px)] lg:block lg:w-[320px]">
+          frame's centre rather than its edge: its bezel starts 1px past the
+          sixth option column boundary at any lg viewport width, leaving the
+          previous column clear and hiding the next one's content. */}
+      <div className="hidden lg:absolute lg:-bottom-12 lg:left-[calc(50%+205px)] lg:block lg:w-[320px]">
         <TryItPrompt
           text={t("heroDemoTryIt", {
             ns: "home",


### PR DESCRIPTION
## What changed

Follow-up to #3221. The phone demo on the landing hero moves 8px to the right: its bezel now starts 1px past the sixth option column boundary instead of overlapping the previous column by 7px. The last visible option keeps its full padding and its right border line, and the next column's content stays hidden (its text starts 16px into the column; the opaque screen edge sits 8px in).

## Why

With the bezel overlapping the previous column, the phone read as crowding the last visible option.

## Reviewer notes

- Verified at 1024 and 1440: offset from the column boundary is identical, and there is no horizontal overflow at 1024.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted the desktop try-it prompt positioning at large viewport sizes for improved alignment within the frame.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->