### PR TITLE
💥 Make the v1 create request mirror the poll it returns

### DIFF
--- a/apps/docs/api-reference/errors.mdx
+++ b/apps/docs/api-reference/errors.mdx
@@ -24,8 +24,6 @@ Every failure is `application/json` with the same shape:
 | 400 | `INVALID_AUTHORIZATION_HEADER` | The `Authorization` header is not `Bearer <key>` |
 | 400 | `ORGANIZER_NOT_MEMBER` | The organizer email is not a member of the space |
 | 400 | `TOO_MANY_OPTIONS` | More than the maximum number of poll options |
-| 400 | `DUPLICATE_DATES` | `options.dates` contains the same date more than once |
-| 400 | `NO_OPTIONS_GENERATED` | No slot generator produced a valid time slot |
 | 401 | `UNAUTHORIZED` | The API key is missing, invalid, expired or revoked |
 | 403 | `SPACE_NOT_PRO` | The space behind the key has no Pro subscription |
 | 404 | `NOT_FOUND` | No route matches the method and path |

--- a/apps/docs/api-reference/openapi.json
+++ b/apps/docs/api-reference/openapi.json
@@ -2,7 +2,7 @@
   "openapi": "3.1.0",
   "info": {
     "title": "Rallly API",
-    "description": "## Versioning\n\n`v1` is stable. Additive changes (new endpoints, new optional fields) may land on this path at any time; breaking changes only arrive under a new version prefix.\n\n## Rate limits\n\nAll endpoints share two limits per space: **60 requests per minute** and **5000 requests per day**. Both are fixed windows that open with the first request and reset when they expire. Both limits are per space, not per API key, so creating additional keys does not increase throughput.\n\nEvery response from an authenticated request includes the standard `RateLimit-*` headers. Responses sent before the limiter runs (`401`, `403`, and the maintenance `503`) do not. `RateLimit-Policy` lists both limits; `RateLimit-Limit`, `RateLimit-Remaining` and `RateLimit-Reset` describe whichever limit is closest to being exhausted. When either limit is exceeded the API responds with `429 Too Many Requests`, a `RATE_LIMIT_EXCEEDED` error body, and a `Retry-After` header indicating how many seconds to wait before retrying.\n\nIf the rate limit store cannot be reached the API fails closed and responds with `503 Service Unavailable`, a `SERVICE_UNAVAILABLE` error body, and a `Retry-After` header.\n\n## Dates and times\n\nEvery poll has a `kind`. A `date` poll offers calendar days: each option carries a `date` in `YYYY-MM-DD` format, which is a floating date with no time component and no timezone, so never convert it through a timezone. A `time` poll offers time slots: each option carries a `startTime` as an ISO 8601 instant in UTC and a `duration` in minutes; convert `startTime` into the poll's `timeZone` (or the viewer's) for display. Timestamps such as `createdAt` and `updatedAt` are always ISO 8601 instants in UTC.\n\n## Request bodies\n\nRequest bodies are validated strictly: a field that is not part of the documented schema is rejected with `VALIDATION_ERROR` rather than ignored, so a misspelt setting never silently falls back to its default.\n\n## Enums\n\nVote types are an open set. The built-in values are `yes`, `ifNeedBe` and `no`; new types may be added without a version change, so clients must tolerate values they do not recognise. `status` and `kind` are closed sets.\n\n## Lists\n\nEvery list endpoint returns the items in `data` and a `nextCursor` beside it. Pass `nextCursor` as the `cursor` query parameter to fetch the next page; it is `null` on the last page.\n\n## Errors\n\nEvery failure is `application/json` with the shape `{ \"error\": { \"code\", \"message\" } }`. `code` is stable and safe to branch on; `message` is human-readable and may change. `VALIDATION_ERROR` messages name each offending field.\n\n| Status | Code | When |\n| --- | --- | --- |\n| 400 | `VALIDATION_ERROR` | The body or query string did not match the schema, contained an unknown field, or the body was not valid JSON |\n| 400 | `INVALID_AUTHORIZATION_HEADER` | The `Authorization` header is not `Bearer <key>` |\n| 400 | `ORGANIZER_NOT_MEMBER` | The organizer email is not a member of the space |\n| 400 | `TOO_MANY_OPTIONS` | More than the maximum number of poll options |\n| 400 | `DUPLICATE_DATES` | `options.dates` contains the same date more than once |\n| 400 | `NO_OPTIONS_GENERATED` | No slot generator produced a valid time slot |\n| 401 | `UNAUTHORIZED` | The API key is missing, invalid, expired or revoked |\n| 403 | `SPACE_NOT_PRO` | The space behind the key has no Pro subscription |\n| 404 | `NOT_FOUND` | No route matches the method and path |\n| 404 | `POLL_NOT_FOUND` | The poll does not exist or belongs to another space |\n| 422 | `TRANSITION_NOT_AVAILABLE` | The requested status change is not supported |\n| 429 | `RATE_LIMIT_EXCEEDED` | A rate limit window is exhausted |\n| 503 | `SERVICE_UNAVAILABLE` | Maintenance, or the rate limit store cannot be reached |\n| 500 | `INTERNAL_ERROR` | Unexpected failure; the request id is logged |",
+    "description": "## Versioning\n\n`v1` is stable. Additive changes (new endpoints, new optional fields) may land on this path at any time; breaking changes only arrive under a new version prefix.\n\n## Rate limits\n\nAll endpoints share two limits per space: **60 requests per minute** and **5000 requests per day**. Both are fixed windows that open with the first request and reset when they expire. Both limits are per space, not per API key, so creating additional keys does not increase throughput.\n\nEvery response from an authenticated request includes the standard `RateLimit-*` headers. Responses sent before the limiter runs (`401`, `403`, and the maintenance `503`) do not. `RateLimit-Policy` lists both limits; `RateLimit-Limit`, `RateLimit-Remaining` and `RateLimit-Reset` describe whichever limit is closest to being exhausted. When either limit is exceeded the API responds with `429 Too Many Requests`, a `RATE_LIMIT_EXCEEDED` error body, and a `Retry-After` header indicating how many seconds to wait before retrying.\n\nIf the rate limit store cannot be reached the API fails closed and responds with `503 Service Unavailable`, a `SERVICE_UNAVAILABLE` error body, and a `Retry-After` header.\n\n## Dates and times\n\nEvery poll has a `kind`. A `date` poll offers calendar days: each option carries a `date` in `YYYY-MM-DD` format, which is a floating date with no time component and no timezone, so never convert it through a timezone. A `time` poll offers time slots: each option carries a `startTime` as an ISO 8601 instant in UTC and a `duration` in minutes; convert `startTime` into the poll's `timeZone` (or the viewer's) for display. Timestamps such as `createdAt` and `updatedAt` are always ISO 8601 instants in UTC.\n\n## Request bodies\n\nRequest bodies are validated strictly: a field that is not part of the documented schema is rejected with `VALIDATION_ERROR` rather than ignored, so a misspelt setting never silently falls back to its default.\n\n## Enums\n\nVote types are an open set. The built-in values are `yes`, `ifNeedBe` and `no`; new types may be added without a version change, so clients must tolerate values they do not recognise. `status` and `kind` are closed sets.\n\n## Lists\n\nEvery list endpoint returns the items in `data` and a `nextCursor` beside it. Pass `nextCursor` as the `cursor` query parameter to fetch the next page; it is `null` on the last page.\n\n## Errors\n\nEvery failure is `application/json` with the shape `{ \"error\": { \"code\", \"message\" } }`. `code` is stable and safe to branch on; `message` is human-readable and may change. `VALIDATION_ERROR` messages name each offending field.\n\n| Status | Code | When |\n| --- | --- | --- |\n| 400 | `VALIDATION_ERROR` | The body or query string did not match the schema, contained an unknown field, or the body was not valid JSON |\n| 400 | `INVALID_AUTHORIZATION_HEADER` | The `Authorization` header is not `Bearer <key>` |\n| 400 | `ORGANIZER_NOT_MEMBER` | The organizer email is not a member of the space |\n| 400 | `TOO_MANY_OPTIONS` | More than the maximum number of poll options |\n| 401 | `UNAUTHORIZED` | The API key is missing, invalid, expired or revoked |\n| 403 | `SPACE_NOT_PRO` | The space behind the key has no Pro subscription |\n| 404 | `NOT_FOUND` | No route matches the method and path |\n| 404 | `POLL_NOT_FOUND` | The poll does not exist or belongs to another space |\n| 422 | `TRANSITION_NOT_AVAILABLE` | The requested status change is not supported |\n| 429 | `RATE_LIMIT_EXCEEDED` | A rate limit window is exhausted |\n| 503 | `SERVICE_UNAVAILABLE` | Maintenance, or the rate limit store cannot be reached |\n| 500 | `INTERNAL_ERROR` | Unexpected failure; the request id is logged |",
     "version": "1.0.0"
   },
   "servers": [
@@ -309,154 +309,7 @@
           "error"
         ]
       },
