### PR TITLE
🐛 Mint participant tokens in the poll admin screenshot capture

### DIFF
--- a/packages/screenshots/capture/poll-admin.spec.ts
+++ b/packages/screenshots/capture/poll-admin.spec.ts
@@ -2,9 +2,17 @@ import { test } from "@playwright/test";
 import { prisma } from "@rallly/database";
 import { deleteAllMessages, loginWithEmail } from "@rallly/test-helpers";
 import dayjs from "dayjs";
+import { customAlphabet } from "nanoid";
 import { screenshotPath } from "./helpers";
 
 const pollId = "screenshot-poll";
+
+// Mirrors generateAccessToken in apps/web/src/features/poll/utils.ts, which
+// this package cannot import. Participant.token has no DB default.
+const generateAccessToken = customAlphabet(
+  "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz",
+  32,
+);
 
 test.beforeAll(async () => {
   await deleteAllMessages();
@@ -61,9 +69,21 @@ test.beforeAll(async () => {
       },
       participants: {
         create: [
-          { name: "Sarah Johnson", email: "sarah@example.com" },
-          { name: "Michael Chen", email: "michael@example.com" },
-          { name: "Emily Rodriguez", email: "emily@example.com" },
+          {
+            name: "Sarah Johnson",
+            email: "sarah@example.com",
+            token: generateAccessToken(),
+          },
+          {
+            name: "Michael Chen",
+            email: "michael@example.com",
+            token: generateAccessToken(),
+          },
+          {
+            name: "Emily Rodriguez",
+            email: "emily@example.com",
+            token: generateAccessToken(),
+          },
         ],
       },
     },

--- a/packages/screenshots/package.json
+++ b/packages/screenshots/package.json
@@ -8,7 +8,8 @@
     "@rallly/database": "workspace:*",
     "@rallly/test-helpers": "workspace:*",
     "dayjs": "^1.11.13",
-    "dotenv": "^17.2.4"
+    "dotenv": "^17.2.4",
+    "nanoid": "^5.0.9"
   },
   "devDependencies": {
     "@playwright/test": "^1.57.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -730,6 +730,9 @@ importers:
       dotenv:
         specifier: ^17.2.4
         version: 17.2.4
+      nanoid:
+        specifier: ^5.0.9
+        version: 5.1.6
     devDependencies:
       '@playwright/test':
         specifier: ^1.57.0


### PR DESCRIPTION
## What

`packages/screenshots/capture/poll-admin.spec.ts` created participants with only `name` and `email`. `Participant.token` is a required column with no database default, so the spec failed `tsc` and the seed failed at runtime. The spec now mints a token per participant with a local nanoid `customAlphabet` matching `generateAccessToken` in `apps/web/src/features/poll/utils.ts`, since the screenshots package cannot import from `apps/web`. Adds `nanoid` to the package.

## Why it slipped through

CI does not type-check `packages/screenshots`. The failure only surfaced from `tsc --noEmit -p packages/screenshots/tsconfig.json` or running the capture. Adding the package to the CI type-check job is a separate decision.

## Verified

- `tsc --noEmit -p packages/screenshots/tsconfig.json` passes
- Biome and sherif clean
- `pnpm --filter @rallly/screenshots capture poll-admin` passes against the local database and produces the screenshot

## Reviewer note

The captured page renders the participant voting form rather than an admin surface. That predates this change and is out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated poll screenshot test setup to assign access tokens to fixture participants.
  * Improved consistency between test data and application access behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->