### PR TITLE
🔒️ Refuse Microsoft sign-ins whose verified email claim does not vouch for the address

### DIFF
--- a/apps/docs/self-hosting/single-sign-on.mdx
+++ b/apps/docs/self-hosting/single-sign-on.mdx
@@ -45,7 +45,7 @@ After creating the application, set the redirect URI to:
 https://<YOUR_DOMAIN>/api/auth/callback/microsoft-entra-id
 ```
 
-Microsoft does not mark email addresses as verified unless the app registration asks for it, and Rallly refuses to create an account from an unverified address. Add the `verified_primary_email` and `verified_secondary_email` optional claims to the ID token. In the app registration open **Manifest** and set:
+If `MICROSOFT_TENANT_ID` is `common`, `organizations` or `consumers`, Rallly only creates an account when Microsoft marks the address as verified, because on a multi-tenant endpoint any tenant can assert any address. Microsoft does not include that information unless the app registration asks for it. Add the `verified_primary_email` and `verified_secondary_email` optional claims to the ID token: in the app registration open **Manifest** and set:
 
 ```json
 "optionalClaims": {
@@ -56,7 +56,7 @@ Microsoft does not mark email addresses as verified unless the app registration 
 }
 ```
 
-Existing users are not affected. Without the claims, new Microsoft sign-ins fail with "Your email address is not verified".
+Existing users are not affected. Without the claims, new Microsoft sign-ins on a multi-tenant endpoint fail with "Your email address is not verified". Single-tenant registrations do not need this.
 </Accordion>
 
 <ParamField path="MICROSOFT_TENANT_ID">

--- a/apps/docs/self-hosting/single-sign-on.mdx
+++ b/apps/docs/self-hosting/single-sign-on.mdx
@@ -45,16 +45,14 @@ After creating the application, set the redirect URI to:
 https://<YOUR_DOMAIN>/api/auth/callback/microsoft-entra-id
 ```
 
-If `MICROSOFT_TENANT_ID` is `common`, `organizations` or `consumers`, Rallly only creates an account when Microsoft marks the address as verified, because on a multi-tenant endpoint any tenant can assert any address. Microsoft does not include that information unless the app registration asks for it. Add the `verified_primary_email` and `verified_secondary_email` optional claims to the ID token: in the app registration open **Manifest** and set:
+If `MICROSOFT_TENANT_ID` is `common`, `organizations` or `consumers`, Rallly only creates an account when Microsoft marks the address as verified, because on a multi-tenant endpoint any tenant can assert any address. Microsoft does not include that information unless the app registration asks for it. Add the `verified_primary_email` and `verified_secondary_email` optional claims to the ID token: in the app registration open **Manifest** and add these two entries to the `optionalClaims.idToken` array, keeping any claims already there:
 
 ```json
-"optionalClaims": {
-  "idToken": [
-    { "name": "verified_primary_email", "source": null, "essential": false, "additionalProperties": [] },
-    { "name": "verified_secondary_email", "source": null, "essential": false, "additionalProperties": [] }
-  ]
-}
+{ "name": "verified_primary_email", "source": null, "essential": false, "additionalProperties": [] },
+{ "name": "verified_secondary_email", "source": null, "essential": false, "additionalProperties": [] }
 ```
+
+If `optionalClaims` is `null`, replace it with `{ "idToken": [ ...the two entries... ] }`.
 
 Existing users are not affected. Without the claims, new Microsoft sign-ins on a multi-tenant endpoint fail with "Your email address is not verified". Single-tenant registrations do not need this.
 </Accordion>