-      "DateOptions": {
-        "type": "object",
-        "properties": {
-          "kind": {
-            "type": "string",
-            "const": "date"
-          },
-          "dates": {
-            "minItems": 1,
-            "type": "array",
-            "items": {
-              "type": "string",
-              "format": "date"
-            },
-            "description": "Calendar days to offer. Each becomes one all-day option. A day may appear once.",
-            "example": [
-              "2027-03-01",
-              "2027-03-02",
-              "2027-03-03"
-            ]
-          }
-        },
-        "required": [
-          "kind",
-          "dates"
-        ],
-        "additionalProperties": false,
-        "title": "Date poll",
-        "description": "Whole days. Dates are floating calendar days with no timezone, so never convert them through one."
-      },
-      "TimeOptions": {
-        "type": "object",
-        "properties": {
-          "kind": {
-            "type": "string",
-            "const": "time"
-          },
-          "duration": {
-            "type": "integer",
-            "minimum": 15,
-            "maximum": 1440,
-            "description": "Length of every slot in minutes",
-            "example": 30
-          },
-          "timeZone": {
-            "description": "IANA time zone the times are written in. Datetime strings without an offset are interpreted in this zone. If omitted, offset-less datetimes are floating times (no conversion) and the poll has no time zone.",
-            "example": "Europe/London",
-            "type": "string"
-          },
-          "times": {
-            "description": "Explicit slots, one per start time.",
-            "minItems": 1,
-            "type": "array",
-            "items": {
-              "type": "string",
-              "format": "date-time",
-              "description": "ISO datetime start time. A string without an offset is wall clock time in `timeZone` when that is set (`2027-03-01T09:00:00` with `timeZone: Europe/London` means 09:00 in London) and a floating time with no conversion otherwise. A string with an offset or `Z` is an absolute instant.",
-              "example": "2027-03-01T09:00:00"
-            }
-          },
-          "generators": {
-            "description": "Slot generators. Each expands into recurring slots from a schedule.",
-            "minItems": 1,
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/SlotGenerator"
-            }
-          }
-        },
-        "required": [
-          "kind",
-          "duration"
-        ],
-        "additionalProperties": false,
-        "title": "Time poll",
-        "description": "Time slots that share one duration. Provide `times`, `generators` or both. Duplicate slots are removed."
-      },
-      "SlotGenerator": {
-        "type": "object",
-        "properties": {
-          "startDate": {
-            "type": "string",
-            "format": "date",
-            "description": "First day of the range to generate slots on, inclusive.",
-            "example": "2027-03-01"
-          },
-          "endDate": {
-            "type": "string",
-            "format": "date",
-            "description": "Last day of the range, inclusive. The range must span fewer than 366 days.",
-            "example": "2027-03-05"
-          },
-          "days": {
-            "minItems": 1,
-            "type": "array",
-            "items": {
-              "type": "string",
-              "enum": [
-                "mon",
-                "tue",
-                "wed",
-                "thu",
-                "fri",
-                "sat",
-                "sun"
-              ]
-            },
-            "description": "Days of the week to generate slots on. Days in the range that are not listed are skipped.",
-            "example": [
-              "mon",
-              "tue",
-              "wed",
-              "thu",
-              "fri"
-            ]
-          },
-          "startTime": {
-            "type": "string",
-            "pattern": "^(?:[01]\\d|2[0-3]):[0-5]\\d$",
-            "description": "Earliest slot start on each day, as a wall clock time in `timeZone`.",
-            "example": "09:00"
-          },
-          "endTime": {
-            "type": "string",
-            "pattern": "^(?:[01]\\d|2[0-3]):[0-5]\\d$",
-            "description": "End of the daily window. A slot is only generated if it ends at or before this time.",
-            "example": "17:00"
-          },
-          "interval": {
-            "description": "Minutes between consecutive slot starts. Defaults to `duration`, which produces back to back slots.",
-            "example": 60,
-            "type": "integer",
-            "minimum": 15,
-            "maximum": 1440
-          }
-        },
-        "required": [
-          "startDate",
-          "endDate",
-          "days",
-          "startTime",
-          "endTime"
-        ],
-        "additionalProperties": false,
-        "title": "Slot generator",
-        "description": "Expands into one slot of `duration` minutes every `interval` minutes between `startTime` and `endTime`, on each listed day of the week between `startDate` and `endDate`. Slots that would not end by `endTime` are not generated."
-      },
-      "CreatePollInput": {
+      "CreateDatePollInput": {
         "type": "object",
         "properties": {
           "title": {
@@ -464,6 +317,11 @@
             "minLength": 1,
             "maxLength": 255,
             "example": "Team sync"
+          },
+          "kind": {
+            "type": "string",
+            "const": "date",
+            "description": "Participants vote on whole days."
           },
           "description": {
             "example": "Pick a time that works for everyone",
@@ -517,29 +375,259 @@
             "additionalProperties": false
           },
           "options": {
-            "oneOf": [
-              {
-                "$ref": "#/components/schemas/DateOptions"
-              },
-              {
-                "$ref": "#/components/schemas/TimeOptions"
+            "minItems": 1,
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/DateOptionInput"
+            },
+            "description": "Calendar days to offer. Dates are floating calendar days with no timezone, so never convert them through one. Duplicates are removed."
+          }
+        },
+        "required": [
+          "title",
+          "kind",
+          "options"
+        ],
+        "additionalProperties": false,
+        "title": "Date poll"
+      },
+      "DateOptionInput": {
+        "type": "object",
+        "properties": {
+          "date": {
+            "type": "string",
+            "format": "date",
+            "description": "Calendar day to offer, as a floating `YYYY-MM-DD` date.",
+            "example": "2027-03-01"
+          }
+        },
+        "required": [
+          "date"
+        ],
+        "additionalProperties": false,
+        "title": "Date option",
+        "description": "One all-day option. The same shape `DateOption` returns."
+      },
+      "CreateTimePollInput": {
+        "type": "object",
+        "properties": {
+          "title": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 255,
+            "example": "Team sync"
+          },
+          "kind": {
+            "type": "string",
+            "const": "time",
+            "description": "Participants vote on time slots."
+          },
+          "description": {
+            "example": "Pick a time that works for everyone",
+            "type": "string",
+            "maxLength": 1000
+          },
+          "location": {
+            "example": "Zoom",
+            "type": "string",
+            "maxLength": 255
+          },
+          "requireEmail": {
+            "description": "Require participants to provide their email address",
+            "example": true,
+            "type": "boolean"
+          },
+          "hideParticipants": {
+            "description": "Hide participant names from other participants",
+            "example": false,
+            "type": "boolean"
+          },
+          "hideScores": {
+            "description": "Hide vote counts from participants",
+            "example": false,
+            "type": "boolean"
+          },
+          "disableComments": {
+            "description": "Disable the comments section. Defaults to true: new polls have comments disabled unless this is set to false.",
+            "example": false,
+            "type": "boolean"
+          },
+          "allowTentativeVotes": {
+            "description": "Allow participants to answer \"if need be\" as well as yes and no. Defaults to true.",
+            "example": true,
+            "type": "boolean"
+          },
+          "organizer": {
+            "description": "Organizer of the poll. Defaults to the space owner if not provided. The organizer must be a member of the space.",
+            "type": "object",
+            "properties": {
+              "email": {
+                "type": "string",
+                "format": "email",
+                "description": "Email address of the organizer",
+                "example": "organizer@example.com"
               }
+            },
+            "required": [
+              "email"
             ],
-            "description": "What participants vote on: whole days (`kind: date`) or time slots (`kind: time`).",
-            "discriminator": {
-              "propertyName": "kind",
-              "mapping": {
-                "date": "#/components/schemas/DateOptions",
-                "time": "#/components/schemas/TimeOptions"
-              }
+            "additionalProperties": false
+          },
+          "timeZone": {
+            "description": "IANA time zone the times are written in. Datetime strings without an offset are interpreted in this zone. If omitted, offset-less datetimes are floating times (no conversion) and the poll has no time zone.",
+            "example": "Europe/London",
+            "type": "string"
+          },
+          "duration": {
+            "description": "Default slot length in minutes. Required when `generators` is set or an option omits its own `duration`.",
+            "example": 30,
+            "type": "integer",
+            "minimum": 15,
+            "maximum": 1440
+          },
+          "options": {
+            "description": "Explicit slots. Provide `options`, `generators` or both. Duplicates are removed.",
+            "minItems": 1,
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/TimeOptionInput"
+            }
+          },
+          "generators": {
+            "description": "Slot generators. Each expands into recurring slots from a schedule and the result is appended to `options`.",
+            "minItems": 1,
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/SlotGenerator"
             }
           }
         },
         "required": [
           "title",
-          "options"
+          "kind"
         ],
-        "additionalProperties": false
+        "additionalProperties": false,
+        "title": "Time poll"
+      },
+      "TimeOptionInput": {
+        "type": "object",
+        "properties": {
+          "startTime": {
+            "type": "string",
+            "format": "date-time",
+            "description": "ISO datetime start time. A string without an offset is wall clock time in `timeZone` when that is set (`2027-03-01T09:00:00` with `timeZone: Europe/London` means 09:00 in London) and a floating time with no conversion otherwise. A string with an offset or `Z` is an absolute instant.",
+            "example": "2027-03-01T09:00:00"
+          },
+          "duration": {
+            "description": "Length of this slot in minutes. Defaults to the poll's `duration`.",
+            "example": 30,
+            "type": "integer",
+            "minimum": 15,
+            "maximum": 1440
+          }
+        },
+        "required": [
+          "startTime"
+        ],
+        "additionalProperties": false,
+        "title": "Time option",
+        "description": "One time slot. The same shape `TimeOption` returns."
+      },
+      "SlotGenerator": {
+        "type": "object",
+        "properties": {
+          "startDate": {
+            "type": "string",
+            "format": "date",
+            "description": "First day of the range to generate slots on, inclusive.",
+            "example": "2027-03-01"
+          },
+          "endDate": {
+            "type": "string",
+            "format": "date",
+            "description": "Last day of the range, inclusive. The range must span fewer than 366 days.",
+            "example": "2027-03-05"
+          },
+          "days": {
+            "default": [
+              "mon",
+              "tue",
+              "wed",
+              "thu",
+              "fri",
+              "sat",
+              "sun"
+            ],
+            "description": "Days of the week to generate slots on. Days in the range that are not listed are skipped. Defaults to every day.",
+            "example": [
+              "mon",
+              "tue",
+              "wed",
+              "thu",
+              "fri"
+            ],
+            "minItems": 1,
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "mon",
+                "tue",
+                "wed",
+                "thu",
+                "fri",
+                "sat",
+                "sun"
+              ]
+            }
+          },
+          "from": {
+            "type": "string",
+            "pattern": "^(?:[01]\\d|2[0-3]):[0-5]\\d$",
+            "description": "Earliest slot start on each day, as a wall clock time in `timeZone`.",
+            "example": "09:00"
+          },
+          "to": {
+            "type": "string",
+            "pattern": "^(?:[01]\\d|2[0-3]):[0-5]\\d$",
+            "description": "End of the daily window, as a wall clock time in `timeZone`. A slot is only generated if it ends at or before this time.",
+            "example": "17:00"
+          },
+          "interval": {
+            "description": "Minutes between consecutive slot starts. Defaults to `duration`, which produces back to back slots.",
+            "example": 60,
+            "type": "integer",
+            "minimum": 15,
+            "maximum": 1440
+          }
+        },
+        "required": [
+          "startDate",
+          "endDate",
+          "from",
+          "to"
+        ],
+        "additionalProperties": false,
+        "title": "Slot generator",
+        "description": "Expands into one slot of `duration` minutes every `interval` minutes between `from` and `to`, on each listed day of the week between `startDate` and `endDate`. Slots that would not end by `to` are not generated."
+      },
+      "CreatePollInput": {
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/CreateDatePollInput"
+          },
+          {
+            "$ref": "#/components/schemas/CreateTimePollInput"
+          }
+        ],
+        "description": "`kind` chooses what participants vote on: whole days (`date`) or time slots (`time`). The request mirrors the poll the API returns: the same settings, and `options` in the same shape as the response.",
+        "discriminator": {
+          "propertyName": "kind",
+          "mapping": {
+            "date": "#/components/schemas/CreateDatePollInput",
+            "time": "#/components/schemas/CreateTimePollInput"
+          }
+        }
       },
       "ListPollsResponse": {
         "type": "object",
@@ -884,7 +972,7 @@
           "Polls"
         ],
         "summary": "Create a poll",
