### PR TITLE
🔒️ Keep email addresses out of PostHog event properties

### DIFF
--- a/apps/landing/src/app/[locale]/(main)/cookie-policy/page.tsx
+++ b/apps/landing/src/app/[locale]/(main)/cookie-policy/page.tsx
@@ -3,12 +3,13 @@
 import { cacheLife } from "next/cache";
 import { LegalPageLayout } from "@/components/legal-page-layout";
 import { Section } from "@/components/section";
+import { LinkBase } from "@/i18n/client/link";
 
 export default async function CookiePolicy() {
   cacheLife("max");
   return (
     <Section>
-      <LegalPageLayout title="Cookie policy" lastUpdated="2026-09-03">
+      <LegalPageLayout title="Cookie policy" lastUpdated="2026-09-08">
         <p>
           This Policy explains how we use cookies and other similar technologies
           on our website, and your options to control them.
@@ -44,11 +45,15 @@ export default async function CookiePolicy() {
         <p>
           We use PostHog for product analytics. PostHog does not set cookies and
           does not store anything on your device. Users who are signed in are
-          recognised through their account. Visitors who are not signed in are
-          counted using a hash derived from IP address and browser that changes
-          every day and cannot be used to identify anyone. The data collected
-          includes pages visited, events triggered, and device type. It is
-          stored on PostHog&apos;s servers in the EU and is not used for
+          recognised through their account: their analytics profile is keyed to
+          their account and carries the name and email address on it, so it is
+          identified data rather than anonymous data. Our{" "}
+          <LinkBase href="/privacy-policy">privacy policy</LinkBase> explains
+          why we keep it and when it is erased. Visitors who are not signed in
+          are counted using a hash derived from IP address and browser that
+          changes every day and cannot be used to identify anyone. The data
+          collected includes pages visited, events triggered, and device type.
+          It is stored on PostHog&apos;s servers in the EU and is not used for
           advertising or shared with third parties.
         </p>
 

--- a/apps/landing/src/app/[locale]/(main)/privacy-policy/page.tsx
+++ b/apps/landing/src/app/[locale]/(main)/privacy-policy/page.tsx
@@ -9,7 +9,7 @@ export default async function PrivacyPolicy() {
   cacheLife("max");
   return (
     <Section>
-      <LegalPageLayout title="Privacy policy" lastUpdated="2026-09-01">
+      <LegalPageLayout title="Privacy policy" lastUpdated="2026-09-08">
         <p>
           At rallly.co, we take your privacy seriously. This privacy policy
           explains how we collect, use, and disclose your personal data, and
@@ -44,6 +44,15 @@ export default async function PrivacyPolicy() {
           stored securely on Posthog&apos;s EU based servers and is used solely
           for the purpose of providing and improving the functionality of the
           website.
+        </p>
+
+        <p>
+          If you have an account, your analytics profile in Posthog is keyed to
+          your account and carries your name and email address. We keep the
+          email address there so that, when you contact us about a problem, we
+          can find your account&apos;s activity and work out what went wrong. It
+          is not written into individual analytics events, is not used for
+          marketing, and is erased from Posthog when you delete your account.
         </p>
 
         <h2>Optional information about your work</h2>
@@ -107,6 +116,15 @@ export default async function PrivacyPolicy() {
           choose to leave as it is. Choosing &quot;Prefer not to say&quot;, or
           leaving a field unanswered, gives no consent and stores nothing. You
           can withdraw consent at any time by asking us to erase the answer.
+        </p>
+
+        <p>
+          We keep your name and email address on your analytics profile on the
+          basis of our legitimate interest in providing support and diagnosing
+          faults: without them we cannot connect a support request to the
+          activity that caused it. You can object to this processing at any time
+          by contacting us at the address below, and we will remove those
+          details from your analytics profile.
         </p>
 
         <h2>Retention of personal data</h2>

--- a/apps/web/src/features/auth/utils.ts
+++ b/apps/web/src/features/auth/utils.ts
@@ -67,11 +67,14 @@ export function isEmailBlocked(email: string) {
   return false;
 }
 
+export const emailDomain = (email: string) =>
+  email.split("@")[1]?.toLowerCase() ?? "";
+
 /**
  * Checks if an email domain is a known temporary/disposable email service
  */
 export const isTemporaryEmail = (email: string): boolean => {
-  const domain = email.split("@")[1]?.toLowerCase();
+  const domain = emailDomain(email);
   if (!domain) return false;
 
   return temporaryEmailDomains.includes(domain);

--- a/apps/web/src/lib/auth.ts
+++ b/apps/web/src/lib/auth.ts
@@ -25,7 +25,11 @@ import { cache } from "react";
 import { getInstanceBranding } from "@/emails/branding";
 import { env } from "@/env";
 import { linkAnonymousUser } from "@/features/auth/mutations";
-import { isEmailBlocked, isTemporaryEmail } from "@/features/auth/utils";
+import {
+  emailDomain,
+  isEmailBlocked,
+  isTemporaryEmail,
+} from "@/features/auth/utils";
 import { getStripe } from "@/features/billing/service";
 import type { UserDTO } from "@/features/user/schema";
 import { jobTitleFieldSchema } from "@/features/user/schema";
@@ -433,14 +437,17 @@ export const authLib = betterAuth({
           }
 
           if (path === "/email-otp/request-email-change") {
-            // Email changes are only available to registered users.
+            // Email changes are only available to registered users. Event
+            // properties are immutable and outlive the person, so only the
+            // domain relationship is recorded here; the address itself lives
+            // on the person profile, which erasure removes.
             track(
               { id: session.user.id, isGuest: false },
               {
                 event: "account_email_change_request",
                 properties: {
-                  fromEmail: session.user.email,
-                  toEmail: newEmail,
+                  domain_changed:
+                    emailDomain(session.user.email) !== emailDomain(newEmail),
                 },
               },
             );


### PR DESCRIPTION
Closes RAL-1589.

## What changed

- `account_email_change_request` no longer sends `fromEmail` / `toEmail` as event properties. It sends `domain_changed: boolean` instead, computed with a new `emailDomain` helper in `features/auth/utils.ts` (also reused by `isTemporaryEmail`).
- Cookie policy: the analytics paragraph now states that a signed-in user's profile is keyed to their account and carries their name and email address, so it is identified data, and links to the privacy policy.
- Privacy policy: adds a paragraph on the PostHog profile (what it holds, that the address is not written into events, that it is erased on account deletion) and a legitimate-interest basis for support and fault diagnosis with a right to object.
- Both legal pages' `lastUpdated` bumped to 2026-09-08.

## Why

Email stays in PostHog as a person property so support can find a user's activity by address. Event properties are immutable and outlive the person, so the two addresses in the email change event were replication with no lookup use and no erasure path. The disclosure had to say what is actually stored.

## Reviewer notes

- No other capture writes an email into event properties; the remaining writes are `$set` person properties, which `deletePostHogPerson` removes (RAL-1594 fixed the region default).
- The guest purge script's predicate (absence of `email`) is unaffected since the capture shape did not change.
- Out of scope, flagged separately: `license_purchase` in `features/billing/webhook/mutations.ts` uses the buyer's email as `distinctId`. That is an immutable event-stream identifier for buyers who may have no account to erase against.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the cookie and privacy policies with the latest revision date.
  * Clarified that analytics profiles for signed-in users may include their name and email address for support and troubleshooting.
  * Added details about data retention, deletion, marketing exclusions, legal basis, and objection rights.

* **Privacy**
  * Email-change analytics now records only whether the email domain changed, rather than the previous and new email addresses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->