### PR TITLE
🐛 Route every participant link through the short base URL

### DIFF
--- a/apps/landing/next.config.ts
+++ b/apps/landing/next.config.ts
@@ -84,6 +84,11 @@ const nextConfig: NextConfig = {
         permanent: true,
       },
       {
+        source: "/e/:path*",
+        destination: createAppUrl("/e/:path*"),
+        permanent: true,
+      },
+      {
         source: "/admin/:path*",
         destination: createAppUrl("/admin/:path*"),
         permanent: true,

--- a/apps/web/.env.sample
+++ b/apps/web/.env.sample
@@ -6,6 +6,11 @@ SECRET_PASSWORD=
 # Example: https://example.com
 NEXT_PUBLIC_BASE_URL=https://web.rallly.test
 
+# Optional. Base url for links handed to participants (poll invites, event
+# pages) when they should live on another domain that redirects here.
+# Defaults to NEXT_PUBLIC_BASE_URL.
+# NEXT_PUBLIC_SHORT_BASE_URL=https://example.com
+
 # A connection string to your Postgres database
 DATABASE_URL=postgres://postgres:postgres@localhost:5450/rallly
 

--- a/apps/web/src/env.ts
+++ b/apps/web/src/env.ts
@@ -204,6 +204,12 @@ export const env = createEnv({
      */
     NEXT_PUBLIC_CDN_BASE_URL: z.url().optional(),
     /**
+     * Base URL for links handed to participants (poll invites, event pages).
+     * Lets those links live on a marketing domain that redirects to this
+     * instance. Defaults to `NEXT_PUBLIC_BASE_URL`.
+     */
+    NEXT_PUBLIC_SHORT_BASE_URL: z.url().optional(),
+    /**
      * Domain to attach to server-set cookies (auth session, locale).
      * Set to a parent domain prefixed with a leading dot (e.g. `.rallly.co`)
      * to make these cookies readable across subdomains. When unset, cookies
@@ -287,6 +293,7 @@ export const env = createEnv({
     API_BASE_URL: process.env.API_BASE_URL,
     NEXT_PUBLIC_TURNSTILE_SITE_KEY: process.env.NEXT_PUBLIC_TURNSTILE_SITE_KEY,
     NEXT_PUBLIC_CDN_BASE_URL: process.env.NEXT_PUBLIC_CDN_BASE_URL,
+    NEXT_PUBLIC_SHORT_BASE_URL: process.env.NEXT_PUBLIC_SHORT_BASE_URL,
     // Empty string means unset: the process env can override an .env file
     // value but never remove it, so this is the only way a dev server on
     // plain localhost can neutralize a configured cookie domain.

--- a/apps/web/src/features/poll/invite/mutations.ts
+++ b/apps/web/src/features/poll/invite/mutations.ts
@@ -3,7 +3,7 @@ import "server-only";
 import { Prisma, prisma } from "@rallly/database";
 import { sendPollInviteEmail } from "@rallly/emails/templates/poll-invite";
 import { createLogger } from "@rallly/logger";
-import { absoluteUrl } from "@rallly/utils/absolute-url";
+import { shortUrl } from "@rallly/utils/absolute-url";
 import { getInstanceBranding, getSpaceBranding } from "@/emails/branding";
 import { resolveSpaceTier } from "@/features/billing/utils";
 import { recordPollActivities } from "@/features/poll/activity/mutations";
@@ -182,7 +182,7 @@ export async function sendPollInvite({
       props: {
         hostName: sender.name,
         pollTitle: poll.title,
-        inviteUrl: absoluteUrl(getPollInvitePath({ pollId, token })),
+        inviteUrl: shortUrl(getPollInvitePath({ pollId, token })),
       },
     });
   } catch (error) {

--- a/apps/web/src/trpc/routers/polls.ts
+++ b/apps/web/src/trpc/routers/polls.ts
@@ -1195,7 +1195,7 @@ export const polls = router({
                 content: event.value,
               },
               props: {
-                pollUrl: absoluteUrl(`/invite/${poll.id}`),
+                pollUrl: shortUrl(`/invite/${poll.id}`),
                 title: poll.title,
                 hostName: poll.user?.name ?? "",
                 date,

--- a/apps/web/src/trpc/routers/polls/invites.ts
+++ b/apps/web/src/trpc/routers/polls/invites.ts
@@ -1,4 +1,4 @@
-import { absoluteUrl } from "@rallly/utils/absolute-url";
+import { shortUrl } from "@rallly/utils/absolute-url";
 import { TRPCError } from "@trpc/server";
 import * as z from "zod";
 import { hasPollAdminAccess } from "@/features/poll/data";
@@ -24,7 +24,7 @@ export const invites = router({
         id: invite.id,
         email: invite.email,
         status: derivePollInviteStatus(invite),
-        inviteUrl: absoluteUrl(
+        inviteUrl: shortUrl(
           getPollInvitePath({ pollId: input.pollId, token: invite.token }),
         ),
       }));

--- a/apps/web/src/trpc/routers/polls/participants.ts
+++ b/apps/web/src/trpc/routers/polls/participants.ts
@@ -3,7 +3,7 @@ import { prisma } from "@rallly/database";
 import { sendNewParticipantEmail } from "@rallly/emails/templates/new-participant";
 import { sendNewParticipantConfirmationEmail } from "@rallly/emails/templates/new-participant-confirmation";
 import { createLogger } from "@rallly/logger";
-import { absoluteUrl } from "@rallly/utils/absolute-url";
+import { absoluteUrl, shortUrl } from "@rallly/utils/absolute-url";
 import { TRPCError } from "@trpc/server";
 import { after } from "next/server";
 import * as z from "zod";
@@ -180,7 +180,7 @@ export const participants = router({
       const participants = rawParticipants.map((participant) => {
         const dto = createParticipantFullDTO(participant);
         const editUrl = isAdmin
-          ? absoluteUrl(getPollInvitePath({ pollId, token: participant.token }))
+          ? shortUrl(getPollInvitePath({ pollId, token: participant.token }))
           : null;
         if (isAdmin || isOwn(participant)) {
           return { ...dto, editUrl };
@@ -436,7 +436,7 @@ export const participants = router({
                 : await getInstanceBranding(),
               props: {
                 title: participant.poll.title,
-                editSubmissionUrl: absoluteUrl(
+                editSubmissionUrl: shortUrl(
                   `/invite/${participant.poll.id}?token=${editToken}`,
                 ),
               },


### PR DESCRIPTION
## What changed

- Email invites, the per invitee copy link, the host's per response edit link, the respondent confirmation email and the finalized participant email now build on `shortUrl` instead of `absoluteUrl`. Admin links (`/poll/*`) stay on the app host.
- The landing gains a `/e/:path*` 308 to the app. The scheduled events list already copied `rallly.co/e/<id>`, which 404ed.
- `NEXT_PUBLIC_SHORT_BASE_URL` is declared in `env.ts` as an optional URL and documented in `.env.sample`.

## Why

Production sets `NEXT_PUBLIC_SHORT_BASE_URL=https://rallly.co`, but only the share dialog, poll list and API routes honoured it. Every other link a participant receives still pointed at `app.rallly.co`, so the same poll showed two different hosts depending on which surface produced the link.

## Reviewer notes

- The landing's `/invite/*` 308 preserves the query string (verified live), so tokenized links survive the redirect.
- The variable was previously read only in `packages/utils/absolute-url.ts` with no validation. A value without a scheme would have thrown inside `new URL()` when the poll list rendered. The schema entry moves that failure to boot.
- The landing's `vercel.json` still rewrites `/poll/*` to the app's invite page. Left untouched; flagging in case nothing links there any more.

## Verification

- `pnpm biome check` on changed files
- `pnpm --filter @rallly/web type-check` and `pnpm --filter @rallly/landing type-check`
- Vitest: `src/features/poll/invite`, `src/app/api`, `src/env` (201 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configurable participant-facing link domains, with a fallback to the existing base URL.
  * Poll invitation and response-edit links now use shorter, participant-friendly URLs.
  * Added routing support for event links through the shortened URL format.

* **Bug Fixes**
  * Ensured invitation and confirmation emails consistently include the configured shortened links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->