-        "description": "Creates a poll and responds with `201 Created` and the full poll, exactly as `GET /polls/:pollId` returns it. Share `inviteUrl` with participants. `options.kind` chooses what participants vote on: whole days or time slots. A poll has at most 100 options.\n\n## Date poll\n\nPass `kind: \"date\"` and `dates`, a list of `YYYY-MM-DD` values. Each becomes one all-day option. Dates are floating calendar days with no timezone, so never convert them through one. A repeated date fails with `DUPLICATE_DATES`.\n\n```json\n{\n  \"title\": \"Team offsite\",\n  \"options\": {\n    \"kind\": \"date\",\n    \"dates\": [\"2027-03-01\", \"2027-03-02\", \"2027-03-03\"]\n  }\n}\n```\n\n## Time poll\n\nPass `kind: \"time\"` with a `duration` in minutes that every slot shares, the slots themselves as `times`, `generators` or both, and optionally a `timeZone` (an IANA zone the times are written in).\n\n### Explicit times\n\nEach ISO datetime string in `times` becomes one slot starting at that moment. A time with no offset, like `2027-03-01T09:00:00`, is wall clock time in `timeZone` when that is set and a floating time with no conversion otherwise; a time with an offset or `Z` is an absolute instant.\n\n```json\n{\n  \"title\": \"Kickoff\",\n  \"options\": {\n    \"kind\": \"time\",\n    \"duration\": 60,\n    \"timeZone\": \"Europe/London\",\n    \"times\": [\"2027-03-01T09:00:00\", \"2027-03-02T14:00:00\"]\n  }\n}\n```\n\n### Slot generators\n\nEach object in `generators` expands into recurring slots from a schedule, so availability across days or weeks does not have to be listed slot by slot.\n\n```json\n{\n  \"title\": \"Interview availability\",\n  \"options\": {\n    \"kind\": \"time\",\n    \"duration\": 30,\n    \"timeZone\": \"America/New_York\",\n    \"generators\": [\n      {\n        \"startDate\": \"2027-03-01\",\n        \"endDate\": \"2027-03-05\",\n        \"days\": [\"mon\", \"tue\", \"wed\", \"thu\", \"fri\"],\n        \"startTime\": \"09:00\",\n        \"endTime\": \"12:00\",\n        \"interval\": 60\n      }\n    ]\n  }\n}\n```\n\nThis produces 30 minute slots at 09:00, 10:00 and 11:00 New York time on each weekday from 1 to 5 March, fifteen options in all. Drop `interval` and the window fills with back to back slots at 09:00, 09:30, 10:00, 10:30, 11:00 and 11:30.\n\n| Field | Meaning |\n| --- | --- |\n| `startDate`, `endDate` | The date range, inclusive. Fewer than 366 days. |\n| `days` | Days of the week to include: `mon` to `sun`. Other days in the range are skipped. |\n| `startTime` | Earliest slot start on each day, `HH:mm` in `timeZone`. |\n| `endTime` | End of the daily window. A slot is only generated if it ends by this time. |\n| `interval` | Minutes between slot starts. Optional; defaults to `duration`, which gives back to back slots. |\n\nGenerators are expanded when the poll is created and duplicate slots are removed. A request that would exceed 100 options fails with `TOO_MANY_OPTIONS`; a generator whose window fits no slot produces nothing, and if nothing in `times` or `generators` yields a slot the request fails with `NO_OPTIONS_GENERATED`.",
+        "description": "Creates a poll and responds with `201 Created` and the full poll, exactly as `GET /polls/:pollId` returns it. Share `inviteUrl` with participants. The request mirrors the response: `kind` chooses what participants vote on, and `options` takes the same shape the poll returns, so a poll can be recreated from the body of a `GET`. A poll has at most 100 options.\n\n## Date poll\n\nPass `kind: \"date\"` and `options`, one `{ \"date\": \"YYYY-MM-DD\" }` per day. Each becomes one all-day option. Dates are floating calendar days with no timezone, so never convert them through one. Duplicate dates are removed.\n\n```json\n{\n  \"title\": \"Team offsite\",\n  \"kind\": \"date\",\n  \"options\": [{ \"date\": \"2027-03-01\" }, { \"date\": \"2027-03-02\" }, { \"date\": \"2027-03-03\" }]\n}\n```\n\n## Time poll\n\nPass `kind: \"time\"`, optionally a `timeZone` (an IANA zone the times are written in) and a default `duration` in minutes, and the slots as `options`, `generators` or both.\n\n### Explicit slots\n\nEach entry in `options` is one slot: a `startTime` and an optional `duration` that overrides the poll default. A `startTime` with no offset, like `2027-03-01T09:00:00`, is wall clock time in `timeZone` when that is set and a floating time with no conversion otherwise; one with an offset or `Z` is an absolute instant.\n\n```json\n{\n  \"title\": \"Kickoff\",\n  \"kind\": \"time\",\n  \"timeZone\": \"Europe/London\",\n  \"duration\": 60,\n  \"options\": [\n    { \"startTime\": \"2027-03-01T09:00:00\" },\n    { \"startTime\": \"2027-03-02T14:00:00\", \"duration\": 90 }\n  ]\n}\n```\n\n### Slot generators\n\nEach object in `generators` expands into recurring slots of `duration` minutes from a schedule, so availability across days or weeks does not have to be listed slot by slot. `duration` is required when `generators` is set.\n\n```json\n{\n  \"title\": \"Interview availability\",\n  \"kind\": \"time\",\n  \"timeZone\": \"America/New_York\",\n  \"duration\": 30,\n  \"generators\": [\n    {\n      \"startDate\": \"2027-03-01\",\n      \"endDate\": \"2027-03-05\",\n      \"days\": [\"mon\", \"tue\", \"wed\", \"thu\", \"fri\"],\n      \"from\": \"09:00\",\n      \"to\": \"12:00\",\n      \"interval\": 60\n    }\n  ]\n}\n```\n\nThis produces 30 minute slots at 09:00, 10:00 and 11:00 New York time on each weekday from 1 to 5 March, fifteen options in all. Drop `interval` and the window fills with back to back slots at 09:00, 09:30, 10:00, 10:30, 11:00 and 11:30.\n\n| Field | Meaning |\n| --- | --- |\n| `startDate`, `endDate` | The date range, inclusive. Fewer than 366 days. |\n| `days` | Days of the week to include: `mon` to `sun`. Optional; defaults to every day. |\n| `from` | Earliest slot start on each day, `HH:mm` in `timeZone`. |\n| `to` | End of the daily window, `HH:mm` in `timeZone`. A slot is only generated if it ends by this time. Must be later than `from`. |\n| `interval` | Minutes between slot starts. Optional; defaults to `duration`, which gives back to back slots. |\n\nA generator that cannot produce a slot is rejected with `VALIDATION_ERROR` naming the field: `to` not later than `from`, a window shorter than `duration`, or a range that contains none of the listed days. Generators are expanded when the poll is created, the result is appended to `options`, and duplicate slots are removed. A request that would exceed 100 options fails with `TOO_MANY_OPTIONS`.",
         "security": [
           {
             "bearerAuth": []
@@ -902,7 +990,7 @@
             }
           },
           "400": {
-            "description": "Invalid input or no valid options generated",
+            "description": "Invalid input",
             "content": {
               "application/json": {
                 "schema": {
@@ -985,35 +1073,42 @@
               "examples": {
                 "Date poll": {
                   "summary": "Date poll (all-day options)",
-                  "description": "Let participants pick between calendar days. Each date becomes an all-day option.",
+                  "description": "Let participants pick between calendar days. Each option is one all-day date.",
                   "value": {
                     "title": "Team offsite",
+                    "kind": "date",
                     "description": "Which days work for a two day offsite?",
-                    "options": {
-                      "kind": "date",
-                      "dates": [
-                        "2027-03-01",
-                        "2027-03-02",
-                        "2027-03-03"
-                      ]
-                    }
+                    "options": [
+                      {
+                        "date": "2027-03-01"
+                      },
+                      {
+                        "date": "2027-03-02"
+                      },
+                      {
+                        "date": "2027-03-03"
+                      }
+                    ]
                   }
                 },
-                "Time poll with explicit times": {
-                  "summary": "Time poll (explicit times)",
-                  "description": "Offer specific time slots. Datetimes without an offset are interpreted as wall-clock in `timeZone` — this example offers 09:00 and 14:00 in London. Append `Z` or an offset to specify an absolute instant instead.",
+                "Time poll with explicit slots": {
+                  "summary": "Time poll (explicit slots)",
+                  "description": "Offer specific time slots. Datetimes without an offset are wall clock times in `timeZone`; this example offers 09:00 and 14:00 in London. Append `Z` or an offset for an absolute instant instead. A slot may override the poll's `duration`.",
                   "value": {
                     "title": "Project kickoff",
+                    "kind": "time",
                     "location": "Zoom",
-                    "options": {
-                      "kind": "time",
-                      "duration": 60,
-                      "timeZone": "Europe/London",
-                      "times": [
-                        "2027-03-01T09:00:00",
-                        "2027-03-01T14:00:00"
-                      ]
-                    }
+                    "timeZone": "Europe/London",
+                    "duration": 60,
+                    "options": [
+                      {
+                        "startTime": "2027-03-01T09:00:00"
+                      },
+                      {
+                        "startTime": "2027-03-01T14:00:00",
+                        "duration": 90
+                      }
+                    ]
                   }
                 },
                 "Time poll with a slot generator": {
@@ -1021,54 +1116,52 @@
                   "description": "Expand recurring slots across a date range. This example generates 30 minute slots at 09:00, 10:00 and 11:00 (New York time) every weekday from 1 to 5 March.",
                   "value": {
                     "title": "Interview availability",
-                    "options": {
-                      "kind": "time",
-                      "duration": 30,
-                      "timeZone": "America/New_York",
-                      "generators": [
-                        {
-                          "startDate": "2027-03-01",
-                          "endDate": "2027-03-05",
-                          "days": [
-                            "mon",
-                            "tue",
-                            "wed",
-                            "thu",
-                            "fri"
-                          ],
-                          "startTime": "09:00",
-                          "endTime": "12:00",
-                          "interval": 60
-                        }
-                      ]
-                    }
+                    "kind": "time",
+                    "timeZone": "America/New_York",
+                    "duration": 30,
+                    "generators": [
+                      {
+                        "startDate": "2027-03-01",
+                        "endDate": "2027-03-05",
+                        "days": [
+                          "mon",
+                          "tue",
+                          "wed",
+                          "thu",
+                          "fri"
+                        ],
+                        "from": "09:00",
+                        "to": "12:00",
+                        "interval": 60
+                      }
+                    ]
                   }
                 },
-                "Time poll mixing times and a generator": {
-                  "summary": "Time poll (explicit times + generator)",
-                  "description": "`times` and `generators` combine. When `interval` is omitted it defaults to `duration`, so this generator produces back to back 90 minute slots at 14:00 and 15:30 on Monday and Wednesday.",
+                "Time poll mixing slots and a generator": {
+                  "summary": "Time poll (explicit slots + generator)",
+                  "description": "`options` and `generators` combine. When `interval` is omitted it defaults to `duration`, so this generator produces back to back 90 minute slots at 14:00 and 15:30 on Monday and Wednesday.",
                   "value": {
                     "title": "Product workshop",
-                    "options": {
-                      "kind": "time",
-                      "duration": 90,
-                      "timeZone": "Europe/Berlin",
-                      "times": [
-                        "2027-03-06T10:00:00"
-                      ],
-                      "generators": [
-                        {
-                          "startDate": "2027-03-08",
-                          "endDate": "2027-03-10",
-                          "days": [
-                            "mon",
-                            "wed"
-                          ],
-                          "startTime": "14:00",
-                          "endTime": "17:00"
-                        }
-                      ]
-                    }
+                    "kind": "time",
+                    "timeZone": "Europe/Berlin",
+                    "duration": 90,
+                    "options": [
+                      {
+                        "startTime": "2027-03-06T10:00:00"
+                      }
+                    ],
+                    "generators": [
+                      {
+                        "startDate": "2027-03-08",
+                        "endDate": "2027-03-10",
+                        "days": [
+                          "mon",
+                          "wed"
+                        ],
+                        "from": "14:00",
+                        "to": "17:00"
+                      }
+                    ]
                   }
                 }
               }

--- a/apps/web/src/app/api/v1/[...route]/route.test.ts
+++ b/apps/web/src/app/api/v1/[...route]/route.test.ts
@@ -196,7 +196,8 @@ describe("API v1 - /polls", () => {
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
           title: "Test Poll",
-          options: { kind: "date", dates: ["2025-01-15"] },
+          kind: "date",
+          options: [{ date: "2025-01-15" }],
         }),
       });
 
@@ -215,7 +216,8 @@ describe("API v1 - /polls", () => {
         },
         body: JSON.stringify({
           title: "Test Poll",
-          options: { kind: "date", dates: ["2025-01-15"] },
+          kind: "date",
+          options: [{ date: "2025-01-15" }],
         }),
       });
 
@@ -235,7 +237,8 @@ describe("API v1 - /polls", () => {
         },
         body: JSON.stringify({
           title: "Test Poll",
-          options: { kind: "date", dates: ["2025-01-15"] },
+          kind: "date",
+          options: [{ date: "2025-01-15" }],
         }),
       });
 
@@ -255,7 +258,8 @@ describe("API v1 - /polls", () => {
         },
         body: JSON.stringify({
           title: "Test Poll",
-          options: { kind: "date", dates: ["2025-01-15"] },
+          kind: "date",
+          options: [{ date: "2025-01-15" }],
         }),
       });
 
@@ -280,7 +284,8 @@ describe("API v1 - /polls", () => {
         },
         body: JSON.stringify({
           title: "Test Poll",
-          options: { kind: "date", dates: ["2025-01-15"] },
+          kind: "date",
+          options: [{ date: "2025-01-15" }],
         }),
       });
 
@@ -306,7 +311,8 @@ describe("API v1 - /polls", () => {
         },
         body: JSON.stringify({
           title: "Test Poll",
-          options: { kind: "date", dates: ["2025-01-15"] },
+          kind: "date",
+          options: [{ date: "2025-01-15" }],
         }),
       });
 
