### PR TITLE
⚡️ Raise the session cookie cache to 15 minutes

### DIFF
--- a/apps/web/src/lib/auth.ts
+++ b/apps/web/src/lib/auth.ts
@@ -653,9 +653,6 @@ export const authLib = betterAuth({
     expiresIn: SESSION_TTL_SECONDS,
     updateAge: 60 * 60 * 24, // 1 day
     cookieCache: {
-      // Every miss is a Redis read of the session. Bans revoke the Redis keys
-      // immediately, but a signed cookie stays valid until it expires, so this
-      // is also the window a banned user keeps cached-read access.
       enabled: true,
       maxAge: 15 * 60, // 15 minutes
     },

--- a/apps/web/src/lib/auth.ts
+++ b/apps/web/src/lib/auth.ts
@@ -653,8 +653,11 @@ export const authLib = betterAuth({
     expiresIn: SESSION_TTL_SECONDS,
     updateAge: 60 * 60 * 24, // 1 day
     cookieCache: {
+      // Every miss is a Redis read of the session. Bans revoke the Redis keys
+      // immediately, but a signed cookie stays valid until it expires, so this
+      // is also the window a banned user keeps cached-read access.
       enabled: true,
-      maxAge: 5 * 60, // 5 minutes
+      maxAge: 15 * 60, // 15 minutes
     },
   },
   advanced: env.NEXT_PUBLIC_COOKIE_DOMAIN


### PR DESCRIPTION
## What

Raises `session.cookieCache.maxAge` in `apps/web/src/lib/auth.ts` from 5 to 15 minutes.

## Why

Sessions live in Upstash via Better Auth's `secondaryStorage`, so every cookie cache miss is a Redis `GET`. With a 5 minute window, active users were generating a steady stream of session reads. 15 minutes cuts those roughly threefold.

This came out of looking at whether shortening the session TTL (60 days) would reduce the Upstash bill. It wouldn't: Upstash bills on commands, and TTL only affects storage of dormant sessions, which is the cheapest line item. It also has no effect on reads from active users. The cookie cache is the lever that actually moves command volume. Session length is unchanged.

## Tradeoff

Bans revoke the Redis session keys immediately (`banUser` → `deleteUserSessions`), but the cookie cache is a signed cookie in the browser, not a Redis read — so a banned user keeps cached-read access until their cookie expires. That window goes from 5 to 15 minutes.

Writes are unaffected: mutations verify against the database, not the session snapshot, so a banned user cannot mutate anything during that window.

## Note

The real spend breakdown is still unconfirmed. `lib/cache/index.ts` (tagged entity cache) and rate limiting are the other candidates, and the v1 API launch may have moved rate-limit volume. Worth checking the Upstash console's command counts before assuming this alone fixes the bill.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved session continuity by allowing cached signed-in sessions to remain valid for up to 15 minutes after session data is revoked.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->