### PR TITLE
💄 Keep password managers out of the participant email field

### DIFF
--- a/apps/web/src/features/poll/components/new-participant-modal.tsx
+++ b/apps/web/src/features/poll/components/new-participant-modal.tsx
@@ -316,6 +316,7 @@ export const NewParticipantForm = (props: NewParticipantModalProps) => {
                 <FormControl>
                   <Input
                     className="w-full"
+                    {...passwordManagerIgnoreProps}
                     disabled={formState.isSubmitting}
                     placeholder={t("emailPlaceholder")}
                     {...field}


### PR DESCRIPTION
## What

The new participant modal's email input now spreads `passwordManagerIgnoreProps`, matching the name field directly above it.

## Why

The modal renders a name field and an email field together, both prefilled for signed-in users. Password managers read that pairing as a credential form and offer to save it. The name field already opted out; the email field did not, so the prompt still fired.

A poll response is not a login, and nothing here is a credential.

## Note on the convention

`CLAUDE.md` scopes `passwordManagerIgnoreProps` to inputs collecting *other people's* details, and this field collects the responder's own email. This is a slight widening of that rule. The underlying intent — keep managers away from inputs that are not the user's own credentials — still holds, and leaving the two fields inconsistent is what produces the prompt.

Worth deciding whether the documented rule should be restated as "not a credential" rather than "not the user's own details".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented password managers from autofilling or interfering with the email field when adding a new participant.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->