@@ -323,7 +329,8 @@ describe("API v1 - /polls", () => {
         },
         body: JSON.stringify({
           title: "Test Poll",
-          options: { kind: "date", dates: ["2025-01-15"] },
+          kind: "date",
+          options: [{ date: "2025-01-15" }],
         }),
       });
 
@@ -430,7 +437,8 @@ describe("API v1 - /polls", () => {
         },
         body: JSON.stringify({
           title: "Test Poll",
-          options: { kind: "date", dates: ["2025-01-15"] },
+          kind: "date",
+          options: [{ date: "2025-01-15" }],
         }),
       });
 
@@ -463,7 +471,8 @@ describe("API v1 - /polls", () => {
         },
         body: JSON.stringify({
           title: "Test Poll",
-          options: { kind: "date", dates: ["2025-01-15"] },
+          kind: "date",
+          options: [{ date: "2025-01-15" }],
         }),
       });
 
@@ -487,10 +496,12 @@ describe("API v1 - /polls", () => {
         },
         body: JSON.stringify({
           title: "Team offsite",
-          options: {
-            kind: "date",
-            dates: ["2025-01-15", "2025-01-16", "2025-01-17"],
-          },
+          kind: "date",
+          options: [
+            { date: "2025-01-15" },
+            { date: "2025-01-16" },
+            { date: "2025-01-17" },
+          ],
         }),
       });
 
@@ -558,7 +569,8 @@ describe("API v1 - /polls", () => {
         },
         body: JSON.stringify({
           title: "Team offsite",
-          options: { kind: "date", dates: ["2025-01-15"] },
+          kind: "date",
+          options: [{ date: "2025-01-15" }],
           requireEmail: true,
           hideParticipants: true,
           hideScores: true,
@@ -630,7 +642,8 @@ describe("API v1 - /polls", () => {
         },
         body: JSON.stringify({
           title: "Team offsite",
-          options: { kind: "date", dates: ["2025-01-15"] },
+          kind: "date",
+          options: [{ date: "2025-01-15" }],
           allowTentativeVotes: false,
         }),
       });
@@ -653,7 +666,8 @@ describe("API v1 - /polls", () => {
         },
         body: JSON.stringify({
           title: "Team offsite",
-          options: { kind: "date", dates: ["2025-01-15"] },
+          kind: "date",
+          options: [{ date: "2025-01-15" }],
         }),
       });
 
@@ -688,7 +702,8 @@ describe("API v1 - /polls", () => {
         body: JSON.stringify({
           title: "Team offsite",
           location: "Conference Room A",
-          options: { kind: "date", dates: ["2025-01-15"] },
+          kind: "date",
+          options: [{ date: "2025-01-15" }],
         }),
       });
 
@@ -715,7 +730,8 @@ describe("API v1 - /polls", () => {
         },
         body: JSON.stringify({
           title: "Test Poll",
-          options: { kind: "date", dates },
+          kind: "date",
+          options: dates.map((date) => ({ date })),
         }),
       });
 
@@ -724,7 +740,7 @@ describe("API v1 - /polls", () => {
       expect(json.error.code).toBe("TOO_MANY_OPTIONS");
     });
 
-    it("should return error when duplicate dates are provided", async () => {
+    it("should remove duplicate dates instead of rejecting them", async () => {
       const res = await app.request("/v1/polls", {
         method: "POST",
         headers: {
@@ -733,17 +749,26 @@ describe("API v1 - /polls", () => {
         },
         body: JSON.stringify({
           title: "Test Poll",
-          options: {
-            kind: "date",
-            dates: ["2025-01-15", "2025-01-16", "2025-01-15", "2025-01-17"],
-          },
+          kind: "date",
+          options: [
+            { date: "2025-01-15" },
+            { date: "2025-01-16" },
+            { date: "2025-01-15" },
+            { date: "2025-01-17" },
+          ],
         }),
       });
 
-      expect(res.status).toBe(400);
-      const json = await res.json();
-      expect(json.error.code).toBe("DUPLICATE_DATES");
-      expect(json.error.message).toContain("Duplicate dates found");
+      expect(res.status).toBe(201);
+      expect(mockCreatePoll).toHaveBeenCalledWith(
+        expect.objectContaining({
+          options: [
+            { startTime: new Date("2025-01-15T00:00:00.000Z"), duration: 0 },
+            { startTime: new Date("2025-01-16T00:00:00.000Z"), duration: 0 },
+            { startTime: new Date("2025-01-17T00:00:00.000Z"), duration: 0 },
+          ],
+        }),
+      );
     });
   });
 
@@ -757,12 +782,13 @@ describe("API v1 - /polls", () => {
         },
         body: JSON.stringify({
           title: "Team sync",
-          options: {
-            kind: "time",
-            duration: 30,
-            timeZone: "Europe/London",
-            times: ["2025-01-15T09:00:00Z", "2025-01-15T10:00:00Z"],
-          },
+          kind: "time",
+          duration: 30,
+          timeZone: "Europe/London",
+          options: [
+            { startTime: "2025-01-15T09:00:00Z" },
+            { startTime: "2025-01-15T10:00:00Z" },
+          ],
         }),
       });
 
@@ -819,12 +845,10 @@ describe("API v1 - /polls", () => {
         },
         body: JSON.stringify({
           title: "Team sync",
-          options: {
-            kind: "time",
-            duration: 30,
-            timeZone: "Europe/London",
-            times: ["2025-01-15T09:00:00Z"],
-          },
+          kind: "time",
+          duration: 30,
+          timeZone: "Europe/London",
+          options: [{ startTime: "2025-01-15T09:00:00Z" }],
         }),
       });
 
@@ -855,11 +879,9 @@ describe("API v1 - /polls", () => {
         },
         body: JSON.stringify({
           title: "Team sync",
-          options: {
-            kind: "time",
-            duration: 30,
-            times: ["2025-01-15T09:00:00Z"],
-          },
+          kind: "time",
+          duration: 30,
+          options: [{ startTime: "2025-01-15T09:00:00Z" }],
         }),
       });
 
@@ -880,12 +902,10 @@ describe("API v1 - /polls", () => {
         },
         body: JSON.stringify({
           title: "Team sync",
-          options: {
-            kind: "time",
-            duration: 30,
-            timeZone: "Invalid/Timezone",
-            times: ["2025-01-15T09:00:00Z"],
-          },
+          kind: "time",
+          duration: 30,
+          timeZone: "Invalid/Timezone",
+          options: [{ startTime: "2025-01-15T09:00:00Z" }],
         }),
       });
 
@@ -901,20 +921,18 @@ describe("API v1 - /polls", () => {
         },
         body: JSON.stringify({
           title: "Weekly standup",
-          options: {
-            kind: "time",
-            duration: 30,
-            timeZone: "Europe/London",
-            generators: [
-              {
-                startDate: "2025-01-20",
-                endDate: "2025-01-22",
-                days: ["mon", "tue", "wed"],
-                startTime: "09:00",
-                endTime: "10:00",
-              },
-            ],
-          },
+          kind: "time",
+          duration: 30,
+          timeZone: "Europe/London",
+          generators: [
+            {
+              startDate: "2025-01-20",
+              endDate: "2025-01-22",
+              days: ["mon", "tue", "wed"],
+              from: "09:00",
+              to: "10:00",
+            },
+          ],
         }),
       });
 
@@ -935,20 +953,18 @@ describe("API v1 - /polls", () => {
         },
         body: JSON.stringify({
           title: "Way too long",
-          options: {
-            kind: "time",
-            duration: 30,
-            timeZone: "Europe/London",
-            generators: [
-              {
-                startDate: "2025-01-01",
-                endDate: "2026-06-01",
-                days: ["sun"],
-                startTime: "09:00",
-                endTime: "09:30",
-              },
-            ],
-          },
+          kind: "time",
+          duration: 30,
+          timeZone: "Europe/London",
+          generators: [
+            {
+              startDate: "2025-01-01",
+              endDate: "2026-06-01",
+              days: ["sun"],
+              from: "09:00",
+              to: "09:30",
+            },
+          ],
         }),
       });
 
@@ -974,20 +990,18 @@ describe("API v1 - /polls", () => {
         },
         body: JSON.stringify({
           title: "Reversed range",
-          options: {
-            kind: "time",
-            duration: 30,
-            timeZone: "Europe/London",
-            generators: [
-              {
-                startDate: "2025-06-01",
-                endDate: "2025-01-01",
-                days: ["mon"],
-                startTime: "09:00",
-                endTime: "10:00",
-              },
-            ],
-          },
+          kind: "time",
+          duration: 30,
+          timeZone: "Europe/London",
+          generators: [
+            {
+              startDate: "2025-06-01",
+              endDate: "2025-01-01",
+              days: ["mon"],
+              from: "09:00",
+              to: "10:00",
+            },
+          ],
         }),
       });
 
@@ -1015,24 +1029,267 @@ describe("API v1 - /polls", () => {
         },
         body: JSON.stringify({
           title: "Boundary range",
-          options: {
-            kind: "time",
-            duration: 30,
-            timeZone: "Europe/London",
-            generators: [
-              {
-                startDate: toIsoDate(start),
-                endDate: toIsoDate(end),
-                days: ["sun"],
-                startTime: "09:00",
-                endTime: "09:30",
-              },
-            ],
-          },
+          kind: "time",
+          duration: 30,
+          timeZone: "Europe/London",
+          generators: [
+            {
+              startDate: toIsoDate(start),
+              endDate: toIsoDate(end),
+              days: ["sun"],
+              from: "09:00",
+              to: "09:30",
+            },
+          ],
         }),
       });
 
       expect(res.status).toBe(400);
