### PR TITLE
🔒️ Reject participant writes once a poll leaves open

### DIFF
--- a/apps/web/src/features/poll/data.ts
+++ b/apps/web/src/features/poll/data.ts
@@ -479,7 +479,12 @@ export async function getParticipant({
 }) {
   return prisma.participant.findFirst({
     where: { id: participantId },
-    select: { id: true, pollId: true, userId: true },
+    select: {
+      id: true,
+      pollId: true,
+      userId: true,
+      poll: { select: { status: true, deleted: true } },
+    },
   });
 }
 

--- a/apps/web/src/trpc/routers/polls/participants.ts
+++ b/apps/web/src/trpc/routers/polls/participants.ts
@@ -309,6 +309,29 @@ export const participants = router({
         ctx,
         input: { pollId, votes, name, email, note, timeZone, token },
       }) => {
+        const poll = await prisma.poll.findUnique({
+          where: { id: pollId },
+          select: { status: true, deleted: true },
+        });
+
+        // A deleted poll never accepts responses.
+        if (!poll || poll.deleted) {
+          throw new TRPCError({
+            code: "NOT_FOUND",
+            message: "Poll not found",
+          });
+        }
+
+        // The voting window is the organizer's control, so it has to hold
+        // here and not only in the client, which hides the form via
+        // `canAddNewParticipant`.
+        if (poll.status !== "open") {
+          throw new TRPCError({
+            code: "BAD_REQUEST",
+            message: "This poll is no longer accepting responses",
+          });
+        }
+
         const participantCount = await prisma.participant.count({
           where: {
             pollId,

--- a/apps/web/src/trpc/routers/polls/utils.ts
+++ b/apps/web/src/trpc/routers/polls/utils.ts
@@ -13,6 +13,11 @@ type Actor = { id: string; isGuest: boolean };
  * owns the response or administers its poll. Admin access is bound to the
  * session only, so a link never unlocks other people's responses.
  *
+ * A poll that is no longer open accepts no edits from anyone, admins
+ * included — the same rule `canEditParticipant` applies in the client. The
+ * lifecycle check comes first: whether the voting window has closed does not
+ * depend on who is asking.
+ *
  * The returned actor is for attribution (activity log, analytics): the
  * session when there is one, otherwise the user the response was created
  * under, who was a guest at the time.
@@ -32,6 +37,20 @@ export async function authorizeParticipantEdit({
     throw new TRPCError({
       code: "NOT_FOUND",
       message: "Participant not found",
+    });
+  }
+
+  if (participant.poll.deleted) {
+    throw new TRPCError({
+      code: "NOT_FOUND",
+      message: "Participant not found",
+    });
+  }
+
+  if (participant.poll.status !== "open") {
+    throw new TRPCError({
+      code: "BAD_REQUEST",
+      message: "This poll is no longer accepting changes",
     });
   }
 

--- a/apps/web/tests/closed-poll-writes.spec.ts
+++ b/apps/web/tests/closed-poll-writes.spec.ts
@@ -1,0 +1,117 @@
+import type { Page } from "@playwright/test";
+import { expect, test } from "@playwright/test";
+import { NewPollPage } from "./new-poll-page";
+
+// The client hides the voting form once a poll leaves "open"
+// (`canAddNewParticipant` / `canEditParticipant`). These tests pin the
+// server-side rule behind that, so a caller reaching the mutations directly
+// cannot write to a poll whose voting window the organizer has ended.
+
+async function getPollId(page: Page) {
+  const pollId = page.url().match(/\/poll\/([^/?]+)/)?.[1];
+  expect(pollId).toBeTruthy();
+  return pollId as string;
+}
+
+async function closePoll(page: Page, pollId: string) {
+  const response = await page.request.post("/api/trpc/polls.close", {
+    data: { json: { pollId } },
+  });
+  expect(response.ok()).toBe(true);
+}
+
+test.describe("writes to a closed poll", () => {
+  test("the API rejects a new response once the poll is closed", async ({
+    page,
+  }) => {
+    const newPollPage = new NewPollPage(page);
+    await newPollPage.goto();
+    const pollPage = await newPollPage.create({ name: "Closed Poll Meetup" });
+    await pollPage.closeShareDialog();
+    const pollId = await getPollId(page);
+
+    // A response added while the poll is still open, so the edit paths below
+    // have a real target that only the poll's status disqualifies.
+    await pollPage.addParticipant("Anne");
+    const participants = await page.request.get(
+      `/api/trpc/polls.participants.list?input=${encodeURIComponent(
+        JSON.stringify({ json: { pollId } }),
+      )}`,
+    );
+    expect(participants.ok()).toBe(true);
+    const participantId = (await participants.json()).result.data.json[0].id;
+    expect(participantId).toBeTruthy();
+
+    await closePoll(page, pollId);
+
+    const options = await page.request.get(
+      `/api/trpc/polls.get?input=${encodeURIComponent(
+        JSON.stringify({ json: { urlId: pollId } }),
+      )}`,
+    );
+    const optionId = (await options.json()).result.data.json.options[0].id;
+
+    const add = await page.request.post("/api/trpc/polls.participants.add", {
+      data: {
+        json: {
+          pollId,
+          name: "Test Participant",
+          votes: [{ optionId, type: "yes" }],
+        },
+      },
+    });
+    expect(add.status()).toBe(400);
+
+    // The same rule has to hold for every write path that reaches an existing
+    // response, not just the one the report named.
+    const update = await page.request.post(
+      "/api/trpc/polls.participants.update",
+      {
+        data: {
+          json: { pollId, participantId, votes: [{ optionId, type: "no" }] },
+        },
+      },
+    );
+    expect(update.status()).toBe(400);
+
+    const rename = await page.request.post(
+      "/api/trpc/polls.participants.rename",
+      { data: { json: { participantId, newName: "Renamed" } } },
+    );
+    expect(rename.status()).toBe(400);
+
+    const remove = await page.request.post(
+      "/api/trpc/polls.participants.delete",
+      { data: { json: { participantId } } },
+    );
+    expect(remove.status()).toBe(400);
+  });
+
+  test("the API still accepts a response while the poll is open", async ({
+    page,
+  }) => {
+    const newPollPage = new NewPollPage(page);
+    await newPollPage.goto();
+    const pollPage = await newPollPage.create({ name: "Open Poll Meetup" });
+    await pollPage.closeShareDialog();
+    const pollId = await getPollId(page);
+
+    const options = await page.request.get(
+      `/api/trpc/polls.get?input=${encodeURIComponent(
+        JSON.stringify({ json: { urlId: pollId } }),
+      )}`,
+    );
+    const optionId = (await options.json()).result.data.json.options[0].id;
+
+    const add = await page.request.post("/api/trpc/polls.participants.add", {
+      data: {
+        json: {
+          pollId,
+          name: "Test Participant",
+          votes: [{ optionId, type: "yes" }],
+        },
+      },
+    });
+    expect(add.ok()).toBe(true);
+  });
+});


### PR DESCRIPTION
Fixes GHSA-mrg5-rhfq-9wvf, reported by @sbouabid-sec. Same class as #3245 (same reporter, filed minutes apart): a lifecycle rule enforced only in the client.

## The problem

The public participant mutations never read `poll.status`. The voting window was enforced only in `client.tsx`, via `canAddNewParticipant` and `canEditParticipant`, which hide the form. A guest session calling the mutations directly could add, edit, rename or delete responses on a poll the organizer had closed, scheduled or canceled.

No privileged account is needed — just the ordinary guest session used for normal participation. Poll results could be changed after the organizer ended the window, which is why the reporter rates this high (CWE-841) rather than medium.

## The fix

- `participants.add` loads the poll and rejects a non-open status with `BAD_REQUEST`.
- `authorizeParticipantEdit` does the same. `update`, `rename` and `delete` all route through that helper, so a future mutation using it inherits the gate rather than having to remember it.
- Both paths reject deleted polls with `NOT_FOUND`, matching what the read procedures already do.

The rule mirrors the client exactly: a poll that is not open accepts no participant writes from anyone, admins included, which is what `canEditParticipant` already enforces. No behavior that any client currently offers is removed.

## Scope note

The report named `add` and `update`. `rename` and `delete` share the same helper and the same shape, so they are gated too — leaving `delete` open would have allowed responses to be removed from a closed poll, which is arguably worse for result integrity than adding one.

## Tests

`closed-poll-writes.spec.ts` drives the mutations directly through a real guest session, reproducing the reported bypass rather than the UI that hides it. It covers all four write paths on a closed poll plus the still-permitted open case.

Verified the test actually catches the vulnerability: with the guard stashed, the closed-poll case returns 200 where the fix returns 400, and the test fails. Lint and type-check clean; the full Playwright suite was not run locally, so CI is the check on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented adding or modifying participants after a poll is closed.
  - Prevented participant changes for deleted or unavailable polls.
  - Continued allowing participant updates while a poll remains open.

- **Tests**
  - Added coverage confirming participant write operations are rejected for closed polls and accepted for open polls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->