### PR TITLE
🔒️ Bind the Stripe checkout return endpoint to the signed-in user

### DIFF
--- a/apps/web/src/app/api/stripe/portal/route.ts
+++ b/apps/web/src/app/api/stripe/portal/route.ts
@@ -3,7 +3,9 @@ import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
 
 import { createStripePortalSession } from "@/features/billing/mutations";
+import { subscriptionCheckoutMetadataSchema } from "@/features/billing/schema";
 import { getStripe } from "@/features/billing/service";
+import { getSession } from "@/lib/auth";
 
 /**
  * Checkout return endpoint. Stripe redirects the browser here after payment
@@ -18,10 +20,27 @@ export async function GET(request: NextRequest) {
     return NextResponse.json({ error: "Missing session_id" }, { status: 400 });
   }
 
+  const userSession = await getSession();
+
+  if (!userSession?.user || userSession.user.isGuest) {
+    return NextResponse.redirect(
+      new URL("/login", request.nextUrl.origin).toString(),
+    );
+  }
+
   let customerId: string;
 
   try {
     const session = await getStripe().checkout.sessions.retrieve(sessionId);
+
+    const metadata = subscriptionCheckoutMetadataSchema.safeParse(
+      session.metadata,
+    );
+
+    if (!metadata.success || metadata.data.userId !== userSession.user.id) {
+      return NextResponse.json({ error: "Not found" }, { status: 404 });
+    }
+
     if (typeof session.customer !== "string") {
       Sentry.captureException(new Error("Invalid customer ID in session"));
       return NextResponse.json(

--- a/apps/web/tests/stripe-portal-auth.spec.ts
+++ b/apps/web/tests/stripe-portal-auth.spec.ts
@@ -1,0 +1,21 @@
+import { expect, test } from "@playwright/test";
+
+test("the checkout return endpoint rejects an anonymous caller", async ({
+  request,
+}) => {
+  const res = await request.get(
+    "/api/stripe/portal?session_id=cs_test_someone_elses_session",
+    { maxRedirects: 0 },
+  );
+
+  expect(res.status()).toBe(307);
+  expect(res.headers().location).toContain("/login");
+  expect(res.headers().location).not.toContain("stripe.com");
+});
+
+test("the checkout return endpoint still requires a session id", async ({
+  request,
+}) => {
+  const res = await request.get("/api/stripe/portal", { maxRedirects: 0 });
+  expect(res.status()).toBe(400);
+});


### PR DESCRIPTION
Fixes GHSA-53rm-g57c-qxjp, reported by @CyberKareem.

## The problem

`/api/stripe/portal` took a `session_id` from the query string, resolved a Stripe customer from it, and minted a billing-portal session — without ever reading the caller's session. Anyone holding a victim's checkout session id could open that customer's billing: invoices, billing address, card brand and last four, change the payment method, or cancel the subscription.

The id is not a secret. It lands in the browser's URL bar on the post-checkout redirect, so it reaches history, referrers, and anything that logs URLs.

The tenant key here lives in Stripe rather than our database, so an unscoped-query review doesn't surface it.

## The fix

The endpoint has to stay reachable without a `customerId` on the user — that is the reason it resolves through Stripe at all. It runs on Stripe's redirect after payment, possibly before the webhook has written `customerId`, so looking up the caller's own `customerId` would fail in exactly the case the route exists to serve.

So it binds to the caller instead: the checkout session already carries `metadata.userId` (set where the session is created in `features/billing/actions.ts`), which the caller cannot forge.

- Anonymous or guest caller → `/login`, before any Stripe call.
- `metadata.userId` not matching the session user → 404.
- Otherwise resolve the customer as before.

## Reviewer notes

- **Not a server action.** This is a third-party GET redirect target (`success_url`), which a server action cannot receive. The UI-initiated path already goes through `openCustomerPortalAction`, which reads `ctx.user.customerId` and was never affected. The two paths are deliberately separate.
- **Behavior change:** completing checkout in a browser where you are signed out now lands on `/login` rather than the portal. That path *was* the vulnerability, but it is a real flow, and there is no post-login forward to the portal — worth deciding whether to add one.
- **Test coverage is partial.** There is no `STRIPE_SECRET_KEY` in the test env, so the specs cover the pre-Stripe half: an anonymous caller gets 307 → `/login`, and a missing `session_id` still gets 400. Verified these fail against unfixed code (the anonymous request reached `getStripe()` and 500'd, confirming no gate existed). The cross-user case — signed in as A, presenting B's `session_id` → 404 — is a two-string comparison but is **not** exercised locally; worth a manual check against a Stripe test key.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Stripe customer portal access controls by requiring an authenticated, non-guest account.
  - Prevented users from accessing portal sessions that do not belong to them.
  - Unauthenticated access now redirects to the login page.
  - Invalid or mismatched portal session details return a not-found response.
  - Requests without a session ID return a clear bad-request response.

- **Tests**
  - Added coverage for authentication and invalid session scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->