+      expect(mockCreatePoll).not.toHaveBeenCalled();
+    });
+    it("should let a slot override the poll duration", async () => {
+      const res = await app.request("/v1/polls", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${testApiKey}`,
+        },
+        body: JSON.stringify({
+          title: "Team sync",
+          kind: "time",
+          duration: 30,
+          options: [
+            { startTime: "2025-01-15T09:00:00Z" },
+            { startTime: "2025-01-15T10:00:00Z", duration: 45 },
+          ],
+        }),
+      });
+
+      expect(res.status).toBe(201);
+      expect(mockCreatePoll).toHaveBeenCalledWith(
+        expect.objectContaining({
+          options: [
+            { startTime: new Date("2025-01-15T09:00:00Z"), duration: 30 },
+            { startTime: new Date("2025-01-15T10:00:00Z"), duration: 45 },
+          ],
+        }),
+      );
+    });
+
+    it("should accept slots that each carry a duration when the poll has no default", async () => {
+      const res = await app.request("/v1/polls", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${testApiKey}`,
+        },
+        body: JSON.stringify({
+          title: "Team sync",
+          kind: "time",
+          options: [{ startTime: "2025-01-15T09:00:00Z", duration: 45 }],
+        }),
+      });
+
+      expect(res.status).toBe(201);
+      expect(mockCreatePoll).toHaveBeenCalledWith(
+        expect.objectContaining({
+          options: [
+            { startTime: new Date("2025-01-15T09:00:00Z"), duration: 45 },
+          ],
+        }),
+      );
+    });
+
+    it("should name the slot that has no duration when the poll has no default", async () => {
+      const res = await app.request("/v1/polls", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${testApiKey}`,
+        },
+        body: JSON.stringify({
+          title: "Team sync",
+          kind: "time",
+          options: [
+            { startTime: "2025-01-15T09:00:00Z", duration: 45 },
+            { startTime: "2025-01-15T10:00:00Z" },
+          ],
+        }),
+      });
+
+      const json = await expectErrorEnvelope(res, {
+        status: 400,
+        code: "VALIDATION_ERROR",
+      });
+      expect(json.error.message).toContain("options.1.duration");
+      expect(mockCreatePoll).not.toHaveBeenCalled();
+    });
+
+    it("should require a poll duration when generators are used", async () => {
+      const res = await app.request("/v1/polls", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${testApiKey}`,
+        },
+        body: JSON.stringify({
+          title: "Weekly standup",
+          kind: "time",
+          generators: [
+            {
+              startDate: "2025-01-20",
+              endDate: "2025-01-22",
+              from: "09:00",
+              to: "10:00",
+            },
+          ],
+        }),
+      });
+
+      const json = await expectErrorEnvelope(res, {
+        status: 400,
+        code: "VALIDATION_ERROR",
+      });
+      expect(json.error.message).toContain("duration");
+      expect(mockCreatePoll).not.toHaveBeenCalled();
+    });
+
+    it("should require options or generators on a time poll", async () => {
+      const res = await app.request("/v1/polls", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${testApiKey}`,
+        },
+        body: JSON.stringify({
+          title: "Team sync",
+          kind: "time",
+          duration: 30,
+        }),
+      });
+
+      const json = await expectErrorEnvelope(res, {
+        status: 400,
+        code: "VALIDATION_ERROR",
+      });
+      expect(json.error.message).toContain("options");
+      expect(mockCreatePoll).not.toHaveBeenCalled();
+    });
+
+    it("should default a generator to every day of the week", async () => {
+      const res = await app.request("/v1/polls", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${testApiKey}`,
+        },
+        body: JSON.stringify({
+          title: "Any day",
+          kind: "time",
+          duration: 30,
+          timeZone: "Europe/London",
+          generators: [
+            {
+              // Saturday to Sunday
+              startDate: "2025-01-18",
+              endDate: "2025-01-19",
+              from: "09:00",
+              to: "09:30",
+            },
+          ],
+        }),
+      });
+
+      expect(res.status).toBe(201);
+      expect(mockCreatePoll).toHaveBeenCalledWith(
+        expect.objectContaining({
+          options: [
+            { startTime: new Date("2025-01-18T09:00:00Z"), duration: 30 },
+            { startTime: new Date("2025-01-19T09:00:00Z"), duration: 30 },
+          ],
+        }),
+      );
+    });
+
+    it("should append generated slots to explicit ones and drop duplicates", async () => {
+      const res = await app.request("/v1/polls", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${testApiKey}`,
+        },
+        body: JSON.stringify({
+          title: "Mixed",
+          kind: "time",
+          duration: 30,
+          timeZone: "Europe/London",
+          options: [{ startTime: "2025-01-20T09:00:00" }],
+          generators: [
+            {
+              startDate: "2025-01-20",
+              endDate: "2025-01-20",
+              days: ["mon"],
+              from: "09:00",
+              to: "10:00",
+            },
+          ],
+        }),
+      });
+
+      expect(res.status).toBe(201);
+      expect(mockCreatePoll).toHaveBeenCalledWith(
+        expect.objectContaining({
+          options: [
+            { startTime: new Date("2025-01-20T09:00:00Z"), duration: 30 },
+            { startTime: new Date("2025-01-20T09:30:00Z"), duration: 30 },
+          ],
+        }),
+      );
+    });
+
+    it.each([
+      {
+        reason: "the window ends before it starts",
+        generator: { from: "12:00", to: "09:00" },
+        path: "generators.0.to",
+      },
+      {
+        reason: "the window is shorter than the duration",
+        generator: { from: "09:00", to: "09:15" },
+        path: "generators.0.to",
+      },
+      {
+        reason: "the range contains none of the listed days",
+        // 2025-01-20 to 2025-01-22 is Monday to Wednesday
+        generator: { from: "09:00", to: "10:00", days: ["sat", "sun"] },
+        path: "generators.0.days",
+      },
+    ])("should reject a generator at validation when $reason", async ({
+      generator,
+      path,
+    }) => {
+      const res = await app.request("/v1/polls", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${testApiKey}`,
+        },
+        body: JSON.stringify({
+          title: "Bad generator",
+          kind: "time",
+          duration: 30,
+          timeZone: "Europe/London",
+          generators: [
+            { startDate: "2025-01-20", endDate: "2025-01-22", ...generator },
+          ],
+        }),
+      });
+
+      const json = await expectErrorEnvelope(res, {
+        status: 400,
+        code: "VALIDATION_ERROR",
+      });
+      expect(json.error.message).toContain(path);
       expect(mockCreatePoll).not.toHaveBeenCalled();
     });
   });
@@ -1062,15 +1319,19 @@ describe("API v1 - /polls", () => {
         },
         body: JSON.stringify({
           title: "Test Poll",
-          options: {
-            kind: "date",
-            options: { kind: "date", dates: ["2025-01-15"] },
-            times: ["2025-01-15T09:00:00Z"],
-          },
+          kind: "date",
+          options: [{ date: "2025-01-15" }],
+          timeZone: "Europe/London",
+          duration: 30,
         }),
       });
 
-      expect(res.status).toBe(400);
+      const json = await expectErrorEnvelope(res, {
+        status: 400,
+        code: "VALIDATION_ERROR",
+      });
+      expect(json.error.message).toContain("timeZone");
+      expect(json.error.message).toContain("duration");
     });
 
     it("should return error when title is missing", async () => {
@@ -1081,7 +1342,8 @@ describe("API v1 - /polls", () => {
           Authorization: `Bearer ${testApiKey}`,
         },
         body: JSON.stringify({
-          options: { kind: "date", dates: ["2025-01-15"] },
+          kind: "date",
+          options: [{ date: "2025-01-15" }],
         }),
       });
 
@@ -1097,7 +1359,8 @@ describe("API v1 - /polls", () => {
         },
         body: JSON.stringify({
           title: "Test Poll",
-          options: { kind: "date", dates: ["2025-01-15"] },
+          kind: "date",
+          options: [{ date: "2025-01-15" }],
           spaceId: "some-other-space",
         }),
       });
@@ -1115,44 +1378,41 @@ describe("API v1 - /polls", () => {
         level: "organizer",
         body: {
           title: "Test Poll",
-          options: { kind: "date", dates: ["2025-01-15"] },
+          kind: "date",
+          options: [{ date: "2025-01-15" }],
           organizer: { email: "a@example.com", name: "Ann" },
         },
         message: 'organizer: Unrecognized key: "name"',
       },
       {
-        level: "options",
+        level: "time poll",
         body: {
           title: "Test Poll",
-          options: {
-            kind: "time",
-            duration: 30,
-            times: ["2025-01-15T09:00:00Z"],
-            timezone: "Europe/London",
-          },
+          kind: "time",
+          duration: 30,
+          options: [{ startTime: "2025-01-15T09:00:00Z" }],
+          timezone: "Europe/London",
         },
-        message: 'options: Unrecognized key: "timezone"',
+        message: 'Unrecognized key: "timezone"',
       },
       {
         level: "slot generator",
         body: {
           title: "Test Poll",
-          options: {
-            kind: "time",
-            duration: 30,
-            generators: [
-              {
-                startDate: "2025-01-13",
-                endDate: "2025-01-17",
-                days: ["mon"],
-                startTime: "09:00",
-                endTime: "12:00",
-                step: 60,
-              },
-            ],
-          },
+          kind: "time",
+          duration: 30,
+          generators: [
+            {
+              startDate: "2025-01-13",
+              endDate: "2025-01-17",
+              days: ["mon"],
+              from: "09:00",
+              to: "12:00",
+              step: 60,
+            },
+          ],
         },
-        message: 'options.generators.0: Unrecognized key: "step"',
+        message: 'generators.0: Unrecognized key: "step"',
       },
     ])("should reject unknown fields nested in the $level object", async ({
       body,
@@ -1184,7 +1444,8 @@ describe("API v1 - /polls", () => {
         },
         body: JSON.stringify({
           title: "x".repeat(MAX_POLL_TITLE_LENGTH + 1),
-          options: { kind: "date", dates: ["2025-01-15"] },
+          kind: "date",
+          options: [{ date: "2025-01-15" }],
         }),
       });
 
@@ -1205,7 +1466,8 @@ describe("API v1 - /polls", () => {
         },
         body: JSON.stringify({
           title: "x".repeat(MAX_POLL_TITLE_LENGTH),
-          options: { kind: "date", dates: ["2025-01-15"] },
+          kind: "date",
+          options: [{ date: "2025-01-15" }],
         }),
       });
 
@@ -1221,7 +1483,8 @@ describe("API v1 - /polls", () => {
         },
         body: JSON.stringify({
           title: "Test Poll",
-          options: { kind: "date", dates: [] },
+          kind: "date",
+          options: [],
         }),
       });
 
@@ -1254,7 +1517,8 @@ describe("API v1 - /polls", () => {
           },
           body: JSON.stringify({
             title: "Forwarded through the prefix handler",
-            options: { kind: "date", dates: ["2027-03-01"] },
+            kind: "date",
+            options: [{ date: "2027-03-01" }],
           }),
         }),
       );
