### PR TITLE
💄 Skip the press scale on buttons that open a menu

### DIFF
--- a/packages/ui/src/button-variants.ts
+++ b/packages/ui/src/button-variants.ts
@@ -10,15 +10,15 @@ export const buttonVariants = cva(
     variants: {
       variant: {
         primary:
-          "bg-primary text-primary-foreground ring-1 ring-button-outline ring-inset hover:bg-primary-hover active:scale-[.98] active:bg-primary-active motion-reduce:active:scale-100",
+          "bg-primary text-primary-foreground ring-1 ring-button-outline ring-inset hover:bg-primary-hover not-aria-[haspopup]:active:scale-[.98] active:bg-primary-active motion-reduce:active:scale-100",
         destructive:
-          "bg-destructive text-destructive-foreground ring-1 ring-button-outline ring-inset hover:bg-destructive-hover active:scale-[.98] active:bg-destructive-active motion-reduce:active:scale-100",
+          "bg-destructive text-destructive-foreground ring-1 ring-button-outline ring-inset hover:bg-destructive-hover not-aria-[haspopup]:active:scale-[.98] active:bg-destructive-active motion-reduce:active:scale-100",
         default:
-          "bg-background/80 ring-1 ring-button-outline ring-inset backdrop-blur-lg hover:bg-accent active:scale-[.98] data-popup-open:bg-accent motion-reduce:active:scale-100 dark:bg-foreground/5",
+          "bg-background/80 ring-1 ring-button-outline ring-inset backdrop-blur-lg hover:bg-accent not-aria-[haspopup]:active:scale-[.98] data-popup-open:bg-accent motion-reduce:active:scale-100 dark:bg-foreground/5",
         ghost:
-          "border-transparent bg-transparent text-foreground ring-1 ring-transparent ring-inset hover:bg-accent active:scale-[.98] data-popup-open:bg-accent motion-reduce:active:scale-100 [&>svg]:opacity-75",
+          "border-transparent bg-transparent text-foreground ring-1 ring-transparent ring-inset hover:bg-accent not-aria-[haspopup]:active:scale-[.98] data-popup-open:bg-accent motion-reduce:active:scale-100 [&>svg]:opacity-75",
         actionBar:
-          "border-transparent bg-action-bar text-action-bar-foreground hover:bg-action-bar-foreground/10 active:scale-[.98] data-popup-open:bg-action-bar-foreground/20 motion-reduce:active:scale-100",
+          "border-transparent bg-action-bar text-action-bar-foreground hover:bg-action-bar-foreground/10 not-aria-[haspopup]:active:scale-[.98] data-popup-open:bg-action-bar-foreground/20 motion-reduce:active:scale-100",
         link: "border-transparent text-primary underline-offset-4 hover:underline",
       },
       size: {


### PR DESCRIPTION
## What

Scopes the button press scale added in #3212 to buttons without `aria-haspopup`, so dropdown menu triggers no longer shrink and spring back on click.

## Why

The space switcher and account menu in the sidebar are full-width ghost `Button` triggers. The 2% press scale sized for compact buttons reads as the whole row bouncing. Opening a menu is already its own feedback (popup appears, trigger gets the open background), so a press cue on top is noise on any menu trigger, not only the sidebar ones.

## How

`active:scale-[.98]` becomes `not-aria-[haspopup]:active:scale-[.98]` in `packages/ui/src/button-variants.ts`. Base UI sets `aria-haspopup="menu"` on every `Menu.Trigger`, so all dropdown triggers opt out regardless of variant, with no per-call-site overrides.

Compiles to `&:not([aria-haspopup]):active { scale: .98 }` (verified with the repo's Tailwind 4.1.18).

## Reviewer notes

- Popover triggers don't carry `aria-haspopup` in Base UI, so a popover trigger built on `Button` still gets the press scale. None exist today.
- Not browser-checked; the change is a single selector scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated button pressed states so popup-triggered buttons retain their standard size and background behavior.
  * Applied consistent pressed-state scaling across primary, destructive, default, ghost, and action bar buttons.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->