### PR TITLE
🔒️ Enforce disableComments in the comments.add mutation

### DIFF
--- a/apps/web/src/trpc/routers/polls/comments.ts
+++ b/apps/web/src/trpc/routers/polls/comments.ts
@@ -98,6 +98,30 @@ export const comments = router({
       }),
     )
     .mutation(async ({ ctx, input }) => {
+      const targetPoll = await prisma.poll.findUnique({
+        where: {
+          id: input.pollId,
+        },
+        select: {
+          disableComments: true,
+          deleted: true,
+        },
+      });
+
+      // A deleted poll never accepts new comments.
+      if (!targetPoll || targetPoll.deleted) {
+        throw new TRPCError({ code: "NOT_FOUND", message: "Poll not found" });
+      }
+
+      // The comment UI is hidden when the host turns comments off, but the
+      // setting is only real if the mutation enforces it too.
+      if (targetPoll.disableComments) {
+        throw new TRPCError({
+          code: "FORBIDDEN",
+          message: "Comments are disabled for this poll",
+        });
+      }
+
       let authorName = input.authorName;
 
       if (!ctx.user.isGuest) {

--- a/apps/web/tests/comments-disabled.spec.ts
+++ b/apps/web/tests/comments-disabled.spec.ts
@@ -1,0 +1,64 @@
+import { expect, test } from "@playwright/test";
+import { NewPollPage } from "./new-poll-page";
+
+// The comment UI is hidden when the host turns comments off. That is a
+// presentation choice; these tests pin the server-side rule behind it, so a
+// caller going straight at the mutation cannot write past the setting.
+test.describe("comments disabled", () => {
+  test("the API rejects a comment on a poll with comments off", async ({
+    page,
+  }) => {
+    const newPollPage = new NewPollPage(page);
+    await newPollPage.goto();
+    // Comments are off by default, so this poll has disableComments = true.
+    const pollPage = await newPollPage.create({ name: "No Comments Meetup" });
+    await pollPage.closeShareDialog();
+
+    const pollId = page.url().match(/\/poll\/([^/?]+)/)?.[1];
+    expect(pollId).toBeTruthy();
+
+    // page.request shares the page's cookie jar, so this carries the same
+    // session the hidden UI would have used.
+    const response = await page.request.post("/api/trpc/polls.comments.add", {
+      data: {
+        json: {
+          pollId,
+          authorName: "Test User",
+          content: "This comment should be rejected",
+        },
+      },
+    });
+
+    expect(response.status()).toBe(403);
+
+    await page.reload();
+    await expect(page.getByRole("button", { name: "Comments" })).toBeHidden();
+  });
+
+  test("the API still accepts a comment when comments are on", async ({
+    page,
+  }) => {
+    const newPollPage = new NewPollPage(page);
+    await newPollPage.goto();
+    const pollPage = await newPollPage.create({
+      name: "Comments Allowed Meetup",
+      enableComments: true,
+    });
+    await pollPage.closeShareDialog();
+
+    const pollId = page.url().match(/\/poll\/([^/?]+)/)?.[1];
+    expect(pollId).toBeTruthy();
+
+    const response = await page.request.post("/api/trpc/polls.comments.add", {
+      data: {
+        json: {
+          pollId,
+          authorName: "Test User",
+          content: "This comment should be accepted",
+        },
+      },
+    });
+
+    expect(response.ok()).toBe(true);
+  });
+});


### PR DESCRIPTION
Fixes GHSA-2j8v-xx77-v45j, reported by @sbouabid-sec.

## The problem

`polls.comments.add` never loaded the target poll, so `disableComments` was enforced only in the frontend — `comments-sheet.tsx` hides the comment UI, and that was the whole control. An ordinary guest session calling the mutation directly could write comments to a poll where the host had turned them off.

`disableComments` defaults to `true`, so this covered most polls rather than only ones explicitly configured that way.

Impact is limited to unwanted content: no private data is exposed and poll results are unaffected. Reporter's CVSS is 5.3 (medium), CWE-863.

## The fix

Load the poll once at the top of the mutation and reject:

- `disableComments` → `FORBIDDEN`
- missing or soft-deleted poll → `NOT_FOUND`

The deleted-poll case shares the same root cause — the poll was never read at all — and restores parity with `comments.list` and `participants.list`, which both already gate on `deleted`.

## Tests

`comments-disabled.spec.ts` hits the mutation directly through a real guest session, reproducing the reported bypass rather than driving the UI that hides it. Covers both the rejection and the still-permitted case, so the guard can't regress into over-blocking.

## Notes

- `comments.list` is unchanged. Making it hide existing comments on a poll whose host later disabled them is a behavior change, not a security fix.
- The 403/404 split tells a caller whether a poll exists. `comments.list` already leaks that same signal, so this matches existing semantics rather than diverging; happy to collapse both to 404 if you'd rather.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented comments from being added to polls that no longer exist or have been deleted.
  - Enforced poll comment settings so comments cannot be submitted when commenting is disabled.
  - The Comments button is now hidden when commenting is unavailable.

- **Tests**
  - Added coverage for comment restrictions and successful commenting when enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->