### PR TITLE
✨ Add the nonprofit entitlement and application record

### DIFF
--- a/apps/web/src/features/billing/nonprofit/constants.ts
+++ b/apps/web/src/features/billing/nonprofit/constants.ts
@@ -1,0 +1,4 @@
+export const NONPROFIT_DISCOUNT_PERCENT = 20;
+
+// Stripe coupon id; derived so the id and the percentage cannot drift.
+export const NONPROFIT_COUPON_ID = `nonprofit-${NONPROFIT_DISCOUNT_PERCENT}`;

--- a/apps/web/src/features/billing/nonprofit/data.ts
+++ b/apps/web/src/features/billing/nonprofit/data.ts
@@ -1,0 +1,30 @@
+import "server-only";
+
+import { prisma } from "@rallly/database";
+import type { NonprofitStatus } from "@/features/billing/nonprofit/types";
+import type { AuthorizedSpaceId } from "@/features/space/types";
+
+export async function getNonprofitStatus(
+  spaceId: AuthorizedSpaceId,
+): Promise<NonprofitStatus> {
+  const space = await prisma.space.findUnique({
+    where: { id: spaceId },
+    select: {
+      nonprofitDiscountGrantedAt: true,
+      nonprofitApplications: {
+        orderBy: { createdAt: "desc" },
+        take: 1,
+        select: { status: true, reason: true },
+      },
+    },
+  });
+
+  const latest = space?.nonprofitApplications[0];
+
+  return {
+    grantedAt: space?.nonprofitDiscountGrantedAt ?? null,
+    latestApplication: latest
+      ? { status: latest.status, reason: latest.reason }
+      : null,
+  };
+}

--- a/apps/web/src/features/billing/nonprofit/loaders.ts
+++ b/apps/web/src/features/billing/nonprofit/loaders.ts
@@ -1,0 +1,10 @@
+import "server-only";
+
+import { cache } from "react";
+import { getNonprofitStatus } from "@/features/billing/nonprofit/data";
+import { getActiveSpace } from "@/features/space/loaders";
+
+export const loadNonprofitStatus = cache(async () => {
+  const space = await getActiveSpace();
+  return getNonprofitStatus(space.id);
+});

--- a/apps/web/src/features/billing/nonprofit/types.ts
+++ b/apps/web/src/features/billing/nonprofit/types.ts
@@ -1,0 +1,9 @@
+export type NonprofitApplicationStatus = "approved" | "rejected" | "failed";
+
+export type NonprofitStatus = {
+  grantedAt: Date | null;
+  latestApplication: {
+    status: NonprofitApplicationStatus;
+    reason: string | null;
+  } | null;
+};

--- a/apps/web/src/lib/feature-flags/config.ts
+++ b/apps/web/src/lib/feature-flags/config.ts
@@ -32,4 +32,7 @@ export const featureFlagConfig: FeatureFlagConfig = {
   // limit and Redis is not required. Cloud runs many short-lived instances,
   // where a per-process counter is no limit at all, so it must use KV.
   inProcessRateLimit: isSelfHosted,
+  // The discount is a Stripe coupon, so it needs billing; applying needs
+  // storage for the verification documents the reviewer reads.
+  nonprofitDiscount: isBillingEnabled && isStorageEnabled,
 };

--- a/apps/web/src/lib/feature-flags/types.ts
+++ b/apps/web/src/lib/feature-flags/types.ts
@@ -10,6 +10,7 @@ export interface FeatureFlagConfig {
   pollAdmin: boolean;
   quickCreate: boolean;
   inProcessRateLimit: boolean;
+  nonprofitDiscount: boolean;
 }
 
 export type Feature = keyof FeatureFlagConfig;