--- a/apps/docs/self-hosting/single-sign-on.mdx
+++ b/apps/docs/self-hosting/single-sign-on.mdx
@@ -45,7 +45,7 @@ After creating the application, set the redirect URI to:
 https://<YOUR_DOMAIN>/api/auth/callback/microsoft-entra-id
 ```
 
-If `MICROSOFT_TENANT_ID` is `common`, `organizations` or `consumers`, Rallly only creates an account when Microsoft marks the address as verified, because on a multi-tenant endpoint any tenant can assert any address. Microsoft does not include that information unless the app registration asks for it. Add the `verified_primary_email` and `verified_secondary_email` optional claims to the ID token: in the app registration open **Manifest** and add these two entries to the `optionalClaims.idToken` array, keeping any claims already there:
+On a multi-tenant endpoint (`MICROSOFT_TENANT_ID` set to `common`, `organizations` or `consumers`) any tenant can assert any email address, so Rallly needs Microsoft to confirm the address before it creates an account from it. Microsoft does not include that information unless the app registration asks for it. While the claims are missing, Rallly still creates the account and logs a warning at sign-in; a later release will refuse these sign-ins. Add the `verified_primary_email` and `verified_secondary_email` optional claims to the ID token: in the app registration open **Manifest** and add these two entries to the `optionalClaims.idToken` array, keeping any claims already there:
 
 ```json
 { "name": "verified_primary_email", "source": null, "essential": false, "additionalProperties": [] },
@@ -54,7 +54,7 @@ If `MICROSOFT_TENANT_ID` is `common`, `organizations` or `consumers`, Rallly onl
 
 If `optionalClaims` is `null`, replace it with `{ "idToken": [ ...the two entries... ] }`.
 
-Existing users are not affected. Without the claims, new Microsoft sign-ins on a multi-tenant endpoint fail with "Your email address is not verified". Single-tenant registrations do not need this.
+Once the claims are present, a Microsoft sign-in whose address is not among the verified ones fails with "Your email address is not verified". Existing users are not affected. Single-tenant registrations do not need this.
 </Accordion>
 
 <ParamField path="MICROSOFT_TENANT_ID">

--- a/apps/docs/self-hosting/single-sign-on.mdx
+++ b/apps/docs/self-hosting/single-sign-on.mdx
@@ -44,6 +44,19 @@ After creating the application, set the redirect URI to:
 ```
 https://<YOUR_DOMAIN>/api/auth/callback/microsoft-entra-id
 ```
+
+Microsoft does not mark email addresses as verified unless the app registration asks for it, and Rallly refuses to create an account from an unverified address. Add the `verified_primary_email` and `verified_secondary_email` optional claims to the ID token. In the app registration open **Manifest** and set:
+
+```json
+"optionalClaims": {
+  "idToken": [
+    { "name": "verified_primary_email", "source": null, "essential": false, "additionalProperties": [] },
+    { "name": "verified_secondary_email", "source": null, "essential": false, "additionalProperties": [] }
+  ]
+}
+```
+
+Existing users are not affected. Without the claims, new Microsoft sign-ins fail with "Your email address is not verified".
 </Accordion>
 
 <ParamField path="MICROSOFT_TENANT_ID">

--- a/apps/web/src/app/[locale]/(auth)/login/components/auth-errors.tsx
+++ b/apps/web/src/app/[locale]/(auth)/login/components/auth-errors.tsx
@@ -6,6 +6,9 @@ export function AuthErrors() {
   const { t } = useTranslation();
   const searchParams = useSearchParams();
   const error = searchParams?.get("error");
+  if (!error) {
+    return null;
+  }
   switch (error) {
     case "OAuthAccountNotLinked":
     case "account_not_linked":
@@ -54,7 +57,9 @@ export function AuthErrors() {
           })}
         </p>
       );
-    case "OAuthSignInFailed":
+    // Better-Auth appends its own code to errorCallbackURL; anything not
+    // mapped above still deserves a message rather than a silent login page.
+    default:
       return (
         <p className="text-destructive text-sm">
           {t("authErrorsOAuthSignInFailed", {
@@ -63,7 +68,5 @@ export function AuthErrors() {
           })}
         </p>
       );
-    default:
-      return null;
   }
 }

