### PR TITLE
🔒️ Close the password sign-up endpoint

### DIFF
--- a/apps/web/src/lib/auth.ts
+++ b/apps/web/src/lib/auth.ts
@@ -81,7 +81,7 @@ const conditionalPlugins: BetterAuthPlugin[] = [
           // Every caller of the OTP send endpoint (combined login/signup
           // page, event RSVP verification) renders the Turnstile widget and
           // sends the token via the x-captcha-response header.
-          endpoints: ["/sign-up/email", "/email-otp/send-verification-otp"],
+          endpoints: ["/email-otp/send-verification-otp"],
         }),
       ]
     : []),
@@ -129,12 +129,11 @@ export const authLib = betterAuth({
   emailAndPassword: {
     enabled: env.EMAIL_LOGIN_ENABLED !== "false",
     requireEmailVerification: true,
-    onExistingUserSignUp: async ({ user }, request) => {
-      await authLib.api.sendVerificationOTP({
-        body: { email: user.email, type: "email-verification" },
-        request,
-      });
-    },
+    // Accounts are only ever created through a verified OTP, and a password
+    // can only be set from a signed-in session. Leaving the sign-up endpoint
+    // open would let anyone reserve an address with a password before its
+    // owner first logs in, which the OTP login would then inherit.
+    disableSignUp: true,
     sendResetPassword: async ({ user, url }) => {
       const locale =
         "locale" in user ? (user.locale as string) : await getLocale();
@@ -292,10 +291,6 @@ export const authLib = betterAuth({
     enabled: env.RATE_LIMIT_ENABLED !== "false",
     storage: redis ? "secondary-storage" : "memory",
     customRules: {
-      "/sign-up/email": {
-        window: 60 * 60, // 1 hour
-        max: 50,
-      },
       "/email-otp/send-verification-otp": {
         window: 60 * 60, // 1 hour
         max: 100,
@@ -322,7 +317,6 @@ export const authLib = betterAuth({
     before: createAuthMiddleware(async (ctx) => {
       if (
         ctx.path.startsWith("/sign-in") ||
-        ctx.path.startsWith("/sign-up") ||
         ctx.path.startsWith("/email-otp")
       ) {
         // The email change endpoints submit the address as `newEmail`

--- a/apps/web/tests/password-sign-up.spec.ts
+++ b/apps/web/tests/password-sign-up.spec.ts
@@ -1,0 +1,21 @@
+import { expect, test } from "@playwright/test";
+import { prisma } from "@rallly/database";
+
+const email = "password-sign-up@example.com";
+
+test.afterAll(async () => {
+  await prisma.user.deleteMany({ where: { email } });
+});
+
+// No UI calls this endpoint. It must stay closed at the API: it is the one
+// path that could attach a password to an address before its owner has
+// verified it, and the OTP login would inherit that password.
+test("the password sign-up endpoint is closed", async ({ request }) => {
+  const signUp = await request.post("/api/better-auth/sign-up/email", {
+    data: { email, password: "attacker-chosen-password", name: "Mallory" },
+  });
+  expect(signUp.status()).toBe(400);
+
+  const user = await prisma.user.findUnique({ where: { email } });
+  expect(user).toBeNull();
+});


### PR DESCRIPTION
## Description

Follow-up to #3220. Sets `emailAndPassword.disableSignUp: true`.

**Why.** No UI calls `/sign-up/email`: accounts are created through a verified OTP, and a password can only be set from a signed-in session after onboarding. The endpoint was still open at the API, so a plain POST with the victim's address, a name and a password created an unverified user carrying that password. That is the precondition for [GHSA-qq9h-g4jm-xgf3](https://github.com/advisories/GHSA-qq9h-g4jm-xgf3). The 1.6.30 bump strips the planted password on `/sign-in/email-otp`, which is the login path when registration is enabled. When registration is disabled the login page verifies through `/email-otp/verify-email`, which upstream did not patch, so a self-hosted instance in that mode inherited the planted password on the owner's first OTP login. I confirmed this end to end against main before writing the fix: after the OTP login, a password sign-in with the planted password returned 200.

**What changed.** Closing the endpoint removes the only way to attach a password to an unverified account, so no revocation hook is needed. `onExistingUserSignUp` and the captcha and rate limit entries for `/sign-up/email` existed only because the endpoint was open, so they go too. The before hook no longer matches `/sign-up` paths for the same reason.

**Tests.** `tests/password-sign-up.spec.ts` posts to the endpoint and asserts a 400 with no user created. Authentication, guest to user migration and RSVP specs pass. Type check and Biome clean.

**Out of scope, flagged.** `/sign-in/email-otp` with `type: "sign-in"` still creates a passwordless verified account on instances with registration disabled, because the RSVP flow relies on `disableSignUp: false` on the OTP plugin. Not a takeover vector, but it is a registration policy bypass and a product decision. Separately, an OIDC provider reporting an unverified email provisions a signed-in account that the real mailbox owner can later land in through OTP login; that is a provisioning gap on its own.

## Checklist

- [x] I have performed a self-review of my code
- [x] My code follows the code style of this project
- [x] I have commented my code, particularly in hard-to-understand areas

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Disabled email/password account registration.
  - Password sign-up attempts are rejected without creating an account.
  - Removed password sign-up requests from related verification, rate-limit, and account-validation flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->