### PR TITLE
🔥 Drop is_guest from the poll group

### DIFF
--- a/apps/web/src/trpc/routers/polls.ts
+++ b/apps/web/src/trpc/routers/polls.ts
@@ -265,7 +265,6 @@ export const polls = router({
         properties: {
           name: poll.title,
           status: poll.status,
-          is_guest: ctx.user.isGuest,
           created_at: poll.createdAt,
           comment_count: 0,
           option_count: poll.options.length,


### PR DESCRIPTION
Follow-up to the poll group taxonomy cleanup, which hid six properties that were written once at creation and then left to go stale.

`is_guest` has the same defect, and the earlier version of this PR missed it — it tried to propagate the property to every write site instead of questioning whether it belonged on the group at all. That approach is dropped; this removes it.

## Why it doesn't belong on the group

`is_guest` describes **the creator's session state at one moment**, not the poll. Guest accounts convert to registered ones — that is a conversion funnel actively measured in this project — and when they do, the group keeps reporting `is_guest: true` indefinitely. A property that looks authoritative while describing a past moment is worse than an absent one.

It was also being silently wiped on every edit: `groupIdentify` replaces a group's entire property set, and the update path never re-sent it.

## The event property is the correct home, and already carries this

`poll_create` sends `isGuest` at **100% coverage** (~53% guest rate), as an immutable record of how the poll was created.

Every saved insight measuring guest behaviour already reads it there, filtering on the `poll_create` action rather than the group:

- Guest → Account Conversion Rate
- Guest Poll to Registered User Conversion
- Polls (Registered vs Guest)
- (one unnamed funnel)

**No saved insight, dashboard, cohort, or notebook used the group property**, so nothing breaks. Anything that wants this should filter `poll_create` on `isGuest`.

`is_guest` on `poll_update_details` is untouched — it records who performed a specific edit, which is a genuine point-in-time fact.

## Result

The poll group now carries: `name`, `status`, `kind`, `timezone`, `created_at`, `muted`, `has_location`, `has_description`, `option_count`, `comment_count`.

The remaining mutable ones (`name`, `status`, `muted`) are re-sent on the update path, so they track the poll's current state rather than going stale.

The taxonomy entry for `is_guest` is hidden in PostHog separately, with a description pointing at `poll_create`.

## Verification

- `pnpm type-check` passes
- `pnpm test:unit` — 733 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated poll creation analytics to stop reporting whether the creator is a guest.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->