--- a/apps/web/src/app/[locale]/(auth)/login/components/auth-errors.tsx
+++ b/apps/web/src/app/[locale]/(auth)/login/components/auth-errors.tsx
@@ -8,6 +8,7 @@ export function AuthErrors() {
   const error = searchParams?.get("error");
   switch (error) {
     case "OAuthAccountNotLinked":
+    case "account_not_linked":
       return (
         <p className="text-destructive text-sm">
           {t("accountNotLinkedDescription", {
@@ -17,6 +18,7 @@ export function AuthErrors() {
         </p>
       );
     case "EmailNotVerified":
+    case "email_not_verified":
       return (
         <p className="text-destructive text-sm">
           {t("authErrorsEmailNotVerified", {

--- a/apps/web/src/app/[locale]/(auth)/login/components/oidc-auto-sign-in.tsx
+++ b/apps/web/src/app/[locale]/(auth)/login/components/oidc-auto-sign-in.tsx
@@ -15,7 +15,7 @@ export function OIDCAutoSignIn() {
     authClient.signIn.oauth2({
       providerId: "oidc",
       callbackURL: validateRedirectUrl(redirectTo) || "/",
-      errorCallbackURL: "/login?error=OAuthSignInFailed",
+      errorCallbackURL: "/login",
     });
   });
 

--- a/apps/web/src/features/auth/components/login-with-oidc.tsx
+++ b/apps/web/src/features/auth/components/login-with-oidc.tsx
@@ -17,7 +17,7 @@ export function LoginWithOIDC({
         authClient.signIn.oauth2({
           providerId: "oidc",
           callbackURL: validateRedirectUrl(redirectTo) || "/",
-          errorCallbackURL: "/login?error=OAuthSignInFailed",
+          errorCallbackURL: "/login",
         });
       }}
       className="w-full"

--- a/apps/web/src/features/auth/components/sso-provider.tsx
+++ b/apps/web/src/features/auth/components/sso-provider.tsx
@@ -39,6 +39,7 @@ export function SSOProvider({
         authClient.signIn.social({
           provider: providerId,
           callbackURL: validateRedirectUrl(redirectTo) || "/",
+          errorCallbackURL: "/login",
         });
       }}
     >

--- a/apps/web/src/lib/auth-plugins/microsoft-email-claim.test.ts
+++ b/apps/web/src/lib/auth-plugins/microsoft-email-claim.test.ts
@@ -14,10 +14,19 @@ describe("readMicrosoftEmailClaim", () => {
   it("is verified when the address is in the primary list", () => {
     expect(
       readMicrosoftEmailClaim({
-        email: "A@Example.com",
+        email: "a@example.com",
         verified_primary_email: ["a@example.com"],
       }),
     ).toBe("verified");
+  });
+
+  it("matches exactly, as better-auth does when it sets emailVerified", () => {
+    expect(
+      readMicrosoftEmailClaim({
+        email: "A@Example.com",
+        verified_primary_email: ["a@example.com"],
+      }),
+    ).toBe("unverified");
   });
 
   it("is verified when the address is only in the secondary list", () => {

--- a/apps/web/src/lib/auth-plugins/microsoft-email-claim.test.ts
+++ b/apps/web/src/lib/auth-plugins/microsoft-email-claim.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  readMicrosoftEmailClaim,
+  rememberMicrosoftEmailClaim,
+  takeMicrosoftEmailClaim,
+} from "./microsoft-email-claim";
+
+describe("readMicrosoftEmailClaim", () => {
+  it("is absent when the registration emits no verification claim", () => {
+    expect(readMicrosoftEmailClaim({ email: "a@example.com" })).toBe("absent");
+  });
+
+  it("is verified when the address is in the primary list", () => {
+    expect(
+      readMicrosoftEmailClaim({
+        email: "A@Example.com",
+        verified_primary_email: ["a@example.com"],
+      }),
+    ).toBe("verified");
+  });
+
+  it("is verified when the address is only in the secondary list", () => {
+    expect(
+      readMicrosoftEmailClaim({
+        email: "a@example.com",
+        verified_primary_email: [],
+        verified_secondary_email: ["a@example.com"],
+      }),
+    ).toBe("verified");
+  });
+
+  it("is unverified when the claim is present but does not carry the address", () => {
+    expect(
+      readMicrosoftEmailClaim({
+        email: "victim@example.com",
+        verified_primary_email: ["attacker@tenant.example"],
+      }),
+    ).toBe("unverified");
+  });
+
+  it("is unverified when the claim is present and empty", () => {
+    expect(
+      readMicrosoftEmailClaim({
+        email: "a@example.com",
+        verified_primary_email: [],
+      }),
+    ).toBe("unverified");
+  });
+
+  it("prefers an explicit email_verified claim", () => {
+    expect(
+      readMicrosoftEmailClaim({
+        email: "a@example.com",
+        email_verified: false,
+        verified_primary_email: ["a@example.com"],
+      }),
+    ).toBe("unverified");
+  });
+});
+
+describe("claim registry", () => {
+  it("hands the reading over once, case-insensitively", () => {
+    rememberMicrosoftEmailClaim({ email: "Hand@Off.test", claim: "absent" });
+    expect(takeMicrosoftEmailClaim("hand@off.test")).toBe("absent");
+    expect(takeMicrosoftEmailClaim("hand@off.test")).toBeUndefined();
+  });
+});

--- a/apps/web/src/lib/auth-plugins/microsoft-email-claim.ts
+++ b/apps/web/src/lib/auth-plugins/microsoft-email-claim.ts
@@ -24,12 +24,11 @@ export function readMicrosoftEmailClaim(profile: {
   if (!Array.isArray(primary) && !Array.isArray(secondary)) {
     return "absent";
   }
-  const email = profile.email?.toLowerCase();
+  // Exact match, the same comparison better-auth makes when it derives
+  // emailVerified from these claims, so the two readings never disagree.
+  const email = profile.email;
   const verified =
-    !!email &&
-    [...(primary ?? []), ...(secondary ?? [])].some(
-      (candidate) => candidate.toLowerCase() === email,
-    );
+    !!email && [...(primary ?? []), ...(secondary ?? [])].includes(email);
   return verified ? "verified" : "unverified";
 }
 

--- a/apps/web/src/lib/auth-plugins/microsoft-email-claim.ts
+++ b/apps/web/src/lib/auth-plugins/microsoft-email-claim.ts
@@ -1,0 +1,64 @@
+// Microsoft only vouches for an address when the app registration requests
+// the verified email optional claims. Their absence means the registration is
+// unconfigured, which is a different situation from Microsoft declining to
+// vouch, and the two need different handling downstream.
+//
+// The claim is only visible where the ID token is decoded (the provider's
+// profile mapping), while the decision is made in the user create hook, which
+// sees the mapped user only. The registry carries the reading between the two
+// within one sign-in; entries are consumed on read and expire quickly.
+
+export type MicrosoftEmailClaim = "verified" | "unverified" | "absent";
+
+export function readMicrosoftEmailClaim(profile: {
+  email?: string | undefined;
+  email_verified?: boolean | undefined;
+  verified_primary_email?: string[] | undefined;
+  verified_secondary_email?: string[] | undefined;
+}): MicrosoftEmailClaim {
+  if (typeof profile.email_verified === "boolean") {
+    return profile.email_verified ? "verified" : "unverified";
+  }
+  const primary = profile.verified_primary_email;
+  const secondary = profile.verified_secondary_email;
+  if (!Array.isArray(primary) && !Array.isArray(secondary)) {
+    return "absent";
+  }
+  const email = profile.email?.toLowerCase();
+  const verified =
+    !!email &&
+    [...(primary ?? []), ...(secondary ?? [])].some(
+      (candidate) => candidate.toLowerCase() === email,
+    );
+  return verified ? "verified" : "unverified";
+}
+
+const TTL_MS = 60_000;
+
+const pending = new Map<string, { claim: MicrosoftEmailClaim; at: number }>();
+
+export function rememberMicrosoftEmailClaim({
+  email,
+  claim,
+}: {
+  email: string;
+  claim: MicrosoftEmailClaim;
+}) {
+  const now = Date.now();
+  for (const [key, entry] of pending) {
+    if (now - entry.at > TTL_MS) {
+      pending.delete(key);
+    }
+  }
+  pending.set(email.toLowerCase(), { claim, at: now });
+}
+
+export function takeMicrosoftEmailClaim(email: string) {
+  const key = email.toLowerCase();
+  const entry = pending.get(key);
+  pending.delete(key);
+  if (!entry || Date.now() - entry.at > TTL_MS) {
+    return undefined;
+  }
+  return entry.claim;
+}

--- a/apps/web/src/lib/auth.ts
+++ b/apps/web/src/lib/auth.ts
@@ -485,6 +485,21 @@ export const authLib = betterAuth({
   databaseHooks: {
     user: {
       create: {
+        // Password sign-up is disabled and OTP sign-in verifies first, so an
+        // unverified non-anonymous user can only come from an OAuth provider
+        // that did not vouch for the address. Provisioning that account
+        // would let the mailbox owner's later OTP login land in it while the
+        // provider link stays. Microsoft needs the verified_primary_email
+        // optional claim on its app registration for this to pass.
+        before: async (user) => {
+          if (user.isAnonymous || user.emailVerified) {
+            return;
+          }
+          throw new APIError("FORBIDDEN", {
+            code: "EMAIL_NOT_VERIFIED",
+            message: "email not verified",
+          });
+        },
         after: async (user, ctx) => {
           if (user.isAnonymous) {
             return;

--- a/apps/web/src/lib/auth.ts
+++ b/apps/web/src/lib/auth.ts
@@ -120,6 +120,12 @@ const conditionalPlugins: BetterAuthPlugin[] = [
     : []),
 ];
 
+const isMultiTenantMicrosoft = [
+  "common",
+  "organizations",
+  "consumers",
+].includes(env.MICROSOFT_TENANT_ID);
+
 export const authLib = betterAuth({
   appName: env.APP_NAME,
   secret: env.SECRET_PASSWORD,
@@ -485,14 +491,21 @@ export const authLib = betterAuth({
   databaseHooks: {
     user: {
       create: {
-        // Password sign-up is disabled and OTP sign-in verifies first, so an
-        // unverified non-anonymous user can only come from an OAuth provider
-        // that did not vouch for the address. Provisioning that account
-        // would let the mailbox owner's later OTP login land in it while the
-        // provider link stays. Microsoft needs the verified_primary_email
-        // optional claim on its app registration for this to pass.
-        before: async (user) => {
-          if (user.isAnonymous || user.emailVerified) {
+        // On a multi-tenant Microsoft endpoint any tenant admin can put any
+        // address on a user, and Microsoft only vouches for it when the app
+        // registration requests the verified_primary_email claim. Provisioning
+        // an unverified address would let the mailbox owner's later OTP login
+        // land in that account while the Microsoft link stays. Single-tenant
+        // Microsoft and OIDC are the instance's own directory, so an
+        // unverified address there is the admin's call, not a cross-tenant
+        // exposure, and Google always asserts email_verified.
+        before: async (user, ctx) => {
+          if (
+            user.isAnonymous ||
+            user.emailVerified ||
+            ctx?.params?.id !== "microsoft" ||
+            !isMultiTenantMicrosoft
+          ) {
             return;
           }
           throw new APIError("FORBIDDEN", {

--- a/apps/web/src/lib/auth.ts
+++ b/apps/web/src/lib/auth.ts
@@ -536,12 +536,14 @@ export const authLib = betterAuth({
           ) {
             return;
           }
+          // better-auth derives emailVerified from the same claims, so an
+          // unverified user here means the claim was absent, declined to
+          // vouch, or never recorded for this sign-in (fail closed).
           const claim = takeMicrosoftEmailClaim(user.email);
-          if (claim === "absent" && !isMultiTenantMicrosoft) {
-            return;
-          }
           if (claim === "absent") {
-            warnMicrosoftClaimMissing();
+            if (isMultiTenantMicrosoft) {
+              warnMicrosoftClaimMissing();
+            }
             return;
           }
           throw new APIError("FORBIDDEN", {

--- a/apps/web/src/lib/auth.ts
+++ b/apps/web/src/lib/auth.ts
@@ -39,6 +39,11 @@ import {
 } from "@/lib/acquisition";
 import { SESSION_TTL_SECONDS } from "@/lib/auth-config";
 import { hostOnlyCookieCleanup } from "@/lib/auth-plugins/host-only-cookie-cleanup";
+import {
+  readMicrosoftEmailClaim,
+  rememberMicrosoftEmailClaim,
+  takeMicrosoftEmailClaim,
+} from "@/lib/auth-plugins/microsoft-email-claim";
 import { redis } from "@/lib/kv";
 import {
   LOCALE_COOKIE_NAME,
@@ -125,6 +130,17 @@ const isMultiTenantMicrosoft = [
   "organizations",
   "consumers",
 ].includes(env.MICROSOFT_TENANT_ID);
+
+let microsoftClaimWarned = false;
+function warnMicrosoftClaimMissing() {
+  if (microsoftClaimWarned) {
+    return;
+  }
+  microsoftClaimWarned = true;
+  logger.warn(
+    "Microsoft sign-in is creating accounts from unverified email addresses because the app registration does not emit the verified_primary_email claim. Add it before the next release, which will refuse these sign-ins: https://support.rallly.co/self-hosting/single-sign-on#microsoft",
+  );
+}
 
 export const authLib = betterAuth({
   appName: env.APP_NAME,
@@ -243,6 +259,15 @@ export const authLib = betterAuth({
             clientId: env.MICROSOFT_CLIENT_ID,
             clientSecret: env.MICROSOFT_CLIENT_SECRET,
             redirectURI: absoluteUrl("/api/auth/callback/microsoft-entra-id"),
+            mapProfileToUser: (profile) => {
+              if (profile.email) {
+                rememberMicrosoftEmailClaim({
+                  email: profile.email,
+                  claim: readMicrosoftEmailClaim(profile),
+                });
+              }
+              return {};
+            },
           }
         : undefined,
   },
@@ -492,13 +517,14 @@ export const authLib = betterAuth({
     user: {
       create: {
         // On a multi-tenant Microsoft endpoint any tenant admin can put any
-        // address on a user, and Microsoft only vouches for it when the app
-        // registration requests the verified_primary_email claim. Provisioning
-        // an unverified address would let the mailbox owner's later OTP login
-        // land in that account while the Microsoft link stays. Single-tenant
-        // Microsoft and OIDC are the instance's own directory, so an
-        // unverified address there is the admin's call, not a cross-tenant
-        // exposure, and Google always asserts email_verified.
+        // address on a user, so an unverified address must not become an
+        // account: the mailbox owner's later OTP login would land in it with
+        // the Microsoft link intact. Microsoft only vouches when the app
+        // registration requests the verified email claims, so their absence
+        // means an unconfigured registration rather than a refusal. That
+        // case is allowed with a warning for now and becomes a rejection in
+        // a later release. Single-tenant Microsoft is the instance's own
+        // directory; OIDC likewise; Google always asserts email_verified.
         before: async (user, ctx) => {
           // The redirect callback names the provider in the route; the
           // ID-token variant of /sign-in/social names it in the body.
@@ -506,9 +532,16 @@ export const authLib = betterAuth({
           if (
             user.isAnonymous ||
             user.emailVerified ||
-            provider !== "microsoft" ||
-            !isMultiTenantMicrosoft
+            provider !== "microsoft"
           ) {
+            return;
+          }
+          const claim = takeMicrosoftEmailClaim(user.email);
+          if (claim === "absent" && !isMultiTenantMicrosoft) {
+            return;
+          }
+          if (claim === "absent") {
+            warnMicrosoftClaimMissing();
             return;
           }
           throw new APIError("FORBIDDEN", {

--- a/apps/web/src/lib/auth.ts
+++ b/apps/web/src/lib/auth.ts
@@ -500,10 +500,13 @@ export const authLib = betterAuth({
         // unverified address there is the admin's call, not a cross-tenant
         // exposure, and Google always asserts email_verified.
         before: async (user, ctx) => {
+          // The redirect callback names the provider in the route; the
+          // ID-token variant of /sign-in/social names it in the body.
+          const provider = ctx?.params?.id ?? ctx?.body?.provider;
           if (
             user.isAnonymous ||
             user.emailVerified ||
-            ctx?.params?.id !== "microsoft" ||
+            provider !== "microsoft" ||
             !isMultiTenantMicrosoft
           ) {
             return;


### PR DESCRIPTION
## Description

Third step after #3220 and #3229. Closes the remaining pre-account hijack path, which runs through Microsoft sign-in on a multi-tenant endpoint rather than passwords.

**The gap.** In better-auth 1.6, a Microsoft sign-in whose token does not vouch for the email still creates a Rallly user with that address and signs them in. Microsoft never vouches unless the app registration emits the `verified_primary_email` claim, and on the `common`, `organizations` or `consumers` endpoints anyone who controls an Entra tenant can set a user's email attribute (the nOAuth pattern). So an attacker could sign in with Microsoft for an address that has no Rallly account, get an account under that email, and wait. When the real owner later logs in by OTP, better-auth finds the row, verifies it and signs them into the attacker's account; the Microsoft link stays. A prod count on 2026-09-08 showed every Microsoft-created user unverified, so the claim was missing.

**The fix, in two halves.**
1. *Config, already done on cloud.* `verified_primary_email` and `verified_secondary_email` optional claims were added to the Rallly app registration on 2026-09-08 and confirmed: new Microsoft sign-ins now land verified, and existing users flip on their next sign-in through better-auth's own update path. No backfill.
2. *Code, this PR.* The Microsoft provider's profile mapping reads the claim off the decoded ID token and hands the reading to the `user.create.before` hook for that sign-in (`lib/auth-plugins/microsoft-email-claim.ts`, unit tested). The hook then distinguishes three cases for an unverified Microsoft user:
   - **Claim present, address not in it.** Microsoft is explicitly declining to vouch. Rejected with `email_not_verified`. This is what protects cloud today.
   - **Claim absent, multi-tenant endpoint.** The registration is unconfigured, which is every self-hosted instance that followed Microsoft's quickstart. Allowed, with a one-time warning in the server log naming the fix and the docs. A later minor release turns this into a rejection.
   - **Claim absent, single-tenant endpoint.** The instance's own directory; passes silently, as today.
   Guests, OTP sign-in, Google (always asserts `email_verified`) and OIDC never reach the hook's Microsoft branch. A Microsoft creation with no reading on record fails closed. The provider is read from the callback route param or, for the ID-token variant of `/sign-in/social`, from the request body.

**Why the grace period.** Enforcing in a patch release would break new-user onboarding on every multi-tenant self-hosted instance until its admin edits the manifest, and patch releases that break login teach self-hosters to delay upgrades. The attack this guards against needs an attacker-controlled Entra tenant and a targeted address with no account yet, so a release cycle of warning is an acceptable trade. Cloud is configured and gets full enforcement now.

**Error routing.** Social sign-in previously had no `errorCallbackURL`, so any callback failure landed on better-auth's built-in error page, and the OIDC entry points pre-filled `?error=OAuthSignInFailed`, which shadowed the code better-auth appends. All entry points now return to a plain `/login`; `AuthErrors` matches better-auth's `email_not_verified` and `account_not_linked` and shows the generic message for anything unmapped, so no failure is silent.

**Self-hosting.** Nothing breaks on upgrade. Multi-tenant Microsoft instances see a warning until they add the optional claims; the SSO docs carry the manifest entries to merge in and say single-tenant registrations do not need it.

**Not covered by an integration test.** The rejection needs a Microsoft callback returning an unverified email, which the suite cannot drive. The claim reader is unit tested, and the authentication, guest migration and RSVP specs prove the hook does not fire on any other creation path.

## Checklist

- [x] I have performed a self-review of my code
- [x] My code follows the code style of this project
- [x] I have commented my code, particularly in hard-to-understand areas

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Microsoft SSO now validates verified email addresses when the provider supplies verification claims.
  * SSO authentication failures consistently return users to the login page with clearer error messaging.
  * Account and email verification errors are handled more reliably across supported sign-in flows.
  * Missing Microsoft verification claims no longer incorrectly block sign-in; affected sign-ins are logged for follow-up.

* **Documentation**
  * Updated Microsoft SSO setup guidance for adding verified-email claims without replacing existing configuration.
  * Added instructions for configuring verified-email claims when no optional claims are currently defined.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->