### PR TITLE
🔔 Report the API rate limiter failing closed to Sentry and ship wide events as logs

### DIFF
--- a/apps/web/sentry.server.config.ts
+++ b/apps/web/sentry.server.config.ts
@@ -17,6 +17,23 @@ Sentry.init({
   // Don't send personal identifiable information (PII) to Sentry.
   sendDefaultPii: false,
 
+  // Ship the 4xx/5xx wide events as structured logs so rate limiter usage
+  // (`rateLimiterDailyConsumedPoints`, 429s per `spaceId`) is queryable and
+  // alertable for 30 days. Info-level events are every request; they stay in
+  // Vercel to keep the log quota for the ones worth searching.
+  enableLogs: true,
+  integrations: [
+    Sentry.pinoIntegration({ log: { levels: ["warn", "error", "fatal"] } }),
+  ],
+  beforeSendLog(log) {
+    // `sendDefaultPii` does not cover custom log attributes.
+    if (log.attributes) {
+      const { ip, ...attributes } = log.attributes;
+      return { ...log, attributes };
+    }
+    return log;
+  },
+
   // Uncomment the line below to enable Spotlight (https://spotlightjs.com)
   // spotlight: process.env.NODE_ENV === 'development',
 });

--- a/apps/web/src/app/api/middleware/rate-limit.ts
+++ b/apps/web/src/app/api/middleware/rate-limit.ts
@@ -1,3 +1,4 @@
+import * as Sentry from "@sentry/nextjs";
 import type { Context } from "hono";
 import { createMiddleware } from "hono/factory";
 import {
@@ -35,6 +36,26 @@ export type RateLimitFailure = {
   reason: "store_unavailable" | "store_error";
   message: string;
 };
+
+/**
+ * The fail-closed 503 is returned, not thrown, so nothing upstream reports it.
+ * A fixed message per reason keeps Sentry grouping to one issue per cause;
+ * the store's own message travels as `cause` and on the wide event.
+ */
+export class RateLimitStoreError extends Error {
+  readonly reason: RateLimitFailure["reason"];
+
+  constructor(reason: RateLimitFailure["reason"], options?: ErrorOptions) {
+    super(
+      reason === "store_unavailable"
+        ? "Rate limit store is not configured"
+        : "Rate limit store request failed",
+      options,
+    );
+    this.name = "RateLimitStoreError";
+    this.reason = reason;
+  }
+}
 
 type RateLimitEnv = {
   Variables: {
@@ -181,8 +202,17 @@ function setRateLimitHeaders(c: Context, info: RateLimitInfo) {
   c.header("RateLimit-Reset", resetSeconds(binding).toString());
 }
 
-function serviceUnavailable(c: Context, failure: RateLimitFailure) {
+function serviceUnavailable(
+  c: Context,
+  failure: RateLimitFailure,
+  { spaceId, cause }: { spaceId: string; cause?: unknown },
+) {
   c.set("rateLimitFailure", failure);
+  Sentry.captureException(new RateLimitStoreError(failure.reason, { cause }), {
+    tags: { rateLimiterError: failure.reason },
+    fingerprint: ["rate-limit-store", failure.reason],
+    extra: { spaceId },
+  });
   return c.json(
     apiError(
       "SERVICE_UNAVAILABLE",
@@ -207,21 +237,30 @@ function serviceUnavailable(c: Context, failure: RateLimitFailure) {
  * the wide event via `rateLimitFailure`.
  */
 export const rateLimit = createMiddleware<RateLimitEnv>(async (c, next) => {
+  const { spaceId } = c.get("apiAuth");
   if (!store) {
-    return serviceUnavailable(c, {
-      reason: "store_unavailable",
-      message: "Rate limit store is not configured",
-    });
+    return serviceUnavailable(
+      c,
+      {
+        reason: "store_unavailable",
+        message: "Rate limit store is not configured",
+      },
+      { spaceId },
+    );
   }
 
   let result: Counters;
   try {
-    result = await store.increment(c.get("apiAuth").spaceId);
+    result = await store.increment(spaceId);
   } catch (error) {
-    return serviceUnavailable(c, {
-      reason: "store_error",
-      message: error instanceof Error ? error.message : String(error),
-    });
+    return serviceUnavailable(
+      c,
+      {
+        reason: "store_error",
+        message: error instanceof Error ? error.message : String(error),
+      },
+      { spaceId, cause: error },
+    );
   }
 
   const [minuteHits, minuteTtl, dayHits, dayTtl] = result;

--- a/apps/web/src/app/api/middleware/rate-limit.ts
+++ b/apps/web/src/app/api/middleware/rate-limit.ts
@@ -202,17 +202,38 @@ function setRateLimitHeaders(c: Context, info: RateLimitInfo) {
   c.header("RateLimit-Reset", resetSeconds(binding).toString());
 }
 
+const STORE_ERROR_REPORT_INTERVAL_MS = 60 * 1000;
+const lastStoreErrorReportAt = new Map<RateLimitFailure["reason"], number>();
+
+/**
+ * During an outage every API request takes this path, so report at most one
+ * event per reason per minute per process. The alert only needs the first;
+ * the wide event keeps the per-request detail.
+ */
+function reportStoreError(
+  failure: RateLimitFailure,
+  { spaceId, cause }: { spaceId: string; cause?: unknown },
+) {
+  const now = Date.now();
+  const lastReportAt = lastStoreErrorReportAt.get(failure.reason);
+  if (lastReportAt && now - lastReportAt < STORE_ERROR_REPORT_INTERVAL_MS) {
+    return;
+  }
+  lastStoreErrorReportAt.set(failure.reason, now);
+  Sentry.captureException(new RateLimitStoreError(failure.reason, { cause }), {
+    tags: { rateLimiterError: failure.reason },
+    fingerprint: ["rate-limit-store", failure.reason],
+    extra: { spaceId },
+  });
+}
+
 function serviceUnavailable(
   c: Context,
   failure: RateLimitFailure,
   { spaceId, cause }: { spaceId: string; cause?: unknown },
 ) {
   c.set("rateLimitFailure", failure);
-  Sentry.captureException(new RateLimitStoreError(failure.reason, { cause }), {
-    tags: { rateLimiterError: failure.reason },
-    fingerprint: ["rate-limit-store", failure.reason],
-    extra: { spaceId },
-  });
+  reportStoreError(failure, { spaceId, cause });
   return c.json(
     apiError(
       "SERVICE_UNAVAILABLE",


### PR DESCRIPTION
## Description

Since #3196 the API rate limiter fails closed, but the 503 is returned rather than thrown, so nothing reported it: a KV outage or a dropped env var would take the whole API down silently until a customer wrote in. This is the code half of [RAL-1620](https://linear.app/rallly/issue/RAL-1620/alert-on-the-api-rate-limiter-failing-closed-and-watch-daily-cap-usage).

Vercel alerts never read log fields, only metric events with fixed dimensions, so `rateLimiterError` and `spaceId` are not alertable there even with Observability Plus (which is off for the team). Sentry indexes structured attributes, issue alerts are on every plan, and Logs come with 5GB/month included.

**Fail closed → Sentry issue.** The fail-closed branch in `api/middleware/rate-limit.ts` captures a `RateLimitStoreError` with a fixed message and fingerprint per reason, so `store_unavailable` (missing env var) and `store_error` (Upstash down) land as two stable issues. The reason is a tag for the alert filter, `spaceId` is extra, and the store's own error travels as `cause`.

**Wide events → Sentry Logs.** `sentry.server.config.ts` enables Sentry Logs with the Pino integration at warn/error/fatal only, so every 4xx/5xx wide event lands with its fields as attributes and the daily cap and 429 queries can run over 30 days grouped by `spaceId`. Info level (every 2xx) stays in Vercel to protect the log quota. The `ip` attribute is dropped in `beforeSendLog` since `sendDefaultPii` does not cover custom attributes. Pino 10.3 publishes the `pino_asJson` diagnostics channel natively, so no bundler externals are needed.

**Reviewer notes**
- Still manual after merge, tracked on RAL-1620: create the Sentry issue alert filtered on the `rateLimiterError` tag, save the two Logs queries, and trip the alert once on a preview with the KV vars removed.
- No new env vars. Logs go through the existing DSN.

## Checklist

- [x] I have performed a self-review of my code
- [x] My code follows the code style of this project
- [x] I have commented my code, particularly in hard-to-understand areas

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Monitoring Improvements**
  - Server-side monitoring now captures structured warnings, errors, and critical failures.
  - Rate-limiting service failures include clearer context for troubleshooting.
  - Repeated rate-limiting failures are throttled to reduce duplicate monitoring events.

- **Privacy**
  - Log data sent for monitoring excludes IP address information, helping prevent transmission of personally identifiable data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
