### PR TITLE
💄 Keep password managers out of inputs that collect other people's details

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -159,6 +159,9 @@ Always use gitmoji prefixes in commit messages. Follow the gitmoji convention (h
 - **Headings and dialog titles are not exempt.** Title Case has no single agreed rule (Chicago, AP and APA disagree), so it cannot be applied consistently; it degrades screen reader pronunciation and removes word-shape cues used by readers with dyslexia and low vision; and the same string often serves as both a button label and a dialog title, so a position-based rule would force two strings for one concept.
 - **Changing `defaults` alone is not enough.** `pnpm i18n:scan` will not overwrite an existing key's value — the UI keeps rendering the old copy. Run `pnpm --filter @rallly/web i18n:sync` (`--sync-primary`; there is no root script) to push changed English values through. Never run `--sync-all`; it clears other locales' translations.
 
+### Password Managers
+An input that collects something other than the user's own credentials or contact details (someone else's email, a confirmation phrase, a display name) spreads `passwordManagerIgnoreProps` from `@rallly/ui`. `autocomplete="off"` is ignored by every manager; the constant carries each vendor's own opt-out attribute. Never write `data-1p-ignore` or its siblings inline.
+
 ### Permission-Gated UI
 Choose the presentation by **why the user lacks the capability**, never ad hoc per surface:
 - **Role or ownership** (another member could act; the user has no self-serve path) → **hide** the control, nav item, or tile — including inline controls and destructive menu items (per-row: omit inapplicable items; omit the menu when empty). If a whole page exists for the capability, show a read-only view of the current values (general settings pattern) or a denied state naming who can act (billing settings pattern). Deep links get the denied state, never a silent 404.

