### PR TITLE
🔒️ Stop polls.get disclosing scheduled invitee names and emails

### DIFF
--- a/apps/web/src/trpc/client/types.ts
+++ b/apps/web/src/trpc/client/types.ts
@@ -21,7 +21,6 @@ export type GetPollApiResponse = {
     id: string;
     start: Date;
     duration: number;
-    attendees: Array<{ name: string; email: string; status: string }>;
     status: string;
   } | null;
 };

--- a/apps/web/src/trpc/routers/polls.ts
+++ b/apps/web/src/trpc/routers/polls.ts
@@ -760,15 +760,6 @@ export const polls = router({
               end: true,
               allDay: true,
               status: true,
-              invites: {
-                select: {
-                  id: true,
-                  inviteeName: true,
-                  inviteeEmail: true,
-                  inviteeTimeZone: true,
-                  status: true,
-                },
-              },
             },
           },
         },
@@ -801,16 +792,6 @@ export const polls = router({
                   dayjs(res.scheduledEvent.start),
                   "minute",
                 ),
-            attendees: res.scheduledEvent.invites
-              .map((invite) => ({
-                name: invite.inviteeName,
-                email: invite.inviteeEmail,
-                status: invite.status,
-              }))
-              .filter(
-                (invite) =>
-                  invite.status === "accepted" || invite.status === "tentative",
-              ),
             status: res.scheduledEvent.status,
           }
         : null;
@@ -821,8 +802,12 @@ export const polls = router({
         ? isSpaceBrandingActive({ ...res.space, spaceBrandingAllowed })
         : false;
 
+      // `event` above is the shape clients read; the raw row would be a
+      // second copy of the same booking in a public payload.
+      const { scheduledEvent: _scheduledEvent, ...pollFields } = res;
+
       return {
-        ...res,
+        ...pollFields,
         space: res.space
           ? {
               ...res.space,


### PR DESCRIPTION
Fixes GHSA-39rr-47j5-8qfv and its duplicates. Reported independently by @arbor-s, @shwoo03, @davidldv, @geo-chen, @maajix, @arpitjain099, @Tike00, @BenBaller1 and @sbouabid-sec — ten open advisories describe this same endpoint.

## The problem

`polls.get` is a `publicProcedure`. The poll id that every invite link carries is the only thing needed to call it, and it returned each scheduled invitee's real name and email address to any unauthenticated caller.

Both privacy signals were ignored: `canManage` was computed and used only as a returned boolean, and `hideParticipants` was selected and never read. The CVE-2025-66027 fix hardened `participants.list` and never reached this procedure, which is why several reporters filed it as an incomplete fix.

Reproduced on `main` with no session at all:

```
canManage: false
hideParticipants: true
attendees: [
  { "name": "Alice Example", "email": "alice@example.com", "status": "accepted" },
  { "name": "Bob Example",   "email": "bob@example.com",   "status": "tentative" }
]
```

## The fix

No client reads attendees — the poll page shows *when* a booked event is, never *who* is attending. So rather than filtering the invites, the query no longer selects them:

- `scheduledEvent.invites` is dropped from the Prisma select, so the PII never enters the process.
- The raw `scheduledEvent` row is no longer spread into the response. It was a second copy of the same booking, and the field the invites rode in on — sanitizing the mapped `event` alone would have left the source data beside it.

`event` keeps `{ id, start, duration, status }`, which is everything the four call sites in `responsive-results.tsx`, `manage-poll.tsx` and `comments-sheet.tsx` actually read.

Net effect is a deletion, not a new privacy branch: nothing to filter, nothing to keep in sync with the client, and one fewer join on the hottest public endpoint. The host reads the attendee list through the event surfaces, which authorize first.

## Reviewer notes

- `GetPollApiResponse` is hand-written rather than inferred from the router, so it is checked against consumers but not against what the procedure actually returns. Re-adding `invites` to the select would reintroduce the leak with type-check still green. That is how the original bug survived.
- `event.attendees` disappears from the public payload without deprecation. Nothing internal read it, but an external API consumer could have.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Changes**
  - Poll event responses now provide only the event’s core details: ID, start time, duration, and status.
  - Attendee information and scheduled-event invite data are no longer included in poll results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->