### PR TITLE
🔒️ Enforce the registration setting where every account is created

### DIFF
--- a/apps/web/src/features/instance-settings/data.ts
+++ b/apps/web/src/features/instance-settings/data.ts
@@ -73,3 +73,18 @@ export async function getRegistrationEnabled() {
 
   return !instanceSettings.disableUserRegistration;
 }
+
+// Uncached twin of getRegistrationEnabled for the auth hooks in lib/auth.ts:
+// an authorization decision must see the control panel toggle the moment it
+// is written, not whenever the page cache revalidates.
+export async function isRegistrationOpen() {
+  if (!isFeatureEnabled("registration")) {
+    return false;
+  }
+  const instanceSettings = await prisma.instanceSettings.findUnique({
+    where: { id: 1 },
+    select: { disableUserRegistration: true },
+  });
+
+  return !instanceSettings?.disableUserRegistration;
+}

--- a/apps/web/src/lib/auth.ts
+++ b/apps/web/src/lib/auth.ts
@@ -351,16 +351,14 @@ export const authLib = betterAuth({
   },
   hooks: {
     before: createAuthMiddleware(async (ctx) => {
-      // Registration policy at the API. Mirrors the OTP plugin's own
-      // disableSignUp behaviour so an unknown address cannot be told apart
-      // from a known one: the send endpoint answers success without sending,
-      // the verify endpoint answers with the invalid-code error.
-      const isOtpSignUp =
-        (ctx.path === "/email-otp/send-verification-otp" &&
-          ctx.body?.type === "sign-in") ||
-        ctx.path === "/sign-in/email-otp";
+      // With registration off, a "sign-in" code for an unknown address
+      // would be refused at account creation anyway (user.create.before);
+      // answering here means the stranger never receives a code. Mirrors
+      // the plugin's own disableSignUp behaviour, success without sending,
+      // so an unknown address cannot be told apart from a known one.
       if (
-        isOtpSignUp &&
+        ctx.path === "/email-otp/send-verification-otp" &&
+        ctx.body?.type === "sign-in" &&
         typeof ctx.body?.email === "string" &&
         !(await isRegistrationOpen())
       ) {
@@ -369,12 +367,6 @@ export const authLib = betterAuth({
           select: { id: true },
         });
         if (!user) {
-          if (ctx.path === "/sign-in/email-otp") {
-            throw new APIError("BAD_REQUEST", {
-              code: "INVALID_OTP",
-              message: "Invalid OTP",
-            });
-          }
           return ctx.json({ success: true });
         }
       }
@@ -555,14 +547,24 @@ export const authLib = betterAuth({
         // a later release. Single-tenant Microsoft is the instance's own
         // directory; OIDC likewise; Google always asserts email_verified.
         before: async (user, ctx) => {
+          if (user.isAnonymous) {
+            return;
+          }
+          // Registration policy: every path that mints an account (OTP
+          // sign-in, social and OIDC callbacks, the ID-token variant of
+          // /sign-in/social) converges here, so this is where "registration
+          // is off" is enforced. The OTP send endpoint also refuses earlier
+          // so strangers get no code, but that is convenience, not the gate.
+          if (!(await isRegistrationOpen())) {
+            throw new APIError("FORBIDDEN", {
+              code: "REGISTRATION_DISABLED",
+              message: "signup disabled",
+            });
+          }
           // The redirect callback names the provider in the route; the
           // ID-token variant of /sign-in/social names it in the body.
           const provider = ctx?.params?.id ?? ctx?.body?.provider;
-          if (
-            user.isAnonymous ||
-            user.emailVerified ||
-            provider !== "microsoft"
-          ) {
+          if (user.emailVerified || provider !== "microsoft") {
             return;
           }
           // better-auth derives emailVerified from the same claims, so an

--- a/apps/web/src/lib/auth.ts
+++ b/apps/web/src/lib/auth.ts
@@ -31,6 +31,7 @@ import {
   isTemporaryEmail,
 } from "@/features/auth/utils";
 import { getStripe } from "@/features/billing/service";
+import { isRegistrationOpen } from "@/features/instance-settings/data";
 import type { UserDTO } from "@/features/user/schema";
 import { jobTitleFieldSchema } from "@/features/user/schema";
 import { getTranslation } from "@/i18n/server";
@@ -199,10 +200,10 @@ export const authLib = betterAuth({
       storeInDatabase: true,
     }),
     emailOTP({
-      // Sign-up via OTP is allowed so that registering for an event can either
-      // log a guest into their existing account or create one for a new email.
-      // The login page is unaffected: it sends "email-verification" OTPs and
-      // verifies with verifyEmail, neither of which is gated by this flag.
+      // The "sign-in" OTP type creates an account for an unknown address; the
+      // login page offers it only while registration is on. The control panel
+      // toggle changes at runtime, so the before hook below applies it per
+      // request rather than this boot-time flag.
       disableSignUp: false,
       expiresIn: 15 * 60,
       resendStrategy: "reuse",
@@ -350,6 +351,33 @@ export const authLib = betterAuth({
   },
   hooks: {
     before: createAuthMiddleware(async (ctx) => {
+      // Registration policy at the API. Mirrors the OTP plugin's own
+      // disableSignUp behaviour so an unknown address cannot be told apart
+      // from a known one: the send endpoint answers success without sending,
+      // the verify endpoint answers with the invalid-code error.
+      const isOtpSignUp =
+        (ctx.path === "/email-otp/send-verification-otp" &&
+          ctx.body?.type === "sign-in") ||
+        ctx.path === "/sign-in/email-otp";
+      if (
+        isOtpSignUp &&
+        typeof ctx.body?.email === "string" &&
+        !(await isRegistrationOpen())
+      ) {
+        const user = await prisma.user.findUnique({
+          where: { email: ctx.body.email.toLowerCase() },
+          select: { id: true },
+        });
+        if (!user) {
+          if (ctx.path === "/sign-in/email-otp") {
+            throw new APIError("BAD_REQUEST", {
+              code: "INVALID_OTP",
+              message: "Invalid OTP",
+            });
+          }
+          return ctx.json({ success: true });
+        }
+      }
       if (
         ctx.path.startsWith("/sign-in") ||
         ctx.path.startsWith("/email-otp")

--- a/apps/web/src/lib/auth.ts
+++ b/apps/web/src/lib/auth.ts
@@ -202,8 +202,8 @@ export const authLib = betterAuth({
     emailOTP({
       // The "sign-in" OTP type creates an account for an unknown address; the
       // login page offers it only while registration is on. The control panel
-      // toggle changes at runtime, so the before hook below applies it per
-      // request rather than this boot-time flag.
+      // toggle changes at runtime, so the registration setting is enforced in
+      // the user.create hook rather than by this boot-time flag.
       disableSignUp: false,
       expiresIn: 15 * 60,
       resendStrategy: "reuse",
@@ -351,25 +351,6 @@ export const authLib = betterAuth({
   },
   hooks: {
     before: createAuthMiddleware(async (ctx) => {
-      // With registration off, a "sign-in" code for an unknown address
-      // would be refused at account creation anyway (user.create.before);
-      // answering here means the stranger never receives a code. Mirrors
-      // the plugin's own disableSignUp behaviour, success without sending,
-      // so an unknown address cannot be told apart from a known one.
-      if (
-        ctx.path === "/email-otp/send-verification-otp" &&
-        ctx.body?.type === "sign-in" &&
-        typeof ctx.body?.email === "string" &&
-        !(await isRegistrationOpen())
-      ) {
-        const user = await prisma.user.findUnique({
-          where: { email: ctx.body.email.toLowerCase() },
-          select: { id: true },
-        });
-        if (!user) {
-          return ctx.json({ success: true });
-        }
-      }
       if (
         ctx.path.startsWith("/sign-in") ||
         ctx.path.startsWith("/email-otp")
@@ -553,12 +534,12 @@ export const authLib = betterAuth({
           // Registration policy: every path that mints an account (OTP
           // sign-in, social and OIDC callbacks, the ID-token variant of
           // /sign-in/social) converges here, so this is where "registration
-          // is off" is enforced. The OTP send endpoint also refuses earlier
-          // so strangers get no code, but that is convenience, not the gate.
+          // is off" is enforced. Same shape better-auth documents for
+          // SIGNUP_DISABLED.
           if (!(await isRegistrationOpen())) {
-            throw new APIError("FORBIDDEN", {
-              code: "REGISTRATION_DISABLED",
-              message: "signup disabled",
+            throw new APIError("BAD_REQUEST", {
+              code: "SIGNUP_DISABLED",
+              message: "Signup is disabled",
             });
           }
           // The redirect callback names the provider in the route; the

--- a/apps/web/tests/otp-sign-up.spec.ts
+++ b/apps/web/tests/otp-sign-up.spec.ts
@@ -65,6 +65,37 @@ test.describe.serial(() => {
     expect(user).toBeNull();
   });
 
+  test("a code issued before registration closed cannot create an account", async ({
+    request,
+  }) => {
+    await prisma.instanceSettings.update({
+      where: { id: 1 },
+      data: { disableUserRegistration: false },
+    });
+    const send = await request.post(
+      "/api/better-auth/email-otp/send-verification-otp",
+      { data: { email: unknownEmail, type: "sign-in" } },
+    );
+    expect(send.status()).toBe(200);
+    const otp = await getCode(unknownEmail);
+
+    await prisma.instanceSettings.update({
+      where: { id: 1 },
+      data: { disableUserRegistration: true },
+    });
+    // The send gate is out of the picture: the code is real. Only the
+    // user.create hook stands between this call and a new account.
+    const verify = await request.post("/api/better-auth/sign-in/email-otp", {
+      data: { email: unknownEmail, otp },
+    });
+    expect(verify.status(), await verify.text()).toBe(403);
+
+    const user = await prisma.user.findUnique({
+      where: { email: unknownEmail },
+    });
+    expect(user).toBeNull();
+  });
+
   test("an existing user still signs in with a code", async ({ request }) => {
     await createUserInDb({
       email: existingEmail,

--- a/apps/web/tests/otp-sign-up.spec.ts
+++ b/apps/web/tests/otp-sign-up.spec.ts
@@ -1,0 +1,87 @@
+import { expect, test } from "@playwright/test";
+import { prisma } from "@rallly/database";
+import { captureOne, deleteAllMessages, getCode } from "@rallly/test-helpers";
+import { createUserInDb } from "./test-utils";
+
+const unknownEmail = "otp-sign-up-unknown@example.com";
+const existingEmail = "otp-sign-up-existing@example.com";
+
+// The "sign-in" OTP type creates an account for an unknown address. The
+// registration setting only reaches the UI, so the API has to honour it.
+test.describe.serial(() => {
+  test.beforeAll(async () => {
+    await prisma.instanceSettings.update({
+      where: { id: 1 },
+      data: { disableUserRegistration: true },
+    });
+    await prisma.verification.deleteMany({
+      where: { identifier: { endsWith: unknownEmail } },
+    });
+  });
+
+  test.beforeEach(async () => {
+    await deleteAllMessages();
+  });
+
+  test.afterAll(async () => {
+    await prisma.instanceSettings.update({
+      where: { id: 1 },
+      data: { disableUserRegistration: false },
+    });
+    await prisma.user.deleteMany({
+      where: { email: { in: [unknownEmail, existingEmail] } },
+    });
+    await prisma.verification.deleteMany({
+      where: { identifier: { endsWith: unknownEmail } },
+    });
+  });
+
+  test("an unknown address gets no code and no account", async ({
+    request,
+  }) => {
+    const send = await request.post(
+      "/api/better-auth/email-otp/send-verification-otp",
+      { data: { email: unknownEmail, type: "sign-in" } },
+    );
+    // Success without a message, so the response does not reveal whether
+    // the address is registered.
+    expect(send.status()).toBe(200);
+    // The plugin writes the pending code before deciding whether to send it;
+    // the gate answers before the plugin runs, so no row exists at all.
+    const pending = await prisma.verification.findFirst({
+      where: { identifier: `sign-in-otp-${unknownEmail}` },
+    });
+    expect(pending).toBeNull();
+    await expect(captureOne(unknownEmail, { wait: 3000 })).rejects.toThrow();
+
+    const verify = await request.post("/api/better-auth/sign-in/email-otp", {
+      data: { email: unknownEmail, otp: "000000" },
+    });
+    expect(verify.status()).toBe(400);
+
+    const user = await prisma.user.findUnique({
+      where: { email: unknownEmail },
+    });
+    expect(user).toBeNull();
+  });
+
+  test("an existing user still signs in with a code", async ({ request }) => {
+    await createUserInDb({
+      email: existingEmail,
+      name: "Existing User",
+      role: "user",
+    });
+
+    const send = await request.post(
+      "/api/better-auth/email-otp/send-verification-otp",
+      { data: { email: existingEmail, type: "sign-in" } },
+    );
+    expect(send.status()).toBe(200);
+
+    const otp = await getCode(existingEmail);
+    const verify = await request.post("/api/better-auth/sign-in/email-otp", {
+      data: { email: existingEmail, otp },
+    });
+    expect(verify.status()).toBe(200);
+  });
+});

--- a/apps/web/tests/otp-sign-up.spec.ts
+++ b/apps/web/tests/otp-sign-up.spec.ts
@@ -1,13 +1,14 @@
 import { expect, test } from "@playwright/test";
 import { prisma } from "@rallly/database";
-import { captureOne, deleteAllMessages, getCode } from "@rallly/test-helpers";
+import { deleteAllMessages, getCode } from "@rallly/test-helpers";
 import { createUserInDb } from "./test-utils";
 
 const unknownEmail = "otp-sign-up-unknown@example.com";
 const existingEmail = "otp-sign-up-existing@example.com";
 
 // The "sign-in" OTP type creates an account for an unknown address. The
-// registration setting only reaches the UI, so the API has to honour it.
+// registration setting is enforced where the account would be created, so a
+// valid code for an unknown address must still end without a user.
 test.describe.serial(() => {
   test.beforeAll(async () => {
     await prisma.instanceSettings.update({
@@ -36,42 +37,9 @@ test.describe.serial(() => {
     });
   });
 
-  test("an unknown address gets no code and no account", async ({
+  test("a verified code for an unknown address creates no account", async ({
     request,
   }) => {
-    const send = await request.post(
-      "/api/better-auth/email-otp/send-verification-otp",
-      { data: { email: unknownEmail, type: "sign-in" } },
-    );
-    // Success without a message, so the response does not reveal whether
-    // the address is registered.
-    expect(send.status()).toBe(200);
-    // The plugin writes the pending code before deciding whether to send it;
-    // the gate answers before the plugin runs, so no row exists at all.
-    const pending = await prisma.verification.findFirst({
-      where: { identifier: `sign-in-otp-${unknownEmail}` },
-    });
-    expect(pending).toBeNull();
-    await expect(captureOne(unknownEmail, { wait: 3000 })).rejects.toThrow();
-
-    const verify = await request.post("/api/better-auth/sign-in/email-otp", {
-      data: { email: unknownEmail, otp: "000000" },
-    });
-    expect(verify.status()).toBe(400);
-
-    const user = await prisma.user.findUnique({
-      where: { email: unknownEmail },
-    });
-    expect(user).toBeNull();
-  });
-
-  test("a code issued before registration closed cannot create an account", async ({
-    request,
-  }) => {
-    await prisma.instanceSettings.update({
-      where: { id: 1 },
-      data: { disableUserRegistration: false },
-    });
     const send = await request.post(
       "/api/better-auth/email-otp/send-verification-otp",
       { data: { email: unknownEmail, type: "sign-in" } },
@@ -79,16 +47,11 @@ test.describe.serial(() => {
     expect(send.status()).toBe(200);
     const otp = await getCode(unknownEmail);
 
-    await prisma.instanceSettings.update({
-      where: { id: 1 },
-      data: { disableUserRegistration: true },
-    });
-    // The send gate is out of the picture: the code is real. Only the
-    // user.create hook stands between this call and a new account.
     const verify = await request.post("/api/better-auth/sign-in/email-otp", {
       data: { email: unknownEmail, otp },
     });
-    expect(verify.status(), await verify.text()).toBe(403);
+    expect(verify.status(), await verify.text()).toBe(400);
+    expect(await verify.json()).toMatchObject({ code: "SIGNUP_DISABLED" });
 
     const user = await prisma.user.findUnique({
       where: { email: unknownEmail },


### PR DESCRIPTION
## Description

Last piece of the 4.14.1 registration work after #3229. The registration switch reached the UI but not the API, and three API paths could still create accounts on a closed instance.

**The gap.** With registration turned off, in the control panel or with `REGISTRATION_ENABLED=false`:
- the `sign-in` OTP type still created an account for any unknown address, because `emailOTP.disableSignUp` is `false`;
- the Google, Microsoft and OIDC buttons still render, since existing users need them, and no provider has `disableSignUp` set, so a new social user got an account;
- the ID-token variant of `/sign-in/social` did the same without a browser.

Not takeovers, the accounts are passwordless and verified, but the switch did not mean what it said. Cloud is unaffected since registration is never disabled there.

**The fix.** Every path that mints an account converges on `user.create`, so that is the single enforcement point: a `user.create.before` hook returns early for guests and otherwise refuses when registration is closed. It reads the row directly (`isRegistrationOpen`) rather than the cached instance settings so an authorization decision never waits on a cache tag. The plugin's boolean `disableSignUp` could not do this because the control panel toggle changes at runtime. The rejection follows the shape [better-auth documents for `SIGNUP_DISABLED`](https://better-auth.com/docs/reference/errors/signup_disabled): `BAD_REQUEST`, "Signup is disabled", thrown from exactly this hook.

**Error surfacing.** OTP verify returns `SIGNUP_DISABLED` (400), which the code form shows through its default branch. Social callbacks land on `/login?error=Signup_is_disabled` and get the generic message from #3230. A stranger who requests a `sign-in` code on a closed instance still receives the email and is then refused at verification; that is the same behaviour as better-auth's own provider-level `disableSignUp`, and the send endpoint is rate limited and captcha gated.

**Tests.** `tests/otp-sign-up.spec.ts` with registration closed:
- a real code for an unknown address verifies to `SIGNUP_DISABLED` with no user created. Against main's `auth.ts` the same call returns 200 and creates the user;
- an existing user still receives a code and signs in.

Authentication and guest migration specs pass, so guest creation and normal OTP login are untouched.

## Checklist

- [x] I have performed a self-review of my code
- [x] My code follows the code style of this project
- [x] I have commented my code, particularly in hard-to-understand areas

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Registration settings now take effect immediately across sign-up flows.
  - When registration is disabled, sign-up attempts receive a clear “Signup is disabled” error.
  - Email verification codes are no longer silently suppressed for unknown addresses; account creation is prevented when sign-up is disabled.
  - Updated error responses use a consistent 400 status and error code.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->