### PR TITLE
🔥 Remove NextAuth-era error cases from the login error banner

### DIFF
--- a/apps/web/public/locales/en/app.json
+++ b/apps/web/public/locales/en/app.json
@@ -79,7 +79,6 @@
   "authErrorsEmailNotVerified": "Your email address is not verified. Please verify your email before logging in.",
   "authErrorsOAuthSignInFailed": "An error occurred while signing in. Please try again or contact the system administrator.",
   "authErrorsUserBanned": "This account has been banned. Please contact support if you believe this is an error.",
-  "authErrorsUserNotFound": "No account found with this email address. Please check the email or register for a new account.",
   "back": "Back",
   "backToHome": "Back to home",
   "banned": "Banned",

--- a/apps/web/src/app/[locale]/(auth)/login/components/auth-errors.tsx
+++ b/apps/web/src/app/[locale]/(auth)/login/components/auth-errors.tsx
@@ -10,7 +10,6 @@ export function AuthErrors() {
     return null;
   }
   switch (error) {
-    case "OAuthAccountNotLinked":
     case "account_not_linked":
       return (
         <p className="text-destructive text-sm">
@@ -20,40 +19,12 @@ export function AuthErrors() {
           })}
         </p>
       );
-    case "EmailNotVerified":
     case "email_not_verified":
       return (
         <p className="text-destructive text-sm">
           {t("authErrorsEmailNotVerified", {
             defaultValue:
               "Your email address is not verified. Please verify your email before logging in.",
-          })}
-        </p>
-      );
-    case "Banned":
-      return (
-        <p className="text-destructive text-sm">
-          {t("authErrorsUserBanned", {
-            defaultValue:
-              "This account has been banned. Please contact support if you believe this is an error.",
-          })}
-        </p>
-      );
-    case "EmailBlocked":
-      return (
-        <p className="text-destructive text-sm">
-          {t("authErrorsEmailBlocked", {
-            defaultValue:
-              "This email address is not allowed. Please use a different email or contact support.",
-          })}
-        </p>
-      );
-    case "UserNotFound":
-      return (
-        <p className="text-destructive text-sm">
-          {t("authErrorsUserNotFound", {
-            defaultValue:
-              "No account found with this email address. Please check the email or register for a new account.",
           })}
         </p>
       );


### PR DESCRIPTION
## Summary

`auth-errors.tsx` renders a message from the `?error=` query parameter on `/login`. It dates from the NextAuth era (#1504, #1745, #1754) and most of its `case` labels were NextAuth error names. #3230 added the better-auth codes and a `default` branch but left the old cases in place.

The only thing that produces `?error=` on `/login` today is better-auth's `errorCallbackURL` redirect from the OAuth callback. Every SSO entry point (`sso-provider.tsx`, `login-with-oidc.tsx`, `oidc-auto-sign-in.tsx`) passes `errorCallbackURL: "/login"`, and better-auth only appends its own snake_case codes.

## Removed

Nothing in the codebase produces any of these labels. A `grep -rnw` across `apps/web/src` and `packages` finds each one only in the switch statement being removed.

- `OAuthAccountNotLinked` — NextAuth name; `account_not_linked` is the live better-auth code on the same case
- `EmailNotVerified` — NextAuth name; `email_not_verified` is the live code on the same case
- `Banned` — bans are surfaced inline by `login-email-form.tsx` from the `BANNED_USER` API error code, never as a query param
- `EmailBlocked` — same, inline from `EMAIL_BLOCKED`
- `UserNotFound` — nothing redirects with it, and the OTP flow deliberately does not reveal whether an address exists

## Kept

- The early return when `error` is empty
- `account_not_linked` and `email_not_verified`
- The `default` branch rendering the generic "An error occurred while signing in" message for every other better-auth code

## i18n

`authErrorsUserBanned` and `authErrorsEmailBlocked` stay because the login form still uses them inline. `authErrorsUserNotFound` became unused and `pnpm i18n:scan` removed it from the English source. Other locales are untouched.

## Verification

- `pnpm type-check` passes
- `pnpm check` passes (one pre-existing unrelated warning in `rich-text-editor.tsx`)
- `pnpm i18n:scan` run
- `tests/authentication.spec.ts` — 16 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated authentication error handling to recognize current error codes for unlinked accounts and unverified email addresses.
  - Authentication errors without a specific supported message now display a generic error message.

- **Localization**
  - Removed the English translation for the “account not found” authentication message.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->