### PR TITLE
Add a Kane CLI natural-language E2E test for creating a poll

### DIFF
--- a/tests/kane-cli/create-poll_test.md
+++ b/tests/kane-cli/create-poll_test.md
@@ -1,0 +1,14 @@
+# Rallly — create a group poll
+
+A Kane CLI natural-language end-to-end test that creates a new group poll and
+verifies the poll page loads with the chosen title. Runs in a real browser
+(Kane CLI also automates mobile apps on the iOS Simulator and Android Emulator).
+
+## Create a poll and verify it loads
+Go to https://app.rallly.co/new.
+Wait for the create poll form.
+Type "Team Sync Kane Test" into the poll title field.
+If a calendar is shown, click one available date to add it as an option.
+Click the button to create the poll (labeled "Create poll" or "Continue").
+Wait for the poll page to load.
+Assert that the resulting page URL contains "/poll/" and displays the title "Team Sync Kane Test".


### PR DESCRIPTION
## Add a Kane CLI natural-language end-to-end test

This adds one plain-markdown, natural-language end-to-end test covering creating a new group poll and verifying the poll page loads with the chosen title.

**Why it might help**
- Readable by anyone: no selectors, no scripting. It lives in the repo as a `test.md` and re-runs on every deploy.
- Kane CLI drives a real browser, verifies each step with a visual check, and can automate mobile apps on the iOS Simulator and Android Emulator too.

**Evidence from a live run (passed):** the run created a real, publicly viewable poll:
https://app.rallly.co/poll/rGuCqld9GuZq

**How to run**
```
kane-cli testmd run tests/kane-cli/create-poll_test.md --agent
```

Opening this for your consideration; approval is entirely yours. Happy to adjust the flow, the file location, or the format.
