### PR TITLE
💄 Animate the landing FAQ accordion and keep one item open

### DIFF
--- a/apps/landing/src/app/[locale]/globals.css
+++ b/apps/landing/src/app/[locale]/globals.css
@@ -82,3 +82,36 @@ h2 {
     @apply font-medium;
   }
 }
+
+/*
+ * FAQ accordion. `interpolate-size` is what makes height:auto animatable;
+ * without it the rules below are inert and <details> toggles instantly.
+ */
+@supports (interpolate-size: allow-keywords) {
+  :root {
+    interpolate-size: allow-keywords;
+  }
+
+  .faq-item::details-content {
+    overflow: hidden;
+    block-size: 0;
+    opacity: 0;
+    transition:
+      block-size 200ms var(--ease-out-expo),
+      opacity 200ms var(--ease-out-expo),
+      content-visibility 200ms allow-discrete;
+    /* content-visibility is discrete; without this the content is hidden
+       for the whole closing transition and only the box animates. */
+  }
+
+  .faq-item[open]::details-content {
+    block-size: auto;
+    opacity: 1;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .faq-item::details-content {
+    transition-property: opacity, content-visibility;
+  }
+}

--- a/apps/landing/src/components/home/faq.tsx
+++ b/apps/landing/src/components/home/faq.tsx
@@ -1,5 +1,5 @@
 import { PlusIcon } from "lucide-react";
-import type * as React from "react";
+import * as React from "react";
 import { Trans } from "react-i18next/TransWithoutContext";
 import {
   SectionContent,
@@ -12,16 +12,22 @@ import { getTranslation } from "@/i18n/server";
 
 export function FaqItem({
   question,
+  name,
   children,
 }: {
   question: React.ReactNode;
+  /**
+   * Shared across a group so the browser keeps only one item open. Injected by
+   * `Faq`; the exclusive behaviour is lost if an item is rendered outside one.
+   */
+  name?: string;
   children: React.ReactNode;
 }) {
   return (
-    <details className="group">
+    <details className="faq-item group" name={name}>
       <summary className="flex cursor-pointer list-none items-center justify-between gap-4 py-5 font-medium text-base text-gray-800 [&::-webkit-details-marker]:hidden">
         {question}
-        <PlusIcon className="size-4 shrink-0 text-gray-400 transition-transform group-open:rotate-45" />
+        <PlusIcon className="size-4 shrink-0 text-gray-400 transition-transform duration-200 ease-out-expo group-open:rotate-45 motion-reduce:transition-none" />
       </summary>
       <p className="max-w-prose pb-5 text-gray-500 text-sm leading-relaxed sm:text-base">
         {children}
@@ -30,8 +36,23 @@ export function FaqItem({
   );
 }
 
-export function Faq({ children }: { children: React.ReactNode }) {
-  return <div className="divide-y">{children}</div>;
+export function Faq({
+  name = "faq",
+  children,
+}: {
+  /** Only needs setting if a page renders more than one FAQ group. */
+  name?: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="divide-y">
+      {React.Children.map(children, (child) =>
+        React.isValidElement<{ name?: string }>(child)
+          ? React.cloneElement(child, { name })
+          : child,
+      )}
+    </div>
+  );
 }
 
 export async function FaqSection({


### PR DESCRIPTION
The FAQ items on the landing pages toggled instantly, so content below them teleported on every open and close. This adds a short height/opacity transition and makes the group exclusive — opening one question closes the previous one.

Both changes are pure CSS/HTML, so `FaqItem` stays a server component with **no client JS added**.

## What changed

**Animation** (`globals.css`)

- `interpolate-size: allow-keywords` makes `height: auto` animatable, so `::details-content` can transition without measuring content height in JS. The whole block sits in `@supports`, so browsers without it toggle instantly exactly as before.
- `content-visibility` transitions with `allow-discrete`. Without this the text is hidden for the entire closing transition and only an empty box collapses.
- 200ms, using the existing `--ease-out-expo` token from `packages/tailwind-config` rather than introducing a parallel curve.
- `prefers-reduced-motion` keeps the opacity fade and drops the height movement (gentler, not zero).

**Single-open** (`faq.tsx`)

- Uses the native `name` attribute on `<details>`, so the browser enforces exclusivity — no state, no effects. `Faq` injects one shared name via `cloneElement` so no call site changes.
- Every page renders exactly one FAQ group (checked all 11), so the default name is safe. The `name` prop is the escape hatch if a page ever renders two.

Height is normally off-limits to animate, but it's the sanctioned exception for accordions — there's no transform equivalent, which is why the duration is kept short.

## Verification

Measured in a real browser rather than eyeballed:

- **Open:** 0 → 90px @60ms → 98px @190ms. Front-loaded, as the expo curve should be.
- **Switching items:** the outgoing item animates 98px → 0 *while* the incoming one animates open. Worth calling out, since exclusive `<details>` flips `open` to `false` with no transition — but `::details-content` still animates, so there's no snap.
- **Reduced motion:** height jumps to full, opacity still fades.
- **Icon:** rotates 0° → 45° on the same curve. (In Tailwind v4 this compiles to the standalone `rotate` property, so it reads as `transform: none` if you inspect the wrong property.)

`type-check` passes and Biome is clean on both files.

## Screenshots

One item open, then after clicking a different question — the previous one has closed itself:

| Open | After switching |
| --- | --- |
| ![One FAQ item expanded](https://github.com/lukevella/rallly/blob/8e1392a15fb116432cf75319a839f81a216487f1/.pr-assets/faq-open.png?raw=true) | ![A different item expanded, previous one collapsed](https://github.com/lukevella/rallly/blob/8e1392a15fb116432cf75319a839f81a216487f1/.pr-assets/faq-mid.png?raw=true) |

## Reviewer notes

Two things that are feel calls rather than correctness, worth a click-through on the preview: the 200ms when moving quickly between questions, and whether the opacity fade wants to be slightly shorter than the height so text doesn't linger while collapsing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * FAQ sections now allow only one item to remain open at a time within each group.
  * Added smoother expansion and collapse animations, including opacity and visibility transitions.
* **Accessibility**
  * Reduced-motion preferences are respected by limiting FAQ animations while preserving clear visibility changes.
  * FAQ controls include improved visual transitions for opening and closing items.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->