### PR TITLE
📝 Clarify what the email invites feature actually does

### DIFF
--- a/apps/landing/public/locales/en/pricing.json
+++ b/apps/landing/public/locales/en/pricing.json
@@ -24,7 +24,7 @@
   "duplicatePolls": "Duplicate polls",
   "duplicatePollsDescription": "Create a new poll based on an existing one",
   "emailInvites": "Email invites",
-  "emailInvitesDescription": "Invite people by email and see who has responded",
+  "emailInvitesDescription": "Track who opened and responded with personal invite links",
   "faq": "Frequently asked questions",
   "featureNameExtendedPollLifetime": "Extended poll lifetime",
   "finalizeDate": "Finalize date",

--- a/apps/landing/src/app/[locale]/(main)/pricing/page.tsx
+++ b/apps/landing/src/app/[locale]/(main)/pricing/page.tsx
@@ -667,7 +667,7 @@ export default async function Page(props: {
                       t={t}
                       ns="pricing"
                       i18nKey="emailInvitesDescription"
-                      defaults="Invite people by email and see who has responded"
+                      defaults="Track who opened and responded with personal invite links"
                     />
                   </CompareTableFeatureDescription>
                 </CompareTableFeature>

--- a/apps/web/public/locales/en/app.json
+++ b/apps/web/public/locales/en/app.json
@@ -288,7 +288,7 @@
   "emailChangeVerifyError": "Verification failed. Please try again.",
   "emailDoesNotMatch": "The email address does not match.",
   "emailInvites": "Email invites",
-  "emailInvitesDescription": "Invite people by email and see who has responded",
+  "emailInvitesDescription": "Track who opened and responded with personal invite links",
   "emailMismatch": "Email does not match the account email",
   "emailPlaceholder": "jessie.smith@example.com",
   "enabled": "Enabled",

--- a/apps/web/src/features/billing/components/pay-wall-dialog.tsx
+++ b/apps/web/src/features/billing/components/pay-wall-dialog.tsx
@@ -129,7 +129,7 @@ const proBenefitsList = [
     description: (
       <Trans
         i18nKey="emailInvitesDescription"
-        defaults="Invite people by email and see who has responded"
+        defaults="Track who opened and responded with personal invite links"
       />
     ),
   },


### PR DESCRIPTION
## Description

A support email asked whether Rallly can invite people to a poll by email, having read the pricing comparison table as saying it cannot:

> I'd like to create a poll and invite users via email to participate in the poll [...] I'm confused at looking at the comparisons where it says that you can't invite users via email to participate in the poll.

She is describing something the free plan does today. The dash in the Free column against **Email invites** reads as *"you cannot email an invite"*, when what is actually gated is Rallly doing the sending and the tracking. Pasting a poll link into your own email client is free and always has been.

The old description didn't help, because it described the medium rather than the capability:

> Invite people by email and see who has responded

"Invite people by email" is exactly the thing a non-technical reader assumes they can already do — so the row looked like it was taking something away.

### Change

One string, in the two places the feature is sold:

```diff
- Invite people by email and see who has responded
+ Track who opened and responded with personal invite links
```

This leads with the part you genuinely only get on Pro. Every claim in it maps to something real in the implementation:

| Claim | Backed by |
| --- | --- |
| opened | `PollInvite.openedAt`, set on first link follow — recorded client-side so mail scanners prefetching the link don't count as an open |
| responded | the `participantId` join, which flips the host's list from Sent to Responded |
| personal invite links | per-invitee CSPRNG token, rotated on reactivation |

### Notes for the reviewer

- **The feature name is deliberately unchanged.** Renaming `emailInvites` would clear the string in all 15 translated locales and strand the published `/blog/introducing-email-invites` post, for a name that arguably reads *more* like "here's a link, go send it yourself". Only `emailInvitesDescription` changes, so Crowdin has one key to retranslate per app.
- Landing and web each have their own `emailInvitesDescription`; both are updated so the feature isn't described two different ways depending on where you meet it.
- Web's `app.json` was updated with `pnpm --filter @rallly/web i18n:sync`. Landing's key was edited directly rather than via `--sync-primary`, which would have rewritten unrelated changed defaults across every landing namespace.
- Landing's i18n scan also wants to drop 5 orphaned `cookieConsent*` keys from `common.json`. That's pre-existing drift unrelated to this change, so it's left alone — it will resurface on the next scan.

### Considered and dropped

A free **Share by link** row (✓ Free, ✓ Pro) placed above this one. It would have made the free plan's distribution story explicit instead of implicit, but adds a row to an already long table to state something most readers assume. Dropped in favour of the description fix alone.

### Verification

`pnpm check:locales`, `biome check`, and `type-check` on both `@rallly/landing` and `@rallly/web` all pass. Copy change only — no behaviour change, no schema change.

## Checklist

- [x] I have performed a self-review of my code
- [x] My code follows the code style of this project
- [x] I have commented my code, particularly in hard-to-understand areas

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Copy Updates**
  - Updated English pricing and plan descriptions to clarify that personal invite links track who opened and responded to email invitations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->