--- a/apps/web/src/app/[locale]/(space)/(dashboard)/members/components/invite-member-dialog.tsx
+++ b/apps/web/src/app/[locale]/(space)/(dashboard)/members/components/invite-member-dialog.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { zodResolver } from "@hookform/resolvers/zod";
+import { passwordManagerIgnoreProps } from "@rallly/ui";
 import { Button } from "@rallly/ui/button";
 import type { DialogProps } from "@rallly/ui/dialog";
 import {
@@ -213,7 +214,7 @@ export function InviteMemberForm({ onSuccess }: { onSuccess?: () => void }) {
                   <Input
                     {...field}
                     placeholder={t("emailPlaceholder")}
-                    data-1p-ignore
+                    {...passwordManagerIgnoreProps}
                   />
                 </FormControl>
                 <FormMessage />

--- a/apps/web/src/app/[locale]/(space)/settings/general/components/delete-space-button.tsx
+++ b/apps/web/src/app/[locale]/(space)/settings/general/components/delete-space-button.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { passwordManagerIgnoreProps } from "@rallly/ui";
 import { Button } from "@rallly/ui/button";
 import type { DialogProps } from "@rallly/ui/dialog";
 import {
@@ -115,7 +116,7 @@ function DeleteSpaceDialog({
                     <FormControl>
                       <Input
                         autoComplete="off"
-                        data-1p-ignore
+                        {...passwordManagerIgnoreProps}
                         placeholder={spaceName}
                         {...field}
                       />

--- a/apps/web/src/app/[locale]/(space)/settings/general/components/leave-space-button.tsx
+++ b/apps/web/src/app/[locale]/(space)/settings/general/components/leave-space-button.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { passwordManagerIgnoreProps } from "@rallly/ui";
 import { Button } from "@rallly/ui/button";
 import type { DialogProps } from "@rallly/ui/dialog";
 import {
@@ -108,7 +109,7 @@ function LeaveSpaceDialog({
                   <FormControl>
                     <Input
                       autoComplete="off"
-                      data-1p-ignore
+                      {...passwordManagerIgnoreProps}
                       placeholder={spaceName}
                       {...field}
                     />

--- a/apps/web/src/app/[locale]/(space)/settings/profile/components/delete-account-dialog.tsx
+++ b/apps/web/src/app/[locale]/(space)/settings/profile/components/delete-account-dialog.tsx
@@ -1,4 +1,5 @@
 "use client";
+import { passwordManagerIgnoreProps } from "@rallly/ui";
 import { Button } from "@rallly/ui/button";
 import {
   Dialog,
@@ -190,7 +191,7 @@ function InstantDeleteAccountDialog({
                   <FormItem>
                     <Input
                       autoComplete="off"
-                      data-1p-ignore
+                      {...passwordManagerIgnoreProps}
                       placeholder={user.email}
                       {...field}
                     />

--- a/apps/web/src/app/[locale]/(space)/settings/spaces/components/leave-space-dialog.test.tsx
+++ b/apps/web/src/app/[locale]/(space)/settings/spaces/components/leave-space-dialog.test.tsx
@@ -37,6 +37,8 @@ describe("LeaveSpaceDialog", () => {
     expect(input).toBeInTheDocument();
     expect(input).toHaveAttribute("autoComplete", "off");
     expect(input).toHaveAttribute("data-1p-ignore", "true");
+    expect(input).toHaveAttribute("data-lpignore", "true");
+    expect(input).toHaveAttribute("data-form-type", "other");
   });
 
   it("renders cancel and leave space buttons", () => {

--- a/apps/web/src/app/[locale]/(space)/settings/spaces/components/leave-space-dialog.tsx
+++ b/apps/web/src/app/[locale]/(space)/settings/spaces/components/leave-space-dialog.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { zodResolver } from "@hookform/resolvers/zod";
+import { passwordManagerIgnoreProps } from "@rallly/ui";
 import { Button } from "@rallly/ui/button";
 import type { DialogProps } from "@rallly/ui/dialog";
 import {
@@ -97,7 +98,7 @@ export function LeaveSpaceDialog({
                   <FormControl>
                     <Input
                       autoComplete="off"
-                      data-1p-ignore
+                      {...passwordManagerIgnoreProps}
                       placeholder={spaceName}
                       {...field}
                     />

--- a/apps/web/src/app/[locale]/setup/components/setup-form.tsx
+++ b/apps/web/src/app/[locale]/setup/components/setup-form.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { zodResolver } from "@hookform/resolvers/zod";
+import { passwordManagerIgnoreProps } from "@rallly/ui";
 import { Button } from "@rallly/ui/button";
 import { ButtonGroup, ButtonGroupItem } from "@rallly/ui/button-group";
 import {
@@ -196,7 +197,7 @@ export function SetupForm({
                 <Input
                   {...field}
                   autoComplete="name"
-                  data-1p-ignore
+                  {...passwordManagerIgnoreProps}
                   placeholder={t("namePlaceholder", {
                     defaultValue: "Jessie Smith",
                   })}
@@ -313,7 +314,7 @@ export function SetupForm({
                   <FormControl>
                     <Input
                       {...field}
-                      data-1p-ignore
+                      {...passwordManagerIgnoreProps}
                       autoFocus={true}
                       placeholder={t("organizationNamePlaceholder", {
                         defaultValue: "e.g. Acme Corp",

--- a/apps/web/src/features/poll/components/comments-sheet.tsx
+++ b/apps/web/src/features/poll/components/comments-sheet.tsx
@@ -1,4 +1,5 @@
 "use client";
+import { passwordManagerIgnoreProps } from "@rallly/ui";
 import { Badge } from "@rallly/ui/badge";
 import { Button } from "@rallly/ui/button";
 import { useDialog } from "@rallly/ui/dialog";
@@ -134,7 +135,7 @@ function NewCommentForm({ onSubmitted }: { onSubmitted: () => void }) {
                   <InputGroupInput
                     placeholder={t("yourName")}
                     maxLength={MAX_COMMENT_AUTHOR_NAME_LENGTH}
-                    data-1p-ignore="true"
+                    {...passwordManagerIgnoreProps}
                     aria-invalid={!!formState.errors.authorName}
                     {...field}
                   />

--- a/apps/web/src/features/poll/components/invite-by-email.tsx
+++ b/apps/web/src/features/poll/components/invite-by-email.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { zodResolver } from "@hookform/resolvers/zod";
+import { passwordManagerIgnoreProps } from "@rallly/ui";
 import { Button } from "@rallly/ui/button";
 import {
   InputGroup,
@@ -247,7 +248,7 @@ export function InviteByEmail() {
                 type="email"
                 inputMode="email"
                 autoComplete="off"
-                data-1p-ignore
+                {...passwordManagerIgnoreProps}
                 placeholder="jessie.smith@example.com"
                 disabled={!isOpen}
                 aria-invalid={form.formState.errors.email ? true : undefined}

--- a/apps/web/src/features/poll/components/invite-by-email.tsx
+++ b/apps/web/src/features/poll/components/invite-by-email.tsx
@@ -247,6 +247,7 @@ export function InviteByEmail() {
                 type="email"
                 inputMode="email"
                 autoComplete="off"
+                data-1p-ignore
                 placeholder="jessie.smith@example.com"
                 disabled={!isOpen}
                 aria-invalid={form.formState.errors.email ? true : undefined}

--- a/apps/web/src/features/poll/components/new-participant-modal.tsx
+++ b/apps/web/src/features/poll/components/new-participant-modal.tsx
@@ -1,7 +1,7 @@
 import { zodResolver } from "@hookform/resolvers/zod";
 import type { VoteType } from "@rallly/database";
 import { posthog } from "@rallly/posthog/client";
-import { buttonVariants, cn } from "@rallly/ui";
+import { buttonVariants, cn, passwordManagerIgnoreProps } from "@rallly/ui";
 import { Button } from "@rallly/ui/button";
 import {
   DialogDescription,
@@ -291,7 +291,7 @@ export const NewParticipantForm = (props: NewParticipantModalProps) => {
                 <FormControl>
                   <Input
                     className="w-full"
-                    data-1p-ignore="true"
+                    {...passwordManagerIgnoreProps}
                     autoFocus={true}
                     disabled={formState.isSubmitting}
                     placeholder={t("namePlaceholder")}

--- a/apps/web/src/features/space/components/create-space-dialog.tsx
+++ b/apps/web/src/features/space/components/create-space-dialog.tsx
@@ -1,5 +1,6 @@
 "use client";
 import { zodResolver } from "@hookform/resolvers/zod";
+import { passwordManagerIgnoreProps } from "@rallly/ui";
 import { Button } from "@rallly/ui/button";
 import type { DialogProps } from "@rallly/ui/dialog";
 import {
@@ -69,7 +70,7 @@ export function CreateSpaceDialog(props: DialogProps) {
                   </FormLabel>
                   <FormControl>
                     <Input
-                      data-1p-ignore="true"
+                      {...passwordManagerIgnoreProps}
                       placeholder="e.g. Acme Corp"
                       {...field}
                     />

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -1,2 +1,3 @@
 export { buttonVariants } from "./button-variants";
+export { passwordManagerIgnoreProps } from "./lib/password-manager-ignore";
 export { cn } from "./lib/utils";

--- a/packages/ui/src/lib/password-manager-ignore.ts
+++ b/packages/ui/src/lib/password-manager-ignore.ts
@@ -1,0 +1,14 @@
+/**
+ * Spread onto an input that should never attract a password manager, e.g. a
+ * field that collects someone else's email or a confirmation phrase. There is
+ * no standard: autocomplete="off" is ignored by every manager, so each vendor
+ * gets its own attribute. Must be present on first render; 1Password caches
+ * the classification when the field is first focused.
+ */
+export const passwordManagerIgnoreProps = {
+  "data-1p-ignore": "true",
+  "data-lpignore": "true",
+  "data-form-type": "other",
+  "data-protonpass-ignore": "true",
+  "data-bwignore": "true",
+} as const;


### PR DESCRIPTION
## What changed

- Adds `passwordManagerIgnoreProps` to `@rallly/ui`: one constant carrying the opt-out attribute for 1Password, LastPass, Dashlane, Proton Pass and Bitwarden.
- Spreads it onto the share dialog invite email input, which previously had nothing and drew the 1Password fill menu on every focus.
- Replaces the ten scattered `data-1p-ignore` attributes (setup form, space and account confirmation inputs, invite member dialog, create space dialog, participant name inputs) with the same constant.

## Why

There is no standard way to keep a password manager off a field. `autocomplete="off"` is ignored by every manager and by Chrome's address autofill, so each vendor reads its own attribute:

| Manager | Attribute |
|---|---|
| 1Password | `data-1p-ignore` |
| LastPass | `data-lpignore="true"` |
| Dashlane | `data-form-type="other"` |
| Proton Pass | `data-protonpass-ignore` |
| Bitwarden | `data-bwignore` |

Supabase's design system input and Proton's own apps ship the same bundle. Most apps only add the 1Password attribute; LastPass usage on GitHub matches 1Password almost one for one, so covering it is the real gain.

## Notes for review

- The constant must be present on first render. 1Password caches its classification when the field is first focused.
- Bitwarden merged a change on 2026-08-26 that puts `data-bwignore` behind an off by default setting, so that attribute becomes inert for most users in their next release. It is kept because it is harmless.
- Browser built in autofill (Chrome, Safari) still offers saved emails on `type="email"` inputs. Avoiding that would mean renaming the field away from "email", which is not worth the validation and accessibility cost.
- The `leave-space-dialog` unit test now also asserts the LastPass and Dashlane attributes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved invitation, confirmation, setup, comment, participant, and space-management fields to prevent unwanted password-manager autofill across more providers.
  * Standardized password-manager handling across relevant forms and dialogs.

* **Tests**
  * Added coverage confirming password-manager prevention attributes are applied to space-leaving confirmation fields.

* **Documentation**
  * Documented when to apply password-manager prevention settings to non-credential inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