@@ -1335,8 +1599,10 @@ describe("API v1 - /polls", () => {
       expect(Object.keys(schemas)).toEqual(
         expect.arrayContaining([
           "CreatePollInput",
-          "DateOptions",
-          "TimeOptions",
+          "CreateDatePollInput",
+          "CreateTimePollInput",
+          "DateOptionInput",
+          "TimeOptionInput",
           "SlotGenerator",
           "Poll",
           "PollStatus",
@@ -1360,16 +1626,33 @@ describe("API v1 - /polls", () => {
         json.paths["/v1/polls"].post.requestBody.content["application/json"]
           .schema,
       ).toEqual({ $ref: "#/components/schemas/CreatePollInput" });
-      expect(schemas.CreatePollInput.properties.options).toMatchObject({
+      // The request body is a union keyed by kind, and each variant's
+      // options mirror the response option shapes.
+      expect(schemas.CreatePollInput).toMatchObject({
         oneOf: [
-          { $ref: "#/components/schemas/DateOptions" },
-          { $ref: "#/components/schemas/TimeOptions" },
+          { $ref: "#/components/schemas/CreateDatePollInput" },
+          { $ref: "#/components/schemas/CreateTimePollInput" },
         ],
         discriminator: { propertyName: "kind" },
       });
-      expect(schemas.TimeOptions.properties.generators.items).toEqual({
+      expect(schemas.CreateDatePollInput.properties.options.items).toEqual({
+        $ref: "#/components/schemas/DateOptionInput",
+      });
+      expect(schemas.CreateTimePollInput.properties.options.items).toEqual({
+        $ref: "#/components/schemas/TimeOptionInput",
+      });
+      expect(schemas.CreateTimePollInput.properties.generators.items).toEqual({
         $ref: "#/components/schemas/SlotGenerator",
       });
+      expect(schemas.SlotGenerator.properties.days.default).toEqual([
+        "mon",
+        "tue",
+        "wed",
+        "thu",
+        "fri",
+        "sat",
+        "sun",
+      ]);
 
       // Contextual .meta() clones keep pointing at the shared component.
       const pollStatusRef = "#/components/schemas/PollStatus";
@@ -1417,24 +1700,27 @@ describe("API v1 - /polls", () => {
       expect(createResponses["201"]).toBeDefined();
       expect(createResponses["200"]).toBeUndefined();
 
-      expect(schemas.CreatePollInput.additionalProperties).toBe(false);
-      expect(schemas.CreatePollInput.properties.spaceId).toBeUndefined();
-      expect(schemas.CreatePollInput.properties.title.maxLength).toBe(
-        MAX_POLL_TITLE_LENGTH,
-      );
-      expect(schemas.PatchPollInput.additionalProperties).toBe(false);
-
-      // Input and output use the same setting names and organizer field.
-      for (const key of [
-        "requireEmail",
-        "hideParticipants",
-        "hideScores",
-        "disableComments",
-        "allowTentativeVotes",
+      for (const variant of [
+        schemas.CreateDatePollInput,
+        schemas.CreateTimePollInput,
       ]) {
-        expect(schemas.CreatePollInput.properties[key]).toBeDefined();
-        expect(schemas.Poll.properties[key]).toBeDefined();
+        expect(variant.additionalProperties).toBe(false);
+        expect(variant.properties.spaceId).toBeUndefined();
+        expect(variant.properties.title.maxLength).toBe(MAX_POLL_TITLE_LENGTH);
+
+        // Input and output use the same setting names and organizer field.
+        for (const key of [
+          "requireEmail",
+          "hideParticipants",
+          "hideScores",
+          "disableComments",
+          "allowTentativeVotes",
+        ]) {
+          expect(variant.properties[key]).toBeDefined();
+          expect(schemas.Poll.properties[key]).toBeDefined();
+        }
       }
+      expect(schemas.PatchPollInput.additionalProperties).toBe(false);
       expect(schemas.Poll.properties.user).toBeUndefined();
       expect(schemas.Poll.properties.organizer).toMatchObject({
         anyOf: expect.arrayContaining([
@@ -2741,7 +3027,8 @@ describe("API v1 - /polls", () => {
         method: "POST",
         headers: { ...authed, "Content-Type": "application/json" },
         body: JSON.stringify({
-          options: { kind: "date", dates: ["not-a-date"] },
+          kind: "date",
+          options: [{ date: "not-a-date" }],
           secret: "do-not-echo",
         }),
       });
@@ -2751,7 +3038,7 @@ describe("API v1 - /polls", () => {
         code: "VALIDATION_ERROR",
       });
       expect(json.error.message).toContain("title:");
-      expect(json.error.message).toContain("options.dates.0:");
+      expect(json.error.message).toContain("options.0.date:");
       expect(Object.keys(json.error).sort()).toEqual(["code", "message"]);
       expect(JSON.stringify(json)).not.toContain("do-not-echo");
       expect(json).not.toHaveProperty("success");
@@ -2859,8 +3146,6 @@ describe("API v1 - /polls", () => {
         "POLL_NOT_FOUND",
         "ORGANIZER_NOT_MEMBER",
         "TOO_MANY_OPTIONS",
-        "DUPLICATE_DATES",
-        "NO_OPTIONS_GENERATED",
         "TRANSITION_NOT_AVAILABLE",
         "SERVICE_UNAVAILABLE",
         "INTERNAL_ERROR",

--- a/apps/web/src/app/api/v1/[...route]/route.ts
+++ b/apps/web/src/app/api/v1/[...route]/route.ts
@@ -305,8 +305,6 @@ async function buildOpenApiSpec() {
           "| 400 | `INVALID_AUTHORIZATION_HEADER` | The `Authorization` header is not `Bearer <key>` |",
           "| 400 | `ORGANIZER_NOT_MEMBER` | The organizer email is not a member of the space |",
           "| 400 | `TOO_MANY_OPTIONS` | More than the maximum number of poll options |",
-          "| 400 | `DUPLICATE_DATES` | `options.dates` contains the same date more than once |",
-          "| 400 | `NO_OPTIONS_GENERATED` | No slot generator produced a valid time slot |",
           "| 401 | `UNAUTHORIZED` | The API key is missing, invalid, expired or revoked |",
           "| 403 | `SPACE_NOT_PRO` | The space behind the key has no Pro subscription |",
           "| 404 | `NOT_FOUND` | No route matches the method and path |",
@@ -370,64 +368,61 @@ app.post(
     tags: ["Polls"],
     summary: "Create a poll",
     description: [
-      "Creates a poll and responds with `201 Created` and the full poll, exactly as `GET /polls/:pollId` returns it. Share `inviteUrl` with participants. `options.kind` chooses what participants vote on: whole days or time slots. A poll has at most 100 options.",
+      "Creates a poll and responds with `201 Created` and the full poll, exactly as `GET /polls/:pollId` returns it. Share `inviteUrl` with participants. The request mirrors the response: `kind` chooses what participants vote on, and `options` takes the same shape the poll returns, so a poll can be recreated from the body of a `GET`. A poll has at most 100 options.",
       "",
       "## Date poll",
       "",
-      'Pass `kind: "date"` and `dates`, a list of `YYYY-MM-DD` values. Each becomes one all-day option. Dates are floating calendar days with no timezone, so never convert them through one. A repeated date fails with `DUPLICATE_DATES`.',
+      'Pass `kind: "date"` and `options`, one `{ "date": "YYYY-MM-DD" }` per day. Each becomes one all-day option. Dates are floating calendar days with no timezone, so never convert them through one. Duplicate dates are removed.',
       "",
       "```json",
       "{",
       '  "title": "Team offsite",',
-      '  "options": {',
-      '    "kind": "date",',
-      '    "dates": ["2027-03-01", "2027-03-02", "2027-03-03"]',
-      "  }",
+      '  "kind": "date",',
+      '  "options": [{ "date": "2027-03-01" }, { "date": "2027-03-02" }, { "date": "2027-03-03" }]',
       "}",
       "```",
       "",
       "## Time poll",
       "",
-      'Pass `kind: "time"` with a `duration` in minutes that every slot shares, the slots themselves as `times`, `generators` or both, and optionally a `timeZone` (an IANA zone the times are written in).',
+      'Pass `kind: "time"`, optionally a `timeZone` (an IANA zone the times are written in) and a default `duration` in minutes, and the slots as `options`, `generators` or both.',
       "",
-      "### Explicit times",
+      "### Explicit slots",
       "",
-      "Each ISO datetime string in `times` becomes one slot starting at that moment. A time with no offset, like `2027-03-01T09:00:00`, is wall clock time in `timeZone` when that is set and a floating time with no conversion otherwise; a time with an offset or `Z` is an absolute instant.",
+      "Each entry in `options` is one slot: a `startTime` and an optional `duration` that overrides the poll default. A `startTime` with no offset, like `2027-03-01T09:00:00`, is wall clock time in `timeZone` when that is set and a floating time with no conversion otherwise; one with an offset or `Z` is an absolute instant.",
       "",
       "```json",
       "{",
       '  "title": "Kickoff",',
-      '  "options": {',
-      '    "kind": "time",',
-      '    "duration": 60,',
-      '    "timeZone": "Europe/London",',
-      '    "times": ["2027-03-01T09:00:00", "2027-03-02T14:00:00"]',
-      "  }",
+      '  "kind": "time",',
+      '  "timeZone": "Europe/London",',
+      '  "duration": 60,',
+      '  "options": [',
+      '    { "startTime": "2027-03-01T09:00:00" },',
+      '    { "startTime": "2027-03-02T14:00:00", "duration": 90 }',
+      "  ]",
       "}",
       "```",
       "",
       "### Slot generators",
       "",
-      "Each object in `generators` expands into recurring slots from a schedule, so availability across days or weeks does not have to be listed slot by slot.",
+      "Each object in `generators` expands into recurring slots of `duration` minutes from a schedule, so availability across days or weeks does not have to be listed slot by slot. `duration` is required when `generators` is set.",
       "",
       "```json",
       "{",
       '  "title": "Interview availability",',
-      '  "options": {',
-      '    "kind": "time",',
-      '    "duration": 30,',
-      '    "timeZone": "America/New_York",',
-      '    "generators": [',
-      "      {",
-      '        "startDate": "2027-03-01",',
-      '        "endDate": "2027-03-05",',
-      '        "days": ["mon", "tue", "wed", "thu", "fri"],',
-      '        "startTime": "09:00",',
-      '        "endTime": "12:00",',
-      '        "interval": 60',
-      "      }",
-      "    ]",
-      "  }",
+      '  "kind": "time",',
+      '  "timeZone": "America/New_York",',
+      '  "duration": 30,',
+      '  "generators": [',
+      "    {",
+      '      "startDate": "2027-03-01",',
+      '      "endDate": "2027-03-05",',
+      '      "days": ["mon", "tue", "wed", "thu", "fri"],',
+      '      "from": "09:00",',
+      '      "to": "12:00",',
+      '      "interval": 60',
+      "    }",
+      "  ]",
       "}",
       "```",
       "",
@@ -436,12 +431,12 @@ app.post(
       "| Field | Meaning |",
       "| --- | --- |",
       "| `startDate`, `endDate` | The date range, inclusive. Fewer than 366 days. |",
-      "| `days` | Days of the week to include: `mon` to `sun`. Other days in the range are skipped. |",
-      "| `startTime` | Earliest slot start on each day, `HH:mm` in `timeZone`. |",
-      "| `endTime` | End of the daily window. A slot is only generated if it ends by this time. |",
+      "| `days` | Days of the week to include: `mon` to `sun`. Optional; defaults to every day. |",
+      "| `from` | Earliest slot start on each day, `HH:mm` in `timeZone`. |",
+      "| `to` | End of the daily window, `HH:mm` in `timeZone`. A slot is only generated if it ends by this time. Must be later than `from`. |",
       "| `interval` | Minutes between slot starts. Optional; defaults to `duration`, which gives back to back slots. |",
       "",
-      "Generators are expanded when the poll is created and duplicate slots are removed. A request that would exceed 100 options fails with `TOO_MANY_OPTIONS`; a generator whose window fits no slot produces nothing, and if nothing in `times` or `generators` yields a slot the request fails with `NO_OPTIONS_GENERATED`.",
+      "A generator that cannot produce a slot is rejected with `VALIDATION_ERROR` naming the field: `to` not later than `from`, a window shorter than `duration`, or a range that contains none of the listed days. Generators are expanded when the poll is created, the result is appended to `options`, and duplicate slots are removed. A request that would exceed 100 options fails with `TOO_MANY_OPTIONS`.",
     ].join("\n"),
     security: [{ bearerAuth: [] }],
     responses: {
@@ -454,7 +449,7 @@ app.post(
         },
       },
       400: {
-        description: "Invalid input or no valid options generated",
+        description: "Invalid input",
         content: {
           "application/json": {
             schema: resolver(errorResponseSchema),
@@ -543,10 +538,8 @@ app.post(
       after(() => flushPostHog());
     };
 
-    const optionsInput = input.options;
-
-    if (optionsInput.kind === "date") {
-      const { dates } = optionsInput;
+    if (input.kind === "date") {
+      const dates = [...new Set(input.options.map((option) => option.date))];
       if (dates.length > MAX_POLL_OPTIONS) {
         return c.json(
           apiError(
@@ -557,19 +550,7 @@ app.post(
         );
       }
 
-      const uniqueDates = [...new Set(dates)];
-      if (uniqueDates.length < dates.length) {
-        const duplicateCount = dates.length - uniqueDates.length;
-        return c.json(
-          apiError(
-            "DUPLICATE_DATES",
-            `Duplicate dates found. Please remove ${duplicateCount} duplicate date${duplicateCount > 1 ? "s" : ""}.`,
-          ),
-          400,
-        );
-      }
-
-      const options = uniqueDates.map((date) => ({
+      const options = dates.map((date) => ({
         startTime: new Date(`${date}T00:00:00.000Z`),
         duration: 0,
       }));
@@ -593,33 +574,42 @@ app.post(
       return c.json(pollResponseSchema.parse(toPollResponseBody(poll)), 201);
     }
 
-    const timeZone = optionsInput.timeZone;
-    const duration = optionsInput.duration;
+    const { timeZone } = input;
+    // The schema guarantees a duration wherever it is read: every option
+    // without its own carries the poll default, and generators require it.
+    const defaultDuration = input.duration ?? 0;
 
     const timeSlots = [
-      ...(optionsInput.times ?? []).map((time) =>
-        parseStartTime(time, timeZone, duration),
+      ...(input.options ?? []).map((option) =>
+        parseStartTime(
+          option.startTime,
+          timeZone,
+          option.duration ?? defaultDuration,
+        ),
       ),
-      ...(optionsInput.generators ?? []).flatMap((generator) => {
+      ...(input.generators ?? []).flatMap((generator) => {
         const slotGenerator: SlotGeneratorInput = {
           startDate: generator.startDate,
           endDate: generator.endDate,
           daysOfWeek: generator.days,
-          fromTime: generator.startTime,
-          toTime: generator.endTime,
+          fromTime: generator.from,
+          toTime: generator.to,
           interval: generator.interval,
         };
-        return generateTimeSlots(slotGenerator, timeZone, duration);
+        return generateTimeSlots(slotGenerator, timeZone, defaultDuration);
       }),
     ];
 
     const options = dedupeTimeSlots(timeSlots);
 
+    // Unreachable for inputs the schema accepts; guards the poll against an
+    // expansion edge case (a window that vanishes on a DST change) rather
+    // than creating it empty.
     if (!options.length) {
       return c.json(
         apiError(
-          "NO_OPTIONS_GENERATED",
-          "No valid options were generated. Check that your slot generators produce valid time slots.",
+          "VALIDATION_ERROR",
+          "generators: no slot fits the daily window on any listed day.",
         ),
         400,
       );

--- a/apps/web/src/app/api/v1/examples.ts
+++ b/apps/web/src/app/api/v1/examples.ts
@@ -8,29 +8,32 @@ export const createPollRequestExamples = {
   "Date poll": {
     summary: "Date poll (all-day options)",
     description:
-      "Let participants pick between calendar days. Each date becomes an all-day option.",
+      "Let participants pick between calendar days. Each option is one all-day date.",
     value: {
       title: "Team offsite",
+      kind: "date",
       description: "Which days work for a two day offsite?",
-      options: {
-        kind: "date",
-        dates: ["2027-03-01", "2027-03-02", "2027-03-03"],
-      },
+      options: [
+        { date: "2027-03-01" },
+        { date: "2027-03-02" },
+        { date: "2027-03-03" },
+      ],
     } satisfies CreatePollInput,
   },
-  "Time poll with explicit times": {
-    summary: "Time poll (explicit times)",
+  "Time poll with explicit slots": {
+    summary: "Time poll (explicit slots)",
     description:
-      "Offer specific time slots. Datetimes without an offset are interpreted as wall-clock in `timeZone` — this example offers 09:00 and 14:00 in London. Append `Z` or an offset to specify an absolute instant instead.",
+      "Offer specific time slots. Datetimes without an offset are wall clock times in `timeZone`; this example offers 09:00 and 14:00 in London. Append `Z` or an offset for an absolute instant instead. A slot may override the poll's `duration`.",
     value: {
       title: "Project kickoff",
+      kind: "time",
       location: "Zoom",
-      options: {
-        kind: "time",
-        duration: 60,
-        timeZone: "Europe/London",
-        times: ["2027-03-01T09:00:00", "2027-03-01T14:00:00"],
-      },
+      timeZone: "Europe/London",
+      duration: 60,
+      options: [
+        { startTime: "2027-03-01T09:00:00" },
+        { startTime: "2027-03-01T14:00:00", duration: 90 },
+      ],
     } satisfies CreatePollInput,
   },
   "Time poll with a slot generator": {
@@ -39,44 +42,40 @@ export const createPollRequestExamples = {
       "Expand recurring slots across a date range. This example generates 30 minute slots at 09:00, 10:00 and 11:00 (New York time) every weekday from 1 to 5 March.",
     value: {
       title: "Interview availability",
-      options: {
-        kind: "time",
-        duration: 30,
-        timeZone: "America/New_York",
-        generators: [
-          {
-            startDate: "2027-03-01",
-            endDate: "2027-03-05",
-            days: ["mon", "tue", "wed", "thu", "fri"],
-            startTime: "09:00",
-            endTime: "12:00",
-            interval: 60,
-          },
-        ],
-      },
+      kind: "time",
+      timeZone: "America/New_York",
+      duration: 30,
+      generators: [
+        {
+          startDate: "2027-03-01",
+          endDate: "2027-03-05",
+          days: ["mon", "tue", "wed", "thu", "fri"],
+          from: "09:00",
+          to: "12:00",
+          interval: 60,
+        },
+      ],
     } satisfies CreatePollInput,
   },
-  "Time poll mixing times and a generator": {
-    summary: "Time poll (explicit times + generator)",
+  "Time poll mixing slots and a generator": {
+    summary: "Time poll (explicit slots + generator)",
     description:
-      "`times` and `generators` combine. When `interval` is omitted it defaults to `duration`, so this generator produces back to back 90 minute slots at 14:00 and 15:30 on Monday and Wednesday.",
+      "`options` and `generators` combine. When `interval` is omitted it defaults to `duration`, so this generator produces back to back 90 minute slots at 14:00 and 15:30 on Monday and Wednesday.",
     value: {
       title: "Product workshop",
-      options: {
-        kind: "time",
-        duration: 90,
-        timeZone: "Europe/Berlin",
-        times: ["2027-03-06T10:00:00"],
-        generators: [
-          {
-            startDate: "2027-03-08",
-            endDate: "2027-03-10",
-            days: ["mon", "wed"],
-            startTime: "14:00",
-            endTime: "17:00",
-          },
-        ],
-      },
+      kind: "time",
+      timeZone: "Europe/Berlin",
+      duration: 90,
+      options: [{ startTime: "2027-03-06T10:00:00" }],
+      generators: [
+        {
+          startDate: "2027-03-08",
+          endDate: "2027-03-10",
+          days: ["mon", "wed"],
+          from: "14:00",
+          to: "17:00",
+        },
+      ],
     } satisfies CreatePollInput,
   },
 };

--- a/apps/web/src/app/api/v1/schemas.ts
+++ b/apps/web/src/app/api/v1/schemas.ts
@@ -13,6 +13,38 @@ export const timeSchema = z.iso.time({ precision: -1 }).meta({
   example: "09:30",
 });
 
+const WEEKDAYS = ["mon", "tue", "wed", "thu", "fri", "sat", "sun"] as const;
+type Weekday = (typeof WEEKDAYS)[number];
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+const daySpan = (startDate: string, endDate: string) =>
+  (Date.parse(endDate) - Date.parse(startDate)) / DAY_MS;
+
+// A calendar date has the same weekday in every zone, so no zone is needed.
+const rangeIncludesWeekday = (
+  startDate: string,
+  endDate: string,
+  days: ReadonlyArray<Weekday>,
+) => {
+  const wanted = new Set(days.map((day) => WEEKDAYS.indexOf(day)));
+  const start = Date.parse(startDate);
+  const span = daySpan(startDate, endDate);
+  for (let offset = 0; offset <= Math.min(span, 6); offset++) {
+    // getUTCDay: 0 = Sunday; WEEKDAYS starts on Monday.
+    const weekday = (new Date(start + offset * DAY_MS).getUTCDay() + 6) % 7;
+    if (wanted.has(weekday)) return true;
+  }
+  return false;
+};
+
+const minutesOfDay = (time: string) => {
+  const [hours, minutes] = time.split(":").map(Number);
+  return hours * 60 + minutes;
+};
+
+const durationSchema = z.number().int().min(15).max(1440);
+
 export const slotGeneratorSchema = z
   .strictObject({
     startDate: dateSchema.meta({
@@ -25,24 +57,25 @@ export const slotGeneratorSchema = z
       example: "2027-03-05",
     }),
     days: z
-      .array(z.enum(["mon", "tue", "wed", "thu", "fri", "sat", "sun"]))
+      .array(z.enum(WEEKDAYS))
       .min(1)
+      .default([...WEEKDAYS])
       .meta({
         description:
-          "Days of the week to generate slots on. Days in the range that are not listed are skipped.",
+          "Days of the week to generate slots on. Days in the range that are not listed are skipped. Defaults to every day.",
         example: ["mon", "tue", "wed", "thu", "fri"],
       }),
-    startTime: timeSchema.meta({
+    from: timeSchema.meta({
       description:
         "Earliest slot start on each day, as a wall clock time in `timeZone`.",
       example: "09:00",
     }),
-    endTime: timeSchema.meta({
+    to: timeSchema.meta({
       description:
-        "End of the daily window. A slot is only generated if it ends at or before this time.",
+        "End of the daily window, as a wall clock time in `timeZone`. A slot is only generated if it ends at or before this time.",
       example: "17:00",
     }),
-    interval: z.number().int().min(15).max(1440).optional().meta({
+    interval: durationSchema.optional().meta({
       description:
         "Minutes between consecutive slot starts. Defaults to `duration`, which produces back to back slots.",
       example: 60,
@@ -52,150 +85,235 @@ export const slotGeneratorSchema = z
   // generator's MAX_SLOT_GENERATION_DAYS cap.
   .refine(
     (data) => {
-      const start = Date.parse(data.startDate);
-      const end = Date.parse(data.endDate);
-      const spanDays = (end - start) / (1000 * 60 * 60 * 24);
-      return spanDays >= 0 && spanDays < MAX_SLOT_GENERATION_DAYS;
+      const span = daySpan(data.startDate, data.endDate);
+      return span >= 0 && span < MAX_SLOT_GENERATION_DAYS;
     },
     {
       message: `The date range must span fewer than ${MAX_SLOT_GENERATION_DAYS} days, with endDate on or after startDate.`,
       path: ["endDate"],
     },
   )
+  .refine((data) => minutesOfDay(data.to) > minutesOfDay(data.from), {
+    message: "Must be later than `from`. Windows cannot cross midnight.",
+    path: ["to"],
+  })
+  .refine(
+    (data) =>
+      daySpan(data.startDate, data.endDate) < 0 ||
+      rangeIncludesWeekday(data.startDate, data.endDate, data.days),
+    {
+      message: "None of the listed days fall between startDate and endDate.",
+      path: ["days"],
+    },
+  )
   .meta({
     id: "SlotGenerator",
     title: "Slot generator",
     description:
-      "Expands into one slot of `duration` minutes every `interval` minutes between `startTime` and `endTime`, on each listed day of the week between `startDate` and `endDate`. Slots that would not end by `endTime` are not generated.",
+      "Expands into one slot of `duration` minutes every `interval` minutes between `from` and `to`, on each listed day of the week between `startDate` and `endDate`. Slots that would not end by `to` are not generated.",
   });
 
-const explicitTimeSchema = z.iso.datetime({ local: true, offset: true }).meta({
-  description:
-    "ISO datetime start time. A string without an offset is wall clock time in `timeZone` when that is set (`2027-03-01T09:00:00` with `timeZone: Europe/London` means 09:00 in London) and a floating time with no conversion otherwise. A string with an offset or `Z` is an absolute instant.",
-  example: "2027-03-01T09:00:00",
-});
-
-const dateOptionsSchema = z
+const dateOptionInputSchema = z
   .strictObject({
-    kind: z.literal("date"),
-    dates: z
-      .array(z.iso.date())
-      .min(1)
-      .meta({
-        description:
-          "Calendar days to offer. Each becomes one all-day option. A day may appear once.",
-        example: ["2027-03-01", "2027-03-02", "2027-03-03"],
-      }),
+    date: dateSchema.meta({
+      description: "Calendar day to offer, as a floating `YYYY-MM-DD` date.",
+      example: "2027-03-01",
+    }),
   })
   .meta({
-    id: "DateOptions",
-    title: "Date poll",
-    description:
-      "Whole days. Dates are floating calendar days with no timezone, so never convert them through one.",
+    id: "DateOptionInput",
+    title: "Date option",
+    description: "One all-day option. The same shape `DateOption` returns.",
   });
 
-const timeOptionsSchema = z
+const timeOptionInputSchema = z
   .strictObject({
-    kind: z.literal("time"),
-    duration: z.number().int().min(15).max(1440).meta({
-      description: "Length of every slot in minutes",
+    startTime: z.iso.datetime({ local: true, offset: true }).meta({
+      description:
+        "ISO datetime start time. A string without an offset is wall clock time in `timeZone` when that is set (`2027-03-01T09:00:00` with `timeZone: Europe/London` means 09:00 in London) and a floating time with no conversion otherwise. A string with an offset or `Z` is an absolute instant.",
+      example: "2027-03-01T09:00:00",
+    }),
+    duration: durationSchema.optional().meta({
+      description:
+        "Length of this slot in minutes. Defaults to the poll's `duration`.",
       example: 30,
     }),
+  })
+  .meta({
+    id: "TimeOptionInput",
+    title: "Time option",
+    description: "One time slot. The same shape `TimeOption` returns.",
+  });
+
+const pollSettingsFields = {
+  title: z
+    .string()
+    .trim()
+    .min(1)
+    .max(MAX_POLL_TITLE_LENGTH)
+    .meta({ example: "Team sync" }),
+  description: z
+    .string()
+    .trim()
+    .max(1000)
+    .optional()
+    .meta({ example: "Pick a time that works for everyone" }),
+  location: z.string().trim().max(255).optional().meta({ example: "Zoom" }),
+  requireEmail: z.boolean().optional().meta({
+    description: "Require participants to provide their email address",
+    example: true,
+  }),
+  hideParticipants: z.boolean().optional().meta({
+    description: "Hide participant names from other participants",
+    example: false,
+  }),
+  hideScores: z.boolean().optional().meta({
+    description: "Hide vote counts from participants",
+    example: false,
+  }),
+  disableComments: z.boolean().optional().meta({
+    description:
+      "Disable the comments section. Defaults to true: new polls have comments disabled unless this is set to false.",
+    example: false,
+  }),
+  allowTentativeVotes: z.boolean().optional().meta({
+    description:
+      'Allow participants to answer "if need be" as well as yes and no. Defaults to true.',
+    example: true,
+  }),
+  organizer: z
+    .strictObject({
+      email: z.email().meta({
+        description: "Email address of the organizer",
+        example: "organizer@example.com",
+      }),
+    })
+    .optional()
+    .meta({
+      description:
+        "Organizer of the poll. Defaults to the space owner if not provided. The organizer must be a member of the space.",
+    }),
+};
+
+// Strict so a misspelt or unsupported field fails loudly instead of being
+// silently ignored.
+const createDatePollInputSchema = z
+  .strictObject({
+    title: pollSettingsFields.title,
+    kind: z.literal("date").meta({
+      description: "Participants vote on whole days.",
+    }),
+    description: pollSettingsFields.description,
+    location: pollSettingsFields.location,
+    requireEmail: pollSettingsFields.requireEmail,
+    hideParticipants: pollSettingsFields.hideParticipants,
+    hideScores: pollSettingsFields.hideScores,
+    disableComments: pollSettingsFields.disableComments,
+    allowTentativeVotes: pollSettingsFields.allowTentativeVotes,
+    organizer: pollSettingsFields.organizer,
+    options: z.array(dateOptionInputSchema).min(1).meta({
+      description:
+        "Calendar days to offer. Dates are floating calendar days with no timezone, so never convert them through one. Duplicates are removed.",
+    }),
+  })
+  .meta({ id: "CreateDatePollInput", title: "Date poll" });
+
+const createTimePollInputSchema = z
+  .strictObject({
+    title: pollSettingsFields.title,
+    kind: z.literal("time").meta({
+      description: "Participants vote on time slots.",
+    }),
+    description: pollSettingsFields.description,
+    location: pollSettingsFields.location,
+    requireEmail: pollSettingsFields.requireEmail,
+    hideParticipants: pollSettingsFields.hideParticipants,
+    hideScores: pollSettingsFields.hideScores,
+    disableComments: pollSettingsFields.disableComments,
+    allowTentativeVotes: pollSettingsFields.allowTentativeVotes,
+    organizer: pollSettingsFields.organizer,
     timeZone: timezoneSchema.optional().meta({
       description:
         "IANA time zone the times are written in. Datetime strings without an offset are interpreted in this zone. If omitted, offset-less datetimes are floating times (no conversion) and the poll has no time zone.",
       example: "Europe/London",
     }),
-    times: z.array(explicitTimeSchema).min(1).optional().meta({
-      description: "Explicit slots, one per start time.",
+    duration: durationSchema.optional().meta({
+      description:
+        "Default slot length in minutes. Required when `generators` is set or an option omits its own `duration`.",
+      example: 30,
+    }),
+    options: z.array(timeOptionInputSchema).min(1).optional().meta({
+      description:
+        "Explicit slots. Provide `options`, `generators` or both. Duplicates are removed.",
     }),
     generators: z.array(slotGeneratorSchema).min(1).optional().meta({
       description:
-        "Slot generators. Each expands into recurring slots from a schedule.",
+        "Slot generators. Each expands into recurring slots from a schedule and the result is appended to `options`.",
     }),
   })
-  .refine((data) => data.times || data.generators, {
-    message: "Provide 'times', 'generators' or both",
-    path: ["times"],
+  // These rules do not survive JSON Schema conversion; the field
+  // descriptions state them instead.
+  .superRefine((data, ctx) => {
+    if (!data.options && !data.generators) {
+      ctx.addIssue({
+        code: "custom",
+        path: ["options"],
+        message: "Provide `options`, `generators` or both.",
+      });
+    }
+    if (data.duration === undefined) {
+      data.options?.forEach((option, index) => {
+        if (option.duration === undefined) {
+          ctx.addIssue({
+            code: "custom",
+            path: ["options", index, "duration"],
+            message: "Required when the poll has no default `duration`.",
+          });
+        }
+      });
+      if (data.generators) {
+        ctx.addIssue({
+          code: "custom",
+          path: ["duration"],
+          message: "Required when `generators` is set.",
+        });
+      }
+      return;
+    }
+    const { duration } = data;
+    data.generators?.forEach((generator, index) => {
+      const window = minutesOfDay(generator.to) - minutesOfDay(generator.from);
+      if (window > 0 && window < duration) {
+        ctx.addIssue({
+          code: "custom",
+          path: ["generators", index, "to"],
+          message: `The window from ${generator.from} to ${generator.to} is shorter than the ${duration} minute duration.`,
+        });
+      }
+    });
   })
-  // The refinement above does not survive JSON Schema conversion. Stating it
-  // as an anyOf would make Mintlify render two identical "Time poll" variants,
-  // so the description carries it instead.
-  .meta({
-    id: "TimeOptions",
-    title: "Time poll",
-    description:
-      "Time slots that share one duration. Provide `times`, `generators` or both. Duplicate slots are removed.",
-  });
+  .meta({ id: "CreateTimePollInput", title: "Time poll" });
 
-// Strict so a misspelt or unsupported field fails loudly instead of being
-// silently ignored.
 export const createPollInputSchema = z
-  .strictObject({
-    title: z
-      .string()
-      .trim()
-      .min(1)
-      .max(MAX_POLL_TITLE_LENGTH)
-      .meta({ example: "Team sync" }),
-    description: z
-      .string()
-      .trim()
-      .max(1000)
-      .optional()
-      .meta({ example: "Pick a time that works for everyone" }),
-    location: z.string().trim().max(255).optional().meta({ example: "Zoom" }),
-    requireEmail: z.boolean().optional().meta({
-      description: "Require participants to provide their email address",
-      example: true,
-    }),
-    hideParticipants: z.boolean().optional().meta({
-      description: "Hide participant names from other participants",
-      example: false,
-    }),
-    hideScores: z.boolean().optional().meta({
-      description: "Hide vote counts from participants",
-      example: false,
-    }),
-    disableComments: z.boolean().optional().meta({
-      description:
-        "Disable the comments section. Defaults to true: new polls have comments disabled unless this is set to false.",
-      example: false,
-    }),
-    allowTentativeVotes: z.boolean().optional().meta({
-      description:
-        'Allow participants to answer "if need be" as well as yes and no. Defaults to true.',
-      example: true,
-    }),
-    organizer: z
-      .strictObject({
-        email: z.email().meta({
-          description: "Email address of the organizer",
-          example: "organizer@example.com",
-        }),
-      })
-      .optional()
-      .meta({
-        description:
-          "Organizer of the poll. Defaults to the space owner if not provided. The organizer must be a member of the space.",
-      }),
-    options: z
-      .discriminatedUnion("kind", [dateOptionsSchema, timeOptionsSchema], {
-        error: 'kind must be "date" or "time"',
-      })
-      .meta({
-        description:
-          "What participants vote on: whole days (`kind: date`) or time slots (`kind: time`).",
-        discriminator: {
-          propertyName: "kind",
-          mapping: {
-            date: "#/components/schemas/DateOptions",
-            time: "#/components/schemas/TimeOptions",
-          },
-        },
-      }),
-  })
-  .meta({ id: "CreatePollInput" });
+  .discriminatedUnion(
+    "kind",
+    [createDatePollInputSchema, createTimePollInputSchema],
+    {
+      error: 'kind must be "date" or "time"',
+    },
+  )
+  .meta({
+    id: "CreatePollInput",
+    description:
+      "`kind` chooses what participants vote on: whole days (`date`) or time slots (`time`). The request mirrors the poll the API returns: the same settings, and `options` in the same shape as the response.",
+    discriminator: {
+      propertyName: "kind",
+      mapping: {
+        date: "#/components/schemas/CreateDatePollInput",
+        time: "#/components/schemas/CreateTimePollInput",
+      },
+    },
+  });
 
 export const errorResponseSchema = z
   .object({


### PR DESCRIPTION
Stacked on #3259 so the regenerated `openapi.json` and the errors page land with the change; the base moves to `main` once that merges. Implements the suggestions in [this comment](https://github.com/lukevella/rallly/pull/3259#issuecomment-5648942462). v1 has no consumers yet, so the request shape changes before it ships. The frozen private route is untouched.

## What changed

The create body now mirrors the poll the API returns: `kind`, `timeZone` and `options` sit at the top level in the same positions and shapes as the response, so a poll can be recreated from the body of a `GET`.

```json
{
  "title": "Interview availability",
  "kind": "time",
  "timeZone": "America/New_York",
  "duration": 30,
  "options": [
    { "startTime": "2027-03-01T13:00:00" },
    { "startTime": "2027-03-01T15:00:00", "duration": 45 }
  ],
  "generators": [
    { "startDate": "2027-03-01", "endDate": "2027-03-05", "days": ["mon", "tue", "wed", "thu", "fri"], "from": "09:00", "to": "12:00", "interval": 60 }
  ]
}
```

```json
{ "title": "Offsite", "kind": "date", "options": [{ "date": "2027-03-01" }, { "date": "2027-03-02" }] }
```

- `options` is an array of `{ date }` or `{ startTime, duration? }`. Top level `duration` is the default and a slot may override it, which the week calendar already allows. `duration` is required when `generators` is set or a slot omits its own.
- Generator windows are `from` and `to`, so `startTime` no longer means `HH:mm` in one object and an ISO datetime in the next. `days` is optional and defaults to every day.
- The body is a discriminated union on `kind`, so `timeZone`, `duration` and `generators` are schema illegal on a date poll. Mintlify renders the two variants as "Date poll" / "Time poll" tabs under Body, verified with `mint dev`.
- Duplicate dates are removed like duplicate slots. `DUPLICATE_DATES` is gone.
- A generator that cannot produce a slot fails validation with a path: `generators.0.to` when `to` is not later than `from` or the window is shorter than `duration`, `generators.0.days` when the range contains none of the listed days. `NO_OPTIONS_GENERATED` is gone; the only remaining empty case is a DST edge in expansion, which returns `VALIDATION_ERROR` rather than creating an empty poll.

## Not in this PR

- `Idempotency-Key` on create needs a store and its own design.
- `dryRun` preview is additive and can follow after launch.

## Verification

- `pnpm exec vitest run src/app/api/v1`: 114 tests pass, including new cases for slot duration override, missing duration paths, `days` default, options plus generators dedupe, and each generator validation path.
- `pnpm check:openapi` passes; the committed spec matches the route.
- `tsc` clean for the touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