--- a/packages/database/prisma/migrations/20260911120000_add_nonprofit_discount/migration.sql
+++ b/packages/database/prisma/migrations/20260911120000_add_nonprofit_discount/migration.sql
@@ -1,0 +1,34 @@
+-- Nonprofit discount: the entitlement lives on the space, each application
+-- (approved, rejected or failed) is kept as an audit record of the automated
+-- review.
+
+-- CreateEnum
+CREATE TYPE "nonprofit_application_status" AS ENUM ('approved', 'rejected', 'failed');
+
+-- AlterTable
+ALTER TABLE "spaces" ADD COLUMN "nonprofit_discount_granted_at" TIMESTAMP(3);
+
+-- CreateTable
+CREATE TABLE "nonprofit_applications" (
+    "id" TEXT NOT NULL,
+    "space_id" TEXT NOT NULL,
+    "user_id" TEXT NOT NULL,
+    "organization_name" TEXT NOT NULL,
+    "website" TEXT NOT NULL,
+    "email_domain" TEXT NOT NULL,
+    "status" "nonprofit_application_status" NOT NULL,
+    "reason" TEXT,
+    "model" TEXT,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "nonprofit_applications_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "nonprofit_applications_space_id_created_at_idx" ON "nonprofit_applications"("space_id", "created_at");
+
+-- AddForeignKey
+ALTER TABLE "nonprofit_applications" ADD CONSTRAINT "nonprofit_applications_space_id_fkey" FOREIGN KEY ("space_id") REFERENCES "spaces"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "nonprofit_applications" ADD CONSTRAINT "nonprofit_applications_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/packages/database/prisma/models/billing.prisma
+++ b/packages/database/prisma/models/billing.prisma
@@ -57,3 +57,33 @@ model PaymentMethod {
 
   @@map("payment_methods")
 }
+
+enum NonprofitApplicationStatus {
+  approved
+  rejected
+  // The verifier could not reach a verdict (model error, unreadable upload).
+  failed
+
+  @@map("nonprofit_application_status")
+}
+
+model NonprofitApplication {
+  id               String                     @id @default(uuid())
+  spaceId          String                     @map("space_id")
+  userId           String                     @map("user_id")
+  organizationName String                     @map("organization_name")
+  website          String
+  emailDomain      String                     @map("email_domain")
+  status           NonprofitApplicationStatus
+  // Verifier's explanation; shown to the applicant on rejection.
+  reason           String?
+  // Model that produced the verdict, kept for auditing the automated review.
+  model            String?
+  createdAt        DateTime                   @default(now()) @map("created_at")
+
+  space Space @relation(fields: [spaceId], references: [id], onDelete: Cascade)
+  user  User  @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@index([spaceId, createdAt])
+  @@map("nonprofit_applications")
+}

--- a/packages/database/prisma/models/space.prisma
+++ b/packages/database/prisma/models/space.prisma
@@ -1,17 +1,17 @@
 model Space {
-  id              String     @id @default(uuid())
-  name            String
-  image           String?
-  ownerId         String     @map("owner_id")
-  tier            SpaceTier  @default(hobby)
-  spaceType       SpaceType? @map("space_type")
+  id                         String     @id @default(uuid())
+  name                       String
+  image                      String?
+  ownerId                    String     @map("owner_id")
+  tier                       SpaceTier  @default(hobby)
+  spaceType                  SpaceType? @map("space_type")
   // Self-declared sector, optional. Stored as a string rather than an enum
   // because the taxonomy is expected to change; validation lives in
   // features/space/schema.ts.
-  industry        String?
-  primaryColor    String?   @map("primary_color")
-  showBranding    Boolean   @default(false) @map("show_branding")
-  hideAttribution Boolean   @default(false) @map("hide_attribution")
+  industry                   String?
+  primaryColor               String?    @map("primary_color")
+  showBranding               Boolean    @default(false) @map("show_branding")
+  hideAttribution            Boolean    @default(false) @map("hide_attribution")
   // The Team collaboration setting (Settings -> Collaboration).
   // Whether members share everything they create (everyone sees
   // everything) or work independently (everyone, admins included, only
@@ -20,9 +20,12 @@ model Space {
   // kept existing multi-member spaces shared to preserve their behavior.
   // When the org layer lands, shared
   // spaces map to teams and unshared spaces to organizations.
-  shared          Boolean   @default(false)
-  createdAt       DateTime  @default(now()) @map("created_at")
-  updatedAt       DateTime  @updatedAt @map("updated_at")
+  shared                     Boolean    @default(false)
+  // Set once the space's nonprofit application is approved; the coupon is
+  // applied at checkout and to the active subscription from this.
+  nonprofitDiscountGrantedAt DateTime?  @map("nonprofit_discount_granted_at")
+  createdAt                  DateTime   @default(now()) @map("created_at")
+  updatedAt                  DateTime   @updatedAt @map("updated_at")
 
   owner           User             @relation("UserSpaces", fields: [ownerId], references: [id], onDelete: Cascade)
   polls           Poll[]
@@ -36,6 +39,8 @@ model Space {
   memberInvites SpaceMemberInvite[]
 
   apiKeys SpaceApiKey[]
+
+  nonprofitApplications NonprofitApplication[]
 
   @@index([ownerId])
   @@map("spaces")

--- a/packages/database/prisma/models/user.prisma
+++ b/packages/database/prisma/models/user.prisma
@@ -70,6 +70,7 @@ model User {
   participants            Participant[]
   paymentMethods          PaymentMethod[]
   spaceMemberInvites      SpaceMemberInvite[]
+  nonprofitApplications   NonprofitApplication[]
 
   subscriptions Subscription[] @relation("UserToSubscription")
   spaces        Space[]        @relation("UserSpaces")

--- a/scripts/check-user-cascade-relations.mjs
+++ b/scripts/check-user-cascade-relations.mjs
@@ -48,6 +48,10 @@ const IGNORED_RELATIONS = new Map([
     "notificationPreferences",
     "Per-user settings, meaningless once the account is gone.",
   ],
+  [
+    "nonprofitApplications",
+    "Audit record of a space's automated nonprofit review. Only a space owner can apply, and guests cannot own a space (the purge already retains anyone with `spaces`), so a guest never has one.",
+  ],
 ]);
 
 /**


### PR DESCRIPTION
Closes RAL-1623. Schema and read side for the automated nonprofit discount. Nothing is user visible yet.

## What changed

- `Space.nonprofitDiscountGrantedAt` (`nonprofit_discount_granted_at`) plus a `nonprofitApplications` relation.
- New `NonprofitApplication` model in `billing.prisma`: `id, spaceId, userId, organizationName, website, emailDomain, status (approved | rejected | failed), reason?, model?, createdAt`. Cascades on space and user, index on `[spaceId, createdAt]`, table `nonprofit_applications`.
- Migration `20260911120000_add_nonprofit_discount`.
- `features/billing/nonprofit/`: `constants.ts` (`NONPROFIT_DISCOUNT_PERCENT = 20`, `NONPROFIT_COUPON_ID` derived from it), `types.ts` (`NonprofitStatus` DTO), `data.ts` (`getNonprofitStatus(spaceId)` taking `AuthorizedSpaceId`), `loaders.ts` (`loadNonprofitStatus` under `cache()`, resolving the active space via `getActiveSpace`).
- Feature flag `nonprofitDiscount: isBillingEnabled && isStorageEnabled` with the reason on the line.
- The new `User` cascade is recorded as ignored in `check-user-cascade-relations.mjs`: only a space owner can apply and guests cannot own a space, so the existing `spaces` guard already retains anyone who could have one.

## Reviewer notes

- The DTO nests the latest application (`{ grantedAt, latestApplication: { status, reason } | null }`) rather than flattening status and reason to the top level. A space with no application is a distinct state from a rejected one, and the nested shape keeps that explicit for RAL-1628.
- The migration was hand written. Verified by applying the full migration chain to a scratch Postgres 16 container and running `prisma migrate diff --from-config-datasource --to-schema`: empty diff.

## Verification

`pnpm db:generate`, `pnpm type-check`, `pnpm check:cascades`, `pnpm check:structure` and Biome all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for nonprofit discount applications and discount eligibility tracking.
  - Nonprofit applications can now be recorded with approved, rejected, or failed statuses, including rejection details.
  - Added support for applying a 20% nonprofit discount when enabled.
  - Added a feature flag to control nonprofit discount availability.
- **Data & Reliability**
  - Nonprofit application history and discount status are now retained for billing and review purposes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->